### PR TITLE
[Impeller] kick off registration and initial PSO compilation of runtime effect earlier.

### DIFF
--- a/impeller/compiler/reflector.cc
+++ b/impeller/compiler/reflector.cc
@@ -352,6 +352,8 @@ std::shared_ptr<RuntimeStageData::Shader> Reflector::GenerateRuntimeStageData()
     uniform_description.rows = spir_type.vecsize;
     uniform_description.columns = spir_type.columns;
     uniform_description.bit_width = spir_type.width;
+    uniform_description.binding =
+        compiler_->get_decoration(var.self, spv::Decoration::DecorationBinding);
     uniform_description.array_elements = GetArrayElements(spir_type);
     FML_CHECK(data->backend != RuntimeStageBackend::kVulkan ||
               spir_type.basetype ==

--- a/impeller/compiler/reflector.cc
+++ b/impeller/compiler/reflector.cc
@@ -354,8 +354,6 @@ std::shared_ptr<RuntimeStageData::Shader> Reflector::GenerateRuntimeStageData()
     uniform_description.rows = spir_type.vecsize;
     uniform_description.columns = spir_type.columns;
     uniform_description.bit_width = spir_type.width;
-    uniform_description.binding =
-        compiler_->get_decoration(var.self, spv::Decoration::DecorationBinding);
     uniform_description.array_elements = GetArrayElements(spir_type);
     FML_CHECK(data->backend != RuntimeStageBackend::kVulkan ||
               spir_type.basetype ==

--- a/impeller/compiler/reflector.cc
+++ b/impeller/compiler/reflector.cc
@@ -348,6 +348,8 @@ std::shared_ptr<RuntimeStageData::Shader> Reflector::GenerateRuntimeStageData()
     uniform_description.name = compiler_->get_name(var.self);
     uniform_description.location = compiler_->get_decoration(
         var.self, spv::Decoration::DecorationLocation);
+    uniform_description.binding =
+        compiler_->get_decoration(var.self, spv::Decoration::DecorationBinding);
     uniform_description.type = spir_type.basetype;
     uniform_description.rows = spir_type.vecsize;
     uniform_description.columns = spir_type.columns;
@@ -412,6 +414,7 @@ std::shared_ptr<RuntimeStageData::Shader> Reflector::GenerateRuntimeStageData()
         .name = ubo.name,
         .location = 64,  // Magic constant that must match the descriptor set
                          // location for fragment programs.
+        .binding = 64,
         .type = spirv_cross::SPIRType::Struct,
         .struct_layout = std::move(struct_layout),
         .struct_float_count = float_count,

--- a/impeller/compiler/types.h
+++ b/impeller/compiler/types.h
@@ -48,6 +48,7 @@ enum class SourceLanguage {
 struct UniformDescription {
   std::string name;
   size_t location = 0u;
+  size_t binding = 0u;
   spirv_cross::SPIRType::BaseType type = spirv_cross::SPIRType::BaseType::Float;
   size_t rows = 0u;
   size_t columns = 0u;

--- a/impeller/core/runtime_types.h
+++ b/impeller/core/runtime_types.h
@@ -39,6 +39,8 @@ struct RuntimeUniformDimensions {
 struct RuntimeUniformDescription {
   std::string name;
   size_t location = 0u;
+  /// Location, but for Vulkan.
+  uint32_t binding = 0u;
   RuntimeUniformType type = RuntimeUniformType::kFloat;
   RuntimeUniformDimensions dimensions = {};
   size_t bit_width = 0u;

--- a/impeller/core/runtime_types.h
+++ b/impeller/core/runtime_types.h
@@ -40,7 +40,7 @@ struct RuntimeUniformDescription {
   std::string name;
   size_t location = 0u;
   /// Location, but for Vulkan.
-  uint32_t binding = 0u;
+  size_t binding = 0u;
   RuntimeUniformType type = RuntimeUniformType::kFloat;
   RuntimeUniformDimensions dimensions = {};
   size_t bit_width = 0u;

--- a/impeller/entity/contents/runtime_effect_contents.h
+++ b/impeller/entity/contents/runtime_effect_contents.h
@@ -35,7 +35,14 @@ class RuntimeEffectContents final : public ColorSourceContents {
               const Entity& entity,
               RenderPass& pass) const override;
 
+  /// Load the runtime effect and ensure a default PSO is initialized.
+  bool BootstrapShader(const ContentContext& renderer) const;
+
  private:
+  bool RegisterShader(const ContentContext& renderer) const;
+
+  std::shared_ptr<Pipeline<PipelineDescriptor>> CreatePipeline(const ContentContext& renderer, ContentContextOptions options) const;
+
   std::shared_ptr<RuntimeStage> runtime_stage_;
   std::shared_ptr<std::vector<uint8_t>> uniform_data_;
   std::vector<TextureInput> texture_inputs_;

--- a/impeller/entity/contents/runtime_effect_contents.h
+++ b/impeller/entity/contents/runtime_effect_contents.h
@@ -41,7 +41,9 @@ class RuntimeEffectContents final : public ColorSourceContents {
  private:
   bool RegisterShader(const ContentContext& renderer) const;
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> CreatePipeline(const ContentContext& renderer, ContentContextOptions options) const;
+  std::shared_ptr<Pipeline<PipelineDescriptor>> CreatePipeline(
+      const ContentContext& renderer,
+      ContentContextOptions options) const;
 
   std::shared_ptr<RuntimeStage> runtime_stage_;
   std::shared_ptr<std::vector<uint8_t>> uniform_data_;

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2242,6 +2242,20 @@ TEST_P(EntityTest, RuntimeEffectCanSuccessfullyRender) {
                   .has_value());
 }
 
+TEST_P(EntityTest, RuntimeEffectCanPrecache) {
+  auto runtime_stages =
+      OpenAssetAsRuntimeStage("runtime_stage_example.frag.iplr");
+  auto runtime_stage =
+      runtime_stages[PlaygroundBackendToRuntimeStageBackend(GetBackend())];
+  ASSERT_TRUE(runtime_stage);
+  ASSERT_TRUE(runtime_stage->IsDirty());
+
+  auto contents = std::make_shared<RuntimeEffectContents>();
+  contents->SetRuntimeStage(runtime_stage);
+
+  EXPECT_TRUE(contents->BootstrapShader(*GetContentContext()));
+}
+
 TEST_P(EntityTest, RuntimeEffectSetsRightSizeWhenUniformIsStruct) {
   if (GetBackend() != PlaygroundBackend::kVulkan) {
     GTEST_SKIP() << "Test only applies to Vulkan";

--- a/impeller/runtime_stage/runtime_stage.cc
+++ b/impeller/runtime_stage/runtime_stage.cc
@@ -10,6 +10,7 @@
 #include "fml/mapping.h"
 #include "impeller/base/validation.h"
 #include "impeller/core/runtime_types.h"
+#include "impeller/core/shader_types.h"
 #include "impeller/runtime_stage/runtime_stage_flatbuffers.h"
 #include "runtime_stage_types_flatbuffers.h"
 
@@ -103,8 +104,9 @@ RuntimeStage::RuntimeStage(const fb::RuntimeStage* runtime_stage,
           desc.struct_layout.push_back(static_cast<uint8_t>(byte_type));
         }
       }
+      desc.binding = i->binding();
       desc.struct_float_count = i->struct_float_count();
-      uniforms_.emplace_back(std::move(desc));
+      uniforms_.push_back(std::move(desc));
     }
   }
 
@@ -113,6 +115,22 @@ RuntimeStage::RuntimeStage(const fb::RuntimeStage* runtime_stage,
       runtime_stage->shader()->size(),     //
       [payload = payload_](auto, auto) {}  //
   );
+
+  for (const auto& uniform : GetUniforms()) {
+    if (uniform.type == kStruct) {
+      descriptor_set_layouts_.push_back(DescriptorSetLayout{
+          static_cast<uint32_t>(uniform.location),
+          DescriptorType::kUniformBuffer,
+          ShaderStage::kFragment,
+      });
+    } else if (uniform.type == kSampledImage) {
+      descriptor_set_layouts_.push_back(DescriptorSetLayout{
+          uniform.binding,
+          DescriptorType::kSampledImage,
+          ShaderStage::kFragment,
+      });
+    }
+  }
 
   is_valid_ = true;
 }
@@ -158,6 +176,11 @@ bool RuntimeStage::IsDirty() const {
 
 void RuntimeStage::SetClean() {
   is_dirty_ = false;
+}
+
+const std::vector<DescriptorSetLayout>& RuntimeStage::GetDescriptorSetLayouts()
+    const {
+  return descriptor_set_layouts_;
 }
 
 }  // namespace impeller

--- a/impeller/runtime_stage/runtime_stage.cc
+++ b/impeller/runtime_stage/runtime_stage.cc
@@ -94,6 +94,7 @@ RuntimeStage::RuntimeStage(const fb::RuntimeStage* runtime_stage,
       RuntimeUniformDescription desc;
       desc.name = i->name()->str();
       desc.location = i->location();
+      desc.binding = i->binding();
       desc.type = ToType(i->type());
       desc.dimensions = RuntimeUniformDimensions{
           static_cast<size_t>(i->rows()), static_cast<size_t>(i->columns())};
@@ -125,7 +126,7 @@ RuntimeStage::RuntimeStage(const fb::RuntimeStage* runtime_stage,
       });
     } else if (uniform.type == kSampledImage) {
       descriptor_set_layouts_.push_back(DescriptorSetLayout{
-          uniform.binding,
+          static_cast<uint32_t>(uniform.binding),
           DescriptorType::kSampledImage,
           ShaderStage::kFragment,
       });

--- a/impeller/runtime_stage/runtime_stage.h
+++ b/impeller/runtime_stage/runtime_stage.h
@@ -12,6 +12,7 @@
 #include "flutter/fml/mapping.h"
 
 #include "flutter/impeller/core/runtime_types.h"
+#include "impeller/core/shader_types.h"
 #include "runtime_stage_types_flatbuffers.h"
 
 namespace impeller {
@@ -35,6 +36,8 @@ class RuntimeStage {
 
   const std::vector<RuntimeUniformDescription>& GetUniforms() const;
 
+  const std::vector<DescriptorSetLayout>& GetDescriptorSetLayouts() const;
+
   const std::string& GetEntrypoint() const;
 
   const RuntimeUniformDescription* GetUniform(const std::string& name) const;
@@ -51,6 +54,7 @@ class RuntimeStage {
   std::string entrypoint_;
   std::shared_ptr<fml::Mapping> code_mapping_;
   std::vector<RuntimeUniformDescription> uniforms_;
+  std::vector<DescriptorSetLayout> descriptor_set_layouts_;
   bool is_valid_ = false;
   bool is_dirty_ = true;
 

--- a/impeller/runtime_stage/runtime_stage_types.fbs
+++ b/impeller/runtime_stage/runtime_stage_types.fbs
@@ -30,6 +30,7 @@ enum StructByteType:uint8 {
 table UniformDescription {
   name: string;
   location: uint64;
+  binding: uint64;
   type: UniformDataType;
   bit_width: uint64;
   rows: uint64;

--- a/lib/ui/painting/fragment_program.cc
+++ b/lib/ui/painting/fragment_program.cc
@@ -75,13 +75,14 @@ std::string FragmentProgram::initFromAsset(const std::string& asset_name) {
   }
 
   if (UIDartState::Current()->IsImpellerEnabled()) {
-    // Spawn (but do not block on) a task that will load the runtime stage and populate
-    // an initial shader variant.
-    ui_dart_state->GetTaskRunners().GetRasterTaskRunner()->PostTask([runtime_stage]() {
-      impeller::RuntimeEffectContents runtime_effect;
-      runtime_effect.SetRuntimeStage(runtime_stage);
-      runtime_effect.BootstrapShader(/*context goes here*/);
-    });
+    // Spawn (but do not block on) a task that will load the runtime stage and
+    // populate an initial shader variant.
+    ui_dart_state->GetTaskRunners().GetRasterTaskRunner()->PostTask(
+        [runtime_stage]() {
+          impeller::RuntimeEffectContents runtime_effect;
+          runtime_effect.SetRuntimeStage(runtime_stage);
+          runtime_effect.BootstrapShader(/*context goes here*/);
+        });
     runtime_effect_ = DlRuntimeEffect::MakeImpeller(std::move(runtime_stage));
   } else {
     const auto& code_mapping = runtime_stage->GetCodeMapping();

--- a/lib/ui/painting/fragment_program.cc
+++ b/lib/ui/painting/fragment_program.cc
@@ -11,17 +11,13 @@
 #include "flutter/assets/asset_manager.h"
 #include "flutter/fml/trace_event.h"
 #include "flutter/impeller/runtime_stage/runtime_stage.h"
-#include "flutter/lib/ui/dart_wrapper.h"
 #include "flutter/lib/ui/ui_dart_state.h"
 #include "flutter/lib/ui/window/platform_configuration.h"
 
 #include "impeller/core/runtime_types.h"
+#include "impeller/entity/contents/runtime_effect_contents.h"
 #include "third_party/skia/include/core/SkString.h"
 #include "third_party/tonic/converter/dart_converter.h"
-#include "third_party/tonic/dart_args.h"
-#include "third_party/tonic/dart_binding_macros.h"
-#include "third_party/tonic/dart_library_natives.h"
-#include "third_party/tonic/typed_data/typed_list.h"
 
 namespace flutter {
 
@@ -44,10 +40,10 @@ static std::string RuntimeStageBackendToString(
 std::string FragmentProgram::initFromAsset(const std::string& asset_name) {
   FML_TRACE_EVENT("flutter", "FragmentProgram::initFromAsset", "asset",
                   asset_name);
-  std::shared_ptr<AssetManager> asset_manager = UIDartState::Current()
-                                                    ->platform_configuration()
-                                                    ->client()
-                                                    ->GetAssetManager();
+  UIDartState* ui_dart_state = UIDartState::Current();
+  std::shared_ptr<AssetManager> asset_manager =
+      ui_dart_state->platform_configuration()->client()->GetAssetManager();
+
   std::unique_ptr<fml::Mapping> data = asset_manager->GetAsMapping(asset_name);
   if (data == nullptr) {
     return std::string("Asset '") + asset_name + std::string("' not found");
@@ -61,7 +57,7 @@ std::string FragmentProgram::initFromAsset(const std::string& asset_name) {
            std::string("' does not contain any shader data.");
   }
 
-  auto backend = UIDartState::Current()->GetRuntimeStageBackend();
+  auto backend = ui_dart_state->GetRuntimeStageBackend();
   auto runtime_stage = runtime_stages[backend];
   if (!runtime_stage) {
     std::ostringstream stream;
@@ -78,18 +74,14 @@ std::string FragmentProgram::initFromAsset(const std::string& asset_name) {
     return stream.str();
   }
 
-  int sampled_image_count = 0;
-  size_t other_uniforms_bytes = 0;
-  for (const auto& uniform_description : runtime_stage->GetUniforms()) {
-    if (uniform_description.type ==
-        impeller::RuntimeUniformType::kSampledImage) {
-      sampled_image_count++;
-    } else {
-      other_uniforms_bytes += uniform_description.GetSize();
-    }
-  }
-
   if (UIDartState::Current()->IsImpellerEnabled()) {
+    // Spawn (but do not block on) a task that will load the runtime stage and populate
+    // an initial shader variant.
+    ui_dart_state->GetTaskRunners().GetRasterTaskRunner()->PostTask([runtime_stage]() {
+      impeller::RuntimeEffectContents runtime_effect;
+      runtime_effect.SetRuntimeStage(runtime_stage);
+      runtime_effect.BootstrapShader(/*context goes here*/);
+    });
     runtime_effect_ = DlRuntimeEffect::MakeImpeller(std::move(runtime_stage));
   } else {
     const auto& code_mapping = runtime_stage->GetCodeMapping();
@@ -110,6 +102,18 @@ std::string FragmentProgram::initFromAsset(const std::string& asset_name) {
   if (Dart_IsError(ths)) {
     Dart_PropagateError(ths);
   }
+
+  int sampled_image_count = 0;
+  size_t other_uniforms_bytes = 0;
+  for (const auto& uniform_description : runtime_stage->GetUniforms()) {
+    if (uniform_description.type ==
+        impeller::RuntimeUniformType::kSampledImage) {
+      sampled_image_count++;
+    } else {
+      other_uniforms_bytes += uniform_description.GetSize();
+    }
+  }
+
   Dart_Handle result = Dart_SetField(ths, tonic::ToDart("_samplerCount"),
                                      Dart_NewInteger(sampled_image_count));
   if (Dart_IsError(result)) {

--- a/lib/ui/painting/fragment_program.cc
+++ b/lib/ui/painting/fragment_program.cc
@@ -15,7 +15,6 @@
 #include "flutter/lib/ui/window/platform_configuration.h"
 
 #include "impeller/core/runtime_types.h"
-#include "impeller/entity/contents/runtime_effect_contents.h"
 #include "third_party/skia/include/core/SkString.h"
 #include "third_party/tonic/converter/dart_converter.h"
 

--- a/lib/ui/snapshot_delegate.h
+++ b/lib/ui/snapshot_delegate.h
@@ -71,6 +71,12 @@ class SnapshotDelegate {
                                             SkISize picture_size) = 0;
 
   virtual sk_sp<SkImage> ConvertToRasterImage(sk_sp<SkImage> image) = 0;
+
+  /// Load and compile and initial PSO for the provided [runtime_stage].
+  ///
+  /// Impeller only.
+  virtual void CacheRuntimeStage(
+      const std::shared_ptr<impeller::RuntimeStage>& runtime_stage) = 0;
 };
 
 }  // namespace flutter

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -432,6 +432,12 @@ sk_sp<SkImage> Rasterizer::ConvertToRasterImage(sk_sp<SkImage> image) {
   return snapshot_controller_->ConvertToRasterImage(image);
 }
 
+// |SnapshotDelegate|
+void Rasterizer::CacheRuntimeStage(
+    const std::shared_ptr<impeller::RuntimeStage>& runtime_stage) {
+  snapshot_controller_->CacheRuntimeStage(runtime_stage);
+}
+
 fml::Milliseconds Rasterizer::GetFrameBudget() const {
   return delegate_.GetFrameBudget();
 };

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -649,6 +649,10 @@ class Rasterizer final : public SnapshotDelegate,
   // |SnapshotDelegate|
   sk_sp<SkImage> ConvertToRasterImage(sk_sp<SkImage> image) override;
 
+  // |SnapshotDelegate|
+  void CacheRuntimeStage(
+      const std::shared_ptr<impeller::RuntimeStage>& runtime_stage) override;
+
   // |Stopwatch::Delegate|
   /// Time limit for a smooth frame.
   ///

--- a/shell/common/snapshot_controller.h
+++ b/shell/common/snapshot_controller.h
@@ -44,6 +44,9 @@ class SnapshotController {
 
   virtual sk_sp<SkImage> ConvertToRasterImage(sk_sp<SkImage> image) = 0;
 
+  virtual void CacheRuntimeStage(
+      const std::shared_ptr<impeller::RuntimeStage>& runtime_stage) = 0;
+
  protected:
   explicit SnapshotController(const Delegate& delegate);
   const Delegate& GetDelegate() { return delegate_; }

--- a/shell/common/snapshot_controller_impeller.cc
+++ b/shell/common/snapshot_controller_impeller.cc
@@ -70,6 +70,17 @@ sk_sp<DlImage> SnapshotControllerImpeller::DoMakeRasterSnapshot(
   return nullptr;
 }
 
+void SnapshotControllerImpeller::CacheRuntimeStage(
+    const std::shared_ptr<impeller::RuntimeStage>& runtime_stage) {
+  impeller::RuntimeEffectContents runtime_effect;
+  runtime_effect.SetRuntimeStage(runtime_stage);
+  auto context = GetDelegate().GetAiksContext();
+  if (!context) {
+    return;
+  }
+  runtime_effect.BootstrapShader(context->GetContentContext());
+}
+
 sk_sp<SkImage> SnapshotControllerImpeller::ConvertToRasterImage(
     sk_sp<SkImage> image) {
   FML_UNREACHABLE();

--- a/shell/common/snapshot_controller_impeller.h
+++ b/shell/common/snapshot_controller_impeller.h
@@ -6,6 +6,7 @@
 #define FLUTTER_SHELL_COMMON_SNAPSHOT_CONTROLLER_IMPELLER_H_
 
 #include "flutter/shell/common/snapshot_controller.h"
+#include "impeller/runtime_stage/runtime_stage.h"
 
 namespace flutter {
 
@@ -19,6 +20,9 @@ class SnapshotControllerImpeller : public SnapshotController {
                                     SkISize size) override;
 
   sk_sp<SkImage> ConvertToRasterImage(sk_sp<SkImage> image) override;
+
+  void CacheRuntimeStage(
+      const std::shared_ptr<impeller::RuntimeStage>& runtime_stage) override;
 
  private:
   sk_sp<DlImage> DoMakeRasterSnapshot(const sk_sp<DisplayList>& display_list,

--- a/shell/common/snapshot_controller_skia.cc
+++ b/shell/common/snapshot_controller_skia.cc
@@ -160,4 +160,7 @@ sk_sp<SkImage> SnapshotControllerSkia::ConvertToRasterImage(
   return result->skia_image();
 }
 
+void SnapshotControllerSkia::CacheRuntimeStage(
+    const std::shared_ptr<impeller::RuntimeStage>& runtime_stage) {}
+
 }  // namespace flutter

--- a/shell/common/snapshot_controller_skia.h
+++ b/shell/common/snapshot_controller_skia.h
@@ -20,6 +20,9 @@ class SnapshotControllerSkia : public SnapshotController {
 
   virtual sk_sp<SkImage> ConvertToRasterImage(sk_sp<SkImage> image) override;
 
+  void CacheRuntimeStage(
+      const std::shared_ptr<impeller::RuntimeStage>& runtime_stage) override;
+
  private:
   sk_sp<DlImage> DoMakeRasterSnapshot(
       SkISize size,


### PR DESCRIPTION
I thought about changing this API so that it blocks on compilation, but I think that isn't necesasary as the workload can happen while the UI thread is building. Plus, even blocking on shader completion does not guarantee that we won't need to compile a variant anyway.

While I was at it I moved the descriptor sets computation to the runtime effect constructor.

With this change the pipleine variant used during the frame is produced much faster than the initial 12ms compilation.

![image](https://github.com/flutter/engine/assets/8975114/42626676-0a71-4503-a3e9-4109c36fbbef)


Fixes https://github.com/flutter/flutter/issues/113719
Fixes https://github.com/flutter/flutter/issues/141222