### PR TITLE
[darwin] Update pixel format handling in FlutterTexture

### DIFF
--- a/shell/platform/darwin/common/framework/Headers/FlutterTexture.h
+++ b/shell/platform/darwin/common/framework/Headers/FlutterTexture.h
@@ -19,7 +19,14 @@ FLUTTER_DARWIN_EXPORT
  * See also: https://github.com/flutter/plugins/tree/master/packages/camera
  */
 @protocol FlutterTexture <NSObject>
-/** Copy the contents of the texture into a `CVPixelBuffer`. */
+/**
+ * Copy the contents of the texture into a `CVPixelBuffer`.
+ *
+ * The type of the pixel buffer is one of the following:
+ * - `kCVPixelFormatType_32BGRA`
+ * - `kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange`
+ * - `kCVPixelFormatType_420YpCbCr8BiPlanarFullRange`
+ */
 - (CVPixelBufferRef _Nullable)copyPixelBuffer;
 
 /**

--- a/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
+++ b/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
@@ -133,8 +133,11 @@ FLUTTER_ASSERT_ARC
   if (_pixelFormat == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange ||
       _pixelFormat == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange) {
     image = [self wrapNV12ExternalPixelBuffer:pixelBuffer context:context];
-  } else {
+  } else if (_pixelFormat == kCVPixelFormatType_32BGRA) {
     image = [self wrapRGBAExternalPixelBuffer:pixelBuffer context:context];
+  } else {
+    FML_LOG(ERROR) << "Unsupported pixel format: " << _pixelFormat;
+    return nullptr;
   }
 
   if (!image) {

--- a/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
+++ b/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.mm
@@ -134,7 +134,7 @@ FLUTTER_ASSERT_ARC
       _pixelFormat == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange) {
     image = [self wrapNV12ExternalPixelBuffer:pixelBuffer context:context];
   } else if (_pixelFormat == kCVPixelFormatType_32BGRA) {
-    image = [self wrapRGBAExternalPixelBuffer:pixelBuffer context:context];
+    image = [self wrapBGRAExternalPixelBuffer:pixelBuffer context:context];
   } else {
     FML_LOG(ERROR) << "Unsupported pixel format: " << _pixelFormat;
     return nullptr;
@@ -238,7 +238,7 @@ FLUTTER_ASSERT_ARC
   return flutter::DlImage::Make(skImage);
 }
 
-- (sk_sp<flutter::DlImage>)wrapRGBAExternalPixelBuffer:(CVPixelBufferRef)pixelBuffer
+- (sk_sp<flutter::DlImage>)wrapBGRAExternalPixelBuffer:(CVPixelBufferRef)pixelBuffer
                                                context:(flutter::Texture::PaintContext&)context {
   SkISize textureSize =
       SkISize::Make(CVPixelBufferGetWidth(pixelBuffer), CVPixelBufferGetHeight(pixelBuffer));

--- a/shell/platform/darwin/macos/framework/Source/FlutterExternalTexture.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterExternalTexture.mm
@@ -43,8 +43,11 @@
   if (pixel_format == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange ||
       pixel_format == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange) {
     return [self populateTextureFromYUVAPixelBuffer:pixelBuffer textureOut:textureOut];
-  } else {
+  } else if (pixel_format == kCVPixelFormatType_32BGRA) {
     return [self populateTextureFromRGBAPixelBuffer:pixelBuffer textureOut:textureOut];
+  } else {
+    NSLog(@"Unsupported pixel format: %d", pixel_format);
+    return NO;
   }
 }
 


### PR DESCRIPTION
CVPixelBuffers from the application can have arbitrary pixel formats. However, current implementation doesn't support all pixel formats. To address this, add a comment to the FlutterTexture class to clarify which pixel formats are supported. Also, reject unsupported pixel formats so that the application can handle them properly.

Fixes [#147242](https://github.com/flutter/flutter/issues/147242).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
