### PR TITLE
[Impeller] Remove libtess2 from libflutter.

### DIFF
--- a/impeller/geometry/BUILD.gn
+++ b/impeller/geometry/BUILD.gn
@@ -87,7 +87,7 @@ executable("geometry_benchmarks") {
   deps = [
     ":geometry",
     "../entity",
-    "../tessellator",
+    "../tessellator:tessellator_libtess",
     "//flutter/benchmarking",
   ]
 }

--- a/impeller/geometry/geometry_benchmarks.cc
+++ b/impeller/geometry/geometry_benchmarks.cc
@@ -10,6 +10,7 @@
 #include "impeller/geometry/path.h"
 #include "impeller/geometry/path_builder.h"
 #include "impeller/tessellator/tessellator.h"
+#include "impeller/tessellator/tessellator_libtess.h"
 
 namespace impeller {
 
@@ -37,7 +38,7 @@ Path CreateQuadratic(bool closed);
 Path CreateRRect();
 }  // namespace
 
-static Tessellator tess;
+static TessellatorLibtess tess;
 
 template <class... Args>
 static void BM_Polyline(benchmark::State& state, Args&&... args) {

--- a/impeller/renderer/BUILD.gn
+++ b/impeller/renderer/BUILD.gn
@@ -135,6 +135,7 @@ impeller_component("renderer_unittests") {
     ":renderer",
     "../fixtures",
     "../playground:playground_test",
+    "../tessellator:tessellator_libtess",
     "//flutter/testing:testing_lib",
   ]
 

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -24,13 +24,10 @@
 #include "impeller/fixtures/sepia.frag.h"
 #include "impeller/fixtures/sepia.vert.h"
 #include "impeller/fixtures/swizzle.frag.h"
-#include "impeller/fixtures/test_texture.frag.h"
-#include "impeller/fixtures/test_texture.vert.h"
 #include "impeller/fixtures/texture.frag.h"
 #include "impeller/fixtures/texture.vert.h"
 #include "impeller/geometry/path_builder.h"
 #include "impeller/playground/playground_test.h"
-#include "impeller/renderer/command.h"
 #include "impeller/renderer/command_buffer.h"
 #include "impeller/renderer/pipeline_builder.h"
 #include "impeller/renderer/pipeline_library.h"
@@ -38,7 +35,7 @@
 #include "impeller/renderer/render_target.h"
 #include "impeller/renderer/renderer.h"
 #include "impeller/renderer/vertex_buffer_builder.h"
-#include "impeller/tessellator/tessellator.h"
+#include "impeller/tessellator/tessellator_libtess.h"
 #include "third_party/imgui/imgui.h"
 
 // TODO(zanderso): https://github.com/flutter/flutter/issues/127701
@@ -394,7 +391,7 @@ TEST_P(RendererTest, CanRenderInstanced) {
   VertexBufferBuilder<VS::PerVertexData> builder;
 
   ASSERT_EQ(Tessellator::Result::kSuccess,
-            Tessellator{}.Tessellate(
+            TessellatorLibtess{}.Tessellate(
                 PathBuilder{}
                     .AddRect(Rect::MakeXYWH(10, 10, 100, 100))
                     .TakePath(FillType::kOdd),

--- a/impeller/tessellator/BUILD.gn
+++ b/impeller/tessellator/BUILD.gn
@@ -15,6 +15,21 @@ impeller_component("tessellator") {
   deps = [
     "../core",
     "//flutter/fml",
+  ]
+}
+
+impeller_component("tessellator_libtess") {
+  sources = [
+    "tessellator_libtess.cc",
+    "tessellator_libtess.h",
+  ]
+
+  public_deps = [ "../geometry" ]
+
+  deps = [
+    ":tessellator",
+    "../core",
+    "//flutter/fml",
     "//third_party/libtess2",
   ]
 }
@@ -30,11 +45,11 @@ impeller_component("tessellator_shared") {
   sources = [
     "c/tessellator.cc",
     "c/tessellator.h",
-    "tessellator.cc",
-    "tessellator.h",
   ]
 
   deps = [
+    ":tessellator",
+    ":tessellator_libtess",
     "../core",
     "../geometry",
     "//flutter/fml",
@@ -50,7 +65,7 @@ impeller_component("tessellator_unittests") {
   testonly = true
   sources = [ "tessellator_unittests.cc" ]
   deps = [
-    ":tessellator",
+    ":tessellator_libtess",
     "../geometry:geometry_asserts",
     "//flutter/testing",
   ]

--- a/impeller/tessellator/c/tessellator.cc
+++ b/impeller/tessellator/c/tessellator.cc
@@ -6,6 +6,8 @@
 
 #include <vector>
 
+#include "impeller/tessellator/tessellator_libtess.h"
+
 namespace impeller {
 PathBuilder* CreatePathBuilder() {
   return new PathBuilder();
@@ -42,7 +44,7 @@ struct Vertices* Tessellate(PathBuilder* builder,
                             Scalar tolerance) {
   auto path = builder->CopyPath(static_cast<FillType>(fill_type));
   std::vector<float> points;
-  if (Tessellator{}.Tessellate(
+  if (TessellatorLibtess{}.Tessellate(
           path, tolerance,
           [&points](const float* vertices, size_t vertices_count,
                     const uint16_t* indices, size_t indices_count) {

--- a/impeller/tessellator/c/tessellator.h
+++ b/impeller/tessellator/c/tessellator.h
@@ -8,7 +8,6 @@
 #include <cstdint>
 
 #include "impeller/geometry/path_builder.h"
-#include "impeller/tessellator/tessellator.h"
 
 #ifdef _WIN32
 #define IMPELLER_API __declspec(dllexport)

--- a/impeller/tessellator/tessellator.cc
+++ b/impeller/tessellator/tessellator.cc
@@ -4,165 +4,14 @@
 
 #include "impeller/tessellator/tessellator.h"
 
-#include "third_party/libtess2/Include/tesselator.h"
-
 namespace impeller {
 
-static void* HeapAlloc(void* userData, unsigned int size) {
-  return malloc(size);
-}
-
-static void* HeapRealloc(void* userData, void* ptr, unsigned int size) {
-  return realloc(ptr, size);
-}
-
-static void HeapFree(void* userData, void* ptr) {
-  free(ptr);
-}
-
-// Note: these units are "number of entities" for bucket size and not in KB.
-static const TESSalloc kAlloc = {
-    HeapAlloc, HeapRealloc, HeapFree, 0, /* =userData */
-    16,                                  /* =meshEdgeBucketSize */
-    16,                                  /* =meshVertexBucketSize */
-    16,                                  /* =meshFaceBucketSize */
-    16,                                  /* =dictNodeBucketSize */
-    16,                                  /* =regionBucketSize */
-    0                                    /* =extraVertices */
-};
-
 Tessellator::Tessellator()
-    : point_buffer_(std::make_unique<std::vector<Point>>()),
-      c_tessellator_(nullptr, &DestroyTessellator) {
+    : point_buffer_(std::make_unique<std::vector<Point>>()) {
   point_buffer_->reserve(2048);
-  TESSalloc alloc = kAlloc;
-  {
-    // libTess2 copies the TESSalloc despite the non-const argument.
-    CTessellator tessellator(::tessNewTess(&alloc), &DestroyTessellator);
-    c_tessellator_ = std::move(tessellator);
-  }
 }
 
 Tessellator::~Tessellator() = default;
-
-static int ToTessWindingRule(FillType fill_type) {
-  switch (fill_type) {
-    case FillType::kOdd:
-      return TESS_WINDING_ODD;
-    case FillType::kNonZero:
-      return TESS_WINDING_NONZERO;
-  }
-  return TESS_WINDING_ODD;
-}
-
-Tessellator::Result Tessellator::Tessellate(const Path& path,
-                                            Scalar tolerance,
-                                            const BuilderCallback& callback) {
-  if (!callback) {
-    return Result::kInputError;
-  }
-
-  point_buffer_->clear();
-  auto polyline =
-      path.CreatePolyline(tolerance, std::move(point_buffer_),
-                          [this](Path::Polyline::PointBufferPtr point_buffer) {
-                            point_buffer_ = std::move(point_buffer);
-                          });
-
-  auto fill_type = path.GetFillType();
-
-  if (polyline.points->empty()) {
-    return Result::kInputError;
-  }
-
-  auto tessellator = c_tessellator_.get();
-  if (!tessellator) {
-    return Result::kTessellationError;
-  }
-
-  constexpr int kVertexSize = 2;
-  constexpr int kPolygonSize = 3;
-
-  //----------------------------------------------------------------------------
-  /// Feed contour information to the tessellator.
-  ///
-  static_assert(sizeof(Point) == 2 * sizeof(float));
-  for (size_t contour_i = 0; contour_i < polyline.contours.size();
-       contour_i++) {
-    size_t start_point_index, end_point_index;
-    std::tie(start_point_index, end_point_index) =
-        polyline.GetContourPointBounds(contour_i);
-
-    ::tessAddContour(tessellator,  // the C tessellator
-                     kVertexSize,  //
-                     polyline.points->data() + start_point_index,  //
-                     sizeof(Point),                                //
-                     end_point_index - start_point_index           //
-    );
-  }
-
-  //----------------------------------------------------------------------------
-  /// Let's tessellate.
-  ///
-  auto result = ::tessTesselate(tessellator,                   // tessellator
-                                ToTessWindingRule(fill_type),  // winding
-                                TESS_POLYGONS,                 // element type
-                                kPolygonSize,                  // polygon size
-                                kVertexSize,                   // vertex size
-                                nullptr  // normal (null is automatic)
-  );
-
-  if (result != 1) {
-    return Result::kTessellationError;
-  }
-
-  int element_item_count = tessGetElementCount(tessellator) * kPolygonSize;
-
-  // We default to using a 16bit index buffer, but in cases where we generate
-  // more tessellated data than this can contain we need to fall back to
-  // dropping the index buffer entirely. Instead code could instead switch to
-  // a uint32 index buffer, but this is done for simplicity with the other
-  // fast path above.
-  if (element_item_count < USHRT_MAX) {
-    int vertex_item_count = tessGetVertexCount(tessellator);
-    auto vertices = tessGetVertices(tessellator);
-    auto elements = tessGetElements(tessellator);
-
-    // libtess uses an int index internally due to usage of -1 as a sentinel
-    // value.
-    std::vector<uint16_t> indices(element_item_count);
-    for (int i = 0; i < element_item_count; i++) {
-      indices[i] = static_cast<uint16_t>(elements[i]);
-    }
-    if (!callback(vertices, vertex_item_count, indices.data(),
-                  element_item_count)) {
-      return Result::kInputError;
-    }
-  } else {
-    std::vector<Point> points;
-    std::vector<float> data;
-
-    int vertex_item_count = tessGetVertexCount(tessellator) * kVertexSize;
-    auto vertices = tessGetVertices(tessellator);
-    points.reserve(vertex_item_count);
-    for (int i = 0; i < vertex_item_count; i += 2) {
-      points.emplace_back(vertices[i], vertices[i + 1]);
-    }
-
-    int element_item_count = tessGetElementCount(tessellator) * kPolygonSize;
-    auto elements = tessGetElements(tessellator);
-    data.reserve(element_item_count);
-    for (int i = 0; i < element_item_count; i++) {
-      data.emplace_back(points[elements[i]].x);
-      data.emplace_back(points[elements[i]].y);
-    }
-    if (!callback(data.data(), element_item_count, nullptr, 0u)) {
-      return Result::kInputError;
-    }
-  }
-
-  return Result::kSuccess;
-}
 
 Path::Polyline Tessellator::CreateTempPolyline(const Path& path,
                                                Scalar tolerance) {
@@ -237,12 +86,6 @@ std::vector<Point> Tessellator::TessellateConvex(const Path& path,
     }
   }
   return output;
-}
-
-void DestroyTessellator(TESStesselator* tessellator) {
-  if (tessellator != nullptr) {
-    ::tessDeleteTess(tessellator);
-  }
 }
 
 static constexpr int kPrecomputedDivisionCount = 1024;

--- a/impeller/tessellator/tessellator.h
+++ b/impeller/tessellator/tessellator.h
@@ -14,18 +14,14 @@
 #include "impeller/geometry/point.h"
 #include "impeller/geometry/trig.h"
 
-struct TESStesselator;
-
 namespace impeller {
-
-void DestroyTessellator(TESStesselator* tessellator);
-
-using CTessellator =
-    std::unique_ptr<TESStesselator, decltype(&DestroyTessellator)>;
 
 //------------------------------------------------------------------------------
 /// @brief      A utility that generates triangles of the specified fill type
 ///             given a polyline. This happens on the CPU.
+///
+///             Also contains functionality for optimized generation of circles
+///             and ellipses.
 ///
 ///             This object is not thread safe, and its methods must not be
 ///             called from multiple threads.
@@ -171,33 +167,7 @@ class Tessellator {
 
   Tessellator();
 
-  ~Tessellator();
-
-  /// @brief A callback that returns the results of the tessellation.
-  ///
-  ///        The index buffer may not be populated, in which case [indices] will
-  ///        be nullptr and indices_count will be 0.
-  using BuilderCallback = std::function<bool(const float* vertices,
-                                             size_t vertices_count,
-                                             const uint16_t* indices,
-                                             size_t indices_count)>;
-
-  //----------------------------------------------------------------------------
-  /// @brief      Generates filled triangles from the path. A callback is
-  ///             invoked once for the entire tessellation.
-  ///
-  /// @param[in]  path  The path to tessellate.
-  /// @param[in]  tolerance  The tolerance value for conversion of the path to
-  ///                        a polyline. This value is often derived from the
-  ///                        Matrix::GetMaxBasisLength of the CTM applied to the
-  ///                        path for rendering.
-  /// @param[in]  callback  The callback, return false to indicate failure.
-  ///
-  /// @return The result status of the tessellation.
-  ///
-  Tessellator::Result Tessellate(const Path& path,
-                                 Scalar tolerance,
-                                 const BuilderCallback& callback);
+  virtual ~Tessellator();
 
   //----------------------------------------------------------------------------
   /// @brief      Given a convex path, create a triangle fan structure.
@@ -296,11 +266,11 @@ class Tessellator {
                                             const Rect& bounds,
                                             const Size& radii);
 
- private:
+ protected:
   /// Used for polyline generation.
   std::unique_ptr<std::vector<Point>> point_buffer_;
-  CTessellator c_tessellator_;
 
+ private:
   // Data for variouos Circle/EllipseGenerator classes, cached per
   // Tessellator instance which is usually the foreground life of an app
   // if not longer.

--- a/impeller/tessellator/tessellator_libtess.cc
+++ b/impeller/tessellator/tessellator_libtess.cc
@@ -1,0 +1,172 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/tessellator/tessellator_libtess.h"
+
+#include "third_party/libtess2/Include/tesselator.h"
+
+namespace impeller {
+
+static void* HeapAlloc(void* userData, unsigned int size) {
+  return malloc(size);
+}
+
+static void* HeapRealloc(void* userData, void* ptr, unsigned int size) {
+  return realloc(ptr, size);
+}
+
+static void HeapFree(void* userData, void* ptr) {
+  free(ptr);
+}
+
+// Note: these units are "number of entities" for bucket size and not in KB.
+static const TESSalloc kAlloc = {
+    HeapAlloc, HeapRealloc, HeapFree, 0, /* =userData */
+    16,                                  /* =meshEdgeBucketSize */
+    16,                                  /* =meshVertexBucketSize */
+    16,                                  /* =meshFaceBucketSize */
+    16,                                  /* =dictNodeBucketSize */
+    16,                                  /* =regionBucketSize */
+    0                                    /* =extraVertices */
+};
+
+TessellatorLibtess::TessellatorLibtess()
+    : Tessellator(), c_tessellator_(nullptr, &DestroyTessellator) {
+  TESSalloc alloc = kAlloc;
+  {
+    // libTess2 copies the TESSalloc despite the non-const argument.
+    CTessellator tessellator(::tessNewTess(&alloc), &DestroyTessellator);
+    c_tessellator_ = std::move(tessellator);
+  }
+}
+
+TessellatorLibtess::~TessellatorLibtess() = default;
+
+static int ToTessWindingRule(FillType fill_type) {
+  switch (fill_type) {
+    case FillType::kOdd:
+      return TESS_WINDING_ODD;
+    case FillType::kNonZero:
+      return TESS_WINDING_NONZERO;
+  }
+  return TESS_WINDING_ODD;
+}
+
+TessellatorLibtess::Result TessellatorLibtess::Tessellate(
+    const Path& path,
+    Scalar tolerance,
+    const BuilderCallback& callback) {
+  if (!callback) {
+    return Result::kInputError;
+  }
+
+  point_buffer_->clear();
+  auto polyline =
+      path.CreatePolyline(tolerance, std::move(point_buffer_),
+                          [this](Path::Polyline::PointBufferPtr point_buffer) {
+                            point_buffer_ = std::move(point_buffer);
+                          });
+
+  auto fill_type = path.GetFillType();
+
+  if (polyline.points->empty()) {
+    return Result::kInputError;
+  }
+
+  auto tessellator = c_tessellator_.get();
+  if (!tessellator) {
+    return Result::kTessellationError;
+  }
+
+  constexpr int kVertexSize = 2;
+  constexpr int kPolygonSize = 3;
+
+  //----------------------------------------------------------------------------
+  /// Feed contour information to the tessellator.
+  ///
+  static_assert(sizeof(Point) == 2 * sizeof(float));
+  for (size_t contour_i = 0; contour_i < polyline.contours.size();
+       contour_i++) {
+    size_t start_point_index, end_point_index;
+    std::tie(start_point_index, end_point_index) =
+        polyline.GetContourPointBounds(contour_i);
+
+    ::tessAddContour(tessellator,  // the C tessellator
+                     kVertexSize,  //
+                     polyline.points->data() + start_point_index,  //
+                     sizeof(Point),                                //
+                     end_point_index - start_point_index           //
+    );
+  }
+
+  //----------------------------------------------------------------------------
+  /// Let's tessellate.
+  ///
+  auto result = ::tessTesselate(tessellator,                   // tessellator
+                                ToTessWindingRule(fill_type),  // winding
+                                TESS_POLYGONS,                 // element type
+                                kPolygonSize,                  // polygon size
+                                kVertexSize,                   // vertex size
+                                nullptr  // normal (null is automatic)
+  );
+
+  if (result != 1) {
+    return Result::kTessellationError;
+  }
+
+  int element_item_count = tessGetElementCount(tessellator) * kPolygonSize;
+
+  // We default to using a 16bit index buffer, but in cases where we generate
+  // more tessellated data than this can contain we need to fall back to
+  // dropping the index buffer entirely. Instead code could instead switch to
+  // a uint32 index buffer, but this is done for simplicity with the other
+  // fast path above.
+  if (element_item_count < USHRT_MAX) {
+    int vertex_item_count = tessGetVertexCount(tessellator);
+    auto vertices = tessGetVertices(tessellator);
+    auto elements = tessGetElements(tessellator);
+
+    // libtess uses an int index internally due to usage of -1 as a sentinel
+    // value.
+    std::vector<uint16_t> indices(element_item_count);
+    for (int i = 0; i < element_item_count; i++) {
+      indices[i] = static_cast<uint16_t>(elements[i]);
+    }
+    if (!callback(vertices, vertex_item_count, indices.data(),
+                  element_item_count)) {
+      return Result::kInputError;
+    }
+  } else {
+    std::vector<Point> points;
+    std::vector<float> data;
+
+    int vertex_item_count = tessGetVertexCount(tessellator) * kVertexSize;
+    auto vertices = tessGetVertices(tessellator);
+    points.reserve(vertex_item_count);
+    for (int i = 0; i < vertex_item_count; i += 2) {
+      points.emplace_back(vertices[i], vertices[i + 1]);
+    }
+
+    int element_item_count = tessGetElementCount(tessellator) * kPolygonSize;
+    auto elements = tessGetElements(tessellator);
+    data.reserve(element_item_count);
+    for (int i = 0; i < element_item_count; i++) {
+      data.emplace_back(points[elements[i]].x);
+      data.emplace_back(points[elements[i]].y);
+    }
+    if (!callback(data.data(), element_item_count, nullptr, 0u)) {
+      return Result::kInputError;
+    }
+  }
+
+  return Result::kSuccess;
+}
+
+void DestroyTessellator(TESStesselator* tessellator) {
+  if (tessellator != nullptr) {
+    ::tessDeleteTess(tessellator);
+  }
+}
+
+}  // namespace impeller

--- a/impeller/tessellator/tessellator_libtess.h
+++ b/impeller/tessellator/tessellator_libtess.h
@@ -1,0 +1,72 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_TESSELLATOR_TESSELLATOR_LIBTESS_H_
+#define FLUTTER_IMPELLER_TESSELLATOR_TESSELLATOR_LIBTESS_H_
+
+#include <functional>
+#include <memory>
+
+#include "impeller/geometry/path.h"
+#include "impeller/tessellator/tessellator.h"
+
+struct TESStesselator;
+
+namespace impeller {
+
+void DestroyTessellator(TESStesselator* tessellator);
+
+using CTessellator =
+    std::unique_ptr<TESStesselator, decltype(&DestroyTessellator)>;
+
+//------------------------------------------------------------------------------
+/// @brief      An extended tessellator that offers arbitrary/concave
+///             tessellation via the libtess2 library.
+///
+///             This object is not thread safe, and its methods must not be
+///             called from multiple threads.
+///
+class TessellatorLibtess : public Tessellator {
+ public:
+  TessellatorLibtess();
+
+  ~TessellatorLibtess();
+
+  /// @brief A callback that returns the results of the tessellation.
+  ///
+  ///        The index buffer may not be populated, in which case [indices] will
+  ///        be nullptr and indices_count will be 0.
+  using BuilderCallback = std::function<bool(const float* vertices,
+                                             size_t vertices_count,
+                                             const uint16_t* indices,
+                                             size_t indices_count)>;
+
+  //----------------------------------------------------------------------------
+  /// @brief      Generates filled triangles from the path. A callback is
+  ///             invoked once for the entire tessellation.
+  ///
+  /// @param[in]  path  The path to tessellate.
+  /// @param[in]  tolerance  The tolerance value for conversion of the path to
+  ///                        a polyline. This value is often derived from the
+  ///                        Matrix::GetMaxBasisLength of the CTM applied to the
+  ///                        path for rendering.
+  /// @param[in]  callback  The callback, return false to indicate failure.
+  ///
+  /// @return The result status of the tessellation.
+  ///
+  Tessellator::Result Tessellate(const Path& path,
+                                 Scalar tolerance,
+                                 const BuilderCallback& callback);
+
+ private:
+  CTessellator c_tessellator_;
+
+  TessellatorLibtess(const TessellatorLibtess&) = delete;
+
+  TessellatorLibtess& operator=(const TessellatorLibtess&) = delete;
+};
+
+}  // namespace impeller
+
+#endif  // FLUTTER_IMPELLER_TESSELLATOR_TESSELLATOR_LIBTESS_H_

--- a/impeller/tessellator/tessellator_unittests.cc
+++ b/impeller/tessellator/tessellator_unittests.cc
@@ -8,7 +8,7 @@
 #include "impeller/geometry/geometry_asserts.h"
 #include "impeller/geometry/path.h"
 #include "impeller/geometry/path_builder.h"
-#include "impeller/tessellator/tessellator.h"
+#include "impeller/tessellator/tessellator_libtess.h"
 
 namespace impeller {
 namespace testing {
@@ -16,7 +16,7 @@ namespace testing {
 TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
   // Zero points.
   {
-    Tessellator t;
+    TessellatorLibtess t;
     auto path = PathBuilder{}.TakePath(FillType::kOdd);
     Tessellator::Result result = t.Tessellate(
         path, 1.0f,
@@ -28,7 +28,7 @@ TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
 
   // One point.
   {
-    Tessellator t;
+    TessellatorLibtess t;
     auto path = PathBuilder{}.LineTo({0, 0}).TakePath(FillType::kOdd);
     Tessellator::Result result = t.Tessellate(
         path, 1.0f,
@@ -40,7 +40,7 @@ TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
 
   // Two points.
   {
-    Tessellator t;
+    TessellatorLibtess t;
     auto path = PathBuilder{}.AddLine({0, 0}, {0, 1}).TakePath(FillType::kOdd);
     Tessellator::Result result = t.Tessellate(
         path, 1.0f,
@@ -52,7 +52,7 @@ TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
 
   // Many points.
   {
-    Tessellator t;
+    TessellatorLibtess t;
     PathBuilder builder;
     for (int i = 0; i < 1000; i++) {
       auto coord = i * 1.0f;
@@ -69,7 +69,7 @@ TEST(TessellatorTest, TessellatorBuilderReturnsCorrectResultStatus) {
 
   // Closure fails.
   {
-    Tessellator t;
+    TessellatorLibtess t;
     auto path = PathBuilder{}.AddLine({0, 0}, {0, 1}).TakePath(FillType::kOdd);
     Tessellator::Result result = t.Tessellate(
         path, 1.0f,


### PR DESCRIPTION
- Move libtess-powered functionality into an `impeller::Tessellator` subclass called `impeller::TessellatorLibtess`.
- `impeller::Tessellator` now only contains `Tessellator::TessellateConvex` and utilities for fast circles/ellipses.
- Use `impeller::TessellatorLibtess` in geometry_benchmarks, renderer_unittests, and the C tessellator API implementation.
- Continue using `impeller::Tessellator` in Impeller, but without the libtess2 dependency.