### PR TITLE
Remove SkScalarIsFinite from Flutter Engine.

### DIFF
--- a/display_list/dl_builder.cc
+++ b/display_list/dl_builder.cc
@@ -707,8 +707,7 @@ void DisplayListBuilder::SaveLayer(const SkRect* bounds,
 }
 
 void DisplayListBuilder::Translate(SkScalar tx, SkScalar ty) {
-  if (std::isfinite(tx) && std::isfinite(ty) &&
-      (tx != 0.0 || ty != 0.0)) {
+  if (std::isfinite(tx) && std::isfinite(ty) && (tx != 0.0 || ty != 0.0)) {
     checkForDeferredSave();
     Push<TranslateOp>(0, tx, ty);
     tracker_.translate(tx, ty);
@@ -718,8 +717,7 @@ void DisplayListBuilder::Translate(SkScalar tx, SkScalar ty) {
   }
 }
 void DisplayListBuilder::Scale(SkScalar sx, SkScalar sy) {
-  if (std::isfinite(sx) && std::isfinite(sy) &&
-      (sx != 1.0 || sy != 1.0)) {
+  if (std::isfinite(sx) && std::isfinite(sy) && (sx != 1.0 || sy != 1.0)) {
     checkForDeferredSave();
     Push<ScaleOp>(0, sx, sy);
     tracker_.scale(sx, sy);
@@ -739,8 +737,7 @@ void DisplayListBuilder::Rotate(SkScalar degrees) {
   }
 }
 void DisplayListBuilder::Skew(SkScalar sx, SkScalar sy) {
-  if (std::isfinite(sx) && std::isfinite(sy) &&
-      (sx != 0.0 || sy != 0.0)) {
+  if (std::isfinite(sx) && std::isfinite(sy) && (sx != 0.0 || sy != 0.0)) {
     checkForDeferredSave();
     Push<SkewOp>(0, sx, sy);
     tracker_.skew(sx, sy);

--- a/display_list/dl_builder.cc
+++ b/display_list/dl_builder.cc
@@ -707,7 +707,7 @@ void DisplayListBuilder::SaveLayer(const SkRect* bounds,
 }
 
 void DisplayListBuilder::Translate(SkScalar tx, SkScalar ty) {
-  if (SkScalarIsFinite(tx) && SkScalarIsFinite(ty) &&
+  if (std::isfinite(tx) && std::isfinite(ty) &&
       (tx != 0.0 || ty != 0.0)) {
     checkForDeferredSave();
     Push<TranslateOp>(0, tx, ty);
@@ -718,7 +718,7 @@ void DisplayListBuilder::Translate(SkScalar tx, SkScalar ty) {
   }
 }
 void DisplayListBuilder::Scale(SkScalar sx, SkScalar sy) {
-  if (SkScalarIsFinite(sx) && SkScalarIsFinite(sy) &&
+  if (std::isfinite(sx) && std::isfinite(sy) &&
       (sx != 1.0 || sy != 1.0)) {
     checkForDeferredSave();
     Push<ScaleOp>(0, sx, sy);
@@ -739,7 +739,7 @@ void DisplayListBuilder::Rotate(SkScalar degrees) {
   }
 }
 void DisplayListBuilder::Skew(SkScalar sx, SkScalar sy) {
-  if (SkScalarIsFinite(sx) && SkScalarIsFinite(sy) &&
+  if (std::isfinite(sx) && std::isfinite(sy) &&
       (sx != 0.0 || sy != 0.0)) {
     checkForDeferredSave();
     Push<SkewOp>(0, sx, sy);
@@ -756,9 +756,9 @@ void DisplayListBuilder::Skew(SkScalar sx, SkScalar sy) {
 void DisplayListBuilder::Transform2DAffine(
     SkScalar mxx, SkScalar mxy, SkScalar mxt,
     SkScalar myx, SkScalar myy, SkScalar myt) {
-  if (SkScalarsAreFinite(mxx, myx) &&
-      SkScalarsAreFinite(mxy, myy) &&
-      SkScalarsAreFinite(mxt, myt)) {
+  if (std::isfinite(mxx) && std::isfinite(myx) &&
+      std::isfinite(mxy) && std::isfinite(myy) &&
+      std::isfinite(mxt) && std::isfinite(myt)) {
     if (mxx == 1 && mxy == 0 &&
         myx == 0 && myy == 1) {
       Translate(mxt, myt);
@@ -788,10 +788,14 @@ void DisplayListBuilder::TransformFullPerspective(
       mwx == 0 && mwy == 0 && mwz == 0 && mwt == 1) {
     Transform2DAffine(mxx, mxy, mxt,
                       myx, myy, myt);
-  } else if (SkScalarsAreFinite(mxx, mxy) && SkScalarsAreFinite(mxz, mxt) &&
-             SkScalarsAreFinite(myx, myy) && SkScalarsAreFinite(myz, myt) &&
-             SkScalarsAreFinite(mzx, mzy) && SkScalarsAreFinite(mzz, mzt) &&
-             SkScalarsAreFinite(mwx, mwy) && SkScalarsAreFinite(mwz, mwt)) {
+  } else if (std::isfinite(mxx) && std::isfinite(mxy) &&
+             std::isfinite(mxz) && std::isfinite(mxt) &&
+             std::isfinite(myx) && std::isfinite(myy) &&
+             std::isfinite(myz) && std::isfinite(myt) &&
+             std::isfinite(mzx) && std::isfinite(mzy) &&
+             std::isfinite(mzz) && std::isfinite(mzt) &&
+             std::isfinite(mwx) && std::isfinite(mwy) &&
+             std::isfinite(mwz) && std::isfinite(mwt)) {
     checkForDeferredSave();
     Push<TransformFullPerspectiveOp>(0,
                                      mxx, mxy, mxz, mxt,
@@ -1377,7 +1381,7 @@ void DisplayListBuilder::DrawAtlas(const sk_sp<DlImage>& atlas,
 
 void DisplayListBuilder::DrawDisplayList(const sk_sp<DisplayList> display_list,
                                          SkScalar opacity) {
-  if (!SkScalarIsFinite(opacity) || opacity <= SK_ScalarNearlyZero ||
+  if (!std::isfinite(opacity) || opacity <= SK_ScalarNearlyZero ||
       display_list->op_count() == 0 || display_list->bounds().isEmpty() ||
       current_layer_->is_nop_) {
     return;

--- a/display_list/dl_builder.h
+++ b/display_list/dl_builder.h
@@ -509,7 +509,7 @@ class DisplayListBuilder final : public virtual DlCanvas,
   // kInvalidSigma is used to indicate that no MaskBlur is currently set.
   static constexpr SkScalar kInvalidSigma = 0.0;
   static bool mask_sigma_valid(SkScalar sigma) {
-    return SkScalarIsFinite(sigma) && sigma > 0.0;
+    return std::isfinite(sigma) && sigma > 0.0;
   }
 
   class SaveInfo {

--- a/display_list/effects/dl_color_filter.cc
+++ b/display_list/effects/dl_color_filter.cc
@@ -147,7 +147,7 @@ bool DlMatrixColorFilter::modifies_transparent_black() const {
   // equation ends up becoming A' = matrix_[19]. Negative results will be
   // clamped to the range [0,1] so we only care about positive values.
   // Non-finite values are clamped to a zero alpha.
-  return (SkScalarIsFinite(matrix_[19]) && matrix_[19] > 0);
+  return (std::isfinite(matrix_[19]) && matrix_[19] > 0);
 }
 
 bool DlMatrixColorFilter::can_commute_with_opacity() const {

--- a/display_list/effects/dl_image_filter.h
+++ b/display_list/effects/dl_image_filter.h
@@ -138,8 +138,8 @@ class DlImageFilter : public DlAttribute<DlImageFilter, DlImageFilterType> {
   static SkVector map_vectors_affine(const SkMatrix& ctm,
                                      SkScalar x,
                                      SkScalar y) {
-    FML_DCHECK(SkScalarIsFinite(x) && x >= 0);
-    FML_DCHECK(SkScalarIsFinite(y) && y >= 0);
+    FML_DCHECK(std::isfinite(x) && x >= 0);
+    FML_DCHECK(std::isfinite(y) && y >= 0);
     FML_DCHECK(ctm.isFinite() && !ctm.hasPerspective());
 
     // The x and y scalars would have been used to expand a local space
@@ -231,7 +231,7 @@ class DlBlurImageFilter final : public DlImageFilter {
   static std::shared_ptr<DlImageFilter> Make(SkScalar sigma_x,
                                              SkScalar sigma_y,
                                              DlTileMode tile_mode) {
-    if (!SkScalarIsFinite(sigma_x) || !SkScalarIsFinite(sigma_y)) {
+    if (!std::isfinite(sigma_x) || !std::isfinite(sigma_y)) {
       return nullptr;
     }
     if (sigma_x < SK_ScalarNearlyZero && sigma_y < SK_ScalarNearlyZero) {
@@ -302,8 +302,8 @@ class DlDilateImageFilter final : public DlImageFilter {
 
   static std::shared_ptr<DlImageFilter> Make(SkScalar radius_x,
                                              SkScalar radius_y) {
-    if (SkScalarIsFinite(radius_x) && radius_x > SK_ScalarNearlyZero &&
-        SkScalarIsFinite(radius_y) && radius_y > SK_ScalarNearlyZero) {
+    if (std::isfinite(radius_x) && radius_x > SK_ScalarNearlyZero &&
+        std::isfinite(radius_y) && radius_y > SK_ScalarNearlyZero) {
       return std::make_shared<DlDilateImageFilter>(radius_x, radius_y);
     }
     return nullptr;
@@ -366,8 +366,8 @@ class DlErodeImageFilter final : public DlImageFilter {
 
   static std::shared_ptr<DlImageFilter> Make(SkScalar radius_x,
                                              SkScalar radius_y) {
-    if (SkScalarIsFinite(radius_x) && radius_x > SK_ScalarNearlyZero &&
-        SkScalarIsFinite(radius_y) && radius_y > SK_ScalarNearlyZero) {
+    if (std::isfinite(radius_x) && radius_x > SK_ScalarNearlyZero &&
+        std::isfinite(radius_y) && radius_y > SK_ScalarNearlyZero) {
       return std::make_shared<DlErodeImageFilter>(radius_x, radius_y);
     }
     return nullptr;

--- a/display_list/effects/dl_mask_filter.h
+++ b/display_list/effects/dl_mask_filter.h
@@ -53,7 +53,7 @@ class DlBlurMaskFilter final : public DlMaskFilter {
   static std::shared_ptr<DlMaskFilter> Make(DlBlurStyle style,
                                             SkScalar sigma,
                                             bool respect_ctm = true) {
-    if (SkScalarIsFinite(sigma) && sigma > 0) {
+    if (std::isfinite(sigma) && sigma > 0) {
       return std::make_shared<DlBlurMaskFilter>(style, sigma, respect_ctm);
     }
     return nullptr;

--- a/display_list/testing/dl_rendering_unittests.cc
+++ b/display_list/testing/dl_rendering_unittests.cc
@@ -4111,7 +4111,7 @@ TEST_F(DisplayListRendering, MatrixColorFilterOpacityCommuteCheck) {
         "matrix[" + std::to_string(element) + "] = " + std::to_string(value);
     matrix[element] = value;
     auto filter = DlMatrixColorFilter::Make(matrix);
-    EXPECT_EQ(SkScalarIsFinite(value), filter != nullptr);
+    EXPECT_EQ(std::isfinite(value), filter != nullptr);
 
     DlPaint paint(DlColor(0x80808080));
     DlPaint opacity_save_paint = DlPaint().setOpacity(0.5);


### PR DESCRIPTION
SkScalarIsFinite is deprecated. Use `std::isfinite` instead.