### PR TITLE
[macOS] Revise the doc for FlutterViewController initializers

### DIFF
--- a/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h
@@ -84,13 +84,26 @@ FLUTTER_DARWIN_EXPORT
 @property(nonatomic) FlutterMouseTrackingMode mouseTrackingMode;
 
 /**
- * Initializes a controller that will run the given project.
+ * Initializes this `FlutterViewController` for the implicit view of a new
+ * `FlutterEngine`.
  *
- * In this initializer, this controller creates an engine, and is attached to
- * that engine as the default controller. In this way, this controller can not
- * be set to other engines. This initializer is suitable for the first Flutter
- * view controller of the app. To use the controller with an existing engine,
- * use initWithEngine:nibName:bundle: instead.
+ * This initializer is a shorthand for creating an engine explicitly and
+ * initializing with `initWithEngine:nibName:bundle:`.
+ *
+ * Since the created engine is only referred by this view controller, once thie
+ * view controller is deallocated, the engine will be shut down, unless anther
+ * strong referrence to the engine is kept. It is recommended to use
+ * `initWithEngine:nibName:bundle:` if the app's implicit view might be closed
+ * at some point, such as running headlessly.
+ *
+ * The engine holds a weak reference to the view controller, while the view controller
+ * holds a strong reference to the engine.
+ *
+ * For an introduction to implicit views, see
+ * [PlatformDispatcher.implicitView](https://api.flutter.dev/flutter/dart-ui/PlatformDispatcher/implicitView.html).
+ *
+ * There isn't a way to create a `FlutterViewController` that's not attached
+ * to an engine.
  *
  * @param project The project to run in this view controller. If nil, a default `FlutterDartProject`
  *                will be used.
@@ -103,12 +116,11 @@ FLUTTER_DARWIN_EXPORT
     NS_DESIGNATED_INITIALIZER;
 - (nonnull instancetype)initWithCoder:(nonnull NSCoder*)nibNameOrNil NS_DESIGNATED_INITIALIZER;
 /**
- * Initializes this FlutterViewController with an existing `FlutterEngine`.
+ * Initializes this FlutterViewController as attached to an existing
+ * `FlutterEngine`.
  *
- * The initialized view controller will add itself to the engine as part of this process.
- *
- * This initializer is suitable for both the first Flutter view controller and
- * the following ones of the app.
+ * The engine holds a weak reference to the view controller, while the view controller
+ * holds a strong reference to the engine.
  *
  * @param engine The `FlutterEngine` instance to attach to. Cannot be nil.
  * @param nibName The NIB name to initialize this controller with.


### PR DESCRIPTION
This RP adds more details to the initializers.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
