### PR TITLE
[Flutter GPU] Add support for drawing Flutter GPU textures in the playground.

### DIFF
--- a/impeller/fixtures/dart_tests.dart
+++ b/impeller/fixtures/dart_tests.dart
@@ -14,11 +14,8 @@ void sayHi() {
 }
 
 /// Pass a texture back to the playground for rendering to the surface.
-///
-/// This callback only works for playground tests that invoke Dart via the
-/// `RendererDartTest::RenderToSurfacePlaygroundCase` method.
-@pragma('vm:external-name', 'DrawToPlaygroundSurface')
-external void drawToPlaygroundSurface(gpu.Texture texture);
+@pragma('vm:external-name', 'SetDisplayTexture')
+external void setDisplayTexture(gpu.Texture texture);
 
 @pragma('vm:entry-point')
 void instantiateDefaultContext() {
@@ -150,5 +147,5 @@ void canCreateRenderPassAndSubmit(int width, int height) {
 
   commandBuffer.submit();
 
-  drawToPlaygroundSurface(renderTexture);
+  setDisplayTexture(renderTexture);
 }

--- a/impeller/fixtures/dart_tests.dart
+++ b/impeller/fixtures/dart_tests.dart
@@ -13,6 +13,13 @@ void sayHi() {
   print('Hi');
 }
 
+/// Pass a texture back to the playground for rendering to the surface.
+///
+/// This callback only works for playground tests that invoke Dart via the
+/// `RendererDartTest::RenderToSurfacePlaygroundCase` method.
+@pragma('vm:external-name', 'DrawToPlaygroundSurface')
+external void drawToPlaygroundSurface(gpu.Texture texture);
+
 @pragma('vm:entry-point')
 void instantiateDefaultContext() {
   // ignore: unused_local_variable
@@ -142,4 +149,6 @@ void canCreateRenderPassAndSubmit() {
   encoder.draw();
 
   commandBuffer.submit();
+
+  drawToPlaygroundSurface(renderTexture);
 }

--- a/impeller/fixtures/dart_tests.dart
+++ b/impeller/fixtures/dart_tests.dart
@@ -109,9 +109,9 @@ ByteData float32(List<double> values) {
 }
 
 @pragma('vm:entry-point')
-void canCreateRenderPassAndSubmit() {
-  final gpu.Texture? renderTexture =
-      gpu.gpuContext.createTexture(gpu.StorageMode.devicePrivate, 100, 100);
+void canCreateRenderPassAndSubmit(int width, int height) {
+  final gpu.Texture? renderTexture = gpu.gpuContext
+      .createTexture(gpu.StorageMode.devicePrivate, width, height);
   assert(renderTexture != null);
 
   final gpu.CommandBuffer commandBuffer = gpu.gpuContext.createCommandBuffer();
@@ -130,9 +130,9 @@ void canCreateRenderPassAndSubmit() {
 
   final gpu.HostBuffer transients = gpu.gpuContext.createHostBuffer();
   final gpu.BufferView vertices = transients.emplace(float32(<double>[
-    -0.5, -0.5, //
+    -0.5, 0.5, //
+    0.0, -0.5, //
     0.5, 0.5, //
-    0.5, -0.5, //
   ]));
   final gpu.BufferView vertInfoData = transients.emplace(float32(<double>[
     1, 0, 0, 0, // mvp

--- a/impeller/playground/playground.cc
+++ b/impeller/playground/playground.cc
@@ -148,6 +148,10 @@ void Playground::SetupWindow() {
   start_time_ = fml::TimePoint::Now().ToEpochDelta();
 }
 
+bool Playground::IsPlaygroundEnabled() const {
+  return switches_.enable_playground;
+}
+
 void Playground::TeardownWindow() {
   if (context_) {
     context_->Shutdown();

--- a/impeller/playground/playground.h
+++ b/impeller/playground/playground.h
@@ -64,6 +64,8 @@ class Playground {
 
   void TeardownWindow();
 
+  bool IsPlaygroundEnabled() const;
+
   Point GetCursorPosition() const;
 
   ISize GetWindowSize() const;

--- a/impeller/renderer/renderer_dart_unittests.cc
+++ b/impeller/renderer/renderer_dart_unittests.cc
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "impeller/renderer/vertex_buffer_builder.h"
-#include "lib/gpu/texture.h"
-#include "testing/test_dart_native_resolver.h"
 #define FML_USED_ON_EMBEDDER
 
 #include <memory>
@@ -13,10 +10,12 @@
 #include "flutter/common/task_runners.h"
 #include "flutter/lib/gpu/context.h"
 #include "flutter/lib/gpu/shader_library.h"
+#include "flutter/lib/gpu/texture.h"
 #include "flutter/runtime/dart_isolate.h"
 #include "flutter/runtime/dart_vm_lifecycle.h"
 #include "flutter/testing/dart_fixture.h"
 #include "flutter/testing/dart_isolate_runner.h"
+#include "flutter/testing/test_dart_native_resolver.h"
 #include "flutter/testing/testing.h"
 #include "fml/memory/ref_ptr.h"
 #include "impeller/fixtures/texture.frag.h"
@@ -24,6 +23,7 @@
 #include "impeller/playground/playground_test.h"
 #include "impeller/renderer/pipeline_library.h"
 #include "impeller/renderer/render_pass.h"
+#include "impeller/renderer/vertex_buffer_builder.h"
 
 #include "gtest/gtest.h"
 #include "third_party/imgui/imgui.h"

--- a/impeller/renderer/renderer_dart_unittests.cc
+++ b/impeller/renderer/renderer_dart_unittests.cc
@@ -59,15 +59,15 @@ class RendererDartTest : public PlaygroundTest,
     //       `RendererDartTest::CreateDartIsolate`) to use the main thread, so
     //       there's no need for additional synchronization.
     {
-      auto draw_to_playground_surface = [this](Dart_NativeArguments args) {
+      auto set_display_texture = [this](Dart_NativeArguments args) {
         flutter::gpu::Texture* texture =
             tonic::DartConverter<flutter::gpu::Texture*>::FromDart(
                 Dart_GetNativeArgument(args, 0));
         assert(texture != nullptr);  // Should always be a valid pointer.
         received_texture_ = texture->GetTexture();
       };
-      AddNativeCallback("DrawToPlaygroundSurface",
-                        CREATE_NATIVE_ENTRY(draw_to_playground_surface));
+      AddNativeCallback("SetDisplayTexture",
+                        CREATE_NATIVE_ENTRY(set_display_texture));
     }
   }
 


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/144640.

Adds support for drawing Flutter GPU textures in the `RendererDartTest` playground harness.

## How to use it
1. Write a Dart function that creates/schedules rendering ops against a texture, and then pass the texture to the harness by calling `setDisplayTexture(Texture)`.
2. Stub a test that calls `RenderDartToPlayground(name)`. For example:
    ```cpp
    TEST_P(RendererDartTest, CanCreateRenderPassAndSubmit) {
      ASSERT_TRUE(RenderDartToPlayground("canCreateRenderPassAndSubmit"));
    }
    ```

When the playground is disabled, `RenderDartToPlayground` falls back to the old behavior and executes the function once to make sure no unhandled exceptions are thrown.

## Capture of `Play/RendererDartTest.CanCreateRenderPassAndSubmit/Metal`:

https://github.com/flutter/engine/assets/919017/c24b40d7-30a4-4456-8ea8-90914b79e189





