### PR TITLE
Workaround HardwareRenderer breakage in Android 14

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -583,6 +583,7 @@ import java.util.List;
     ensureAlive();
     if (flutterEngine != null) {
       updateSystemUiOverlays();
+      flutterEngine.getPlatformViewsController().onResume();
     } else {
       Log.w(TAG, "onPostResume() invoked before FlutterFragment was attached to an Activity.");
     }
@@ -1020,6 +1021,7 @@ import java.util.List;
         flutterEngine.getSystemChannel().sendMemoryPressureWarning();
       }
       flutterEngine.getRenderer().onTrimMemory(level);
+      flutterEngine.getPlatformViewsController().onTrimMemory(level);
     }
   }
 

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -9,6 +9,7 @@ import static android.view.MotionEvent.PointerProperties;
 import static io.flutter.Build.API_LEVELS;
 
 import android.annotation.TargetApi;
+import android.content.ComponentCallbacks2;
 import android.content.Context;
 import android.content.MutableContextWrapper;
 import android.os.Build;
@@ -1050,6 +1051,24 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
       final int viewId = platformViews.keyAt(0);
       // Dispose deletes the entry from platformViews and clears associated resources.
       channelHandler.dispose(viewId);
+    }
+  }
+
+  // Invoked when the Android system is requesting we reduce memory usage.
+  public void onTrimMemory(int level) {
+    if (level < ComponentCallbacks2.TRIM_MEMORY_BACKGROUND) {
+      return;
+    }
+    for (VirtualDisplayController vdc : vdControllers.values()) {
+      vdc.clearSurface();
+    }
+  }
+
+  // Called after the application has been resumed.
+  // This is where we undo whatever may have been done in onTrimMemory.
+  public void onResume() {
+    for (VirtualDisplayController vdc : vdControllers.values()) {
+      vdc.resetSurface();
     }
   }
 


### PR DESCRIPTION
- Destroy ImageReaders on memory trim.
- Unset the VirtualDisplay's surface on memory trim.
- On resume, recreate ImageReaders.
- On resume, do a dumb little dance and then set the VirtualDisplay's surface

Fixes: https://github.com/flutter/flutter/issues/146499
Fixes: https://github.com/flutter/flutter/issues/144219

Internal bug: b/335646931
Android Fix: https://googleplex-android-review.git.corp.google.com/c/platform/frameworks/base/+/27015418

Android 15 will include the fix. Unclear if Android 14 will be patched.
