### PR TITLE
Break dependency cycle of FlutterViewController <-> FlutterPlatformView

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h
@@ -8,15 +8,6 @@
 #include <Metal/Metal.h>
 #include <UIKit/UIKit.h>
 
-#include <memory>
-
-#include "flutter/fml/memory/weak_ptr.h"
-#include "flutter/shell/common/shell.h"
-#import "flutter/shell/platform/darwin/ios/ios_surface.h"
-#include "fml/platform/darwin/cf_utils.h"
-
-#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h"
-
 /// UIViews that are used by |FlutterPlatformViews| to present Flutter
 /// rendering on top of system compositor rendering (ex. a web view).
 ///

--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
@@ -3,20 +3,11 @@
 // found in the LICENSE file.
 
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h"
-#include <CoreGraphics/CGColorSpace.h>
-#include <Metal/Metal.h>
 
-#include "flutter/common/settings.h"
-#include "flutter/common/task_runners.h"
-#include "flutter/flow/layers/layer_tree.h"
-#include "flutter/fml/platform/darwin/cf_utils.h"
-#include "flutter/fml/synchronization/waitable_event.h"
-#include "flutter/fml/trace_event.h"
-#include "flutter/shell/common/platform_view.h"
-#include "flutter/shell/common/rasterizer.h"
+#include <CoreGraphics/CGColorSpace.h>
+
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterView.h"
-#import "flutter/shell/platform/darwin/ios/ios_surface_software.h"
-#include "third_party/skia/include/utils/mac/SkCGUtils.h"
+#include "fml/platform/darwin/cf_utils.h"
 
 // This is mostly a duplication of FlutterView.
 // TODO(amirh): once GL support is in evaluate if we can merge this with FlutterView.

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -2,21 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <Metal/Metal.h>
-#import <UIKit/UIGestureRecognizerSubclass.h>
-
-#include <list>
-#include <map>
-#include <memory>
-#include <string>
-
-#include "flutter/common/graphics/persistent_cache.h"
-#include "flutter/fml/platform/darwin/scoped_nsobject.h"
-#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterChannels.h"
-#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h"
+
+#include <Metal/Metal.h>
+
+#include "flutter/fml/platform/darwin/scoped_nsobject.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterView.h"
-#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h"
 #import "flutter/shell/platform/darwin/ios/ios_surface.h"
 
 @implementation UIView (FirstResponder)
@@ -171,11 +163,11 @@ void FlutterPlatformViewsController::SetFlutterView(UIView* flutter_view) {
 }
 
 void FlutterPlatformViewsController::SetFlutterViewController(
-    UIViewController* flutter_view_controller) {
+    UIViewController<FlutterViewResponder>* flutter_view_controller) {
   flutter_view_controller_.reset([flutter_view_controller retain]);
 }
 
-UIViewController* FlutterPlatformViewsController::getFlutterViewController() {
+UIViewController<FlutterViewResponder>* FlutterPlatformViewsController::getFlutterViewController() {
   return flutter_view_controller_.get();
 }
 
@@ -1147,7 +1139,7 @@ void FlutterPlatformViewsController::ResetFrameState() {
   // This gesture recognizer retains the `FlutterViewController` until the
   // end of a gesture sequence, that is all the touches in touchesBegan are concluded
   // with |touchesCancelled| or |touchesEnded|.
-  fml::scoped_nsobject<UIViewController> _flutterViewController;
+  fml::scoped_nsobject<UIViewController<FlutterViewResponder>> _flutterViewController;
 }
 
 - (instancetype)initWithTarget:(id)target
@@ -1198,7 +1190,7 @@ void FlutterPlatformViewsController::ResetFrameState() {
   // Flutter needs all the cancelled touches to be "cancelled" change types in order to correctly
   // handle gesture sequence.
   // We always override the change type to "cancelled".
-  [((FlutterViewController*)_flutterViewController.get()) forceTouchesCancelled:touches];
+  [_flutterViewController.get() forceTouchesCancelled:touches];
   _currentTouchPointersCount -= touches.count;
   if (_currentTouchPointersCount == 0) {
     self.state = UIGestureRecognizerStateFailed;

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -6,13 +6,12 @@
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
-#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterBinaryMessenger.h"
+#import "flutter/fml/thread.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlatformViews.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterTouchInterceptingView_Test.h"
-#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h"
 #import "flutter/shell/platform/darwin/ios/platform_view_ios.h"
 
 FLUTTER_ASSERT_ARC
@@ -2158,7 +2157,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(const std::string& name) {
   [forwardGectureRecognizer touchesBegan:touches1 withEvent:event1];
   OCMVerify([mockFlutterViewContoller touchesBegan:touches1 withEvent:event1]);
 
-  UIViewController* mockFlutterViewContoller2 = OCMClassMock([UIViewController class]);
+  FlutterViewController* mockFlutterViewContoller2 = OCMClassMock([FlutterViewController class]);
   flutterPlatformViewsController->SetFlutterViewController(mockFlutterViewContoller2);
 
   // Touch events should still send to the old FlutterViewController if FlutterViewController

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -5,15 +5,17 @@
 #ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERPLATFORMVIEWS_INTERNAL_H_
 #define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERPLATFORMVIEWS_INTERNAL_H_
 
-#include <Metal/Metal.h>
-#include "flutter/flow/embedded_views.h"
-#include "flutter/fml/platform/darwin/scoped_nsobject.h"
-#include "flutter/shell/common/shell.h"
-#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterBinaryMessenger.h"
-#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterChannels.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlatformViews.h"
+
+#include <Metal/Metal.h>
+
+#include "flutter/flow/surface.h"
+#include "flutter/fml/memory/weak_ptr.h"
+#include "flutter/fml/platform/darwin/scoped_nsobject.h"
+#include "flutter/fml/trace_event.h"
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterChannels.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h"
-#import "flutter/shell/platform/darwin/ios/framework/Source/SemanticsObject.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterViewResponder.h"
 #import "flutter/shell/platform/darwin/ios/ios_context.h"
 
 @class FlutterTouchInterceptingView;
@@ -210,9 +212,9 @@ class FlutterPlatformViewsController {
 
   void SetFlutterView(UIView* flutter_view);
 
-  void SetFlutterViewController(UIViewController* flutter_view_controller);
+  void SetFlutterViewController(UIViewController<FlutterViewResponder>* flutter_view_controller);
 
-  UIViewController* getFlutterViewController();
+  UIViewController<FlutterViewResponder>* getFlutterViewController();
 
   void RegisterViewFactory(
       NSObject<FlutterPlatformViewFactory>* factory,
@@ -353,7 +355,7 @@ class FlutterPlatformViewsController {
 
   fml::scoped_nsobject<FlutterMethodChannel> channel_;
   fml::scoped_nsobject<UIView> flutter_view_;
-  fml::scoped_nsobject<UIViewController> flutter_view_controller_;
+  fml::scoped_nsobject<UIViewController<FlutterViewResponder>> flutter_view_controller_;
   fml::scoped_nsobject<FlutterClippingMaskViewPool> mask_view_pool_;
   std::map<std::string, fml::scoped_nsobject<NSObject<FlutterPlatformViewFactory>>> factories_;
   std::map<int64_t, fml::scoped_nsobject<NSObject<FlutterPlatformView>>> views_;

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.h
@@ -5,16 +5,11 @@
 #ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERVIEW_H_
 #define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERVIEW_H_
 
-#include <Metal/Metal.h>
+#import <Metal/Metal.h>
 #import <UIKit/UIKit.h>
 
-#include <memory>
-
-#include "flutter/fml/memory/weak_ptr.h"
-#include "flutter/shell/common/shell.h"
+#include "flutter/shell/common/rasterizer.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h"
-#import "flutter/shell/platform/darwin/ios/ios_context.h"
-#import "flutter/shell/platform/darwin/ios/ios_surface.h"
 
 @protocol FlutterViewEngineDelegate <NSObject>
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -3,19 +3,8 @@
 // found in the LICENSE file.
 
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterView.h"
-#include <Metal/Metal.h>
 
-#include "flutter/common/settings.h"
-#include "flutter/common/task_runners.h"
-#include "flutter/flow/layers/layer_tree.h"
 #include "flutter/fml/platform/darwin/cf_utils.h"
-#include "flutter/fml/synchronization/waitable_event.h"
-#include "flutter/fml/trace_event.h"
-#include "flutter/shell/common/platform_view.h"
-#include "flutter/shell/common/rasterizer.h"
-#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h"
-#import "flutter/shell/platform/darwin/ios/ios_surface_software.h"
-#include "third_party/skia/include/utils/mac/SkCGUtils.h"
 
 @implementation FlutterView {
   id<FlutterViewEngineDelegate> _delegate;

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
@@ -60,9 +60,6 @@ typedef void (^FlutterKeyboardAnimationCallback)(fml::TimePoint);
 - (fml::WeakNSObject<FlutterViewController>)getWeakNSObject;
 - (std::shared_ptr<flutter::FlutterPlatformViewsController>&)platformViewsController;
 - (FlutterRestorationPlugin*)restorationPlugin;
-// Send touches to the Flutter Engine while forcing the change type to be cancelled.
-// The `phase`s in `touches` are ignored.
-- (void)forceTouchesCancelled:(NSSet*)touches;
 
 // Accepts keypress events, and then calls |nextAction| if the event was not
 // handled.

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewResponder.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewResponder.h
@@ -8,15 +8,44 @@
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Protocol to send touch events, typically a `FlutterViewController`.
+ */
 @protocol FlutterViewResponder <NSObject>
 
 @property(nonatomic, strong) UIView* view;
 
+/**
+ * See `-[UIResponder touchesBegan:withEvent:]`
+ */
 - (void)touchesBegan:(NSSet*)touches withEvent:(UIEvent*)event;
+
+/**
+ * See `-[UIResponder touchesMoved:withEvent:]`
+ */
 - (void)touchesMoved:(NSSet*)touches withEvent:(UIEvent*)event;
+
+/**
+ * See `-[UIResponder touchesEnded:withEvent:]`
+ */
 - (void)touchesEnded:(NSSet*)touches withEvent:(UIEvent*)event;
+
+/**
+ * See `-[UIResponder touchesCancelled:withEvent:]`
+ */
 - (void)touchesCancelled:(NSSet*)touches withEvent:(UIEvent*)event;
+
+/**
+ * See `-[UIResponder touchesEstimatedPropertiesUpdated:]`
+ */
 - (void)touchesEstimatedPropertiesUpdated:(NSSet*)touches;
+
+/**
+ * Send touches to the Flutter Engine while forcing the change type to be cancelled.
+ * The `phase`s in `touches` are ignored.
+ */
+- (void)forceTouchesCancelled:(NSSet*)touches;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewTest.mm
@@ -4,8 +4,6 @@
 
 #import <XCTest/XCTest.h>
 
-#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
-#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterView.h"
 
 FLUTTER_ASSERT_ARC

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -5,7 +5,7 @@
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 
-#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterBinaryMessenger.h"
+#import "flutter/fml/thread.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlatformViews.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h"


### PR DESCRIPTION
Trying to migrate the iOS embedder MRC to ARC, I'm attempting to break some dependency cycles so it's easier to migrate the "leaf" dependencies to ARC, working my way up.

The cycle is:
**`FlutterViewController`** -> `FlutterView` -> `FlutterPlatformView` ->  (Before this PR)**`FlutterViewController`** 

`FlutterViewController` depends on many other large MRC classes, like FlutterEngine., so I'd like to pull that one out so `FlutterView`, `FlutterPlatformView`, and `FlutterOverlayView` can be migrated to ARC in a smaller PR.

`FlutterPlatformView` only depends on `FlutterViewController` in this one place, casting a `UIViewController` and calling `-forceTouchesCancelled:`.  

https://github.com/flutter/engine/blob/55670b71eb00fbe80601b7227f68c1df4cae827b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm#L1201

Instead, move `-forceTouchesCancelled:` to the existing `FlutterViewResponder` protocol with the other touch events, which `FlutterViewController` already implements.  The cast can then be removed, breaking the cycle.

Clean up all the imports.

Part of https://github.com/flutter/flutter/issues/137801, though this doesn't actually migrate anything to ARC.
