### PR TITLE
Fix function type cast warnings for macOS embedder callbacks

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -399,7 +399,8 @@ constexpr char kTextPlainFormat[] = "text/plain";
 // Callbacks provided to the engine. See the called methods for documentation.
 #pragma mark - Static methods provided to engine configuration
 
-static void OnPlatformMessage(const FlutterPlatformMessage* message, FlutterEngine* engine) {
+static void OnPlatformMessage(const FlutterPlatformMessage* message, void* user_data) {
+  FlutterEngine* engine = (__bridge FlutterEngine*)user_data;
   [engine engineCallbackOnPlatformMessage:message];
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterRenderer.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterRenderer.mm
@@ -12,22 +12,22 @@
 
 #pragma mark - Static callbacks that require the engine.
 
-static FlutterMetalTexture OnGetNextDrawable(FlutterEngine* engine,
-                                             const FlutterFrameInfo* frameInfo) {
+static FlutterMetalTexture OnGetNextDrawable(void* user_data, const FlutterFrameInfo* frameInfo) {
   NSCAssert(NO, @"The renderer config should not be used to get the next drawable.");
   return FlutterMetalTexture{};
 }
 
-static bool OnPresentDrawable(FlutterEngine* engine, const FlutterMetalTexture* texture) {
+static bool OnPresentDrawable(void* user_data, const FlutterMetalTexture* texture) {
   NSCAssert(NO, @"The renderer config should not be used to present drawable.");
   return false;
 }
 
-static bool OnAcquireExternalTexture(FlutterEngine* engine,
+static bool OnAcquireExternalTexture(void* user_data,
                                      int64_t textureIdentifier,
                                      size_t width,
                                      size_t height,
                                      FlutterMetalExternalTexture* metalTexture) {
+  FlutterEngine* engine = (__bridge FlutterEngine*)user_data;
   return [engine.renderer populateTextureWithIdentifier:textureIdentifier
                                            metalTexture:metalTexture];
 }


### PR DESCRIPTION
The latest version of Clang is reporting warnings from the -Wcast-function-type-mismatch check when a function taking a __strong pointer parameter is converted to a void* parameter.