### PR TITLE
[web] Expose browser_detection through ui_web.

### DIFF
--- a/lib/web_ui/lib/src/engine/browser_detection.dart
+++ b/lib/web_ui/lib/src/engine/browser_detection.dart
@@ -15,13 +15,13 @@ bool get isDesktop => ui_web.browser.isDesktop;
 /// Flutter web considers "mobile" everything that's not [isDesktop].
 bool get isMobile => ui_web.browser.isMobile;
 
-/// Whether the current [browserEngine] is [BrowserEngine.blink] (Chrom(e|ium)).
+/// Whether the current browser is [ui_web.BrowserEngine.blink] (Chrom(e|ium)).
 bool get isChromium => ui_web.browser.isChromium;
 
-/// Whether the current [browserEngine] is [BrowserEngine.webkit] (Safari).
+/// Whether the current browser is [ui_web.BrowserEngine.webkit] (Safari).
 bool get isSafari => ui_web.browser.isSafari;
 
-/// Whether the current [browserEngine] is [BrowserEngine.firefox].
+/// Whether the current browser is [ui_web.BrowserEngine.firefox].
 bool get isFirefox => ui_web.browser.isFirefox;
 
 /// Whether the current browser is Edge.

--- a/lib/web_ui/lib/src/engine/browser_detection.dart
+++ b/lib/web_ui/lib/src/engine/browser_detection.dart
@@ -3,220 +3,51 @@
 // found in the LICENSE file.
 
 import 'package:meta/meta.dart';
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import 'dom.dart';
 
-// iOS 15 launched WebGL 2.0, but there's something broken about it, which
-// leads to apps failing to load. For now, we're forcing WebGL 1 on iOS.
-//
-// TODO(yjbanov): https://github.com/flutter/flutter/issues/91333
-bool get _workAroundBug91333 => operatingSystem == OperatingSystem.iOs;
-
-/// The HTML engine used by the current browser.
-enum BrowserEngine {
-  /// The engine that powers Chrome, Samsung Internet Browser, UC Browser,
-  /// Microsoft Edge, Opera, and others.
-  ///
-  /// Blink is assumed in case when a more precise browser engine wasn't
-  /// detected.
-  blink,
-
-  /// The engine that powers Safari.
-  webkit,
-
-  /// The engine that powers Firefox.
-  firefox,
-}
-
-/// The signature of [getUserAgent].
-typedef UserAgentGetter = String Function();
-
-/// Returns the current user agent string.
-///
-/// This function is read-writable, so it can be overridden in tests.
-UserAgentGetter getUserAgent = defaultGetUserAgent;
-
-/// The default implementation of [getUserAgent].
-String defaultGetUserAgent() {
-  return domWindow.navigator.userAgent;
-}
-
-/// html webgl version qualifier constants.
-abstract class WebGLVersion {
-  /// WebGL 1.0 is based on OpenGL ES 2.0 / GLSL 1.00
-  static const int webgl1 = 1;
-
-  /// WebGL 2.0 is based on OpenGL ES 3.0 / GLSL 3.00
-  static const int webgl2 = 2;
-}
-
-/// Lazily initialized current browser engine.
-final BrowserEngine _browserEngine = _detectBrowserEngine();
-
-/// Override the value of [browserEngine].
-///
-/// Setting this to `null` lets [browserEngine] detect the browser that the
-/// app is running on.
-///
-/// This is intended to be used for testing and debugging only.
-BrowserEngine? debugBrowserEngineOverride;
-
-/// Returns the [BrowserEngine] used by the current browser.
-///
-/// This is used to implement browser-specific behavior.
-BrowserEngine get browserEngine {
-  return debugBrowserEngineOverride ?? _browserEngine;
-}
-
-BrowserEngine _detectBrowserEngine() {
-  final String vendor = domWindow.navigator.vendor;
-  final String agent = domWindow.navigator.userAgent.toLowerCase();
-  return detectBrowserEngineByVendorAgent(vendor, agent);
-}
-
-/// Detects browser engine for a given vendor and agent string.
-///
-/// Used for testing this library.
-@visibleForTesting
-BrowserEngine detectBrowserEngineByVendorAgent(String vendor, String agent) {
-  if (vendor == 'Google Inc.') {
-    return BrowserEngine.blink;
-  } else if (vendor == 'Apple Computer, Inc.') {
-    return BrowserEngine.webkit;
-  } else if (agent.contains('Edg/')) {
-    // Chromium based Microsoft Edge has `Edg` in the user-agent.
-    // https://docs.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-string
-    return BrowserEngine.blink;
-  } else if (vendor == '' && agent.contains('firefox')) {
-    // An empty string means firefox:
-    // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/vendor
-    return BrowserEngine.firefox;
-  }
-
-  // Assume Blink otherwise, but issue a warning.
-  print(
-      'WARNING: failed to detect current browser engine. Assuming this is a Chromium-compatible browser.');
-  return BrowserEngine.blink;
-}
-
-/// Operating system where the current browser runs.
-///
-/// Taken from the navigator platform.
-/// <https://developer.mozilla.org/en-US/docs/Web/API/NavigatorID/platform>
-enum OperatingSystem {
-  /// iOS: <http://www.apple.com/ios/>
-  iOs,
-
-  /// Android: <https://www.android.com/>
-  android,
-
-  /// Linux: <https://www.linux.org/>
-  linux,
-
-  /// Windows: <https://www.microsoft.com/windows/>
-  windows,
-
-  /// MacOs: <https://www.apple.com/macos/>
-  macOs,
-
-  /// We were unable to detect the current operating system.
-  unknown,
-}
-
-/// Lazily initialized current operating system.
-final OperatingSystem _operatingSystem = detectOperatingSystem();
-
-/// Returns the [OperatingSystem] the current browsers works on.
-///
-/// This is used to implement operating system specific behavior such as
-/// soft keyboards.
-OperatingSystem get operatingSystem {
-  return debugOperatingSystemOverride ?? _operatingSystem;
-}
-
-/// Override the value of [operatingSystem].
-///
-/// Setting this to `null` lets [operatingSystem] detect the real OS that the
-/// app is running on.
-///
-/// This is intended to be used for testing and debugging only.
-OperatingSystem? debugOperatingSystemOverride;
-
-/// Detects operating system using platform and UA used for unit testing.
-@visibleForTesting
-OperatingSystem detectOperatingSystem({
-  String? overridePlatform,
-  int? overrideMaxTouchPoints,
-}) {
-  final String platform = overridePlatform ?? domWindow.navigator.platform!;
-  final String userAgent = getUserAgent();
-
-  if (platform.startsWith('Mac')) {
-    // iDevices requesting a "desktop site" spoof their UA so it looks like a Mac.
-    // This checks if we're in a touch device, or on a real mac.
-    final int maxTouchPoints = overrideMaxTouchPoints ??
-        domWindow.navigator.maxTouchPoints?.toInt() ??
-        0;
-    if (maxTouchPoints > 2) {
-      return OperatingSystem.iOs;
-    }
-    return OperatingSystem.macOs;
-  } else if (platform.toLowerCase().contains('iphone') ||
-      platform.toLowerCase().contains('ipad') ||
-      platform.toLowerCase().contains('ipod')) {
-    return OperatingSystem.iOs;
-  } else if (userAgent.contains('Android')) {
-    // The Android OS reports itself as "Linux armv8l" in
-    // [domWindow.navigator.platform]. So we have to check the user-agent to
-    // determine if the OS is Android or not.
-    return OperatingSystem.android;
-  } else if (platform.startsWith('Linux')) {
-    return OperatingSystem.linux;
-  } else if (platform.startsWith('Win')) {
-    return OperatingSystem.windows;
-  } else {
-    return OperatingSystem.unknown;
-  }
-}
-
-/// List of Operating Systems we know to be working on laptops/desktops.
-///
-/// These devices tend to behave differently on many core issues such as events,
-/// screen readers, input devices.
-const Set<OperatingSystem> _desktopOperatingSystems = <OperatingSystem>{
-  OperatingSystem.macOs,
-  OperatingSystem.linux,
-  OperatingSystem.windows,
-};
-
-/// A flag to check if the current operating system is a laptop/desktop
+/// A flag to check if the current [operatingSystem] is a laptop/desktop
 /// operating system.
-///
-/// See [_desktopOperatingSystems].
-bool get isDesktop => _desktopOperatingSystems.contains(operatingSystem);
+bool get isDesktop => ui_web.browser.isDesktop;
 
 /// A flag to check if the current browser is running on a mobile device.
 ///
-/// See [_desktopOperatingSystems].
-/// See [isDesktop].
-bool get isMobile => !isDesktop;
+/// Flutter web considers "mobile" everything that not [isDesktop].
+bool get isMobile => ui_web.browser.isMobile;
+
+/// Whether the current [browserEngine] is [BrowserEngine.blink] (Chrom(e|ium)).
+bool get isChromium => ui_web.browser.isChromium;
+
+/// Whether the current [browserEngine] is [BrowserEngine.webkit] (Safari).
+bool get isSafari => ui_web.browser.isSafari;
+
+/// Whether the current [browserEngine] is [BrowserEngine.firefox].
+bool get isFirefox => ui_web.browser.isFirefox;
+
+/// Whether the current browser is Edge.
+bool get isEdge => ui_web.browser.isEdge;
+
+/// Whether we are running from a wasm module compiled with dart2wasm.
+///
+/// Note: Currently the ffi library is available from dart2wasm but not dart2js
+/// or dartdevc.
+bool get isWasm => ui_web.browser.isWasm;
+
+// Whether the detected `operatingSystem` is `OperatingSystem.iOs`.
+bool get _isIOS => ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs;
 
 /// Whether the browser is running on macOS or iOS.
 ///
 /// - See [operatingSystem].
 /// - See [OperatingSystem].
-bool get isMacOrIOS =>
-    operatingSystem == OperatingSystem.iOs ||
-    operatingSystem == OperatingSystem.macOs;
+bool get isMacOrIOS => _isIOS || ui_web.browser.operatingSystem == ui_web.OperatingSystem.macOs;
 
 /// Detect iOS 15.
-bool get isIOS15 {
-  if (debugIsIOS15 != null) {
-    return debugIsIOS15!;
-  }
-  return operatingSystem == OperatingSystem.iOs &&
-      domWindow.navigator.userAgent.contains('OS 15_');
-}
+bool get isIOS15 => debugIsIOS15 ?? _isIOS && ui_web.browser.userAgent.contains('OS 15_');
+
+/// Use in tests to simulate the detection of iOS 15.
+bool? debugIsIOS15;
 
 /// Detect if running on Chrome version 110 or older.
 ///
@@ -234,7 +65,7 @@ bool get isChrome110OrOlder {
   }
   final RegExp chromeRegexp = RegExp(r'Chrom(e|ium)\/([0-9]+)\.');
   final RegExpMatch? match =
-      chromeRegexp.firstMatch(domWindow.navigator.userAgent);
+      chromeRegexp.firstMatch(ui_web.browser.userAgent);
   if (match != null) {
     final int chromeVersion = int.parse(match.group(2)!);
     return _cachedIsChrome110OrOlder = chromeVersion <= 110;
@@ -246,45 +77,37 @@ bool get isChrome110OrOlder {
 // since we check this on every frame.
 bool? _cachedIsChrome110OrOlder;
 
+/// Use in tests to simulated the detection of Chrome 110 or older on Windows.
+bool? debugIsChrome110OrOlder;
+
+/// Returns true if the browser is iOS Safari, false otherwise.
+bool get isIosSafari => debugEmulateIosSafari || _isActualIosSafari;
+
+bool get _isActualIosSafari =>
+    ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit &&
+    ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs;
+
 /// If set to true pretends that the current browser is iOS Safari.
 ///
 /// Useful for tests. Do not use in production code.
 @visibleForTesting
 bool debugEmulateIosSafari = false;
 
-/// Returns true if the browser is iOS Safari, false otherwise.
-bool get isIosSafari => debugEmulateIosSafari || _isActualIosSafari;
+/// html webgl version qualifier constants.
+abstract class WebGLVersion {
+  /// WebGL 1.0 is based on OpenGL ES 2.0 / GLSL 1.00
+  static const int webgl1 = 1;
 
-bool get _isActualIosSafari =>
-    browserEngine == BrowserEngine.webkit &&
-    operatingSystem == OperatingSystem.iOs;
-
-/// Whether the current browser is Safari.
-bool get isSafari => browserEngine == BrowserEngine.webkit;
-
-/// Whether the current browser is Firefox.
-bool get isFirefox => browserEngine == BrowserEngine.firefox;
-
-/// Whether the current browser is Edge.
-bool get isEdge => domWindow.navigator.userAgent.contains('Edg/');
-
-/// Whether we are running from a wasm module compiled with dart2wasm.
-/// Note: Currently the ffi library is available from dart2wasm but not dart2js
-/// or dartdevc.
-bool get isWasm => const bool.fromEnvironment('dart.library.ffi');
-
-/// Use in tests to simulate the detection of iOS 15.
-bool? debugIsIOS15;
-
-/// Use in tests to simulated the detection of Chrome 110 or older on Windows.
-bool? debugIsChrome110OrOlder;
-
-int? _cachedWebGLVersion;
+  /// WebGL 2.0 is based on OpenGL ES 3.0 / GLSL 3.00
+  static const int webgl2 = 2;
+}
 
 /// The highest WebGL version supported by the current browser, or -1 if WebGL
 /// is not supported.
 int get webGLVersion =>
     _cachedWebGLVersion ?? (_cachedWebGLVersion = _detectWebGLVersion());
+
+int? _cachedWebGLVersion;
 
 /// Detects the highest WebGL version supported by the current browser, or
 /// -1 if WebGL is not supported.
@@ -311,6 +134,12 @@ int _detectWebGLVersion() {
   }
   return -1;
 }
+
+// iOS 15 launched WebGL 2.0, but there's something broken about it, which
+// leads to apps failing to load. For now, we're forcing WebGL 1 on iOS.
+//
+// TODO(yjbanov): https://github.com/flutter/flutter/issues/91333
+bool get _workAroundBug91333 => _isIOS;
 
 /// Whether the current browser supports the Chromium variant of CanvasKit.
 bool get browserSupportsCanvaskitChromium =>

--- a/lib/web_ui/lib/src/engine/browser_detection.dart
+++ b/lib/web_ui/lib/src/engine/browser_detection.dart
@@ -7,13 +7,12 @@ import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import 'dom.dart';
 
-/// A flag to check if the current [operatingSystem] is a laptop/desktop
-/// operating system.
+/// A flag to check if the current browser is running on a laptop/desktop device.
 bool get isDesktop => ui_web.browser.isDesktop;
 
 /// A flag to check if the current browser is running on a mobile device.
 ///
-/// Flutter web considers "mobile" everything that not [isDesktop].
+/// Flutter web considers "mobile" everything that's not [isDesktop].
 bool get isMobile => ui_web.browser.isMobile;
 
 /// Whether the current [browserEngine] is [BrowserEngine.blink] (Chrom(e|ium)).
@@ -77,7 +76,7 @@ bool get isChrome110OrOlder {
 // since we check this on every frame.
 bool? _cachedIsChrome110OrOlder;
 
-/// Use in tests to simulated the detection of Chrome 110 or older on Windows.
+/// Used in tests to simulate the detection of Chrome 110 or older on Windows.
 bool? debugIsChrome110OrOlder;
 
 /// Returns true if the browser is iOS Safari, false otherwise.

--- a/lib/web_ui/lib/src/engine/canvas_pool.dart
+++ b/lib/web_ui/lib/src/engine/canvas_pool.dart
@@ -7,8 +7,8 @@ import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
-import 'browser_detection.dart';
 import 'display.dart';
 import 'dom.dart';
 import 'engine_canvas.dart';
@@ -343,7 +343,7 @@ class CanvasPool extends _SaveStackTracking {
   void endOfPaint() {
     if (_reusablePool != null) {
       for (final DomCanvasElement e in _reusablePool!) {
-        if (browserEngine == BrowserEngine.webkit) {
+        if (ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit) {
           e.width = e.height = 0;
         }
         e.remove();
@@ -787,7 +787,7 @@ class CanvasPool extends _SaveStackTracking {
 
       // TODO(hterkelsen): Shadows with transparent occluders are not supported
       // on webkit since filter is unsupported.
-      if (transparentOccluder && browserEngine != BrowserEngine.webkit) {
+      if (transparentOccluder && ui_web.browser.browserEngine != ui_web.BrowserEngine.webkit) {
         // We paint shadows using a path and a mask filter instead of the
         // built-in shadow* properties. This is because the color alpha of the
         // paint is added to the shadow. The effect we're looking for is to just
@@ -841,7 +841,7 @@ class CanvasPool extends _SaveStackTracking {
     // towards the threshold. Setting width and height to zero tricks Webkit
     // into thinking that this canvas has a zero size so it doesn't count it
     // towards the threshold.
-    if (browserEngine == BrowserEngine.webkit && _canvas != null) {
+    if (ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit && _canvas != null) {
       _canvas!.width = _canvas!.height = 0;
     }
     _clearActiveCanvasList();
@@ -850,7 +850,7 @@ class CanvasPool extends _SaveStackTracking {
   void _clearActiveCanvasList() {
     if (_activeCanvasList != null) {
       for (final DomCanvasElement c in _activeCanvasList!) {
-        if (browserEngine == BrowserEngine.webkit) {
+        if (ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit) {
           c.width = c.height = 0;
         }
         c.remove();
@@ -955,7 +955,7 @@ class ContextStateHandle {
   /// This is used in screenshot tests to test Safari codepaths.
   static bool debugEmulateWebKitMaskFilter = false;
 
-  bool get _renderMaskFilterForWebkit => browserEngine == BrowserEngine.webkit || debugEmulateWebKitMaskFilter;
+  bool get _renderMaskFilterForWebkit => ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit || debugEmulateWebKitMaskFilter;
 
   /// Sets paint properties on the current canvas.
   ///

--- a/lib/web_ui/lib/src/engine/clipboard.dart
+++ b/lib/web_ui/lib/src/engine/clipboard.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
-import 'browser_detection.dart';
 import 'dom.dart';
 import 'services.dart';
 
@@ -132,7 +132,7 @@ abstract class CopyToClipboardStrategy {
 /// APIs and the browser.
 abstract class PasteFromClipboardStrategy {
   factory PasteFromClipboardStrategy() {
-    return (browserEngine == BrowserEngine.firefox ||
+    return (ui_web.browser.browserEngine == ui_web.BrowserEngine.firefox ||
             domWindow.navigator.clipboard == null)
         ? ExecCommandPasteStrategy()
         : ClipboardAPIPasteStrategy();

--- a/lib/web_ui/lib/src/engine/html/backdrop_filter.dart
+++ b/lib/web_ui/lib/src/engine/html/backdrop_filter.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
-import '../browser_detection.dart';
 import '../color_filter.dart';
 import '../dom.dart';
 import '../util.dart';
@@ -121,7 +121,7 @@ class PersistedBackdropFilter extends PersistedContainerSurface
       ..top = '${top}px'
       ..width = '${width}px'
       ..height = '${height}px';
-    if (browserEngine == BrowserEngine.firefox) {
+    if (ui_web.browser.browserEngine == ui_web.BrowserEngine.firefox) {
       // For FireFox for now render transparent black background.
       // TODO(ferhat): Switch code to use filter when
       // See https://caniuse.com/#feat=css-backdrop-filter.
@@ -142,7 +142,7 @@ class PersistedBackdropFilter extends PersistedContainerSurface
       // CSS uses pixel radius for blur. Flutter & SVG use sigma parameters. For
       // Gaussian blur with standard deviation (normal distribution),
       // the blur will fall within 2 * sigma pixels.
-      if (browserEngine == BrowserEngine.webkit) {
+      if (ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit) {
         setElementStyle(_filterElement!, '-webkit-backdrop-filter',
             backendFilter.filterAttribute);
       }

--- a/lib/web_ui/lib/src/engine/html/bitmap_canvas.dart
+++ b/lib/web_ui/lib/src/engine/html/bitmap_canvas.dart
@@ -6,8 +6,8 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
-import '../browser_detection.dart';
 import '../canvas_pool.dart';
 import '../display.dart';
 import '../dom.dart';
@@ -572,7 +572,7 @@ class BitmapCanvas extends EngineCanvas {
       final bool isStroke = paint.style == ui.PaintingStyle.stroke;
       final String cssColor = colorValueToCssString(paint.color);
       final double sigma = paint.maskFilter!.webOnlySigma;
-      if (browserEngine == BrowserEngine.webkit && !isStroke) {
+      if (ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit && !isStroke) {
         // A bug in webkit leaves artifacts when this element is animated
         // with filter: blur, we use boxShadow instead.
         element.style.boxShadow = '0px 0px ${sigma * 2.0}px $cssColor';
@@ -1050,7 +1050,7 @@ class BitmapCanvas extends EngineCanvas {
   void endOfPaint() {
     _canvasPool.endOfPaint();
     _elementCache?.commitFrame();
-    if (_contains3dTransform && browserEngine == BrowserEngine.webkit) {
+    if (_contains3dTransform && ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit) {
       // Copy the children list to avoid concurrent modification.
       final List<DomElement> children = rootElement.children.toList();
       for (final DomElement element in children) {
@@ -1450,7 +1450,7 @@ List<DomElement> _clipContent(List<SaveClipEntry> clipStack,
 /// Only supported in non-WebKit browsers.
 String maskFilterToCanvasFilter(ui.MaskFilter? maskFilter) {
   assert(
-    browserEngine != BrowserEngine.webkit,
+    ui_web.browser.browserEngine != ui_web.BrowserEngine.webkit,
     'WebKit (Safari) does not support `filter` canvas property.',
   );
   if (maskFilter != null) {

--- a/lib/web_ui/lib/src/engine/html/color_filter.dart
+++ b/lib/web_ui/lib/src/engine/html/color_filter.dart
@@ -3,9 +3,9 @@
 // found in the LICENSE file.
 
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../../engine/color_filter.dart';
-import '../browser_detection.dart';
 import '../dom.dart';
 import '../svg.dart';
 import '../util.dart';
@@ -298,7 +298,7 @@ class SvgFilterBuilder {
 
     // WebKit will not render if x/y/width/height is specified. So we return
     // explicit size here unless running on WebKit.
-    if (browserEngine != BrowserEngine.webkit) {
+    if (ui_web.browser.browserEngine != ui_web.BrowserEngine.webkit) {
       element.x!.baseVal!.newValueSpecifiedUnits(svgLengthTypeNumber, 0);
       element.y!.baseVal!.newValueSpecifiedUnits(svgLengthTypeNumber, 0);
       element.width!.baseVal!.newValueSpecifiedUnits(svgLengthTypeNumber, width);

--- a/lib/web_ui/lib/src/engine/html/dom_canvas.dart
+++ b/lib/web_ui/lib/src/engine/html/dom_canvas.dart
@@ -6,8 +6,8 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
-import '../browser_detection.dart';
 import '../dom.dart';
 import '../engine_canvas.dart';
 import '../svg.dart';
@@ -261,7 +261,7 @@ DomHTMLElement buildDrawRectElement(
 
   if (paint.maskFilter != null) {
     final double sigma = paint.maskFilter!.webOnlySigma;
-    if (browserEngine == BrowserEngine.webkit && !isStroke) {
+    if (ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit && !isStroke) {
       // A bug in webkit leaves artifacts when this element is animated
       // with filter: blur, we use boxShadow instead.
       style.boxShadow = '0px 0px ${sigma * 2.0}px $cssColor';

--- a/lib/web_ui/lib/src/engine/html/path_to_svg_clip.dart
+++ b/lib/web_ui/lib/src/engine/html/path_to_svg_clip.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
-import '../browser_detection.dart';
 import '../dom.dart';
 import '../svg.dart';
 import 'path/path.dart';
@@ -47,7 +47,7 @@ SVGSVGElement pathToSvgClipPath(ui.Path path,
 
   // Firefox objectBoundingBox fails to scale to 1x1 units, instead use
   // no clipPathUnits but write the path in target units.
-  if (browserEngine != BrowserEngine.firefox) {
+  if (ui_web.browser.browserEngine != ui_web.BrowserEngine.firefox) {
     clipPath.setAttribute('clipPathUnits', 'objectBoundingBox');
     svgPath.setAttribute('transform', 'scale($scaleX, $scaleY)');
   }

--- a/lib/web_ui/lib/src/engine/html/resource_manager.dart
+++ b/lib/web_ui/lib/src/engine/html/resource_manager.dart
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import '../browser_detection.dart';
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
+
 import '../dom.dart';
 import '../view_embedder/dom_manager.dart';
 import '../window.dart';
@@ -47,7 +48,7 @@ class ResourceManager {
     resourcesHost.style.visibility = 'hidden';
     _resourcesHost = resourcesHost;
 
-    if (browserEngine == BrowserEngine.webkit) {
+    if (ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit) {
       final DomElement rootElement = _domManager.rootElement;
       // The resourcesHost *must* be a sibling of the rootElement.
       rootElement.parent!.prepend(resourcesHost);

--- a/lib/web_ui/lib/src/engine/html/shader_mask.dart
+++ b/lib/web_ui/lib/src/engine/html/shader_mask.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
-import '../browser_detection.dart';
 import '../dom.dart';
 import 'bitmap_canvas.dart';
 import 'color_filter.dart';
@@ -39,7 +39,7 @@ class PersistedShaderMask extends PersistedContainerSurface
   final ui.BlendMode blendMode;
   final ui.FilterQuality filterQuality;
   DomElement? _shaderElement;
-  final bool isWebKit = browserEngine == BrowserEngine.webkit;
+  final bool isWebKit = ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit;
 
   @override
   void adoptElements(PersistedShaderMask oldSurface) {

--- a/lib/web_ui/lib/src/engine/html_image_codec.dart
+++ b/lib/web_ui/lib/src/engine/html_image_codec.dart
@@ -8,7 +8,6 @@ import 'dart:typed_data';
 import 'package:ui/ui.dart' as ui;
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
-import 'browser_detection.dart';
 import 'dom.dart';
 import 'safe_browser_api.dart';
 
@@ -57,7 +56,7 @@ class HtmlCodec implements ui.Codec {
         int naturalWidth = imgElement.naturalWidth.toInt();
         int naturalHeight = imgElement.naturalHeight.toInt();
         // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=700533.
-        if (naturalWidth == 0 && naturalHeight == 0 && browserEngine == BrowserEngine.firefox) {
+        if (naturalWidth == 0 && naturalHeight == 0 && ui_web.browser.browserEngine == ui_web.BrowserEngine.firefox) {
           const int kDefaultImageSizeFallback = 300;
           naturalWidth = kDefaultImageSizeFallback;
           naturalHeight = kDefaultImageSizeFallback;

--- a/lib/web_ui/lib/src/engine/initialization.dart
+++ b/lib/web_ui/lib/src/engine/initialization.dart
@@ -226,7 +226,7 @@ Future<void> initializeEngineUi() async {
   }
   _initializationState = DebugEngineInitializationState.initializingUi;
 
-  RawKeyboard.initialize(onMacOs: operatingSystem == OperatingSystem.macOs);
+  RawKeyboard.initialize(onMacOs: ui_web.browser.operatingSystem == ui_web.OperatingSystem.macOs);
   KeyboardBinding.initInstance();
 
   if (!configuration.multiViewEnabled) {

--- a/lib/web_ui/lib/src/engine/keyboard_binding.dart
+++ b/lib/web_ui/lib/src/engine/keyboard_binding.dart
@@ -6,10 +6,10 @@ import 'dart:js_interop';
 
 import 'package:meta/meta.dart';
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 import 'package:web_locale_keymap/web_locale_keymap.dart' as locale_keymap;
 
 import '../engine.dart'  show registerHotRestartListener;
-import 'browser_detection.dart';
 import 'dom.dart';
 import 'key_map.g.dart';
 import 'platform_dispatcher.dart';
@@ -132,8 +132,8 @@ class KeyboardBinding {
   ///
   /// By default it is derived from [operatingSystem].
   @protected
-  OperatingSystem get localPlatform {
-    return operatingSystem;
+  ui_web.OperatingSystem get localPlatform {
+    return ui_web.browser.operatingSystem;
   }
 
   KeyboardConverter get converter => _converter;
@@ -223,8 +223,8 @@ class FlutterHtmlKeyboardEvent {
 // [dispatchKeyData] as given in the constructor. Some key data might be
 // dispatched asynchronously.
 class KeyboardConverter {
-  KeyboardConverter(this.performDispatchKeyData, OperatingSystem platform)
-    : onDarwin = platform == OperatingSystem.macOs || platform == OperatingSystem.iOs,
+  KeyboardConverter(this.performDispatchKeyData, ui_web.OperatingSystem platform)
+    : onDarwin = platform == ui_web.OperatingSystem.macOs || platform == ui_web.OperatingSystem.iOs,
       _mapping = _mappingFromPlatform(platform);
 
   final DispatchKeyData performDispatchKeyData;
@@ -234,16 +234,16 @@ class KeyboardConverter {
   /// Maps logical keys from key event properties.
   final locale_keymap.LocaleKeymap _mapping;
 
-  static locale_keymap.LocaleKeymap _mappingFromPlatform(OperatingSystem platform) {
+  static locale_keymap.LocaleKeymap _mappingFromPlatform(ui_web.OperatingSystem platform) {
     switch (platform) {
-      case OperatingSystem.iOs:
-      case OperatingSystem.macOs:
+      case ui_web.OperatingSystem.iOs:
+      case ui_web.OperatingSystem.macOs:
         return locale_keymap.LocaleKeymap.darwin();
-      case OperatingSystem.windows:
+      case ui_web.OperatingSystem.windows:
         return locale_keymap.LocaleKeymap.win();
-      case OperatingSystem.android:
-      case OperatingSystem.linux:
-      case OperatingSystem.unknown:
+      case ui_web.OperatingSystem.android:
+      case ui_web.OperatingSystem.linux:
+      case ui_web.OperatingSystem.unknown:
         return locale_keymap.LocaleKeymap.linux();
     }
   }

--- a/lib/web_ui/lib/src/engine/pointer_binding.dart
+++ b/lib/web_ui/lib/src/engine/pointer_binding.dart
@@ -9,9 +9,10 @@ import 'dart:math' as math;
 import 'package:meta/meta.dart';
 import 'package:ui/src/engine/keyboard_binding.dart';
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../engine.dart' show registerHotRestartListener;
-import 'browser_detection.dart';
+import 'browser_detection.dart' show isIosSafari;
 import 'dom.dart';
 import 'platform_dispatcher.dart';
 import 'pointer_binding/event_position_helper.dart';
@@ -588,7 +589,7 @@ mixin _WheelEventListenerMixin on _BaseAdapter {
     // https://github.com/WebKit/WebKit/blob/main/Source/WebCore/platform/mac/PlatformEventFactoryMac.mm
     // https://searchfox.org/mozilla-central/source/dom/events/WheelEvent.h
     // https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-mousewheel
-    if (browserEngine == BrowserEngine.firefox) {
+    if (ui_web.browser.browserEngine == ui_web.BrowserEngine.firefox) {
       // Firefox has restricted the wheelDelta properties, they do not provide
       // enough information to accurately disambiguate trackpad events from mouse
       // wheel events.
@@ -656,7 +657,7 @@ mixin _WheelEventListenerMixin on _BaseAdapter {
         deltaX *= _view.physicalSize.width;
         deltaY *= _view.physicalSize.height;
       case domDeltaPixel:
-        if (operatingSystem == OperatingSystem.macOs) {
+        if (ui_web.browser.operatingSystem == ui_web.OperatingSystem.macOs) {
           // Safari and Firefox seem to report delta in logical pixels while
           // Chrome uses physical pixels.
           deltaX *= _view.devicePixelRatio;
@@ -669,7 +670,7 @@ mixin _WheelEventListenerMixin on _BaseAdapter {
     final List<ui.PointerData> data = <ui.PointerData>[];
     final ui.Offset offset = computeEventOffsetToTarget(event, _view);
     bool ignoreCtrlKey = false;
-    if (operatingSystem == OperatingSystem.macOs) {
+    if (ui_web.browser.operatingSystem == ui_web.OperatingSystem.macOs) {
       ignoreCtrlKey = (_keyboardConverter?.keyIsPressed(kPhysicalControlLeft) ?? false) ||
                       (_keyboardConverter?.keyIsPressed(kPhysicalControlRight) ?? false);
     }

--- a/lib/web_ui/lib/src/engine/raw_keyboard.dart
+++ b/lib/web_ui/lib/src/engine/raw_keyboard.dart
@@ -4,9 +4,9 @@
 
 import 'dart:async';
 import 'dart:typed_data';
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../engine.dart'  show registerHotRestartListener;
-import 'browser_detection.dart';
 import 'dom.dart';
 import 'keyboard_binding.dart';
 import 'platform_dispatcher.dart';
@@ -120,7 +120,7 @@ class RawKeyboard {
         _lastMetaState |= modifierNumLock;
       } else if (event.key == 'ScrollLock') {
         _lastMetaState |= modifierScrollLock;
-      } else if (event.key == 'Meta' && operatingSystem == OperatingSystem.linux) {
+      } else if (event.key == 'Meta' && ui_web.browser.operatingSystem == ui_web.OperatingSystem.linux) {
         // On Chrome Linux, metaState can be wrong when a Meta key is pressed.
         _lastMetaState |= _modifierMeta;
       } else if (event.code == 'MetaLeft' && event.key == 'Process') {

--- a/lib/web_ui/lib/src/engine/safe_browser_api.dart
+++ b/lib/web_ui/lib/src/engine/safe_browser_api.dart
@@ -18,8 +18,9 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
-import 'browser_detection.dart';
+import 'browser_detection.dart' show WebGLVersion, webGLVersion;
 import 'display.dart';
 import 'dom.dart';
 import 'vector_math.dart';
@@ -188,10 +189,10 @@ bool get _defaultBrowserSupportsImageDecoder =>
 // Frequently, when a browser launches an API that other browsers already
 // support, there are subtle incompatibilities that may cause apps to crash if,
 // we blindly adopt the new implementation. This variable prevents us from
-// picking up potentially incompatible implementations of ImagdeDecoder API.
+// picking up potentially incompatible implementations of ImageDecoder API.
 // Instead, when a new browser engine launches the API, we'll evaluate it and
 // enable it explicitly.
-bool get _isBrowserImageDecoderStable => browserEngine == BrowserEngine.blink;
+bool get _isBrowserImageDecoderStable => ui_web.browser.browserEngine == ui_web.BrowserEngine.blink;
 
 /// Corresponds to the browser's `ImageDecoder` type.
 ///
@@ -791,8 +792,8 @@ class GlContext {
     const int kBytesPerPixel = 4;
     final int bufferWidth = _widthInPixels!;
     final int bufferHeight = _heightInPixels!;
-    if (browserEngine == BrowserEngine.webkit ||
-        browserEngine == BrowserEngine.firefox) {
+    if (ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit ||
+        ui_web.browser.browserEngine == ui_web.BrowserEngine.firefox) {
       final Uint8List pixels =
       Uint8List(bufferWidth * bufferHeight * kBytesPerPixel);
       js_util.callMethod<void>(glContext, 'readPixels',
@@ -1044,6 +1045,6 @@ class OffScreenCanvas {
   static bool get supported => _supported ??=
       // Safari 16.4 implements OffscreenCanvas, but without WebGL support. So
       // it's not really supported in a way that is useful to us.
-      !isSafari
+      !ui_web.browser.isSafari
       && js_util.hasProperty(domWindow, 'OffscreenCanvas');
 }

--- a/lib/web_ui/lib/src/engine/semantics/semantics_helper.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics_helper.dart
@@ -5,8 +5,8 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
-import '../browser_detection.dart';
 import '../dom.dart';
 import 'semantics.dart';
 
@@ -43,7 +43,7 @@ String placeholderMessage = 'Enable accessibility';
 /// See [DesktopSemanticsEnabler], [MobileSemanticsEnabler].
 class SemanticsHelper {
   SemanticsEnabler _semanticsEnabler =
-      isDesktop ? DesktopSemanticsEnabler() : MobileSemanticsEnabler();
+      ui_web.browser.isDesktop ? DesktopSemanticsEnabler() : MobileSemanticsEnabler();
 
   @visibleForTesting
   set semanticsEnabler(SemanticsEnabler semanticsEnabler) {
@@ -257,7 +257,7 @@ class MobileSemanticsEnabler extends SemanticsEnabler {
 
     if (_schedulePlaceholderRemoval) {
       // The event type can also be click for VoiceOver.
-      final bool removeNow = browserEngine != BrowserEngine.webkit ||
+      final bool removeNow = ui_web.browser.browserEngine != ui_web.BrowserEngine.webkit ||
           event.type == 'touchend' ||
           event.type == 'pointerup' ||
           event.type == 'click';

--- a/lib/web_ui/lib/src/engine/semantics/text_field.dart
+++ b/lib/web_ui/lib/src/engine/semantics/text_field.dart
@@ -4,8 +4,9 @@
 
 import 'dart:async';
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
-import '../browser_detection.dart';
+import '../browser_detection.dart' show isIosSafari;
 import '../dom.dart';
 import '../platform_dispatcher.dart';
 import '../text_editing/text_editing.dart';
@@ -287,11 +288,11 @@ class TextField extends PrimaryRoleManager {
   }
 
   void _setupDomElement() {
-    switch (browserEngine) {
-      case BrowserEngine.blink:
-      case BrowserEngine.firefox:
+    switch (ui_web.browser.browserEngine) {
+      case ui_web.BrowserEngine.blink:
+      case ui_web.BrowserEngine.firefox:
         _initializeForBlink();
-      case BrowserEngine.webkit:
+      case ui_web.BrowserEngine.webkit:
         _initializeForWebkit();
     }
   }
@@ -339,7 +340,7 @@ class TextField extends PrimaryRoleManager {
   /// semanicsObject.element to avoid confusing VoiceOver.
   void _initializeForWebkit() {
     // Safari for desktop is also initialized as the other browsers.
-    if (operatingSystem == OperatingSystem.macOs) {
+    if (ui_web.browser.operatingSystem == ui_web.OperatingSystem.macOs) {
       _initializeForBlink();
       return;
     }

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -7,7 +7,6 @@ import 'dart:math' as math;
 import 'package:ui/ui.dart' as ui;
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
-import '../browser_detection.dart';
 import '../dom.dart';
 import '../util.dart';
 import '../view_embedder/style_manager.dart';
@@ -1006,7 +1005,7 @@ void applyTextStyleToElement({
       final String? textDecoration =
           _textDecorationToCssString(style.decoration, style.decorationStyle);
       if (textDecoration != null) {
-        if (browserEngine == BrowserEngine.webkit) {
+        if (ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit) {
           setElementStyle(element, '-webkit-text-decoration', textDecoration);
         } else {
           cssStyle.textDecoration = textDecoration;

--- a/lib/web_ui/lib/src/engine/text/ruler.dart
+++ b/lib/web_ui/lib/src/engine/text/ruler.dart
@@ -5,7 +5,6 @@
 import 'package:ui/ui.dart' as ui;
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
-import '../browser_detection.dart';
 import '../dom.dart';
 import '../util.dart';
 import '../view_embedder/style_manager.dart';
@@ -121,7 +120,7 @@ class TextDimensions {
   /// The height of the paragraph being measured.
   double get height {
     double cachedHeight = _readAndCacheMetrics().height;
-    if (browserEngine == BrowserEngine.firefox &&
+    if (ui_web.browser.browserEngine == ui_web.BrowserEngine.firefox &&
       // In the flutter tester environment, we use a predictable-size for font
       // measurement tests.
       !ui_web.debugEmulateFlutterTesterEnvironment) {

--- a/lib/web_ui/lib/src/engine/text_editing/input_action.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/input_action.dart
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import '../browser_detection.dart';
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
+
 import '../dom.dart';
 
 /// Various input action types used in text fields.
@@ -82,8 +83,8 @@ abstract class EngineInputAction {
 
     // Only apply `enterkeyhint` in mobile browsers so that the right virtual
     // keyboard shows up.
-    if (operatingSystem == OperatingSystem.iOs ||
-        operatingSystem == OperatingSystem.android ||
+    if (ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs ||
+        ui_web.browser.operatingSystem == ui_web.OperatingSystem.android ||
         enterkeyhintAttribute == EngineInputAction.none.enterkeyhintAttribute) {
       domElement.setAttribute('enterkeyhint', enterkeyhintAttribute!);
     }

--- a/lib/web_ui/lib/src/engine/text_editing/input_type.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/input_type.dart
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import '../browser_detection.dart';
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
+
 import '../dom.dart';
 
 /// Various types of inputs used in text fields.
@@ -81,8 +82,8 @@ abstract class EngineInputType {
 
     // Only apply `inputmode` in mobile browsers so that the right virtual
     // keyboard shows up.
-    if (operatingSystem == OperatingSystem.iOs ||
-        operatingSystem == OperatingSystem.android ||
+    if (ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs ||
+        ui_web.browser.operatingSystem == ui_web.OperatingSystem.android ||
         inputmodeAttribute == EngineInputType.none.inputmodeAttribute) {
       domElement.setAttribute('inputmode', inputmodeAttribute!);
     }

--- a/lib/web_ui/lib/src/engine/text_editing/text_capitalization.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_capitalization.dart
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import '../browser_detection.dart';
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
+
 import '../dom.dart';
 
 /// Controls the capitalization of the text.
@@ -64,7 +65,7 @@ class TextCapitalizationConfig {
         // TODO(mdebbar): There is a bug for `words` level capitalization in IOS now.
         // For now go back to default. Remove the check after bug is resolved.
         // https://bugs.webkit.org/show_bug.cgi?id=148504
-        if (browserEngine == BrowserEngine.webkit) {
+        if (ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit) {
           autocapitalize = 'sentences';
         } else {
           autocapitalize = 'words';

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -8,8 +8,8 @@ import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
-import '../browser_detection.dart';
 import '../dom.dart';
 import '../mouse/prevent_default.dart';
 import '../platform_dispatcher.dart';
@@ -41,8 +41,8 @@ const int offScreenOffset = -9999;
 /// Blink and Webkit engines, bring an overlay on top of the text field when it
 /// is autofilled.
 bool browserHasAutofillOverlay() =>
-    browserEngine == BrowserEngine.blink ||
-    browserEngine == BrowserEngine.webkit;
+    ui_web.browser.browserEngine == ui_web.BrowserEngine.blink ||
+    ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit;
 
 /// `transparentTextEditing` class is configured to make the autofill overlay
 /// transparent.
@@ -1992,13 +1992,13 @@ class TextInputSetClient extends TextInputCommand {
 DefaultTextEditingStrategy createDefaultTextEditingStrategy(HybridTextEditing textEditing) {
   DefaultTextEditingStrategy strategy;
 
-  if(operatingSystem == OperatingSystem.iOs) {
+  if(ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs) {
     strategy = IOSTextEditingStrategy(textEditing);
-  } else if(operatingSystem == OperatingSystem.android) {
+  } else if(ui_web.browser.operatingSystem == ui_web.OperatingSystem.android) {
     strategy = AndroidTextEditingStrategy(textEditing);
-  } else if(browserEngine == BrowserEngine.webkit) {
+  } else if(ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit) {
     strategy = SafariDesktopTextEditingStrategy(textEditing);
-  } else if(browserEngine == BrowserEngine.firefox) {
+  } else if(ui_web.browser.browserEngine == ui_web.BrowserEngine.firefox) {
     strategy = FirefoxTextEditingStrategy(textEditing);
   } else {
     strategy = GloballyPositionedTextEditingStrategy(textEditing);

--- a/lib/web_ui/lib/src/engine/util.dart
+++ b/lib/web_ui/lib/src/engine/util.dart
@@ -9,8 +9,9 @@ import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
-import 'browser_detection.dart';
+import 'browser_detection.dart' show isIOS15, isMacOrIOS;
 import 'dom.dart';
 import 'safe_browser_api.dart';
 import 'services.dart';
@@ -495,7 +496,7 @@ Float32List offsetListToFloat32List(List<ui.Offset> offsetList) {
 /// * Use 3D transform instead of 2D: this does not work because it causes text
 ///   blurriness: https://github.com/flutter/flutter/issues/32274
 void applyWebkitClipFix(DomElement? containerElement) {
-  if (browserEngine == BrowserEngine.webkit) {
+  if (ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit) {
     containerElement!.style.zIndex = '0';
   }
 }
@@ -690,7 +691,7 @@ void setElementStyle(DomElement element, String name, String? value) {
 }
 
 void setClipPath(DomElement element, String? value) {
-  if (browserEngine == BrowserEngine.webkit) {
+  if (ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit) {
     if (value == null) {
       element.style.removeProperty('-webkit-clip-path');
     } else {

--- a/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/full_page_dimensions_provider.dart
+++ b/lib/web_ui/lib/src/engine/view_embedder/dimensions_provider/full_page_dimensions_provider.dart
@@ -4,11 +4,11 @@
 
 import 'dart:async';
 
-import 'package:ui/src/engine/browser_detection.dart';
 import 'package:ui/src/engine/display.dart';
 import 'package:ui/src/engine/dom.dart';
 import 'package:ui/src/engine/window.dart';
 import 'package:ui/ui.dart' as ui show Size;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import 'dimensions_provider.dart';
 
@@ -71,7 +71,7 @@ class FullPageDimensionsProvider extends DimensionsProvider {
     final double devicePixelRatio = EngineFlutterDisplay.instance.devicePixelRatio;
 
     if (viewport != null) {
-      if (operatingSystem == OperatingSystem.iOs) {
+      if (ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs) {
         /// Chrome on iOS reports incorrect viewport.height when app
         /// starts in portrait orientation and the phone is rotated to
         /// landscape.
@@ -108,7 +108,7 @@ class FullPageDimensionsProvider extends DimensionsProvider {
     late double windowInnerHeight;
 
     if (viewport != null) {
-      if (operatingSystem == OperatingSystem.iOs && !isEditingOnMobile) {
+      if (ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs && !isEditingOnMobile) {
         windowInnerHeight =
             domDocument.documentElement!.clientHeight * devicePixelRatio;
       } else {

--- a/lib/web_ui/lib/ui_web/src/ui_web.dart
+++ b/lib/web_ui/lib/ui_web/src/ui_web.dart
@@ -10,6 +10,7 @@ library ui_web;
 
 export 'ui_web/asset_manager.dart';
 export 'ui_web/benchmarks.dart';
+export 'ui_web/browser_detection.dart';
 export 'ui_web/flutter_views_proxy.dart';
 export 'ui_web/images.dart';
 export 'ui_web/initialization.dart';

--- a/lib/web_ui/lib/ui_web/src/ui_web/browser_detection.dart
+++ b/lib/web_ui/lib/ui_web/src/ui_web/browser_detection.dart
@@ -1,0 +1,205 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:meta/meta.dart';
+
+import 'package:ui/src/engine/dom.dart' show DomNavigatorExtension, DomWindowExtension, domWindow;
+
+/// The HTML engine used by the current browser.
+enum BrowserEngine {
+  /// The engine that powers Chrome, Samsung Internet Browser, UC Browser,
+  /// Microsoft Edge, Opera, and others.
+  ///
+  /// Blink is assumed in case when a more precise browser engine wasn't
+  /// detected.
+  blink,
+  /// The engine that powers Safari.
+  webkit,
+  /// The engine that powers Firefox.
+  firefox,
+}
+
+/// Operating system where the current browser runs.
+///
+/// Taken from the navigator platform.
+/// <https://developer.mozilla.org/en-US/docs/Web/API/NavigatorID/platform>
+enum OperatingSystem {
+  /// iOS: <http://www.apple.com/ios/>
+  iOs,
+  /// Android: <https://www.android.com/>
+  android,
+  /// Linux: <https://www.linux.org/>
+  linux,
+  /// Windows: <https://www.microsoft.com/windows/>
+  windows,
+  /// MacOs: <https://www.apple.com/macos/>
+  macOs,
+  /// We were unable to detect the current operating system.
+  unknown,
+}
+
+// List of Operating Systems we know to be working on laptops/desktops.
+//
+// These devices tend to behave differently on many core issues such as events,
+// screen readers, input devices.
+const Set<OperatingSystem> _desktopOperatingSystems = <OperatingSystem>{
+  OperatingSystem.macOs,
+  OperatingSystem.linux,
+  OperatingSystem.windows,
+};
+
+/// The core Browser Detection functionality from the Flutter web engine.
+class BrowserDetection {
+  BrowserDetection._();
+
+  /// The singleton instance of the [BrowserDetection] class.
+  static final BrowserDetection instance = BrowserDetection._();
+
+  /// Returns the User Agent of the current browser.
+  String get userAgent => debugUserAgentOverride ?? _userAgent;
+
+  /// Override value for [userAgent].
+  ///
+  /// Setting this to `null` uses the default [domWindow.navigator.userAgent].
+  @visibleForTesting
+  String? debugUserAgentOverride;
+
+  // Lazily initialized current user agent.
+  late final String _userAgent = _detectUserAgent();
+
+  String _detectUserAgent() {
+    return domWindow.navigator.userAgent;
+  }
+
+  /// Returns the [BrowserEngine] used by the current browser.
+  ///
+  /// This is used to implement browser-specific behavior.
+  BrowserEngine get browserEngine {
+    return debugBrowserEngineOverride ?? _browserEngine;
+  }
+
+  /// Override the value of [browserEngine].
+  ///
+  /// Setting this to `null` lets [browserEngine] detect the browser that the
+  /// app is running on.
+  @visibleForTesting
+  BrowserEngine? debugBrowserEngineOverride;
+
+  // Lazily initialized current browser engine.
+  late final BrowserEngine _browserEngine = _detectBrowserEngine();
+
+  BrowserEngine _detectBrowserEngine() {
+    final String vendor = domWindow.navigator.vendor;
+    final String agent = userAgent.toLowerCase();
+    return detectBrowserEngineByVendorAgent(vendor, agent);
+  }
+
+  /// Detects browser engine for a given vendor and agent string.
+  @visibleForTesting
+  BrowserEngine detectBrowserEngineByVendorAgent(String vendor, String agent) {
+    if (vendor == 'Google Inc.') {
+      return BrowserEngine.blink;
+    } else if (vendor == 'Apple Computer, Inc.') {
+      return BrowserEngine.webkit;
+    } else if (agent.contains('Edg/')) {
+      // Chromium based Microsoft Edge has `Edg` in the user-agent.
+      // https://docs.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-string
+      return BrowserEngine.blink;
+    } else if (vendor == '' && agent.contains('firefox')) {
+      // An empty string means firefox:
+      // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/vendor
+      return BrowserEngine.firefox;
+    }
+
+    // Assume Blink otherwise, but issue a warning.
+    print(
+        'WARNING: failed to detect current browser engine. Assuming this is a Chromium-compatible browser.');
+    return BrowserEngine.blink;
+  }
+
+  /// Returns the [OperatingSystem] the current browsers works on.
+  ///
+  /// This is used to implement operating system specific behavior such as
+  /// soft keyboards.
+  OperatingSystem get operatingSystem {
+    return debugOperatingSystemOverride ?? _operatingSystem;
+  }
+
+  /// Override the value of [operatingSystem].
+  ///
+  /// Setting this to `null` lets [operatingSystem] detect the real OS that the
+  /// app is running on.
+  ///
+  /// This is intended to be used for testing and debugging only.
+  OperatingSystem? debugOperatingSystemOverride;
+
+  /// Lazily initialized current operating system.
+  late final OperatingSystem _operatingSystem = detectOperatingSystem();
+
+  /// Detects operating system using platform and UA used for unit testing.
+  @visibleForTesting
+  OperatingSystem detectOperatingSystem({
+    String? overridePlatform,
+    int? overrideMaxTouchPoints,
+  }) {
+    final String platform = overridePlatform ?? domWindow.navigator.platform!;
+
+    if (platform.startsWith('Mac')) {
+      // iDevices requesting a "desktop site" spoof their UA so it looks like a Mac.
+      // This checks if we're in a touch device, or on a real mac.
+      final int maxTouchPoints = overrideMaxTouchPoints ??
+          domWindow.navigator.maxTouchPoints?.toInt() ??
+          0;
+      if (maxTouchPoints > 2) {
+        return OperatingSystem.iOs;
+      }
+      return OperatingSystem.macOs;
+    } else if (platform.toLowerCase().contains('iphone') ||
+        platform.toLowerCase().contains('ipad') ||
+        platform.toLowerCase().contains('ipod')) {
+      return OperatingSystem.iOs;
+    } else if (userAgent.contains('Android')) {
+      // The Android OS reports itself as "Linux armv8l" in
+      // [domWindow.navigator.platform]. So we have to check the user-agent to
+      // determine if the OS is Android or not.
+      return OperatingSystem.android;
+    } else if (platform.startsWith('Linux')) {
+      return OperatingSystem.linux;
+    } else if (platform.startsWith('Win')) {
+      return OperatingSystem.windows;
+    } else {
+      return OperatingSystem.unknown;
+    }
+  }
+
+  /// A flag to check if the current [operatingSystem] is a laptop/desktop
+  /// operating system.
+  bool get isDesktop => _desktopOperatingSystems.contains(operatingSystem);
+
+  /// A flag to check if the current browser is running on a mobile device.
+  ///
+  /// Flutter web considers "mobile" everything that not [isDesktop].
+  bool get isMobile => !isDesktop;
+
+  /// Whether the current [browserEngine] is [BrowserEngine.blink] (Chrom(e|ium)).
+  bool get isChromium => browserEngine == BrowserEngine.blink;
+
+  /// Whether the current [browserEngine] is [BrowserEngine.webkit] (Safari).
+  bool get isSafari => browserEngine == BrowserEngine.webkit;
+
+  /// Whether the current [browserEngine] is [BrowserEngine.firefox].
+  bool get isFirefox => browserEngine == BrowserEngine.firefox;
+
+  /// Whether the current browser is Edge.
+  bool get isEdge => userAgent.contains('Edg/');
+
+  /// Whether we are running from a wasm module compiled with dart2wasm.
+  ///
+  /// Note: Currently the ffi library is available from dart2wasm but not dart2js
+  /// or dartdevc.
+  bool get isWasm => const bool.fromEnvironment('dart.library.ffi');
+}
+
+/// A short-hand accessor to the [BrowserDetection.instance] singleton.
+BrowserDetection browser = BrowserDetection.instance;

--- a/lib/web_ui/test/canvaskit/canvaskit_api_tt_on_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_tt_on_test.dart
@@ -5,11 +5,12 @@
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../common/matchers.dart';
 import 'canvaskit_api_test.dart';
 
-final bool isBlink = browserEngine == BrowserEngine.blink;
+final bool isBlink = ui_web.browser.browserEngine == ui_web.BrowserEngine.blink;
 
 const String goodUrl = 'https://www.unpkg.com/blah-blah/33.x/canvaskit.js';
 const String badUrl = 'https://www.unpkg.com/soemthing/not-canvaskit.js';

--- a/lib/web_ui/test/engine/browser_detect_test.dart
+++ b/lib/web_ui/test/engine/browser_detect_test.dart
@@ -2,12 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:js_interop';
-
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
-import 'package:ui/src/engine/browser_detection.dart';
-import 'package:ui/src/engine/safe_browser_api.dart';
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 void main() {
   internalBootstrapBrowserTest(() => testMain);
@@ -17,90 +14,90 @@ void testMain() {
   group('detectBrowserEngineByVendorAgent', () {
     test('Should detect Blink', () {
       // Chrome Version 89.0.4389.90 (Official Build) (x86_64) / MacOS
-      final BrowserEngine browserEngine = detectBrowserEngineByVendorAgent(
+      final ui_web.BrowserEngine browserEngine = ui_web.browser.detectBrowserEngineByVendorAgent(
           'Google Inc.',
           'mozilla/5.0 (macintosh; intel mac os x 11_2_3) applewebkit/537.36 '
               '(khtml, like gecko) chrome/89.0.4389.90 safari/537.36');
-      expect(browserEngine, BrowserEngine.blink);
+      expect(browserEngine, ui_web.BrowserEngine.blink);
     });
 
     test('Should detect Firefox', () {
       // 85.0.2 (64-bit) / MacOS
-      final BrowserEngine browserEngine = detectBrowserEngineByVendorAgent(
+      final ui_web.BrowserEngine browserEngine = ui_web.browser.detectBrowserEngineByVendorAgent(
           '',
           'mozilla/5.0 (macintosh; intel mac os x 10.16; rv:85.0) '
               'gecko/20100101 firefox/85.0');
-      expect(browserEngine, BrowserEngine.firefox);
+      expect(browserEngine, ui_web.BrowserEngine.firefox);
     });
 
     test('Should detect Safari', () {
-      final BrowserEngine browserEngine = detectBrowserEngineByVendorAgent(
+      final ui_web.BrowserEngine browserEngine = ui_web.browser.detectBrowserEngineByVendorAgent(
           'Apple Computer, Inc.',
           'mozilla/5.0 (macintosh; intel mac os x 10_15_6) applewebkit/605.1.15 '
               '(khtml, like gecko) version/14.0.3 safari/605.1.15');
-      expect(browserEngine, BrowserEngine.webkit);
+      expect(browserEngine, ui_web.BrowserEngine.webkit);
     });
   });
 
   group('detectOperatingSystem', () {
     void expectOs(
-      OperatingSystem expectedOs, {
+      ui_web.OperatingSystem expectedOs, {
       String platform = 'any',
       String ua = 'any',
       int touchPoints = 0,
     }) {
       try {
-        getUserAgent = () => ua;
+        ui_web.browser.debugUserAgentOverride = ua;
         expect(
-          detectOperatingSystem(
+          ui_web.browser.detectOperatingSystem(
             overridePlatform: platform,
             overrideMaxTouchPoints: touchPoints,
           ),
           expectedOs,
         );
       } finally {
-        getUserAgent = defaultGetUserAgent;
+        ui_web.browser.debugUserAgentOverride = null;
       }
     }
 
     test('Determine unknown for weird values of platform/ua', () {
-      expectOs(OperatingSystem.unknown);
+      expectOs(ui_web.OperatingSystem.unknown);
     });
 
     test('Determine MacOS if platform starts by Mac', () {
       expectOs(
-        OperatingSystem.macOs,
+        ui_web.OperatingSystem.macOs,
         platform: 'MacIntel',
       );
       expectOs(
-        OperatingSystem.macOs,
+        ui_web.OperatingSystem.macOs,
         platform: 'MacAnythingElse',
       );
     });
 
     test('Determine iOS if platform contains iPhone/iPad/iPod', () {
       expectOs(
-        OperatingSystem.iOs,
+        ui_web.OperatingSystem.iOs,
         platform: 'iPhone',
       );
       expectOs(
-        OperatingSystem.iOs,
+        ui_web.OperatingSystem.iOs,
         platform: 'iPhone Simulator',
       );
       expectOs(
-        OperatingSystem.iOs,
+        ui_web.OperatingSystem.iOs,
         platform: 'iPad',
       );
       expectOs(
-        OperatingSystem.iOs,
+        ui_web.OperatingSystem.iOs,
         platform: 'iPad Simulator',
       );
       expectOs(
-        OperatingSystem.iOs,
+        ui_web.OperatingSystem.iOs,
         platform: 'iPod',
       );
       expectOs(
-        OperatingSystem.iOs,
+        ui_web.OperatingSystem.iOs,
         platform: 'iPod Simulator',
       );
     });
@@ -108,12 +105,12 @@ void testMain() {
     // See https://github.com/flutter/flutter/issues/81918
     test('Tell apart MacOS from iOS requesting a desktop site.', () {
       expectOs(
-        OperatingSystem.macOs,
+        ui_web.OperatingSystem.macOs,
         platform: 'MacARM',
       );
 
       expectOs(
-        OperatingSystem.iOs,
+        ui_web.OperatingSystem.iOs,
         platform: 'MacARM',
         touchPoints: 5,
       );
@@ -121,119 +118,43 @@ void testMain() {
 
     test('Determine Android if user agent contains Android', () {
       expectOs(
-        OperatingSystem.android,
+        ui_web.OperatingSystem.android,
         ua: 'Mozilla/5.0 (Linux; U; Android 2.2) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1',
       );
     });
 
     test('Determine Linux if the platform begins with Linux', () {
       expectOs(
-        OperatingSystem.linux,
+        ui_web.OperatingSystem.linux,
         platform: 'Linux',
       );
       expectOs(
-        OperatingSystem.linux,
+        ui_web.OperatingSystem.linux,
         platform: 'Linux armv8l',
       );
       expectOs(
-        OperatingSystem.linux,
+        ui_web.OperatingSystem.linux,
         platform: 'Linux x86_64',
       );
     });
 
     test('Determine Windows if the platform begins with Win', () {
       expectOs(
-        OperatingSystem.windows,
+        ui_web.OperatingSystem.windows,
         platform: 'Windows',
       );
       expectOs(
-        OperatingSystem.windows,
+        ui_web.OperatingSystem.windows,
         platform: 'Win32',
       );
       expectOs(
-        OperatingSystem.windows,
+        ui_web.OperatingSystem.windows,
         platform: 'Win16',
       );
       expectOs(
-        OperatingSystem.windows,
+        ui_web.OperatingSystem.windows,
         platform: 'WinCE',
       );
     });
   });
-
-  group('browserSupportsCanvasKitChromium', () {
-    JSAny? oldV8BreakIterator = v8BreakIterator;
-    JSAny? oldIntlSegmenter = intlSegmenter;
-
-    setUp(() {
-      oldV8BreakIterator = v8BreakIterator;
-      oldIntlSegmenter = intlSegmenter;
-    });
-    tearDown(() {
-      v8BreakIterator = oldV8BreakIterator;
-      intlSegmenter = oldIntlSegmenter;
-      debugResetBrowserSupportsImageDecoder();
-    });
-
-    test('Detect browsers that support CanvasKit Chromium', () {
-      v8BreakIterator = Object().toJSBox; // Any non-null value.
-      intlSegmenter = Object().toJSBox; // Any non-null value.
-      browserSupportsImageDecoder = true;
-
-      expect(browserSupportsCanvaskitChromium, isTrue);
-    });
-
-    test('Detect browsers that do not support image codecs', () {
-      v8BreakIterator = Object().toJSBox; // Any non-null value.
-      intlSegmenter = Object().toJSBox; // Any non-null value.
-      browserSupportsImageDecoder = false;
-
-      // TODO(mdebbar): we don't check image codecs for now.
-      // https://github.com/flutter/flutter/issues/122331
-      expect(browserSupportsCanvaskitChromium, isTrue);
-    });
-
-    test('Detect browsers that do not support v8BreakIterator', () {
-      v8BreakIterator = null;
-      intlSegmenter = Object().toJSBox; // Any non-null value.
-      browserSupportsImageDecoder = true;
-
-      expect(browserSupportsCanvaskitChromium, isFalse);
-    });
-
-    test('Detect browsers that support neither', () {
-      v8BreakIterator = null;
-      intlSegmenter = Object().toJSBox; // Any non-null value.
-      browserSupportsImageDecoder = false;
-
-      expect(browserSupportsCanvaskitChromium, isFalse);
-    });
-
-    test('Detect browsers that support v8BreakIterator but no Intl.Segmenter', () {
-      v8BreakIterator = Object().toJSBox; // Any non-null value.
-      intlSegmenter = null;
-
-      expect(browserSupportsCanvaskitChromium, isFalse);
-    });
-  });
-
-  group('OffscreenCanvas', () {
-    test('OffscreenCanvas is detected as unsupported in Safari', () {
-      debugBrowserEngineOverride = BrowserEngine.webkit;
-      expect(OffScreenCanvas.supported, isFalse);
-      debugBrowserEngineOverride = null;
-    });
-  });
 }
-
-@JS('window.Intl.v8BreakIterator')
-external JSAny? get v8BreakIterator;
-
-@JS('window.Intl.v8BreakIterator')
-external set v8BreakIterator(JSAny? x);
-
-@JS('window.Intl.Segmenter')
-external JSAny? get intlSegmenter;
-
-@JS('window.Intl.Segmenter')
-external set intlSegmenter(JSAny? x);

--- a/lib/web_ui/test/engine/composition_test.dart
+++ b/lib/web_ui/test/engine/composition_test.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../common/test_initialization.dart';
 
@@ -354,6 +355,6 @@ Future<void> testMain() async {
     // it's likely that this will be fixed by https://github.com/flutter/flutter/issues/105243.
     // Until the refactor gets merged, this test should run on all other browsers to prevent
     // regressions in the meantime.
-    skip: browserEngine == BrowserEngine.firefox);
+    skip: ui_web.browser.browserEngine == ui_web.BrowserEngine.firefox);
   });
 }

--- a/lib/web_ui/test/engine/engine_browser_detect_test.dart
+++ b/lib/web_ui/test/engine/engine_browser_detect_test.dart
@@ -1,0 +1,93 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:js_interop';
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine/browser_detection.dart';
+import 'package:ui/src/engine/safe_browser_api.dart';
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  group('browserSupportsCanvasKitChromium', () {
+    JSAny? oldV8BreakIterator = v8BreakIterator;
+    JSAny? oldIntlSegmenter = intlSegmenter;
+
+    setUp(() {
+      oldV8BreakIterator = v8BreakIterator;
+      oldIntlSegmenter = intlSegmenter;
+    });
+    tearDown(() {
+      v8BreakIterator = oldV8BreakIterator;
+      intlSegmenter = oldIntlSegmenter;
+      debugResetBrowserSupportsImageDecoder();
+    });
+
+    test('Detect browsers that support CanvasKit Chromium', () {
+      v8BreakIterator = Object().toJSBox; // Any non-null value.
+      intlSegmenter = Object().toJSBox; // Any non-null value.
+      browserSupportsImageDecoder = true;
+
+      expect(browserSupportsCanvaskitChromium, isTrue);
+    });
+
+    test('Detect browsers that do not support image codecs', () {
+      v8BreakIterator = Object().toJSBox; // Any non-null value.
+      intlSegmenter = Object().toJSBox; // Any non-null value.
+      browserSupportsImageDecoder = false;
+
+      // TODO(mdebbar): we don't check image codecs for now.
+      // https://github.com/flutter/flutter/issues/122331
+      expect(browserSupportsCanvaskitChromium, isTrue);
+    });
+
+    test('Detect browsers that do not support v8BreakIterator', () {
+      v8BreakIterator = null;
+      intlSegmenter = Object().toJSBox; // Any non-null value.
+      browserSupportsImageDecoder = true;
+
+      expect(browserSupportsCanvaskitChromium, isFalse);
+    });
+
+    test('Detect browsers that support neither', () {
+      v8BreakIterator = null;
+      intlSegmenter = Object().toJSBox; // Any non-null value.
+      browserSupportsImageDecoder = false;
+
+      expect(browserSupportsCanvaskitChromium, isFalse);
+    });
+
+    test('Detect browsers that support v8BreakIterator but no Intl.Segmenter', () {
+      v8BreakIterator = Object().toJSBox; // Any non-null value.
+      intlSegmenter = null;
+
+      expect(browserSupportsCanvaskitChromium, isFalse);
+    });
+  });
+
+  group('OffscreenCanvas', () {
+    test('OffscreenCanvas is detected as unsupported in Safari', () {
+      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
+      expect(OffScreenCanvas.supported, isFalse);
+      ui_web.browser.debugBrowserEngineOverride = null;
+    });
+  });
+}
+
+@JS('window.Intl.v8BreakIterator')
+external JSAny? get v8BreakIterator;
+
+@JS('window.Intl.v8BreakIterator')
+external set v8BreakIterator(JSAny? x);
+
+@JS('window.Intl.Segmenter')
+external JSAny? get intlSegmenter;
+
+@JS('window.Intl.Segmenter')
+external set intlSegmenter(JSAny? x);

--- a/lib/web_ui/test/engine/keyboard_converter_test.dart
+++ b/lib/web_ui/test/engine/keyboard_converter_test.dart
@@ -8,6 +8,7 @@ import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../common/keyboard_test_common.dart';
 
@@ -86,7 +87,7 @@ void testMain() {
       keyDataList.add(key);
       // Only handle down events
       return key.type == ui.KeyEventType.down;
-    }, OperatingSystem.linux);
+    }, ui_web.OperatingSystem.linux);
 
     converter.handleEvent(keyDownEvent('KeyA', 'a')..timeStamp = 1);
     expectKeyData(keyDataList.last,
@@ -139,7 +140,7 @@ void testMain() {
       keyDataList.add(key);
       // Only handle down events
       return key.type == ui.KeyEventType.down;
-    }, OperatingSystem.windows);
+    }, ui_web.OperatingSystem.windows);
 
     // en-in.win, with AltGr
     converter.handleEvent(keyDownEvent('KeyL', 'l̥', kCtrl | kAlt)..timeStamp = 1);
@@ -159,7 +160,7 @@ void testMain() {
       keyDataList.add(key);
       // Only handle down events
       return key.type == ui.KeyEventType.down;
-    }, OperatingSystem.linux);
+    }, ui_web.OperatingSystem.linux);
 
     converter.handleEvent(keyDownEvent('ShiftLeft', 'Shift', kShift, kLocationLeft));
     expectKeyData(keyDataList.last,
@@ -237,7 +238,7 @@ void testMain() {
     final KeyboardConverter converter = KeyboardConverter((ui.KeyData key) {
       keyDataList.add(key);
       return true;
-    }, OperatingSystem.linux);
+    }, ui_web.OperatingSystem.linux);
 
     converter.handleEvent(keyDownEvent('ShiftLeft', 'Shift', kShift, kLocationLeft));
     expectKeyData(keyDataList.last,
@@ -281,7 +282,7 @@ void testMain() {
     final KeyboardConverter converter = KeyboardConverter((ui.KeyData key) {
       keyDataList.add(key);
       return true;
-    }, OperatingSystem.linux);
+    }, ui_web.OperatingSystem.linux);
 
     converter.handleEvent(keyDownEvent('', 'Shift', kShift));
     expectKeyData(keyDataList.last,
@@ -361,7 +362,7 @@ void testMain() {
     final KeyboardConverter converter = KeyboardConverter((ui.KeyData key) {
       keyDataList.add(key);
       return true;
-    }, OperatingSystem.linux);
+    }, ui_web.OperatingSystem.linux);
 
     converter.handleEvent(keyDownEvent('Digit1', '1'));
     expectKeyData(keyDataList.last,
@@ -405,7 +406,7 @@ void testMain() {
     final KeyboardConverter converter = KeyboardConverter((ui.KeyData key) {
       keyDataList.add(key);
       return true;
-    }, OperatingSystem.linux);
+    }, ui_web.OperatingSystem.linux);
 
     // The absolute values of the following logical keys are not guaranteed.
     const int kLogicalAltE = 0x1740070008;
@@ -485,7 +486,7 @@ void testMain() {
     final KeyboardConverter converter = KeyboardConverter((ui.KeyData key) {
       keyDataList.add(key);
       return true;
-    }, OperatingSystem.linux);
+    }, ui_web.OperatingSystem.linux);
 
     converter.handleEvent(keyDownEvent('ShiftLeft', 'Shift', kShift, kLocationLeft));
     expect(MockKeyboardEvent.lastDefaultPrevented, isTrue);
@@ -530,7 +531,7 @@ void testMain() {
     final KeyboardConverter converter = KeyboardConverter((ui.KeyData key) {
       keyDataList.add(key);
       return true;
-    }, OperatingSystem.linux);
+    }, ui_web.OperatingSystem.linux);
 
     // This test simulates the use of 'BracketLeft' on a french keyboard, see:
     // https://github.com/flutter/flutter/issues/126247#issuecomment-1856112566.
@@ -572,7 +573,7 @@ void testMain() {
     final KeyboardConverter converter = KeyboardConverter((ui.KeyData key) {
       keyDataList.add(key);
       return true;
-    }, OperatingSystem.linux);
+    }, ui_web.OperatingSystem.linux);
 
     // A KeyDown of ShiftRight is missed due to loss of focus.
     converter.handleEvent(keyUpEvent('ShiftRight', 'Shift', 0, kLocationRight));
@@ -587,7 +588,7 @@ void testMain() {
     final KeyboardConverter converter = KeyboardConverter((ui.KeyData key) {
       keyDataList.add(key);
       return true;
-    }, OperatingSystem.linux);
+    }, ui_web.OperatingSystem.linux);
 
     // Same layout
     converter.handleEvent(keyDownEvent('KeyA', 'a'));
@@ -622,7 +623,7 @@ void testMain() {
     );
   });
 
-  for (final OperatingSystem system in <OperatingSystem>[OperatingSystem.macOs, OperatingSystem.iOs]) {
+  for (final ui_web.OperatingSystem system in <ui_web.OperatingSystem>[ui_web.OperatingSystem.macOs, ui_web.OperatingSystem.iOs]) {
     testFakeAsync('CapsLock down synthesizes an immediate cancel on $system', (FakeAsync async) {
       final List<ui.KeyData> keyDataList = <ui.KeyData>[];
       final KeyboardConverter converter = KeyboardConverter((ui.KeyData key) {
@@ -706,7 +707,7 @@ void testMain() {
     final KeyboardConverter converter = KeyboardConverter((ui.KeyData key) {
       keyDataList.add(key);
       return true;
-    }, OperatingSystem.linux);
+    }, ui_web.OperatingSystem.linux);
 
     converter.handleEvent(keyDownEvent('CapsLock', 'CapsLock'));
     expect(keyDataList, hasLength(1));
@@ -755,7 +756,7 @@ void testMain() {
     );
   });
 
-  for (final OperatingSystem system in <OperatingSystem>[OperatingSystem.macOs, OperatingSystem.iOs]) {
+  for (final ui_web.OperatingSystem system in <ui_web.OperatingSystem>[ui_web.OperatingSystem.macOs, ui_web.OperatingSystem.iOs]) {
     testFakeAsync('Key guards: key down events are guarded on $system', (FakeAsync async) {
       final List<ui.KeyData> keyDataList = <ui.KeyData>[];
       final KeyboardConverter converter = KeyboardConverter((ui.KeyData key) {
@@ -831,7 +832,7 @@ void testMain() {
     final KeyboardConverter converter = KeyboardConverter((ui.KeyData key) {
       keyDataList.add(key);
       return true;
-    }, OperatingSystem.macOs);
+    }, ui_web.OperatingSystem.macOs);
 
     converter.handleEvent(keyDownEvent('MetaLeft', 'Meta', kMeta, kLocationLeft)..timeStamp = 100);
     async.elapse(const Duration(milliseconds: 100));
@@ -898,7 +899,7 @@ void testMain() {
     final KeyboardConverter converter = KeyboardConverter((ui.KeyData key) {
       keyDataList.add(key);
       return true;
-    }, OperatingSystem.macOs);
+    }, ui_web.OperatingSystem.macOs);
 
     converter.handleEvent(keyDownEvent('MetaLeft', 'Meta', kMeta, kLocationLeft)..timeStamp = 100);
     async.elapse(const Duration(milliseconds: 100));
@@ -959,7 +960,7 @@ void testMain() {
     final KeyboardConverter converter = KeyboardConverter((ui.KeyData key) {
       keyDataList.add(key);
       return true;
-    }, OperatingSystem.linux);
+    }, ui_web.OperatingSystem.linux);
 
     converter.handleEvent(keyDownEvent('MetaLeft', 'Meta', kMeta, kLocationLeft)..timeStamp = 100);
     async.elapse(const Duration(milliseconds: 100));
@@ -984,7 +985,7 @@ void testMain() {
     final KeyboardConverter converter = KeyboardConverter((ui.KeyData key) {
       keyDataList.add(key);
       return true;
-    }, OperatingSystem.linux);
+    }, ui_web.OperatingSystem.linux);
 
     converter.handleEvent(keyDownEvent('ScrollLock', 'ScrollLock'));
     expect(keyDataList, hasLength(1));
@@ -1035,7 +1036,7 @@ void testMain() {
     final KeyboardConverter converter = KeyboardConverter((ui.KeyData key) {
       keyDataList.add(key);
       return true;
-    }, OperatingSystem.linux);
+    }, ui_web.OperatingSystem.linux);
 
     converter.handleEvent(keyDownEvent('ShiftRight', 'Shift', kShift, kLocationRight));
     expectKeyData(keyDataList.last,
@@ -1096,7 +1097,7 @@ void testMain() {
     final KeyboardConverter converter = KeyboardConverter((ui.KeyData key) {
       keyDataList.add(key);
       return true;
-    }, OperatingSystem.linux);
+    }, ui_web.OperatingSystem.linux);
 
     converter.handleEvent(keyDownEvent('ShiftLeft', 'Shift', kShift, kLocationLeft));
     expectKeyData(keyDataList.last,
@@ -1149,7 +1150,7 @@ void testMain() {
     final KeyboardConverter converter = KeyboardConverter((ui.KeyData key) {
       keyDataList.add(key);
       return true;
-    }, OperatingSystem.linux);
+    }, ui_web.OperatingSystem.linux);
 
     converter.handleEvent(keyDownEvent(null, null));
     converter.handleEvent(keyUpEvent(null, null));

--- a/lib/web_ui/test/engine/pointer_binding_test.dart
+++ b/lib/web_ui/test/engine/pointer_binding_test.dart
@@ -8,6 +8,7 @@ import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import 'keyboard_converter_test.dart';
 
@@ -46,7 +47,7 @@ void testMain() {
     return KeyboardConverter((ui.KeyData key) {
       keyDataList.add(key);
       return true;
-    }, OperatingSystem.linux);
+    }, ui_web.OperatingSystem.linux);
   }
 
   setUp(() {
@@ -820,7 +821,7 @@ void testMain() {
       final _ButtonedEventMixin context = _PointerEventContext();
 
       const double dpi = 2.5;
-      debugOperatingSystemOverride = OperatingSystem.macOs;
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.macOs;
       EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(dpi);
 
       final List<ui.PointerDataPacket> packets = <ui.PointerDataPacket>[];
@@ -853,7 +854,7 @@ void testMain() {
       expect(packets[0].data[0].scrollDeltaY, equals(10.0 * dpi));
 
       EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(1.0);
-      debugBrowserEngineOverride = null;
+      ui_web.browser.debugBrowserEngineOverride = null;
     },
   );
 
@@ -1108,7 +1109,7 @@ void testMain() {
         packets.add(packet);
       };
 
-      debugOperatingSystemOverride = OperatingSystem.macOs;
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.macOs;
 
       rootElement.dispatchEvent(context.wheel(
         buttons: 0,
@@ -1197,7 +1198,7 @@ void testMain() {
       expect(packets[2].data[0].scrollDeltaX, equals(0.0));
       expect(packets[2].data[0].scrollDeltaY, equals(240.0));
 
-      debugOperatingSystemOverride = null;
+      ui_web.browser.debugOperatingSystemOverride = null;
     },
   );
 
@@ -2916,7 +2917,7 @@ void _testClickDebouncer({required PointerBinding Function() getBinding}) {
       isEmpty,
     );
     // TODO(yjbanov): https://github.com/flutter/flutter/issues/142991.
-  }, skip: operatingSystem == OperatingSystem.windows);
+  }, skip: ui_web.browser.operatingSystem == ui_web.OperatingSystem.windows);
 
   testWithSemantics('Forwards click if enough time passed after the last flushed pointerup', () async {
     expect(EnginePlatformDispatcher.instance.semanticsEnabled, true);

--- a/lib/web_ui/test/engine/raw_keyboard_test.dart
+++ b/lib/web_ui/test/engine/raw_keyboard_test.dart
@@ -9,6 +9,7 @@ import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 void main() {
   internalBootstrapBrowserTest(() => testMain);
@@ -179,7 +180,7 @@ void testMain() {
         'keyCode': 0,
       });
       RawKeyboard.instance!.dispose();
-    }, skip: operatingSystem != OperatingSystem.linux);
+    }, skip: ui_web.browser.operatingSystem != ui_web.OperatingSystem.linux);
 
     // Regression test for https://github.com/flutter/flutter/issues/141186.
     test('updates meta state for Meta key seen as "Process" key', () {

--- a/lib/web_ui/test/engine/semantics/semantics_helper_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_helper_test.dart
@@ -7,6 +7,7 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine/browser_detection.dart';
 import 'package:ui/src/engine/dom.dart';
 import 'package:ui/src/engine/semantics.dart';
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 void main() {
   internalBootstrapBrowserTest(() => testMain);
@@ -58,7 +59,7 @@ void testMain() {
       expect(shouldForwardToFramework, isTrue);
 
       // Pointer events are not defined in webkit.
-      if (browserEngine != BrowserEngine.webkit) {
+      if (ui_web.browser.browserEngine != ui_web.BrowserEngine.webkit) {
         event = createDomEvent('Event', 'pointermove');
         shouldForwardToFramework =
             desktopSemanticsEnabler.tryEnableSemantics(event);
@@ -160,6 +161,6 @@ void testMain() {
       });
     },
     // We can run `MobileSemanticsEnabler` tests in mobile browsers and in desktop Chrome.
-    skip: isDesktop && browserEngine != BrowserEngine.blink,
+    skip: isDesktop && ui_web.browser.browserEngine != ui_web.BrowserEngine.blink,
   );
 }

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -1393,8 +1393,8 @@ void _testVerticalScrolling() {
     int browserMaxScrollDiff = 0;
     // The max scroll value varies between `9` and `10` for Safari desktop
     // browsers.
-    if (browserEngine == BrowserEngine.webkit &&
-        operatingSystem == OperatingSystem.macOs) {
+    if (ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit &&
+        ui_web.browser.operatingSystem == ui_web.OperatingSystem.macOs) {
       browserMaxScrollDiff = 1;
     }
 
@@ -1544,8 +1544,8 @@ void _testHorizontalScrolling() {
     int browserMaxScrollDiff = 0;
     // The max scroll value varies between `9` and `10` for Safari desktop
     // browsers.
-    if (browserEngine == BrowserEngine.webkit &&
-        operatingSystem == OperatingSystem.macOs) {
+    if (ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit &&
+        ui_web.browser.operatingSystem == ui_web.OperatingSystem.macOs) {
       browserMaxScrollDiff = 1;
     }
     expect(scrollable.scrollLeft >= (10 - browserMaxScrollDiff), isTrue);
@@ -1830,7 +1830,7 @@ void _testTextField() {
     semantics().semanticsEnabled = false;
   }, // TODO(yjbanov): https://github.com/flutter/flutter/issues/46638
       // TODO(yjbanov): https://github.com/flutter/flutter/issues/50590
-      skip: browserEngine != BrowserEngine.blink);
+      skip: ui_web.browser.browserEngine != ui_web.BrowserEngine.blink);
 }
 
 void _testCheckables() {

--- a/lib/web_ui/test/engine/semantics/text_field_test.dart
+++ b/lib/web_ui/test/engine/semantics/text_field_test.dart
@@ -11,6 +11,7 @@ import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart' hide window;
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../../common/test_initialization.dart';
 import 'semantics_tester.dart';
@@ -131,7 +132,7 @@ void testMain() {
       expect(await logger.actionLog.first, ui.SemanticsAction.didLoseAccessibilityFocus);
     }, // TODO(yjbanov): https://github.com/flutter/flutter/issues/46638
        // TODO(yjbanov): https://github.com/flutter/flutter/issues/50590
-    skip: browserEngine != BrowserEngine.blink);
+    skip: ui_web.browser.browserEngine != ui_web.BrowserEngine.blink);
 
     test('Syncs semantic state from framework', () {
       expect(owner().semanticsHost.ownerDocument?.activeElement, domDocument.body);
@@ -479,16 +480,16 @@ void testMain() {
       strategy = SemanticsTextEditingStrategy.instance;
       testTextEditing.debugTextEditingStrategyOverride = strategy;
       testTextEditing.configuration = singlelineConfig;
-      debugBrowserEngineOverride = BrowserEngine.webkit;
-      debugOperatingSystemOverride = OperatingSystem.iOs;
+      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.iOs;
       semantics()
         ..debugOverrideTimestampFunction(() => _testTime)
         ..semanticsEnabled = true;
     });
 
     tearDown(() {
-      debugBrowserEngineOverride = null;
-      debugOperatingSystemOverride = null;
+      ui_web.browser.debugBrowserEngineOverride = null;
+      ui_web.browser.debugOperatingSystemOverride = null;
       semantics().semanticsEnabled = false;
     });
 

--- a/lib/web_ui/test/engine/surface/scene_builder_test.dart
+++ b/lib/web_ui/test/engine/surface/scene_builder_test.dart
@@ -13,6 +13,7 @@ import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../../common/matchers.dart';
 import '../../common/rendering.dart';
@@ -182,7 +183,7 @@ void testMain() {
       expect(picture.updateCount, 0);
       expect(picture.applyPaintCount, 2);
     }, // TODO(yjbanov): https://github.com/flutter/flutter/issues/46638
-        skip: browserEngine == BrowserEngine.firefox);
+        skip: ui_web.browser.browserEngine == ui_web.BrowserEngine.firefox);
   });
 
   group('Compositing order', () {

--- a/lib/web_ui/test/engine/surface/surface_test.dart
+++ b/lib/web_ui/test/engine/surface/surface_test.dart
@@ -6,6 +6,7 @@ import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart';
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../../common/test_initialization.dart';
 
@@ -207,8 +208,8 @@ void testMain() {
     },
         // This method failed on iOS Safari.
         // TODO(ferhat): https://github.com/flutter/flutter/issues/60036
-        skip: browserEngine == BrowserEngine.webkit &&
-            operatingSystem == OperatingSystem.iOs);
+        skip: ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit &&
+            ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs);
 
     test('is retained', () {
       final SceneBuilder builder1 = SceneBuilder();

--- a/lib/web_ui/test/engine/text_editing_test.dart
+++ b/lib/web_ui/test/engine/text_editing_test.dart
@@ -10,6 +10,7 @@ import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../common/spy.dart';
 import '../common/test_initialization.dart';
@@ -206,7 +207,7 @@ Future<void> testMain() async {
       expect(defaultTextEditingRoot.querySelectorAll('input'), hasLength(1));
       final DomElement input = defaultTextEditingRoot.querySelector('input')!;
       expect(editingStrategy!.domElement, input);
-      if (operatingSystem == OperatingSystem.iOs || operatingSystem == OperatingSystem.android){
+      if (ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs || ui_web.browser.operatingSystem == ui_web.OperatingSystem.android){
         expect(input.getAttribute('enterkeyhint'), 'send');
       } else {
         expect(input.getAttribute('enterkeyhint'), null);
@@ -943,8 +944,8 @@ Future<void> testMain() async {
           domDocument.body);
     },
         // Test on ios-safari only.
-        skip: browserEngine != BrowserEngine.webkit ||
-            operatingSystem != OperatingSystem.iOs);
+        skip: ui_web.browser.browserEngine != ui_web.BrowserEngine.webkit ||
+            ui_web.browser.operatingSystem != ui_web.OperatingSystem.iOs);
 
     test('finishAutofillContext closes connection no autofill element',
         () async {
@@ -1393,8 +1394,8 @@ Future<void> testMain() async {
       final DomHTMLInputElement inputElement =
           textEditing!.strategy.domElement! as DomHTMLInputElement;
       expect(inputElement.value, 'abcd');
-      if (!(browserEngine == BrowserEngine.webkit &&
-          operatingSystem == OperatingSystem.macOs)) {
+      if (!(ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit &&
+          ui_web.browser.operatingSystem == ui_web.OperatingSystem.macOs)) {
         // In Safari Desktop Autofill menu appears as soon as an element is
         // focused, therefore the input element is only focused after the
         // location is received.
@@ -1510,8 +1511,8 @@ Future<void> testMain() async {
 
       // Test for mobile Safari. `sentences` is the default attribute for
       // mobile browsers. Check if `off` is added to the input element.
-      if (browserEngine == BrowserEngine.webkit &&
-          operatingSystem == OperatingSystem.iOs) {
+      if (ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit &&
+          ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs) {
         expect(
             textEditing!.strategy.domElement!
                 .getAttribute('autocapitalize'),
@@ -1549,8 +1550,8 @@ Future<void> testMain() async {
       spy.messages.clear();
 
       // Test for mobile Safari.
-      if (browserEngine == BrowserEngine.webkit &&
-          operatingSystem == OperatingSystem.iOs) {
+      if (ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit &&
+          ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs) {
         expect(
             textEditing!.strategy.domElement!
                 .getAttribute('autocapitalize'),
@@ -1610,7 +1611,7 @@ Future<void> testMain() async {
       expect(spy.messages, isEmpty);
     },
         // TODO(mdebbar): https://github.com/flutter/flutter/issues/50590
-        skip: browserEngine == BrowserEngine.webkit);
+        skip: ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit);
 
     test(
         'setClient, show, setEditableSizeAndTransform, setStyle, setEditingState, clearClient',
@@ -1669,8 +1670,8 @@ Future<void> testMain() async {
       );
 
       // For `blink` and `webkit` browser engines the overlay would be hidden.
-      if (browserEngine == BrowserEngine.blink ||
-          browserEngine == BrowserEngine.webkit) {
+      if (ui_web.browser.browserEngine == ui_web.BrowserEngine.blink ||
+          ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit) {
         expect(textEditing!.strategy.domElement!.classList.contains('transparentTextEditing'),
             isTrue);
       } else {
@@ -1683,7 +1684,7 @@ Future<void> testMain() async {
       sendFrameworkMessage(codec.encodeMethodCall(clearClient));
     },
         // TODO(mdebbar): https://github.com/flutter/flutter/issues/50590
-        skip: browserEngine == BrowserEngine.webkit);
+        skip: ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit);
 
     test('input font set successfully with null fontWeightIndex', () {
       final MethodCall setClient = MethodCall(
@@ -1728,7 +1729,7 @@ Future<void> testMain() async {
       hideKeyboard();
     },
         // TODO(mdebbar): https://github.com/flutter/flutter/issues/50590
-        skip: browserEngine == BrowserEngine.webkit);
+        skip: ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit);
 
     test('Canonicalizes font family', () {
       showKeyboard(inputType: 'text');
@@ -1841,7 +1842,7 @@ Future<void> testMain() async {
       spy.messages.clear();
 
       input.setSelectionRange(2, 5);
-      if (browserEngine == BrowserEngine.firefox) {
+      if (ui_web.browser.browserEngine == ui_web.BrowserEngine.firefox) {
         final DomEvent keyup = createDomEvent('Event', 'keyup');
         textEditing!.strategy.domElement!.dispatchEvent(keyup);
       } else {
@@ -1894,7 +1895,7 @@ Future<void> testMain() async {
       spy.messages.clear();
 
       input.setSelectionRange(2, 5);
-      if (browserEngine == BrowserEngine.firefox) {
+      if (ui_web.browser.browserEngine == ui_web.BrowserEngine.firefox) {
         final DomEvent keyup = createDomEvent('Event', 'keyup');
         textEditing!.strategy.domElement!.dispatchEvent(keyup);
       } else {
@@ -2128,7 +2129,7 @@ Future<void> testMain() async {
       // Autofill one of the form elements.
       final DomHTMLInputElement element = formElement.childNodes.toList()[0] as
           DomHTMLInputElement;
-      if (browserEngine == BrowserEngine.firefox) {
+      if (ui_web.browser.browserEngine == ui_web.BrowserEngine.firefox) {
         expect(element.name,
             BrowserAutofillHints.instance.flutterToEngine(hintForFirstElement));
       } else {
@@ -2205,7 +2206,7 @@ Future<void> testMain() async {
 
       textarea.dispatchEvent(createDomEvent('Event', 'input'));
       textarea.setSelectionRange(2, 5);
-      if (browserEngine == BrowserEngine.firefox) {
+      if (ui_web.browser.browserEngine == ui_web.BrowserEngine.firefox) {
         textEditing!.strategy.domElement!
             .dispatchEvent(createDomEvent('Event', 'keyup'));
       } else {
@@ -2306,8 +2307,8 @@ Future<void> testMain() async {
     });
 
     test('sets correct input type in Android', () {
-      debugOperatingSystemOverride = OperatingSystem.android;
-      debugBrowserEngineOverride = BrowserEngine.blink;
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.android;
+      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.blink;
 
       /// During initialization [HybridTextEditing] will pick the correct
       /// text editing strategy for [OperatingSystem.android].
@@ -2346,8 +2347,8 @@ Future<void> testMain() async {
     });
 
     test('sets correct input type for Firefox on Android', () {
-      debugOperatingSystemOverride = OperatingSystem.android;
-      debugBrowserEngineOverride = BrowserEngine.firefox;
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.android;
+      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.firefox;
 
       /// During initialization [HybridTextEditing] will pick the correct
       /// text editing strategy for [OperatingSystem.android].
@@ -2382,8 +2383,8 @@ Future<void> testMain() async {
 
     test('prevent mouse events on Android', () {
       // Regression test for https://github.com/flutter/flutter/issues/124483.
-      debugOperatingSystemOverride = OperatingSystem.android;
-      debugBrowserEngineOverride = BrowserEngine.blink;
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.android;
+      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.blink;
 
       /// During initialization [HybridTextEditing] will pick the correct
       /// text editing strategy for [OperatingSystem.android].
@@ -2436,8 +2437,8 @@ Future<void> testMain() async {
 
     test('sets correct input type in iOS', () {
       // Test on ios-safari only.
-      if (browserEngine == BrowserEngine.webkit &&
-          operatingSystem == OperatingSystem.iOs) {
+      if (ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit &&
+          ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs) {
         /// During initialization [HybridTextEditing] will pick the correct
         /// text editing strategy for [OperatingSystem.iOs].
         textEditing = HybridTextEditing();
@@ -2741,7 +2742,7 @@ Future<void> testMain() async {
       expect(firstElement.id,
           BrowserAutofillHints.instance.flutterToEngine('password'));
       expect(firstElement.type, 'password');
-      if (browserEngine == BrowserEngine.firefox) {
+      if (ui_web.browser.browserEngine == ui_web.BrowserEngine.firefox) {
         expect(firstElement.name,
             BrowserAutofillHints.instance.flutterToEngine('password'));
       } else {
@@ -2760,8 +2761,8 @@ Future<void> testMain() async {
       expect(css.backgroundColor, 'transparent');
 
       // For `blink` and `webkit` browser engines the overlay would be hidden.
-      if (browserEngine == BrowserEngine.blink ||
-          browserEngine == BrowserEngine.webkit) {
+      if (ui_web.browser.browserEngine == ui_web.BrowserEngine.blink ||
+          ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit) {
         expect(firstElement.classList.contains('transparentTextEditing'), isTrue);
       } else {
         expect(firstElement.classList.contains('transparentTextEditing'),
@@ -3045,7 +3046,7 @@ Future<void> testMain() async {
       expect(testInputElement.id,
           BrowserAutofillHints.instance.flutterToEngine(testHint));
       expect(testInputElement.type, 'text');
-      if (browserEngine == BrowserEngine.firefox) {
+      if (ui_web.browser.browserEngine == ui_web.BrowserEngine.firefox) {
         expect(testInputElement.name,
             BrowserAutofillHints.instance.flutterToEngine(testHint));
       } else {
@@ -3577,8 +3578,8 @@ void cleanTextEditingStrategy() {
 }
 
 void cleanTestFlags() {
-  debugBrowserEngineOverride = null;
-  debugOperatingSystemOverride = null;
+  ui_web.browser.debugBrowserEngineOverride = null;
+  ui_web.browser.debugOperatingSystemOverride = null;
 }
 
 void checkInputEditingState(

--- a/lib/web_ui/test/engine/util_test.dart
+++ b/lib/web_ui/test/engine/util_test.dart
@@ -8,6 +8,7 @@ import 'dart:typed_data';
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 final Float32List identityTransform = Matrix4.identity().storage;
 final Float32List xTranslation = (Matrix4.identity()..translate(10)).storage;
@@ -42,7 +43,7 @@ void testMain() {
   });
 
   test('canonicalizes font families correctly on iOS (not 15)', () {
-    debugOperatingSystemOverride = OperatingSystem.iOs;
+    ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.iOs;
     debugIsIOS15 = false;
 
     expect(
@@ -58,12 +59,12 @@ void testMain() {
       '-apple-system, BlinkMacSystemFont',
     );
 
-    debugOperatingSystemOverride = null;
+    ui_web.browser.debugOperatingSystemOverride = null;
     debugIsIOS15 = null;
   });
 
   test('does not use -apple-system on iOS 15', () {
-    debugOperatingSystemOverride = OperatingSystem.iOs;
+    ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.iOs;
     debugIsIOS15 = true;
 
     expect(
@@ -79,7 +80,7 @@ void testMain() {
       'BlinkMacSystemFont',
     );
 
-    debugOperatingSystemOverride = null;
+    ui_web.browser.debugOperatingSystemOverride = null;
     debugIsIOS15 = null;
   });
 

--- a/lib/web_ui/test/engine/view_embedder/dom_manager_test.dart
+++ b/lib/web_ui/test/engine/view_embedder/dom_manager_test.dart
@@ -9,6 +9,7 @@ import 'dart:js_interop';
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../../common/matchers.dart';
 
@@ -74,7 +75,7 @@ void doTests() {
 
       // For some reason, only Firefox is able to correctly compute styles for
       // the `::placeholder` pseudo-element.
-    }, skip: browserEngine != BrowserEngine.firefox);
+    }, skip: ui_web.browser.browserEngine != ui_web.BrowserEngine.firefox);
   });
 
   group('Shadow root', () {
@@ -97,8 +98,8 @@ void doTests() {
 
       // The shadow root should be initialized with correct parameters.
       expect(domManager.renderingHost.mode, 'open');
-      if (browserEngine != BrowserEngine.firefox &&
-          browserEngine != BrowserEngine.webkit) {
+      if (ui_web.browser.browserEngine != ui_web.BrowserEngine.firefox &&
+          ui_web.browser.browserEngine != ui_web.BrowserEngine.webkit) {
         // Older versions of Safari and Firefox don't support this flag yet.
         // See: https://caniuse.com/mdn-api_shadowroot_delegatesfocus
         expect(domManager.renderingHost.delegatesFocus, isFalse);

--- a/lib/web_ui/test/engine/view_embedder/style_manager_test.dart
+++ b/lib/web_ui/test/engine/view_embedder/style_manager_test.dart
@@ -5,6 +5,7 @@
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../../common/matchers.dart';
 
@@ -24,7 +25,7 @@ void doTests() {
         styleNonce: 'testing',
         cssSelectorPrefix: DomManager.flutterViewTagName,
       );
-      final String expected = browserEngine == BrowserEngine.firefox
+      final String expected = ui_web.browser.browserEngine == ui_web.BrowserEngine.firefox
         ? 'rgb(0, 0, 0) 0px'
         : 'rgb(0, 0, 0) none 0px';
       final String got  = domWindow.getComputedStyle(flutterViewElement, 'focus').outline;

--- a/lib/web_ui/test/fallbacks/fallbacks_test.dart
+++ b/lib/web_ui/test/fallbacks/fallbacks_test.dart
@@ -6,6 +6,7 @@
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../common/test_initialization.dart';
 import '../ui/utils.dart';
@@ -20,7 +21,7 @@ Future<void> testMain() async {
   );
 
   test('bootstrapper selects correct builds', () {
-    if (browserEngine == BrowserEngine.blink) {
+    if (ui_web.browser.browserEngine == ui_web.BrowserEngine.blink) {
       expect(isWasm, isTrue);
       expect(isSkwasm, isTrue);
     } else {

--- a/lib/web_ui/test/html/path_test.dart
+++ b/lib/web_ui/test/html/path_test.dart
@@ -9,6 +9,7 @@ import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' hide window;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../common/matchers.dart';
 
@@ -420,7 +421,7 @@ void testMain() {
       EngineFlutterDisplay.instance.debugOverrideDevicePixelRatio(1.0);
       // TODO(ferhat): Investigate failure on CI. Locally this passes.
       // [Exception... "Failure"  nsresult: "0x80004005 (NS_ERROR_FAILURE)"
-    }, skip: browserEngine == BrowserEngine.firefox);
+    }, skip: ui_web.browser.browserEngine == ui_web.BrowserEngine.firefox);
 
     // Path contains should handle case where invalid RRect with large
     // corner radius is used for hit test. Use case is a RenderPhysicalShape

--- a/lib/web_ui/test/html/recording_canvas_golden_test.dart
+++ b/lib/web_ui/test/html/recording_canvas_golden_test.dart
@@ -9,6 +9,7 @@ import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart' hide ColorSpace;
 import 'package:ui/ui.dart' hide TextStyle;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 import 'package:web_engine_tester/golden_tester.dart';
 
 import '../common/matchers.dart';
@@ -323,8 +324,8 @@ Future<void> testMain() async {
     );
     await checkScreenshot(rc, 'draw_paragraph');
   },  // TODO(mdebbar): https://github.com/flutter/flutter/issues/65789
-      skip: browserEngine == BrowserEngine.webkit &&
-          operatingSystem == OperatingSystem.iOs);
+      skip: ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit &&
+            ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs);
 
   test('Computes paint bounds for multi-line draw paragraph', () async {
     final RecordingCanvas rc = RecordingCanvas(screenRect);
@@ -355,8 +356,8 @@ Future<void> testMain() async {
     );
     await checkScreenshot(rc, 'draw_paragraph_multi_line');
   },  // TODO(mdebbar): https://github.com/flutter/flutter/issues/65789
-      skip: browserEngine == BrowserEngine.webkit &&
-          operatingSystem == OperatingSystem.iOs);
+      skip: ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit &&
+          ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs);
 
   test('Should exclude painting outside simple clipRect', () async {
     // One clipped line.

--- a/lib/web_ui/test/html/resource_manager_test.dart
+++ b/lib/web_ui/test/html/resource_manager_test.dart
@@ -5,6 +5,7 @@
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 void main() {
   internalBootstrapBrowserTest(() => testMain);
@@ -26,7 +27,7 @@ void testMain() {
   });
 
   test('prepends resources host as sibling to root element (webkit)', () {
-    debugBrowserEngineOverride = BrowserEngine.webkit;
+    ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
 
     // Resource host hasn't been inserted yet.
     expect(
@@ -49,11 +50,11 @@ void testMain() {
     // Make sure the resources were correctly inserted into the host.
     expect(resourcesHost.children, resources);
 
-    debugBrowserEngineOverride = null;
+    ui_web.browser.debugBrowserEngineOverride = null;
   });
 
   test('prepends resources host inside the shadow root (non-webkit)', () {
-    debugBrowserEngineOverride = BrowserEngine.blink;
+    ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.blink;
 
     // Resource host hasn't been inserted yet.
     expect(
@@ -76,7 +77,7 @@ void testMain() {
     // Make sure the resources were correctly inserted into the host.
     expect(resourcesHost.children, resources);
 
-    debugBrowserEngineOverride = null;
+    ui_web.browser.debugBrowserEngineOverride = null;
   });
 
   test('can remove resource', () {

--- a/lib/web_ui/test/html/text/canvas_paragraph_builder_test.dart
+++ b/lib/web_ui/test/html/text/canvas_paragraph_builder_test.dart
@@ -15,14 +15,14 @@ import '../paragraph/helper.dart';
 /// info in the following tests only pass in Chrome, they are slightly different
 /// on each browser. So we need to ignore position info on non-Chrome browsers
 /// when comparing expectations with actual output.
-bool get isBlink => browserEngine == BrowserEngine.blink;
+bool get isBlink => ui_web.browser.browserEngine == ui_web.BrowserEngine.blink;
 
 String fontFamilyToAttribute(String fontFamily) {
   fontFamily = canonicalizeFontFamily(fontFamily)!;
-  if (browserEngine == BrowserEngine.firefox) {
+  if (ui_web.browser.browserEngine == ui_web.BrowserEngine.firefox) {
     return fontFamily.replaceAll('"', '&quot;');
-  } else if (browserEngine == BrowserEngine.blink ||
-      browserEngine == BrowserEngine.webkit) {
+  } else if (ui_web.browser.browserEngine == ui_web.BrowserEngine.blink ||
+      ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit) {
     return fontFamily.replaceAll('"', '');
   }
   return fontFamily;

--- a/lib/web_ui/test/html/text/font_collection_test.dart
+++ b/lib/web_ui/test/html/text/font_collection_test.dart
@@ -6,6 +6,7 @@ import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 
 import 'package:ui/src/engine.dart';
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../../common/fake_asset_manager.dart';
 import '../../common/test_initialization.dart';
@@ -72,7 +73,7 @@ void testMain() {
         expect(fontFamilyList.first, 'Ahem ahem ahem');
       },
           // TODO(mdebbar): https://github.com/flutter/flutter/issues/51142
-          skip: browserEngine == BrowserEngine.webkit);
+          skip: ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit);
 
       test('Register Asset with capital case letters', () async {
         const String testFontFamily = 'AhEm';
@@ -133,7 +134,7 @@ void testMain() {
           fontFamilyList.add(f.family!);
         });
 
-        if (browserEngine != BrowserEngine.firefox) {
+        if (ui_web.browser.browserEngine != ui_web.BrowserEngine.firefox) {
           expect(fontFamilyList.length, equals(2));
           expect(fontFamilyList, contains("'/Ahem'"));
           expect(fontFamilyList, contains('/Ahem'));
@@ -143,7 +144,7 @@ void testMain() {
         }
       },
           // TODO(mdebbar): https://github.com/flutter/flutter/issues/51142
-          skip: browserEngine == BrowserEngine.webkit);
+          skip: ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit);
 
       test('Register Asset twice with exclamation mark', () async {
         const String testFontFamily = 'Ahem!!ahem';
@@ -160,7 +161,7 @@ void testMain() {
           fontFamilyList.add(f.family!);
         });
 
-        if (browserEngine != BrowserEngine.firefox) {
+        if (ui_web.browser.browserEngine != ui_web.BrowserEngine.firefox) {
           expect(fontFamilyList.length, equals(2));
           expect(fontFamilyList, contains("'Ahem!!ahem'"));
           expect(fontFamilyList, contains('Ahem!!ahem'));
@@ -170,7 +171,7 @@ void testMain() {
         }
       },
           // TODO(mdebbar): https://github.com/flutter/flutter/issues/51142
-          skip: browserEngine == BrowserEngine.webkit);
+          skip: ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit);
 
       test('Register Asset twice with comma', () async {
         const String testFontFamily = 'Ahem ,ahem';
@@ -187,7 +188,7 @@ void testMain() {
           fontFamilyList.add(f.family!);
         });
 
-        if (browserEngine != BrowserEngine.firefox) {
+        if (ui_web.browser.browserEngine != ui_web.BrowserEngine.firefox) {
           expect(fontFamilyList.length, equals(2));
           expect(fontFamilyList, contains("'Ahem ,ahem'"));
           expect(fontFamilyList, contains('Ahem ,ahem'));
@@ -197,7 +198,7 @@ void testMain() {
         }
       },
           // TODO(mdebbar): https://github.com/flutter/flutter/issues/51142
-          skip: browserEngine == BrowserEngine.webkit);
+          skip: ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit);
 
       test('Register Asset twice with a digit at the start of a token',
           () async {
@@ -215,7 +216,7 @@ void testMain() {
           fontFamilyList.add(f.family!);
         });
 
-        if (browserEngine != BrowserEngine.firefox) {
+        if (ui_web.browser.browserEngine != ui_web.BrowserEngine.firefox) {
           expect(fontFamilyList.length, equals(2));
           expect(fontFamilyList, contains('Ahem 1998'));
           expect(fontFamilyList, contains("'Ahem 1998'"));
@@ -225,7 +226,7 @@ void testMain() {
         }
       },
           // TODO(mdebbar): https://github.com/flutter/flutter/issues/51142
-          skip: browserEngine == BrowserEngine.webkit);
+          skip: ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit);
     });
   });
 }

--- a/lib/web_ui/test/html/text/font_loading_test.dart
+++ b/lib/web_ui/test/html/text/font_loading_test.dart
@@ -10,6 +10,7 @@ import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
+import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../../common/test_initialization.dart';
 
@@ -33,7 +34,7 @@ Future<void> testMain() async {
       );
     },
         // TODO(hterkelsen): https://github.com/flutter/flutter/issues/56702
-        skip: browserEngine == BrowserEngine.webkit);
+        skip: ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit);
 
     test('loads Blehm font from buffer', () async {
       expect(_containsFontFamily('Blehm'), isFalse);
@@ -44,7 +45,7 @@ Future<void> testMain() async {
       expect(_containsFontFamily('Blehm'), isTrue);
     },
         // TODO(hterkelsen): https://github.com/flutter/flutter/issues/56702
-        skip: browserEngine == BrowserEngine.webkit);
+        skip: ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit);
 
     test('loading font should clear measurement caches', () async {
       final EngineParagraphStyle style = EngineParagraphStyle();
@@ -67,7 +68,7 @@ Future<void> testMain() async {
       expect(Spanometer.rulers.length, 0);
     },
         // TODO(hterkelsen): https://github.com/flutter/flutter/issues/56702
-        skip: browserEngine == BrowserEngine.webkit);
+        skip: ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit);
 
     test('loading font should send font change message', () async {
       final ui.PlatformMessageCallback? oldHandler = ui.PlatformDispatcher.instance.onPlatformMessage;
@@ -91,7 +92,7 @@ Future<void> testMain() async {
       expect(message, '{"type":"fontsChange"}');
     },
         // TODO(hterkelsen): https://github.com/flutter/flutter/issues/56702
-        skip: browserEngine == BrowserEngine.webkit);
+        skip: ui_web.browser.browserEngine == ui_web.BrowserEngine.webkit);
   });
 }
 

--- a/lib/web_ui/test/html/text_test.dart
+++ b/lib/web_ui/test/html/text_test.dart
@@ -26,8 +26,8 @@ Future<void> testMain() async {
 
   late String fallback;
   setUp(() {
-    if (operatingSystem == OperatingSystem.macOs ||
-        operatingSystem == OperatingSystem.iOs) {
+    if (ui_web.browser.operatingSystem == ui_web.OperatingSystem.macOs ||
+        ui_web.browser.operatingSystem == ui_web.OperatingSystem.iOs) {
       if (isIOS15) {
         fallback = 'BlinkMacSystemFont';
       } else {
@@ -360,7 +360,7 @@ Future<void> testMain() async {
     expect(spans[1].style.fontFamily, 'FlutterTest, $fallback, sans-serif');
   },
       // TODO(mdebbar): https://github.com/flutter/flutter/issues/46638
-      skip: browserEngine == BrowserEngine.firefox);
+      skip: ui_web.browser.browserEngine == ui_web.BrowserEngine.firefox);
 
   test('adds Arial and sans-serif as fallback fonts', () {
     // Set this to false so it doesn't default to the test font.
@@ -378,7 +378,7 @@ Future<void> testMain() async {
     ui_web.debugEmulateFlutterTesterEnvironment = true;
   },
       // TODO(mdebbar): https://github.com/flutter/flutter/issues/46638
-      skip: browserEngine == BrowserEngine.firefox);
+      skip: ui_web.browser.browserEngine == ui_web.BrowserEngine.firefox);
 
   test('does not add fallback fonts to generic families', () {
     // Set this to false so it doesn't default to the default test font.


### PR DESCRIPTION
This PR moves the core of `browser_detection.dart` to a location in `dart:ui_web` so it can be used by apps and plugins.

In order for the code to be a little bit tidier in ui_web, it's encapsulated in a singleton instance that can be accessed through `BrowserDetection.instance` or a top level global `browser` in `dart:ui_web`.

## Issues

* Needed to fix: https://github.com/flutter/flutter/issues/128943
* Needed to land: https://github.com/flutter/flutter/pull/147346

## Tests

Updated affected tests. Mostly the update was to call the methods from `web_ui.browser.methodName` rather than a global scope. Also split the tests for this module in two files:

* `engine_browser_detect_test.dart` - with the tests specific to the engine (capability detection, etc...)
* `browser_detect_test.dart` - only the tests pertaining to the "core" of the library.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
