### PR TITLE
Skip files in the clang-tidy driver if clang-tidy crashes when processing the file

### DIFF
--- a/tools/clang_tidy/test/clang_tidy_test.dart
+++ b/tools/clang_tidy/test/clang_tidy_test.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io' as io show Directory, File, Platform, ProcessSignal, stderr;
 import 'dart:convert' show jsonEncode;
+import 'dart:io' as io show Directory, File, Platform, ProcessSignal, stderr;
 
 import 'package:clang_tidy/clang_tidy.dart';
 import 'package:clang_tidy/src/command.dart';
@@ -621,7 +621,7 @@ Future<int> main(List<String> args) async {
     );
     final String firstFilePath = (await fileListFixture.tool.computeFilesOfInterest()).first.path;
 
-    FakeProcessManager fakeProcessManager = FakeProcessManager(
+    final FakeProcessManager fakeProcessManager = FakeProcessManager(
       onStart: (List<String> command) {
         if (command.first.endsWith('clang-tidy')) {
           return FakeProcess(exitCode: -io.ProcessSignal.sigsegv.signalNumber);
@@ -638,7 +638,7 @@ Future<int> main(List<String> args) async {
       },
     ];
 
-    io.File commands = io.File(path.join(
+    final io.File commands = io.File(path.join(
         io.Directory.systemTemp.path, 'test_compile_commands.json'));
     int result;
     try {

--- a/tools/pkg/process_fakes/lib/process_fakes.dart
+++ b/tools/pkg/process_fakes/lib/process_fakes.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io' as io;
 
@@ -101,11 +102,13 @@ final class FakeProcess implements io.Process {
     String stderr = '',
   })  : _exitCode = exitCode,
         _stdout = stdout,
-        _stderr = stderr;
+        _stderr = stderr,
+        _stdin = io.IOSink(StreamController<List<int>>.broadcast().sink);
 
   final int _exitCode;
   final String _stdout;
   final String _stderr;
+  final io.IOSink _stdin;
 
   @override
   Future<int> get exitCode async => _exitCode;
@@ -122,7 +125,7 @@ final class FakeProcess implements io.Process {
   }
 
   @override
-  io.IOSink get stdin => throw UnimplementedError();
+  io.IOSink get stdin => _stdin;
 
   @override
   Stream<List<int>> get stdout {


### PR DESCRIPTION
Recent versions of clang-tidy have been segfaulting when processing a few of the engine source files.  This patch skips over those errors so that the engine can roll Clang.

See https://github.com/flutter/flutter/issues/143178