### PR TITLE
Fix docs for SemanticsAction

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -7,10 +7,10 @@ part of dart.ui;
 /// The possible actions that can be conveyed from the operating system
 /// accessibility APIs to a semantics node.
 ///
-/// [!Warning]
-/// When changes are made to this class, the equivalent APIs in
-/// `lib/ui/semantics/semantics_node.h` and in each of the embedders
-/// *must* be updated.
+/// > [!Warning]
+/// > When changes are made to this class, the equivalent APIs in
+/// > `lib/ui/semantics/semantics_node.h` and in each of the embedders
+/// > *must* be updated.
 class SemanticsAction {
   const SemanticsAction._(this.index, this.name);
 

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -6,11 +6,11 @@ part of dart.ui;
 
 /// The possible actions that can be conveyed from the operating system
 /// accessibility APIs to a semantics node.
-///
-/// > [!Warning]
-/// > When changes are made to this class, the equivalent APIs in
-/// > `lib/ui/semantics/semantics_node.h` and in each of the embedders
-/// > *must* be updated.
+//
+// > [!Warning]
+// > When changes are made to this class, the equivalent APIs in
+// > `lib/ui/semantics/semantics_node.h` and in each of the embedders
+// > *must* be updated.
 class SemanticsAction {
   const SemanticsAction._(this.index, this.name);
 

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -7,11 +7,10 @@ part of dart.ui;
 /// The possible actions that can be conveyed from the operating system
 /// accessibility APIs to a semantics node.
 ///
-/// \warning When changes are made to this class, the equivalent APIs in
-///         `lib/ui/semantics/semantics_node.h` and in each of the embedders
-///         *must* be updated.
-/// See also:
-///   - file://./../../lib/ui/semantics/semantics_node.h
+/// [!Warning]
+/// When changes are made to this class, the equivalent APIs in
+/// `lib/ui/semantics/semantics_node.h` and in each of the embedders
+/// *must* be updated.
 class SemanticsAction {
   const SemanticsAction._(this.index, this.name);
 


### PR DESCRIPTION
The old rendering:

![image](https://github.com/flutter/engine/assets/1227763/201c1bed-b27b-40de-8abf-0c091fb20d3f)

This changes uses markdown syntax introduced in https://github.com/dart-lang/markdown/commit/5fab3a7bc880ddf979ccabfbcbad3fea091d7d0b

Fixes https://github.com/flutter/flutter/issues/94494.