### PR TITLE
Add containsCommand matcher

### DIFF
--- a/tools/engine_tool/test/build_command_test.dart
+++ b/tools/engine_tool/test/build_command_test.dart
@@ -360,13 +360,12 @@ void main() {
         '//flutter/fml:fml_arc_unittests',
       ]);
       expect(result, equals(0));
-      expect(testEnv.processHistory.length, greaterThan(6));
-      expect(testEnv.processHistory[6].command[0], contains('ninja'));
-      expect(testEnv.processHistory[6].command[2], endsWith('/host_debug'));
-      expect(
-        testEnv.processHistory[6].command[5],
-        equals('flutter/fml:fml_arc_unittests'),
-      );
+      expect(testEnv.processHistory, containsCommand((List<String> command) {
+        return command.length > 5 &&
+            command[0].contains('ninja') &&
+            command[2].endsWith('/host_debug') &&
+            command[5] == 'flutter/fml:fml_arc_unittests';
+      }));
     } finally {
       testEnv.cleanup();
     }
@@ -389,21 +388,14 @@ void main() {
         '//flutter/...',
       ]);
       expect(result, equals(0));
-      expect(testEnv.processHistory.length, greaterThan(6));
-      expect(testEnv.processHistory[6].command[0], contains('ninja'));
-      expect(testEnv.processHistory[6].command[2], endsWith('/host_debug'));
-      expect(
-        testEnv.processHistory[6].command[5],
-        equals('flutter/display_list:display_list_unittests'),
-      );
-      expect(
-        testEnv.processHistory[6].command[6],
-        equals('flutter/flow:flow_unittests'),
-      );
-      expect(
-        testEnv.processHistory[6].command[7],
-        equals('flutter/fml:fml_arc_unittests'),
-      );
+      expect(testEnv.processHistory, containsCommand((List<String> command) {
+        return command.length > 7 &&
+            command[0].contains('ninja') &&
+            command[2].endsWith('/host_debug') &&
+            command[5] == 'flutter/display_list:display_list_unittests' &&
+            command[6] == 'flutter/flow:flow_unittests' &&
+            command[7] == 'flutter/fml:fml_arc_unittests';
+      }));
     } finally {
       testEnv.cleanup();
     }

--- a/tools/engine_tool/test/utils_test.dart
+++ b/tools/engine_tool/test/utils_test.dart
@@ -1,0 +1,67 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:litetest/litetest.dart';
+
+import 'utils.dart';
+
+void main() async {
+  final List<CannedProcess> cannedProcesses = <CannedProcess>[
+    CannedProcess((List<String> command) => command.contains('ulfuls'),
+        stdout: 'Ashita ga aru sa'),
+    CannedProcess((List<String> command) => command.contains('quruli'),
+        stdout: 'Tokyo'),
+    CannedProcess((List<String> command) => command.contains('elizaveta'),
+        stdout: 'Moshimo ano toki'),
+    CannedProcess((List<String> command) => command.contains('scott_murphy'),
+        stdout: 'Donna toki mo'),
+  ];
+
+  test('containsCommand passes if command matched', () async {
+    final TestEnvironment testEnvironment = TestEnvironment.withTestEngine(
+      cannedProcesses: cannedProcesses,
+    );
+    try {
+      await testEnvironment.environment.processRunner.runProcess(
+          <String>['ulfuls', '--lyrics'],
+          workingDirectory: testEnvironment.environment.engine.srcDir,
+          failOk: true);
+      await testEnvironment.environment.processRunner.runProcess(
+          <String>['quruli', '--lyrics'],
+          workingDirectory: testEnvironment.environment.engine.srcDir,
+          failOk: true);
+      final List<ExecutedProcess> history = testEnvironment.processHistory;
+      expect(history, containsCommand((List<String> command) {
+        return command.isNotEmpty && command[0] == 'quruli';
+      }));
+      expect(history, containsCommand((List<String> command) {
+        return command.length > 1 && command[1] == '--lyrics';
+      }));
+    } finally {
+      testEnvironment.cleanup();
+    }
+  });
+
+  test('doesNotContainCommand passes if command not matched', () async {
+    final TestEnvironment testEnvironment = TestEnvironment.withTestEngine(
+      cannedProcesses: cannedProcesses,
+    );
+    try {
+      await testEnvironment.environment.processRunner.runProcess(
+          <String>['elizaveta', '--lyrics'],
+          workingDirectory: testEnvironment.environment.engine.srcDir,
+          failOk: true);
+      await testEnvironment.environment.processRunner.runProcess(
+          <String>['scott_murphy', '--lyrics'],
+          workingDirectory: testEnvironment.environment.engine.srcDir,
+          failOk: true);
+      final List<ExecutedProcess> history = testEnvironment.processHistory;
+      expect(history, doesNotContainCommand((List<String> command) {
+        return command.length > 1 && command[1] == '--not-an-option';
+      }));
+    } finally {
+      testEnvironment.cleanup();
+    }
+  });
+}


### PR DESCRIPTION
Adds a `Matcher` that can be used against a `List<ExecutedProcess>` to check if a command that matches a predicate was executed. Fails if no such command was found.

An alternative would be to take a single regex instead of a closure.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
