### PR TITLE
Remove "gclient sync" warning call during pre-rebase

### DIFF
--- a/tools/githooks/lib/src/messages.dart
+++ b/tools/githooks/lib/src/messages.dart
@@ -10,9 +10,6 @@ const String _reset = '\x1B[0m';
 /// Prints a reminder to stdout to run `gclient sync -D`. Uses colors when
 /// stdout supports ANSI escape codes.
 void printGclientSyncReminder(String command) {
-  if (command == 'pre-rebase') {
-    return;
-  }
   final String prefix = io.stdout.supportsAnsiEscapes ? _redBoldUnderline : '';
   final String postfix = io.stdout.supportsAnsiEscapes ? _reset : '';
   io.stderr.writeln('$command: The engine source tree has been updated.');

--- a/tools/githooks/lib/src/pre_rebase_command.dart
+++ b/tools/githooks/lib/src/pre_rebase_command.dart
@@ -16,7 +16,6 @@ class PreRebaseCommand extends Command<bool> {
 
   @override
   Future<bool> run() async {
-    printGclientSyncReminder(name);
     // Returning false here will block the rebase.
     return true;
   }

--- a/tools/githooks/lib/src/pre_rebase_command.dart
+++ b/tools/githooks/lib/src/pre_rebase_command.dart
@@ -4,8 +4,6 @@
 
 import 'package:args/command_runner.dart';
 
-import 'messages.dart';
-
 /// The command that implements the pre-rebase githook
 class PreRebaseCommand extends Command<bool> {
   @override


### PR DESCRIPTION
Remove `pre-rebase` check from `gclient sync` warning, and instead remove the warning call from `pre_rebase_command`

Follow-up to https://github.com/flutter/engine/pull/52133#discussion_r1575447161

