### PR TITLE
[Impeller] dont use half precision constants / Fixes for SPIRV tools roll

### DIFF
--- a/impeller/compiler/shader_lib/impeller/constants.glsl
+++ b/impeller/compiler/shader_lib/impeller/constants.glsl
@@ -29,6 +29,5 @@ const float kSqrtThree = 1.73205080757;
 // which results in sharper looking images when mip sampling is enabled. This is
 // the same constant that Skia uses.
 const float kDefaultMipBias = -0.475;
-const float kDefaultMipBiasHalf = -0.475hf;
 
 #endif

--- a/impeller/compiler/shader_lib/impeller/texture.glsl
+++ b/impeller/compiler/shader_lib/impeller/texture.glsl
@@ -82,22 +82,20 @@ vec4 IPSampleWithTileMode(sampler2D tex,
   return texture(tex, coords, kDefaultMipBias);
 }
 
-const float16_t kTileModeDecalHf = 3.0hf;
-
 /// Sample a texture, emulating a specific tile mode.
 ///
 /// This is useful for Impeller graphics backend that don't have native support
 /// for Decal.
 f16vec4 IPHalfSampleWithTileMode(f16sampler2D tex,
                                  vec2 coords,
-                                 float16_t x_tile_mode,
-                                 float16_t y_tile_mode) {
-  if (x_tile_mode == kTileModeDecalHf && (coords.x < 0.0 || coords.x >= 1.0) ||
-      y_tile_mode == kTileModeDecalHf && (coords.y < 0.0 || coords.y >= 1.0)) {
+                                 float x_tile_mode,
+                                 float y_tile_mode) {
+  if (x_tile_mode == kTileModeDecal && (coords.x < 0.0 || coords.x >= 1.0) ||
+      y_tile_mode == kTileModeDecal && (coords.y < 0.0 || coords.y >= 1.0)) {
     return f16vec4(0.0hf);
   }
 
-  return texture(tex, coords, kDefaultMipBiasHalf);
+  return texture(tex, coords, float16_t(kDefaultMipBias));
 }
 
 /// Sample a texture, emulating a specific tile mode.
@@ -137,7 +135,7 @@ f16vec4 IPHalfSampleDecal(f16sampler2D texture_sampler, vec2 coords) {
       any(greaterThanEqual(coords, vec2(1)))) {
     return f16vec4(0.0);
   }
-  return texture(texture_sampler, coords, kDefaultMipBiasHalf);
+  return texture(texture_sampler, coords, float16_t(kDefaultMipBias));
 }
 
 /// Sample a texture, emulating a specific tile mode.

--- a/impeller/entity/shaders/filters/morphology_filter.frag
+++ b/impeller/entity/shaders/filters/morphology_filter.frag
@@ -12,15 +12,15 @@ layout(constant_id = 0) const float supports_decal = 1.0;
 
 // These values must correspond to the order of the items in the
 // 'FilterContents::MorphType' enum class.
-const float16_t kMorphTypeDilate = 0.0hf;
-const float16_t kMorphTypeErode = 1.0hf;
+const float kMorphTypeDilate = 0.0;
+const float kMorphTypeErode = 1.0;
 
 uniform f16sampler2D texture_sampler;
 
 uniform FragInfo {
   f16vec2 uv_offset;
   float16_t radius;
-  float16_t morph_type;
+  float morph_type;
   float supports_decal_sampler_address_mode;
 }
 frag_info;

--- a/impeller/entity/shaders/filters/morphology_filter.frag
+++ b/impeller/entity/shaders/filters/morphology_filter.frag
@@ -12,8 +12,8 @@ layout(constant_id = 0) const float supports_decal = 1.0;
 
 // These values must correspond to the order of the items in the
 // 'FilterContents::MorphType' enum class.
-const float kMorphTypeDilate = 0.0;
-const float kMorphTypeErode = 1.0;
+// const float kMorphTypeDilate = 0.0;
+// const float kMorphTypeErode = 1.0;
 
 uniform f16sampler2D texture_sampler;
 
@@ -30,8 +30,9 @@ in highp vec2 v_texture_coords;
 out f16vec4 frag_color;
 
 void main() {
-  f16vec4 result =
-      frag_info.morph_type == kMorphTypeDilate ? f16vec4(0.0) : f16vec4(1.0);
+  f16vec4 result = frag_info.morph_type == /*kMorphTypeDilate*/ 0.0
+                       ? f16vec4(0.0)
+                       : f16vec4(1.0);
   for (float16_t i = -frag_info.radius; i <= frag_info.radius; i++) {
     vec2 texture_coords = v_texture_coords + frag_info.uv_offset * i;
 
@@ -42,7 +43,7 @@ void main() {
       color = IPHalfSampleDecal(texture_sampler, texture_coords);
     }
 
-    if (frag_info.morph_type == kMorphTypeDilate) {
+    if (frag_info.morph_type == /*kMorphTypeDilate*/ 0.0) {
       result = max(color, result);
     } else {
       result = min(color, result);

--- a/impeller/entity/shaders/filters/yuv_to_rgb_filter.frag
+++ b/impeller/entity/shaders/filters/yuv_to_rgb_filter.frag
@@ -13,8 +13,8 @@ uniform f16sampler2D uv_texture;
 
 // These values must correspond to the order of the items in the
 // 'YUVColorSpace' enum class.
-const float kBT601LimitedRange = 0.0;
-const float kBT601FullRange = 1.0;
+// const float kBT601LimitedRange = 0.0;
+// const float kBT601FullRange = 1.0;
 
 uniform FragInfo {
   mat4 matrix;
@@ -29,7 +29,7 @@ out f16vec4 frag_color;
 void main() {
   f16vec3 yuv;
   f16vec3 yuv_offset = f16vec3(0.0hf, 0.5hf, 0.5hf);
-  if (frag_info.yuv_color_space == kBT601LimitedRange) {
+  if (frag_info.yuv_color_space == /*kBT601LimitedRange*/ 0.0) {
     yuv_offset.x = 16.0hf / 255.0hf;
   }
 

--- a/impeller/entity/shaders/filters/yuv_to_rgb_filter.frag
+++ b/impeller/entity/shaders/filters/yuv_to_rgb_filter.frag
@@ -13,12 +13,12 @@ uniform f16sampler2D uv_texture;
 
 // These values must correspond to the order of the items in the
 // 'YUVColorSpace' enum class.
-const float16_t kBT601LimitedRange = 0.0hf;
-const float16_t kBT601FullRange = 1.0hf;
+const float kBT601LimitedRange = 0.0;
+const float kBT601FullRange = 1.0;
 
 uniform FragInfo {
   mat4 matrix;
-  float16_t yuv_color_space;
+  float yuv_color_space;
 }
 frag_info;
 

--- a/impeller/entity/shaders/texture_fill.frag
+++ b/impeller/entity/shaders/texture_fill.frag
@@ -16,6 +16,6 @@ out f16vec4 frag_color;
 
 void main() {
   f16vec4 sampled =
-      texture(texture_sampler, v_texture_coords, kDefaultMipBiasHalf);
+      texture(texture_sampler, v_texture_coords, float16_t(kDefaultMipBias));
   frag_color = sampled * v_alpha;
 }

--- a/impeller/entity/shaders/texture_fill_strict_src.frag
+++ b/impeller/entity/shaders/texture_fill_strict_src.frag
@@ -25,6 +25,6 @@ void main() {
                              clamp(v_texture_coords.y, frag_info.source_rect.y,
                                    frag_info.source_rect.w));
   f16vec4 sampled =
-      texture(texture_sampler, texture_coords, kDefaultMipBiasHalf);
+      texture(texture_sampler, texture_coords, float16_t(kDefaultMipBias));
   frag_color = sampled * v_alpha;
 }


### PR DESCRIPTION
See b/335381180

In an upcoming version of SPIRV tools, these constants are being flagged as invalid. Due to some combination of the macros + inlining we're ending up with multiple precision modifiers on the constants:

```
third_party/flutter_engine/impeller/entity/shaders/radial_gradient_fill.frag: GLSL to SPIRV failed; Compilation error. 0 error(s) and 1 warning(s).
third_party/flutter_engine/impeller/entity/shaders/radial_gradient_fill.frag:14: warning: '' : all default precisions are highp; use precision statements to quiet warning, e.g.:
third_party/flutter_engine/impeller/entity/shaders/radial_gradient_fill.frag:          "precision mediump int; precision highp float;" 
shaderc: internal error: compilation succeeded but failed to optimize: ID '112' decorated with RelaxedPrecision multiple times is not allowed.
  %float_n0_474999994 = OpConstant %float -0.474999994
  ```
  
  We don't really benefit from half precision on these, since we're either using them for equality or can cheaply convert to half precision anyway.