### PR TITLE
[et] Fix path canonicalization

### DIFF
--- a/bin/et
+++ b/bin/et
@@ -27,7 +27,7 @@ function follow_links() (
   echo "$file"
 )
 
-SCRIPT_DIR=$(follow_links "$(dirname -- "${BASH_SOURCE[0]}")")
+SCRIPT_DIR="$(dirname -- "$(follow_links "${BASH_SOURCE[0]}")")"
 ENGINE_DIR="$(cd "$SCRIPT_DIR/.."; pwd -P)"
 
 case "$(uname -s)" in


### PR DESCRIPTION
Previously we were getting the enclosing directory path of the `et` tool (via the `dirname` builtin), then canonicalising the path by resolving symlinks. This doesn't work if the `et` on the path is itself a symlink. For example, if a user created a symlink `et` in a concrete directory at `~/.local/bin`:

```
~/.local/bin/et -> ~/src/flutter/engines/src/flutter/bin/et
```
first we'd compute the dirname of the script:
```
~/.local/bin
```
then we'd resolve symlinks:
```
~/.local/bin
```
and incorrectly assume that was the engine directory.

Instead, we now resolve symlinks, then compute the enclosing directory.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
