### PR TITLE
[et] Don't require the --verbose flag when requesting a ci/ build

### DIFF
--- a/tools/engine_tool/lib/main.dart
+++ b/tools/engine_tool/lib/main.dart
@@ -17,6 +17,8 @@ import 'src/logger.dart';
 
 void main(List<String> args) async {
   final bool verbose = args.contains('--verbose') || args.contains('-v');
+  final bool help = args.contains('help') || args.contains('--help') ||
+                    args.contains('-h');
 
   // Find the engine repo.
   final Engine engine;
@@ -66,6 +68,7 @@ void main(List<String> args) async {
     environment: environment,
     configs: configs,
     verbose: verbose,
+    help: help,
   );
 
   try {

--- a/tools/engine_tool/lib/src/commands/build_command.dart
+++ b/tools/engine_tool/lib/src/commands/build_command.dart
@@ -16,9 +16,13 @@ final class BuildCommand extends CommandBase {
     required super.environment,
     required Map<String, BuilderConfig> configs,
     super.verbose = false,
+    super.help = false,
     super.usageLineLength,
   }) {
-    builds = runnableBuilds(environment, configs, verbose);
+    // When printing the help/usage for this command, only list all builds
+    // when the --verbose flag is supplied.
+    final bool includeCiBuilds = verbose || !help;
+    builds = runnableBuilds(environment, configs, includeCiBuilds);
     debugCheckBuilds(builds);
     addConfigOption(
       environment,

--- a/tools/engine_tool/lib/src/commands/command.dart
+++ b/tools/engine_tool/lib/src/commands/command.dart
@@ -16,6 +16,7 @@ abstract base class CommandBase extends Command<int> {
   CommandBase({
     required this.environment,
     this.verbose = false,
+    this.help = false,
     int? usageLineLength,
   }) : argParser = ArgParser(usageLineLength: usageLineLength);
 
@@ -24,6 +25,10 @@ abstract base class CommandBase extends Command<int> {
 
   /// Whether verbose logging is enabled.
   final bool verbose;
+
+  /// Whether the Command is being constructed only to print the usage/help
+  /// message.
+  final bool help;
 
   @override
   final ArgParser argParser;

--- a/tools/engine_tool/lib/src/commands/command_runner.dart
+++ b/tools/engine_tool/lib/src/commands/command_runner.dart
@@ -26,6 +26,7 @@ final class ToolCommandRunner extends CommandRunner<int> {
     required this.environment,
     required this.configs,
     this.verbose = false,
+    this.help = false,
   }) : super(toolName, toolDescription, usageLineLength: _usageLineLength) {
     final List<Command<int>> commands = <Command<int>>[
       FetchCommand(
@@ -40,12 +41,14 @@ final class ToolCommandRunner extends CommandRunner<int> {
         environment: environment,
         configs: configs,
         verbose: verbose,
+        help: help,
         usageLineLength: _usageLineLength,
       ),
       BuildCommand(
         environment: environment,
         configs: configs,
         verbose: verbose,
+        help: help,
         usageLineLength: _usageLineLength,
       ),
       RunCommand(
@@ -62,6 +65,7 @@ final class ToolCommandRunner extends CommandRunner<int> {
         environment: environment,
         configs: configs,
         verbose: verbose,
+        help: help,
         usageLineLength: _usageLineLength,
       ),
     ];
@@ -92,6 +96,9 @@ final class ToolCommandRunner extends CommandRunner<int> {
 
   /// Whether et should emit verbose logs.
   final bool verbose;
+
+  /// Whether the invocation is for a help command
+  final bool help;
 
   @override
   Future<int> run(Iterable<String> args) async {

--- a/tools/engine_tool/lib/src/commands/query_command.dart
+++ b/tools/engine_tool/lib/src/commands/query_command.dart
@@ -16,6 +16,7 @@ final class QueryCommand extends CommandBase {
     required super.environment,
     required this.configs,
     super.verbose = false,
+    super.help = false,
     super.usageLineLength,
   }) {
     // Add options here that are common to all queries.
@@ -45,11 +46,13 @@ final class QueryCommand extends CommandBase {
       environment: environment,
       configs: configs,
       verbose: verbose,
+      help: help,
     ));
     addSubcommand(QueryTargetsCommand(
       environment: environment,
       configs: configs,
       verbose: verbose,
+      help: help,
     ));
   }
 
@@ -71,6 +74,7 @@ final class QueryBuildersCommand extends CommandBase {
     required super.environment,
     required this.configs,
     super.verbose = false,
+    super.help = false,
   });
 
   /// Build configurations loaded from the engine from under ci/builders.
@@ -137,8 +141,12 @@ final class QueryTargetsCommand extends CommandBase {
     required super.environment,
     required this.configs,
     super.verbose = false,
+    super.help = false,
   }) {
-    builds = runnableBuilds(environment, configs, verbose);
+    // When printing the help/usage for this command, only list all builds
+    // when the --verbose flag is supplied.
+    final bool includeCiBuilds = verbose || !help;
+    builds = runnableBuilds(environment, configs, includeCiBuilds);
     debugCheckBuilds(builds);
     addConfigOption(
       environment,

--- a/tools/engine_tool/lib/src/commands/run_command.dart
+++ b/tools/engine_tool/lib/src/commands/run_command.dart
@@ -19,9 +19,13 @@ final class RunCommand extends CommandBase {
     required super.environment,
     required Map<String, BuilderConfig> configs,
     super.verbose = false,
+    super.help = false,
     super.usageLineLength,
   }) {
-    builds = runnableBuilds(environment, configs, verbose);
+    // When printing the help/usage for this command, only list all builds
+    // when the --verbose flag is supplied.
+    final bool includeCiBuilds = verbose || !help;
+    builds = runnableBuilds(environment, configs, includeCiBuilds);
     debugCheckBuilds(builds);
     // We default to nothing in order to automatically detect attached devices
     // and select an appropriate target from them.

--- a/tools/engine_tool/lib/src/commands/test_command.dart
+++ b/tools/engine_tool/lib/src/commands/test_command.dart
@@ -18,9 +18,13 @@ final class TestCommand extends CommandBase {
     required super.environment,
     required Map<String, BuilderConfig> configs,
     super.verbose = false,
+    super.help = false,
     super.usageLineLength,
   }) {
-    builds = runnableBuilds(environment, configs, verbose);
+    // When printing the help/usage for this command, only list all builds
+    // when the --verbose flag is supplied.
+    final bool includeCiBuilds = verbose || !help;
+    builds = runnableBuilds(environment, configs, includeCiBuilds);
     debugCheckBuilds(builds);
     addConfigOption(
       environment,

--- a/tools/engine_tool/test/build_command_test.dart
+++ b/tools/engine_tool/test/build_command_test.dart
@@ -68,7 +68,6 @@ void main() {
       final ToolCommandRunner runner = ToolCommandRunner(
         environment: testEnv.environment,
         configs: configs,
-        verbose: true,
       );
       final int result = await runner.run(<String>[
         'build',
@@ -91,7 +90,6 @@ void main() {
       final ToolCommandRunner runner = ToolCommandRunner(
         environment: testEnv.environment,
         configs: configs,
-        verbose: true,
       );
       final int result = await runner.run(<String>[
         'build',
@@ -114,7 +112,6 @@ void main() {
       final ToolCommandRunner runner = ToolCommandRunner(
         environment: testEnv.environment,
         configs: configs,
-        verbose: true,
       );
       final int result = await runner.run(<String>[
         'build',
@@ -140,7 +137,6 @@ void main() {
       final ToolCommandRunner runner = ToolCommandRunner(
         environment: testEnv.environment,
         configs: configs,
-        verbose: true,
       );
       final int result = await runner.run(<String>[
         'build',
@@ -163,7 +159,6 @@ void main() {
       final ToolCommandRunner runner = ToolCommandRunner(
         environment: testEnv.environment,
         configs: configs,
-        verbose: true,
       );
       final int result = await runner.run(<String>[
         'build',
@@ -190,7 +185,6 @@ void main() {
       final ToolCommandRunner runner = ToolCommandRunner(
         environment: testEnv.environment,
         configs: configs,
-        verbose: true,
       );
       final int result = await runner.run(<String>[
         'build',
@@ -219,7 +213,6 @@ void main() {
       final ToolCommandRunner runner = ToolCommandRunner(
         environment: testEnv.environment,
         configs: configs,
-        verbose: true,
       );
       final int result = await runner.run(<String>[
         'build',
@@ -293,7 +286,6 @@ void main() {
       final ToolCommandRunner runner = ToolCommandRunner(
         environment: testEnv.environment,
         configs: configs,
-        verbose: true,
       );
       final int result = await runner.run(<String>[
         'build',
@@ -327,7 +319,6 @@ void main() {
       final ToolCommandRunner runner = ToolCommandRunner(
         environment: env,
         configs: configs,
-        verbose: true,
       );
       final int result = await runner.run(<String>[
         'build',
@@ -351,7 +342,6 @@ void main() {
       final ToolCommandRunner runner = ToolCommandRunner(
         environment: testEnv.environment,
         configs: configs,
-        verbose: true,
       );
       final int result = await runner.run(<String>[
         'build',
@@ -379,7 +369,6 @@ void main() {
       final ToolCommandRunner runner = ToolCommandRunner(
         environment: testEnv.environment,
         configs: configs,
-        verbose: true,
       );
       final int result = await runner.run(<String>[
         'build',
@@ -413,6 +402,7 @@ void main() {
             environment: testEnv.environment,
             configs: configs,
             verbose: true,
+            help: true,
           );
           final int result = await runner.run(<String>[
             'help', 'build',
@@ -430,6 +420,38 @@ void main() {
     );
     for (final String line in prints) {
       expect(line.length, lessThanOrEqualTo(100));
+    }
+  });
+
+  test('non-verbose "et help build" does not contain ci builds', () async {
+    final List<String> prints = <String>[];
+    await runZoned(
+      () async {
+        final TestEnvironment testEnv = TestEnvironment.withTestEngine(
+          cannedProcesses: cannedProcesses,
+        );
+        try {
+          final ToolCommandRunner runner = ToolCommandRunner(
+            environment: testEnv.environment,
+            configs: configs,
+            help: true,
+          );
+          final int result = await runner.run(<String>[
+            'help', 'build',
+          ]);
+          expect(result, equals(0));
+        } finally {
+          testEnv.cleanup();
+        }
+      },
+      zoneSpecification: ZoneSpecification(
+        print: (Zone self, ZoneDelegate parent, Zone zone, String line) {
+          prints.addAll(line.split('\n'));
+        },
+      ),
+    );
+    for (final String line in prints) {
+      expect(line.contains('[ci/'), isFalse);
     }
   });
 }


### PR DESCRIPTION
https://github.com/flutter/engine/pull/52021 introduced a bug where `ci` build could only be specified when also passing the `--verbose` flag. This PR fixes the issue so that by default the `help` message will only show `ci` builds when `--verbose` is passed to `help`, but the `ci` builds can be specified even without the `--verbose` flag.