### PR TITLE
[Impeller] Cleanup `PipelineVK::Create`

### DIFF
--- a/fml/status_or.h
+++ b/fml/status_or.h
@@ -37,6 +37,10 @@ class StatusOr {
 
   // These constructors are intended be compatible with absl::status_or.
   // NOLINTNEXTLINE(google-explicit-constructor)
+  StatusOr(T&& value) : status_(), value_(std::move(value)) {}
+
+  // These constructors are intended be compatible with absl::status_or.
+  // NOLINTNEXTLINE(google-explicit-constructor)
   StatusOr(const Status& status) : status_(status), value_() {
     // It's not valid to construct a StatusOr with an OK status and no value.
     FML_CHECK(!status_.ok());

--- a/impeller/renderer/backend/vulkan/pipeline_vk.cc
+++ b/impeller/renderer/backend/vulkan/pipeline_vk.cc
@@ -169,7 +169,7 @@ namespace {
 fml::StatusOr<vk::UniqueDescriptorSetLayout> MakeDescriptorSetLayout(
     const PipelineDescriptor& desc,
     const std::shared_ptr<DeviceHolderVK>& device_holder,
-    std::shared_ptr<SamplerVK> immutable_sampler) {
+    const std::shared_ptr<SamplerVK>& immutable_sampler) {
   std::vector<vk::DescriptorSetLayoutBinding> set_bindings;
 
   vk::Sampler vk_immutable_sampler =


### PR DESCRIPTION
`PipelineVK::Create` was one giant function.  Now its 3 smaller functions and one less giant but still big function.

This is groundwork for trying to batch calls.

I tried to split out the creation of the `vk::GraphicsPipelineCreateInfo` but it holds pointers to things on the stack so it's hard to do.

test exempt: refactor, no new functionality

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
