### PR TITLE
Migrate PlatformMessageHandlerIos to ARC

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -117,6 +117,8 @@ source_set("flutter_framework_source_arc") {
     "ios_surface_metal_skia.mm",
     "ios_surface_software.h",
     "ios_surface_software.mm",
+    "platform_message_handler_ios.h",
+    "platform_message_handler_ios.mm",
     "rendering_api_selection.h",
     "rendering_api_selection.mm",
   ]
@@ -180,8 +182,6 @@ source_set("flutter_framework_source") {
     "framework/Source/accessibility_text_entry.mm",
     "ios_external_view_embedder.h",
     "ios_external_view_embedder.mm",
-    "platform_message_handler_ios.h",
-    "platform_message_handler_ios.mm",
     "platform_view_ios.h",
     "platform_view_ios.mm",
   ]

--- a/shell/platform/darwin/ios/platform_message_handler_ios.h
+++ b/shell/platform/darwin/ios/platform_message_handler_ios.h
@@ -6,6 +6,7 @@
 #define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_PLATFORM_MESSAGE_HANDLER_IOS_H_
 
 #include "flutter/fml/platform/darwin/scoped_block.h"
+#include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/fml/task_runner.h"
 #include "flutter/shell/common/platform_message_handler.h"
 #import "flutter/shell/platform/darwin/ios/flutter_task_queue_dispatch.h"
@@ -32,7 +33,7 @@ class PlatformMessageHandlerIos : public PlatformMessageHandler {
                          NSObject<FlutterTaskQueue>* task_queue);
 
   struct HandlerInfo {
-    NSObject<FlutterTaskQueueDispatch>* task_queue;
+    fml::scoped_nsprotocol<NSObject<FlutterTaskQueueDispatch>*> task_queue;
     fml::ScopedBlock<FlutterBinaryMessageHandler> handler;
   };
 

--- a/shell/platform/darwin/ios/platform_message_handler_ios.h
+++ b/shell/platform/darwin/ios/platform_message_handler_ios.h
@@ -5,13 +5,9 @@
 #ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_PLATFORM_MESSAGE_HANDLER_IOS_H_
 #define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_PLATFORM_MESSAGE_HANDLER_IOS_H_
 
-#include <unordered_map>
-
-#include "flutter/common/task_runners.h"
 #include "flutter/fml/platform/darwin/scoped_block.h"
-#include "flutter/fml/platform/darwin/scoped_nsobject.h"
+#include "flutter/fml/task_runner.h"
 #include "flutter/shell/common/platform_message_handler.h"
-#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterBinaryMessenger.h"
 #import "flutter/shell/platform/darwin/ios/flutter_task_queue_dispatch.h"
 
 namespace flutter {
@@ -36,7 +32,7 @@ class PlatformMessageHandlerIos : public PlatformMessageHandler {
                          NSObject<FlutterTaskQueue>* task_queue);
 
   struct HandlerInfo {
-    fml::scoped_nsprotocol<NSObject<FlutterTaskQueueDispatch>*> task_queue;
+    NSObject<FlutterTaskQueueDispatch>* task_queue;
     fml::ScopedBlock<FlutterBinaryMessageHandler> handler;
   };
 

--- a/shell/platform/darwin/ios/platform_message_handler_ios.mm
+++ b/shell/platform/darwin/ios/platform_message_handler_ios.mm
@@ -14,7 +14,7 @@ FLUTTER_ASSERT_ARC
 static uint64_t platform_message_counter = 1;
 
 @interface FLTSerialTaskQueue : NSObject <FlutterTaskQueueDispatch>
-@property(nonatomic, strong) dispatch_queue_t queue;
+@property(nonatomic, readonly) dispatch_queue_t queue;
 @end
 
 @implementation FLTSerialTaskQueue

--- a/shell/platform/darwin/ios/platform_message_handler_ios.mm
+++ b/shell/platform/darwin/ios/platform_message_handler_ios.mm
@@ -80,8 +80,8 @@ void PlatformMessageHandlerIos::HandlePlatformMessage(std::unique_ptr<PlatformMe
         });
       };
 
-      if (handler_info.task_queue) {
-        [handler_info.task_queue dispatch:run_handler];
+      if (handler_info.task_queue.get()) {
+        [handler_info.task_queue.get() dispatch:run_handler];
       } else {
         dispatch_async(dispatch_get_main_queue(), run_handler);
       }
@@ -124,7 +124,8 @@ void PlatformMessageHandlerIos::SetMessageHandler(const std::string& channel,
   message_handlers_.erase(channel);
   if (handler) {
     message_handlers_[channel] = {
-        .task_queue = (NSObject<FlutterTaskQueueDispatch>*)task_queue,
+        .task_queue =
+            fml::scoped_nsprotocol(static_cast<NSObject<FlutterTaskQueueDispatch>*>(task_queue)),
         .handler =
             fml::ScopedBlock<FlutterBinaryMessageHandler>{
                 handler, fml::scoped_policy::OwnershipPolicy::kRetain},


### PR DESCRIPTION
Smart pointers support ARC as of https://github.com/flutter/engine/pull/47612, and the unit tests were migrated in https://github.com/flutter/engine/pull/48162.

Migrate `PlatformMessageHandlerIos` from MRC to ARC.  Clean up the `#include`s.

Part of https://github.com/flutter/flutter/issues/137801.
