### PR TITLE
[macOS] Consolidate view management

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -562,13 +562,6 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
       }
     }
   }
-  // Detach all view controllers.
-  NSEnumerator* viewControllerEnumerator = [_viewControllers objectEnumerator];
-  FlutterViewController* nextViewController;
-  while ((nextViewController = [viewControllerEnumerator nextObject])) {
-    [nextViewController detachFromEngine];
-  }
-  [_viewControllers removeAllObjects];
 
   // Clear any published values, just in case a plugin has created a retain cycle with the
   // registrar.

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -885,8 +885,8 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
 #pragma mark - Framework-internal methods
 
 - (void)addViewController:(FlutterViewController*)controller {
-  // Adding a view controller when there is no implicit view should always
-  // assign it to the implicit view controller.
+  // FlutterEngine can only handle the implicit view for now. Adding more views
+  // throws an assertion.
   NSAssert(self.viewController == nil,
            @"The engine already has a view controller for the implicit view.");
   self.viewController = controller;

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -562,7 +562,6 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
       }
     }
   }
-
   // Clear any published values, just in case a plugin has created a retain cycle with the
   // registrar.
   for (NSString* pluginName in _pluginRegistrars) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -742,10 +742,14 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
                viewIdentifier:viewIdentifier
            threadSynchronizer:_threadSynchronizer];
   NSAssert(controller.viewIdentifier == viewIdentifier, @"Failed to assign view ID.");
-  NSAssert(controller.attached && controller.engine == self,
-           @"The FlutterViewController unexpectedly stays unattached after being added. "
-           @"In unit tests, this is likely because either the FlutterViewController or "
-           @"the FlutterEngine is mocked. Please subclass these classes instead.");
+  // Verify that the controller's property are updated accordingly. Failing the
+  // assertions is likely because either the FlutterViewController or the
+  // FlutterEngine is mocked. Please subclass these classes instead.
+  NSAssert(controller.attached, @"The FlutterViewController should switch to the attached mode "
+                                @"after it is added to a FlutterEngine.");
+  NSAssert(controller.engine == self,
+           @"The FlutterViewController was added to %@, but its engine unexpectedly became %@.",
+           self, controller.engine);
 
   if (controller.viewLoaded) {
     [self viewControllerViewDidLoad:controller];
@@ -781,8 +785,8 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
 
 - (void)deregisterViewControllerForIdentifier:(FlutterViewIdentifier)viewIdentifier {
   FlutterViewController* controller = [self viewControllerForIdentifier:viewIdentifier];
-  // The controller might be nil, because the engine only stores a weak ref, and
-  // this method might have been called from the controller's dealloc.
+  // The controller can be nil. The engine stores only a weak ref, and this
+  // method could have been called from the controller's dealloc.
   if (controller != nil) {
     [controller detachFromEngine];
     NSAssert(!controller.attached,

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
@@ -127,7 +127,7 @@ typedef NS_ENUM(NSInteger, FlutterAppExitResponse) {
  *
  * Since FlutterEngine can only handle the implicit view for now, the given
  * controller will always be assigned to the implicit view, if there isn't an
- * implicit view yet.  If the engine already has an implicit view, this call
+ * implicit view yet. If the engine already has an implicit view, this call
  * throws an assertion.
  *
  * The engine holds a weak reference to the attached view controller.

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
@@ -125,10 +125,10 @@ typedef NS_ENUM(NSInteger, FlutterAppExitResponse) {
 /**
  * Attach a view controller to the engine as its default controller.
  *
- * Practically, since FlutterEngine can only be attached with one controller,
- * the given controller, if successfully attached, will always have the default
- * view ID kFlutterImplicitViewId. If the engine already has an implicit view,
- * this call throws an assertion.
+ * Since FlutterEngine can only handle the implicit view for now, the given
+ * controller will always be assigned to the implicit view, if there isn't an
+ * implicit view yet.  If the engine already has an implicit view, this call
+ * throws an assertion.
  *
  * The engine holds a weak reference to the attached view controller.
  *
@@ -147,9 +147,6 @@ typedef NS_ENUM(NSInteger, FlutterAppExitResponse) {
  *
  * If the view controller is not associated with this engine, this call throws an
  * assertion.
- *
- * Practically, since FlutterEngine can only be attached with one controller for
- * now, the given controller must be the current view controller.
  */
 - (void)removeViewController:(FlutterViewController*)viewController;
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
@@ -127,7 +127,8 @@ typedef NS_ENUM(NSInteger, FlutterAppExitResponse) {
  *
  * Practically, since FlutterEngine can only be attached with one controller,
  * the given controller, if successfully attached, will always have the default
- * view ID kFlutterImplicitViewId.
+ * view ID kFlutterImplicitViewId. If the engine already has an implicit view,
+ * this call throws an assertion.
  *
  * The engine holds a weak reference to the attached view controller.
  *


### PR DESCRIPTION
This PR improves view management logic of the macOS `FlutterEngine` class.
* View operation assertions are now centralized in `registerViewController:` and `deregisterViewControllerForIdentifier:`.
* `addViewController` now directly calls `.viewController =` on implicit views, so that it matches its verbatim description.
* The doc for `addViewController` correctly reflects the fact that it doesn't support multiple views yet.

Additionally, a useless (for now) member variable is removed.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
