### PR TITLE
Get native sync fence.

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -14,6 +14,7 @@ import android.graphics.ImageDecoder;
 import android.graphics.SurfaceTexture;
 import android.os.Build;
 import android.os.Looper;
+import android.os.Parcel;
 import android.util.DisplayMetrics;
 import android.util.Size;
 import android.util.TypedValue;
@@ -1492,6 +1493,14 @@ public class FlutterJNI {
           "Methods marked with @UiThread must be executed on the main thread. Current thread: "
               + Thread.currentThread().getName());
     }
+  }
+
+  // TESTING
+
+  private native void nativeWaitOnParceledSyncFence(Parcel parcel);
+
+  public void WaitOnParceledSyncFence(Parcel parcel) {
+    nativeWaitOnParceledSyncFence(parcel);
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -18,6 +18,7 @@ import android.media.ImageReader;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.Parcel;
 import android.view.Surface;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
@@ -696,7 +697,13 @@ public class FlutterRenderer implements TextureRegistry {
     private void waitOnFence(Image image) {
       try {
         SyncFence fence = image.getFence();
-        fence.awaitForever();
+        // Testing: can I send sync fence to C++ ?
+        Parcel parcel = Parcel.obtain();
+        // Writes a bool then an int.
+        fence.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+        flutterJNI.WaitOnParceledSyncFence(parcel);
+        parcel.recycle();
       } catch (IOException e) {
         // Drop.
       }


### PR DESCRIPTION
Based off of some code I saw in https://source.corp.google.com/h/android/platform/superproject/+/android-14.0.0_r11:cts/tests/tests/hardware/jni/android_hardware_cts_HardwareBufferTest.cpp.

basically I think this should work, but it doesn't - acquring the native parcellable immediately crashes.