### PR TITLE
[Impeller] cleaned up semantics for RenderPipelineT and added docstrings

### DIFF
--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -96,149 +96,165 @@ namespace impeller {
 
 #ifdef IMPELLER_DEBUG
 using CheckerboardPipeline =
-    RenderPipelineT<CheckerboardVertexShader, CheckerboardFragmentShader>;
+    RenderPipelineHandle<CheckerboardVertexShader, CheckerboardFragmentShader>;
 #endif  // IMPELLER_DEBUG
 
 using LinearGradientFillPipeline =
-    RenderPipelineT<GradientFillVertexShader, LinearGradientFillFragmentShader>;
+    RenderPipelineHandle<GradientFillVertexShader,
+                         LinearGradientFillFragmentShader>;
 using SolidFillPipeline =
-    RenderPipelineT<SolidFillVertexShader, SolidFillFragmentShader>;
+    RenderPipelineHandle<SolidFillVertexShader, SolidFillFragmentShader>;
 using RadialGradientFillPipeline =
-    RenderPipelineT<GradientFillVertexShader, RadialGradientFillFragmentShader>;
+    RenderPipelineHandle<GradientFillVertexShader,
+                         RadialGradientFillFragmentShader>;
 using ConicalGradientFillPipeline =
-    RenderPipelineT<GradientFillVertexShader,
-                    ConicalGradientFillFragmentShader>;
+    RenderPipelineHandle<GradientFillVertexShader,
+                         ConicalGradientFillFragmentShader>;
 using SweepGradientFillPipeline =
-    RenderPipelineT<GradientFillVertexShader, SweepGradientFillFragmentShader>;
+    RenderPipelineHandle<GradientFillVertexShader,
+                         SweepGradientFillFragmentShader>;
 using LinearGradientSSBOFillPipeline =
-    RenderPipelineT<GradientFillVertexShader,
-                    LinearGradientSsboFillFragmentShader>;
+    RenderPipelineHandle<GradientFillVertexShader,
+                         LinearGradientSsboFillFragmentShader>;
 using ConicalGradientSSBOFillPipeline =
-    RenderPipelineT<GradientFillVertexShader,
-                    ConicalGradientSsboFillFragmentShader>;
+    RenderPipelineHandle<GradientFillVertexShader,
+                         ConicalGradientSsboFillFragmentShader>;
 using RadialGradientSSBOFillPipeline =
-    RenderPipelineT<GradientFillVertexShader,
-                    RadialGradientSsboFillFragmentShader>;
+    RenderPipelineHandle<GradientFillVertexShader,
+                         RadialGradientSsboFillFragmentShader>;
 using SweepGradientSSBOFillPipeline =
-    RenderPipelineT<GradientFillVertexShader,
-                    SweepGradientSsboFillFragmentShader>;
+    RenderPipelineHandle<GradientFillVertexShader,
+                         SweepGradientSsboFillFragmentShader>;
 using RRectBlurPipeline =
-    RenderPipelineT<RrectBlurVertexShader, RrectBlurFragmentShader>;
-using BlendPipeline = RenderPipelineT<BlendVertexShader, BlendFragmentShader>;
+    RenderPipelineHandle<RrectBlurVertexShader, RrectBlurFragmentShader>;
+using BlendPipeline =
+    RenderPipelineHandle<BlendVertexShader, BlendFragmentShader>;
 using TexturePipeline =
-    RenderPipelineT<TextureFillVertexShader, TextureFillFragmentShader>;
+    RenderPipelineHandle<TextureFillVertexShader, TextureFillFragmentShader>;
 using TextureStrictSrcPipeline =
-    RenderPipelineT<TextureFillVertexShader,
-                    TextureFillStrictSrcFragmentShader>;
-using PositionUVPipeline =
-    RenderPipelineT<TextureFillVertexShader, TiledTextureFillFragmentShader>;
+    RenderPipelineHandle<TextureFillVertexShader,
+                         TextureFillStrictSrcFragmentShader>;
+using PositionUVPipeline = RenderPipelineHandle<TextureFillVertexShader,
+                                                TiledTextureFillFragmentShader>;
 using TiledTexturePipeline =
-    RenderPipelineT<TextureFillVertexShader, TiledTextureFillFragmentShader>;
+    RenderPipelineHandle<TextureFillVertexShader,
+                         TiledTextureFillFragmentShader>;
 using KernelDecalPipeline =
-    RenderPipelineT<KernelVertexShader, KernelDecalFragmentShader>;
+    RenderPipelineHandle<KernelVertexShader, KernelDecalFragmentShader>;
 using KernelPipeline =
-    RenderPipelineT<KernelVertexShader, KernelNodecalFragmentShader>;
+    RenderPipelineHandle<KernelVertexShader, KernelNodecalFragmentShader>;
 using BorderMaskBlurPipeline =
-    RenderPipelineT<BorderMaskBlurVertexShader, BorderMaskBlurFragmentShader>;
+    RenderPipelineHandle<BorderMaskBlurVertexShader,
+                         BorderMaskBlurFragmentShader>;
 using MorphologyFilterPipeline =
-    RenderPipelineT<MorphologyFilterVertexShader,
-                    MorphologyFilterFragmentShader>;
+    RenderPipelineHandle<MorphologyFilterVertexShader,
+                         MorphologyFilterFragmentShader>;
 using ColorMatrixColorFilterPipeline =
-    RenderPipelineT<FilterVertexShader, ColorMatrixColorFilterFragmentShader>;
+    RenderPipelineHandle<FilterVertexShader,
+                         ColorMatrixColorFilterFragmentShader>;
 using LinearToSrgbFilterPipeline =
-    RenderPipelineT<FilterVertexShader, LinearToSrgbFilterFragmentShader>;
+    RenderPipelineHandle<FilterVertexShader, LinearToSrgbFilterFragmentShader>;
 using SrgbToLinearFilterPipeline =
-    RenderPipelineT<FilterVertexShader, SrgbToLinearFilterFragmentShader>;
+    RenderPipelineHandle<FilterVertexShader, SrgbToLinearFilterFragmentShader>;
 using GlyphAtlasPipeline =
-    RenderPipelineT<GlyphAtlasVertexShader, GlyphAtlasFragmentShader>;
+    RenderPipelineHandle<GlyphAtlasVertexShader, GlyphAtlasFragmentShader>;
 using GlyphAtlasColorPipeline =
-    RenderPipelineT<GlyphAtlasVertexShader, GlyphAtlasColorFragmentShader>;
+    RenderPipelineHandle<GlyphAtlasVertexShader, GlyphAtlasColorFragmentShader>;
 using PorterDuffBlendPipeline =
-    RenderPipelineT<PorterDuffBlendVertexShader, PorterDuffBlendFragmentShader>;
-using ClipPipeline = RenderPipelineT<ClipVertexShader, ClipFragmentShader>;
+    RenderPipelineHandle<PorterDuffBlendVertexShader,
+                         PorterDuffBlendFragmentShader>;
+using ClipPipeline = RenderPipelineHandle<ClipVertexShader, ClipFragmentShader>;
 
 using GeometryColorPipeline =
-    RenderPipelineT<PositionColorVertexShader, VerticesFragmentShader>;
+    RenderPipelineHandle<PositionColorVertexShader, VerticesFragmentShader>;
 using YUVToRGBFilterPipeline =
-    RenderPipelineT<FilterVertexShader, YuvToRgbFilterFragmentShader>;
+    RenderPipelineHandle<FilterVertexShader, YuvToRgbFilterFragmentShader>;
 
 // Advanced blends
-using BlendColorPipeline =
-    RenderPipelineT<AdvancedBlendVertexShader, AdvancedBlendFragmentShader>;
+using BlendColorPipeline = RenderPipelineHandle<AdvancedBlendVertexShader,
+                                                AdvancedBlendFragmentShader>;
 using BlendColorBurnPipeline =
-    RenderPipelineT<AdvancedBlendVertexShader, AdvancedBlendFragmentShader>;
+    RenderPipelineHandle<AdvancedBlendVertexShader,
+                         AdvancedBlendFragmentShader>;
 using BlendColorDodgePipeline =
-    RenderPipelineT<AdvancedBlendVertexShader, AdvancedBlendFragmentShader>;
-using BlendDarkenPipeline =
-    RenderPipelineT<AdvancedBlendVertexShader, AdvancedBlendFragmentShader>;
+    RenderPipelineHandle<AdvancedBlendVertexShader,
+                         AdvancedBlendFragmentShader>;
+using BlendDarkenPipeline = RenderPipelineHandle<AdvancedBlendVertexShader,
+                                                 AdvancedBlendFragmentShader>;
 using BlendDifferencePipeline =
-    RenderPipelineT<AdvancedBlendVertexShader, AdvancedBlendFragmentShader>;
+    RenderPipelineHandle<AdvancedBlendVertexShader,
+                         AdvancedBlendFragmentShader>;
 using BlendExclusionPipeline =
-    RenderPipelineT<AdvancedBlendVertexShader, AdvancedBlendFragmentShader>;
+    RenderPipelineHandle<AdvancedBlendVertexShader,
+                         AdvancedBlendFragmentShader>;
 using BlendHardLightPipeline =
-    RenderPipelineT<AdvancedBlendVertexShader, AdvancedBlendFragmentShader>;
-using BlendHuePipeline =
-    RenderPipelineT<AdvancedBlendVertexShader, AdvancedBlendFragmentShader>;
-using BlendLightenPipeline =
-    RenderPipelineT<AdvancedBlendVertexShader, AdvancedBlendFragmentShader>;
+    RenderPipelineHandle<AdvancedBlendVertexShader,
+                         AdvancedBlendFragmentShader>;
+using BlendHuePipeline = RenderPipelineHandle<AdvancedBlendVertexShader,
+                                              AdvancedBlendFragmentShader>;
+using BlendLightenPipeline = RenderPipelineHandle<AdvancedBlendVertexShader,
+                                                  AdvancedBlendFragmentShader>;
 using BlendLuminosityPipeline =
-    RenderPipelineT<AdvancedBlendVertexShader, AdvancedBlendFragmentShader>;
-using BlendMultiplyPipeline =
-    RenderPipelineT<AdvancedBlendVertexShader, AdvancedBlendFragmentShader>;
-using BlendOverlayPipeline =
-    RenderPipelineT<AdvancedBlendVertexShader, AdvancedBlendFragmentShader>;
+    RenderPipelineHandle<AdvancedBlendVertexShader,
+                         AdvancedBlendFragmentShader>;
+using BlendMultiplyPipeline = RenderPipelineHandle<AdvancedBlendVertexShader,
+                                                   AdvancedBlendFragmentShader>;
+using BlendOverlayPipeline = RenderPipelineHandle<AdvancedBlendVertexShader,
+                                                  AdvancedBlendFragmentShader>;
 using BlendSaturationPipeline =
-    RenderPipelineT<AdvancedBlendVertexShader, AdvancedBlendFragmentShader>;
-using BlendScreenPipeline =
-    RenderPipelineT<AdvancedBlendVertexShader, AdvancedBlendFragmentShader>;
+    RenderPipelineHandle<AdvancedBlendVertexShader,
+                         AdvancedBlendFragmentShader>;
+using BlendScreenPipeline = RenderPipelineHandle<AdvancedBlendVertexShader,
+                                                 AdvancedBlendFragmentShader>;
 using BlendSoftLightPipeline =
-    RenderPipelineT<AdvancedBlendVertexShader, AdvancedBlendFragmentShader>;
+    RenderPipelineHandle<AdvancedBlendVertexShader,
+                         AdvancedBlendFragmentShader>;
 // Framebuffer Advanced Blends
 using FramebufferBlendColorPipeline =
-    RenderPipelineT<FramebufferBlendVertexShader,
-                    FramebufferBlendFragmentShader>;
+    RenderPipelineHandle<FramebufferBlendVertexShader,
+                         FramebufferBlendFragmentShader>;
 using FramebufferBlendColorBurnPipeline =
-    RenderPipelineT<FramebufferBlendVertexShader,
-                    FramebufferBlendFragmentShader>;
+    RenderPipelineHandle<FramebufferBlendVertexShader,
+                         FramebufferBlendFragmentShader>;
 using FramebufferBlendColorDodgePipeline =
-    RenderPipelineT<FramebufferBlendVertexShader,
-                    FramebufferBlendFragmentShader>;
+    RenderPipelineHandle<FramebufferBlendVertexShader,
+                         FramebufferBlendFragmentShader>;
 using FramebufferBlendDarkenPipeline =
-    RenderPipelineT<FramebufferBlendVertexShader,
-                    FramebufferBlendFragmentShader>;
+    RenderPipelineHandle<FramebufferBlendVertexShader,
+                         FramebufferBlendFragmentShader>;
 using FramebufferBlendDifferencePipeline =
-    RenderPipelineT<FramebufferBlendVertexShader,
-                    FramebufferBlendFragmentShader>;
+    RenderPipelineHandle<FramebufferBlendVertexShader,
+                         FramebufferBlendFragmentShader>;
 using FramebufferBlendExclusionPipeline =
-    RenderPipelineT<FramebufferBlendVertexShader,
-                    FramebufferBlendFragmentShader>;
+    RenderPipelineHandle<FramebufferBlendVertexShader,
+                         FramebufferBlendFragmentShader>;
 using FramebufferBlendHardLightPipeline =
-    RenderPipelineT<FramebufferBlendVertexShader,
-                    FramebufferBlendFragmentShader>;
+    RenderPipelineHandle<FramebufferBlendVertexShader,
+                         FramebufferBlendFragmentShader>;
 using FramebufferBlendHuePipeline =
-    RenderPipelineT<FramebufferBlendVertexShader,
-                    FramebufferBlendFragmentShader>;
+    RenderPipelineHandle<FramebufferBlendVertexShader,
+                         FramebufferBlendFragmentShader>;
 using FramebufferBlendLightenPipeline =
-    RenderPipelineT<FramebufferBlendVertexShader,
-                    FramebufferBlendFragmentShader>;
+    RenderPipelineHandle<FramebufferBlendVertexShader,
+                         FramebufferBlendFragmentShader>;
 using FramebufferBlendLuminosityPipeline =
-    RenderPipelineT<FramebufferBlendVertexShader,
-                    FramebufferBlendFragmentShader>;
+    RenderPipelineHandle<FramebufferBlendVertexShader,
+                         FramebufferBlendFragmentShader>;
 using FramebufferBlendMultiplyPipeline =
-    RenderPipelineT<FramebufferBlendVertexShader,
-                    FramebufferBlendFragmentShader>;
+    RenderPipelineHandle<FramebufferBlendVertexShader,
+                         FramebufferBlendFragmentShader>;
 using FramebufferBlendOverlayPipeline =
-    RenderPipelineT<FramebufferBlendVertexShader,
-                    FramebufferBlendFragmentShader>;
+    RenderPipelineHandle<FramebufferBlendVertexShader,
+                         FramebufferBlendFragmentShader>;
 using FramebufferBlendSaturationPipeline =
-    RenderPipelineT<FramebufferBlendVertexShader,
-                    FramebufferBlendFragmentShader>;
+    RenderPipelineHandle<FramebufferBlendVertexShader,
+                         FramebufferBlendFragmentShader>;
 using FramebufferBlendScreenPipeline =
-    RenderPipelineT<FramebufferBlendVertexShader,
-                    FramebufferBlendFragmentShader>;
+    RenderPipelineHandle<FramebufferBlendVertexShader,
+                         FramebufferBlendFragmentShader>;
 using FramebufferBlendSoftLightPipeline =
-    RenderPipelineT<FramebufferBlendVertexShader,
-                    FramebufferBlendFragmentShader>;
+    RenderPipelineHandle<FramebufferBlendVertexShader,
+                         FramebufferBlendFragmentShader>;
 
 /// Geometry Pipelines
 using PointsComputeShaderPipeline = ComputePipelineBuilder<PointsComputeShader>;
@@ -246,11 +262,12 @@ using UvComputeShaderPipeline = ComputePipelineBuilder<UvComputeShader>;
 
 #ifdef IMPELLER_ENABLE_OPENGLES
 using TextureExternalPipeline =
-    RenderPipelineT<TextureFillVertexShader, TextureFillExternalFragmentShader>;
+    RenderPipelineHandle<TextureFillVertexShader,
+                         TextureFillExternalFragmentShader>;
 
 using TiledTextureExternalPipeline =
-    RenderPipelineT<TextureFillVertexShader,
-                    TiledTextureFillExternalFragmentShader>;
+    RenderPipelineHandle<TextureFillVertexShader,
+                         TiledTextureFillExternalFragmentShader>;
 #endif  // IMPELLER_ENABLE_OPENGLES
 
 // A struct used to isolate command buffer storage from the content

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -859,6 +859,13 @@ class ContentContext {
   /// RenderPipelineHandle<SolidFillVertexShader, SolidFillFragmentShader>
   /// instances for different blend modes. From them you can access the
   /// Pipeline.
+  ///
+  /// See also:
+  ///  - impeller::ContentContextOptions - options from which variants are
+  ///    created.
+  ///  - impeller::Pipeline::CreateVariant
+  ///  - impeller::RenderPipelineHandle<> - The type of objects this typically
+  ///    contains.
   template <class PipelineHandleT>
   class Variants {
    public:
@@ -878,8 +885,8 @@ class ContentContext {
     void CreateDefault(const Context& context,
                        const ContentContextOptions& options,
                        const std::initializer_list<Scalar>& constants = {}) {
-      auto desc =
-          PipelineHandleT::Builder::MakeDefaultPipelineDescriptor(context, constants);
+      auto desc = PipelineHandleT::Builder::MakeDefaultPipelineDescriptor(
+          context, constants);
       if (!desc.has_value()) {
         VALIDATION_LOG << "Failed to create default pipeline.";
         return;
@@ -1045,7 +1052,7 @@ class ContentContext {
 
     RenderPipelineHandleT* default_handle = container.GetDefault();
 
-    // The prototype must always be initialized in the constructor.
+    // The default must always be initialized in the constructor.
     FML_CHECK(default_handle != nullptr);
 
     std::shared_ptr<Pipeline<PipelineDescriptor>> pipeline =

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -1021,9 +1021,10 @@ class ContentContext {
     return pipeline->WaitAndGet();
   }
 
-  template <class TypedPipeline>
-  TypedPipeline* CreateIfNeeded(Variants<TypedPipeline>& container,
-                                ContentContextOptions opts) const {
+  template <class RenderPipelineHandleT>
+  RenderPipelineHandleT* CreateIfNeeded(
+      Variants<RenderPipelineHandleT>& container,
+      ContentContextOptions opts) const {
     if (!IsValid()) {
       return nullptr;
     }
@@ -1032,11 +1033,11 @@ class ContentContext {
       opts.wireframe = true;
     }
 
-    if (TypedPipeline* found = container.Get(opts)) {
+    if (RenderPipelineHandleT* found = container.Get(opts)) {
       return found;
     }
 
-    TypedPipeline* prototype = container.GetDefault();
+    RenderPipelineHandleT* prototype = container.GetDefault();
 
     // The prototype must always be initialized in the constructor.
     FML_CHECK(prototype != nullptr);
@@ -1054,8 +1055,8 @@ class ContentContext {
           desc.SetLabel(
               SPrintF("%s V#%zu", desc.GetLabel().c_str(), variants_count));
         });
-    std::unique_ptr<TypedPipeline> variant =
-        std::make_unique<TypedPipeline>(std::move(variant_future));
+    std::unique_ptr<RenderPipelineHandleT> variant =
+        std::make_unique<RenderPipelineHandleT>(std::move(variant_future));
     container.Set(opts, std::move(variant));
     return container.Get(opts);
   }

--- a/impeller/renderer/pipeline.h
+++ b/impeller/renderer/pipeline.h
@@ -88,6 +88,12 @@ PipelineFuture<ComputePipelineDescriptor> CreatePipelineFuture(
     const Context& context,
     std::optional<ComputePipelineDescriptor> desc);
 
+/// Holds a reference to a Pipeline used for rendering while also maintaining
+/// the vertex shader and fragment shader types at compile-time.
+///
+/// See also:
+///   - impeller::ContentContext::Variants - the typical container for
+///     RenderPipelineHandles.
 template <class VertexShader_, class FragmentShader_>
 class RenderPipelineHandle {
   static_assert(

--- a/impeller/renderer/pipeline.h
+++ b/impeller/renderer/pipeline.h
@@ -138,22 +138,23 @@ class RenderPipelineHandle {
 };
 
 template <class ComputeShader_>
-class ComputePipelineT {
+class ComputePipelineHandle {
  public:
   using ComputeShader = ComputeShader_;
   using Builder = ComputePipelineBuilder<ComputeShader>;
 
-  explicit ComputePipelineT(const Context& context)
-      : ComputePipelineT(CreatePipelineFuture(
+  explicit ComputePipelineHandle(const Context& context)
+      : ComputePipelineHandle(CreatePipelineFuture(
             context,
             Builder::MakeDefaultPipelineDescriptor(context))) {}
 
-  explicit ComputePipelineT(
+  explicit ComputePipelineHandle(
       const Context& context,
       std::optional<ComputePipelineDescriptor> compute_desc)
-      : ComputePipelineT(CreatePipelineFuture(context, compute_desc)) {}
+      : ComputePipelineHandle(CreatePipelineFuture(context, compute_desc)) {}
 
-  explicit ComputePipelineT(PipelineFuture<ComputePipelineDescriptor> future)
+  explicit ComputePipelineHandle(
+      PipelineFuture<ComputePipelineDescriptor> future)
       : pipeline_future_(std::move(future)) {}
 
   std::shared_ptr<Pipeline<ComputePipelineDescriptor>> WaitAndGet() {
@@ -172,9 +173,9 @@ class ComputePipelineT {
   std::shared_ptr<Pipeline<ComputePipelineDescriptor>> pipeline_;
   bool did_wait_ = false;
 
-  ComputePipelineT(const ComputePipelineT&) = delete;
+  ComputePipelineHandle(const ComputePipelineHandle&) = delete;
 
-  ComputePipelineT& operator=(const ComputePipelineT&) = delete;
+  ComputePipelineHandle& operator=(const ComputePipelineHandle&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/renderer/pipeline.h
+++ b/impeller/renderer/pipeline.h
@@ -89,7 +89,7 @@ PipelineFuture<ComputePipelineDescriptor> CreatePipelineFuture(
     std::optional<ComputePipelineDescriptor> desc);
 
 template <class VertexShader_, class FragmentShader_>
-class RenderPipelineT {
+class RenderPipelineHandle {
   static_assert(
       ShaderStageCompatibilityChecker<VertexShader_, FragmentShader_>::Check(),
       "The output slots for the fragment shader don't have matches in the "
@@ -100,16 +100,16 @@ class RenderPipelineT {
   using FragmentShader = FragmentShader_;
   using Builder = PipelineBuilder<VertexShader, FragmentShader>;
 
-  explicit RenderPipelineT(const Context& context)
-      : RenderPipelineT(CreatePipelineFuture(
+  explicit RenderPipelineHandle(const Context& context)
+      : RenderPipelineHandle(CreatePipelineFuture(
             context,
             Builder::MakeDefaultPipelineDescriptor(context))) {}
 
-  explicit RenderPipelineT(const Context& context,
-                           std::optional<PipelineDescriptor> desc)
-      : RenderPipelineT(CreatePipelineFuture(context, desc)) {}
+  explicit RenderPipelineHandle(const Context& context,
+                                std::optional<PipelineDescriptor> desc)
+      : RenderPipelineHandle(CreatePipelineFuture(context, desc)) {}
 
-  explicit RenderPipelineT(PipelineFuture<PipelineDescriptor> future)
+  explicit RenderPipelineHandle(PipelineFuture<PipelineDescriptor> future)
       : pipeline_future_(std::move(future)) {}
 
   std::shared_ptr<Pipeline<PipelineDescriptor>> WaitAndGet() {
@@ -132,9 +132,9 @@ class RenderPipelineT {
   std::shared_ptr<Pipeline<PipelineDescriptor>> pipeline_;
   bool did_wait_ = false;
 
-  RenderPipelineT(const RenderPipelineT&) = delete;
+  RenderPipelineHandle(const RenderPipelineHandle&) = delete;
 
-  RenderPipelineT& operator=(const RenderPipelineT&) = delete;
+  RenderPipelineHandle& operator=(const RenderPipelineHandle&) = delete;
 };
 
 template <class ComputeShader_>

--- a/impeller/scene/scene_context.h
+++ b/impeller/scene/scene_context.h
@@ -125,13 +125,13 @@ class SceneContext {
   /// If a pipeline could not be created, returns nullptr.
   std::unique_ptr<PipelineVariants> MakePipelineVariants(Context& context) {
     auto pipeline =
-        PipelineVariantsT<RenderPipelineT<VertexShader, FragmentShader>>(
+        PipelineVariantsT<RenderPipelineHandle<VertexShader, FragmentShader>>(
             context);
     if (!pipeline.IsValid()) {
       return nullptr;
     }
     return std::make_unique<
-        PipelineVariantsT<RenderPipelineT<VertexShader, FragmentShader>>>(
+        PipelineVariantsT<RenderPipelineHandle<VertexShader, FragmentShader>>>(
         std::move(pipeline));
   }
 


### PR DESCRIPTION
I just tried to capture all thing things I found confusing about these and clean them up.  We were mixing up Pipeline and RenderPipelineT in our generics arguments and RenderPipelineT wasn't clear since it was named like a template parameter but was a runtime type.

Summary of edits:
-  RenderPipelineT -> RenderPipelineHandle
- Added docstrings for RenderPipelineHandle and Variants
- cleaned up generics parameters to ContentContext methods and Variants
- replaced references that called the variant's default pipeline handle a "prototype" since it clashed with places that just call it the "default".

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
