### PR TITLE
Fix some warnings reported by recent versions of clang-tidy

### DIFF
--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -371,6 +371,7 @@
 ../../../flutter/shell/platform/glfw/client_wrapper/flutter_window_unittests.cc
 ../../../flutter/shell/platform/glfw/client_wrapper/plugin_registrar_glfw_unittests.cc
 ../../../flutter/shell/platform/glfw/client_wrapper/testing
+../../../flutter/shell/platform/linux/.clang-tidy
 ../../../flutter/shell/platform/linux/testing
 ../../../flutter/shell/platform/windows/README.md
 ../../../flutter/shell/platform/windows/accessibility_bridge_windows_unittests.cc

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -2457,7 +2457,8 @@ FlutterEngineResult FlutterEngineSendPointerEvent(
         SAFE_ACCESS(current, signal_kind, kFlutterPointerSignalKindNone));
     pointer_data.scroll_delta_x = SAFE_ACCESS(current, scroll_delta_x, 0.0);
     pointer_data.scroll_delta_y = SAFE_ACCESS(current, scroll_delta_y, 0.0);
-    FlutterPointerDeviceKind device_kind = SAFE_ACCESS(current, device_kind, 0);
+    FlutterPointerDeviceKind device_kind =
+        SAFE_ACCESS(current, device_kind, kFlutterPointerDeviceKindMouse);
     // For backwards compatibility with embedders written before the device
     // kind and buttons were exposed, if the device kind is not set treat it
     // as a mouse, with a synthesized primary button state based on the phase.

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -2337,6 +2337,7 @@ TEST_F(EmbedderTest, InvalidAOTDataSourcesMustReturnError) {
   ASSERT_EQ(FlutterEngineCreateAOTData(&data_in, nullptr), kInvalidArguments);
 
   // Invalid FlutterEngineAOTDataSourceType type specified.
+  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
   data_in.type = static_cast<FlutterEngineAOTDataSourceType>(-1);
   ASSERT_EQ(FlutterEngineCreateAOTData(&data_in, &data_out), kInvalidArguments);
   ASSERT_EQ(data_out, nullptr);

--- a/shell/platform/linux/.clang-tidy
+++ b/shell/platform/linux/.clang-tidy
@@ -1,0 +1,5 @@
+InheritParentConfig: true
+
+# EnumCastOutOfRange warns about some common usages of GTK macros
+Checks: >-
+  -clang-analyzer-optin.core.EnumCastOutOfRange


### PR DESCRIPTION
* Invalid enum values in the embedder library
* Disable a check that warns about standard usage of GTK macros in the Linux embedder