### PR TITLE
[et] Fix concurrent modification exception

### DIFF
--- a/tools/engine_tool/lib/src/commands/test_command.dart
+++ b/tools/engine_tool/lib/src/commands/test_command.dart
@@ -72,7 +72,7 @@ et test //flutter/fml:fml_benchmarks  # Run a single test target in `//flutter/f
 
     final List<BuildTarget> testTargets = <BuildTarget>[];
     for (final BuildTarget target in selectedTargets) {
-      if (target.testOnly && target.type == BuildTargetType.executable) {
+      if (_isTestExecutable(target)) {
         testTargets.add(target);
       }
       if (target.executable == null) {
@@ -101,5 +101,10 @@ et test //flutter/fml:fml_benchmarks  # Run a single test target in `//flutter/f
           target.label, environment, environment.engine.srcDir, commandLine));
     }
     return await workerPool.run(tasks) ? 0 : 1;
+  }
+
+  /// Returns true if `target` is a testonly executable.
+  static bool _isTestExecutable(BuildTarget target) {
+    return target.testOnly && target.type == BuildTargetType.executable;
   }
 }

--- a/tools/engine_tool/lib/src/commands/test_command.dart
+++ b/tools/engine_tool/lib/src/commands/test_command.dart
@@ -70,10 +70,10 @@ et test //flutter/fml:fml_benchmarks  # Run a single test target in `//flutter/f
       );
     }
 
+    final List<BuildTarget> testTargets = <BuildTarget>[];
     for (final BuildTarget target in selectedTargets) {
-      if (!target.testOnly || target.type != BuildTargetType.executable) {
-        // Remove any targets that aren't testOnly and aren't executable.
-        selectedTargets.remove(target);
+      if (target.testOnly && target.type == BuildTargetType.executable) {
+        testTargets.add(target);
       }
       if (target.executable == null) {
         environment.logger.fatal(
@@ -81,7 +81,7 @@ et test //flutter/fml:fml_benchmarks  # Run a single test target in `//flutter/f
       }
     }
     // Chop off the '//' prefix.
-    final List<String> buildTargets = selectedTargets
+    final List<String> buildTargets = testTargets
         .map<String>(
             (BuildTarget target) => target.label.substring('//'.length))
         .toList();
@@ -95,7 +95,7 @@ et test //flutter/fml:fml_benchmarks  # Run a single test target in `//flutter/f
     final WorkerPool workerPool =
         WorkerPool(environment, ProcessTaskProgressReporter(environment));
     final Set<ProcessTask> tasks = <ProcessTask>{};
-    for (final BuildTarget target in selectedTargets) {
+    for (final BuildTarget target in testTargets) {
       final List<String> commandLine = <String>[target.executable!.path];
       tasks.add(ProcessTask(
           target.label, environment, environment.engine.srcDir, commandLine));

--- a/tools/engine_tool/test/test_command_test.dart
+++ b/tools/engine_tool/test/test_command_test.dart
@@ -67,4 +67,28 @@ void main() {
       testEnvironment.cleanup();
     }
   });
+
+  test('test command skips non-testonly executables', () async {
+    final TestEnvironment testEnvironment = TestEnvironment.withTestEngine(
+      cannedProcesses: cannedProcesses,
+    );
+    try {
+      final Environment env = testEnvironment.environment;
+      final ToolCommandRunner runner = ToolCommandRunner(
+        environment: env,
+        configs: configs,
+      );
+      final int result = await runner.run(<String>[
+        'test',
+        '//third_party/protobuf:protoc',
+      ]);
+      expect(result, equals(1));
+      expect(testEnvironment.processHistory.length, lessThan(3));
+      expect(testEnvironment.processHistory.where((ExecutedProcess process) {
+        return process.command[0].contains('protoc');
+      }), isEmpty);
+    } finally {
+      testEnvironment.cleanup();
+    }
+  });
 }


### PR DESCRIPTION
We cannot modify the list of build targets as we're iterating over it. Instead of removing non-test/non-executable elements, instead we add executable test targets to a separate testTargets list and use that.

Noticed while working on: https://github.com/flutter/flutter/issues/147071

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
