### PR TITLE
Remove references to goma

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -44,12 +44,6 @@ vars = {
   # See https://github.com/flutter/flutter/wiki/Engine-pre‐submits-and-post‐submits#post-submit
   'clang_version': 'git_revision:725656bdd885483c39f482a01ea25d67acf39c46',
 
-  # The goma version and the clang version can be tightly coupled. If goma
-  # stops working on a clang roll, this may need to be updated using the value
-  # from the 'integration' tag of
-  # https://chrome-infra-packages.appspot.com/p/fuchsia/third_party/goma/client
-  'goma_version': ' git_revision:41b3bcb64014144a844153fd5588c36411fffb56',
-
   'reclient_version': 'git_revision:2c9285bdffcfd1b21afb028d57494ff78761af81',
 
   'gcloud_version': 'version:2@444.0.0.chromium.3',
@@ -130,11 +124,6 @@ vars = {
 
   # Setup Git hooks by default.
   'setup_githooks': True,
-
-  # When this is true, the goma client will be downloaded from cipd, and
-  # the engine build will prefer to use this client over a client that is
-  # specified by GOMA_DIR, or installed in the default goma install location.
-  'use_cipd_goma': False,
 
   # When this is true, the Flutter Engine's configuration files and scripts for
   # RBE will be downloaded from CIPD. This option is only usable by Googlers.
@@ -908,40 +897,6 @@ deps = {
     'dep_type': 'cipd',
   },
 
-  # GOMA
-  'src/flutter/buildtools/mac-x64/goma': {
-    'packages': [
-      {
-        'package': 'fuchsia/third_party/goma/client/mac-amd64',
-        'version': Var('goma_version'),
-      }
-    ],
-    'condition': 'use_cipd_goma and host_os == "mac"',
-    'dep_type': 'cipd',
-  },
-
-  'src/flutter/buildtools/linux-x64/goma': {
-    'packages': [
-      {
-        'package': 'fuchsia/third_party/goma/client/linux-amd64',
-        'version': Var('goma_version'),
-      }
-    ],
-    'condition': 'use_cipd_goma and host_os == "linux"',
-    'dep_type': 'cipd',
-  },
-
-  'src/flutter/buildtools/windows-x64/goma': {
-    'packages': [
-      {
-        'package': 'fuchsia/third_party/goma/client/windows-amd64',
-        'version': Var('goma_version'),
-      }
-    ],
-    'condition': 'use_cipd_goma and download_windows_deps',
-    'dep_type': 'cipd',
-  },
-
   # RBE binaries and configs.
   'src/flutter/buildtools/linux-x64/reclient': {
     'packages': [
@@ -1165,36 +1120,6 @@ hooks = [
     'action': [
       'python3',
       'src/flutter/tools/activate_emsdk.py',
-    ]
-  },
-  {
-    'name': 'Start compiler proxy',
-    'pattern': '.',
-    'condition': 'use_cipd_goma and host_os == "mac"',
-    'action': [
-      'python3',
-      'src/flutter/buildtools/mac-x64/goma/goma_ctl.py',
-      'ensure_start'
-    ]
-  },
-  {
-    'name': 'Start compiler proxy',
-    'pattern': '.',
-    'condition': 'use_cipd_goma and host_os == "linux"',
-    'action': [
-      'python3',
-      'src/flutter/buildtools/linux-x64/goma/goma_ctl.py',
-      'ensure_start'
-    ]
-  },
-  {
-    'name': 'Start compiler proxy',
-    'pattern': '.',
-    'condition': 'use_cipd_goma and download_windows_deps',
-    'action': [
-      'python3',
-      'src/flutter/buildtools/windows-x64/goma/goma_ctl.py',
-      'ensure_start'
     ]
   },
   {

--- a/impeller/docs/android_cpu_profile.md
+++ b/impeller/docs/android_cpu_profile.md
@@ -8,7 +8,7 @@ Add the `--no-stripped` flag to the gn config when building the android engine.
 
 Example config:
 
- `gn --no-lto --no-goma --runtime-mode=profile --android --android-cpu=arm64 --no-stripped`
+ `gn --no-lto --runtime-mode=profile --android --android-cpu=arm64 --no-stripped`
 
 2. Configure Gradle to not remove strip sources
 

--- a/shell/platform/darwin/macos/README.md
+++ b/shell/platform/darwin/macos/README.md
@@ -31,18 +31,15 @@ you can build the macOS embedder from the `src/flutter` directory using the
 following commands:
 ```sh
 # Perform the host build.
-./tools/gn --unopt --no-goma
-autoninja -C ../out/host_debug_unopt      
+./tools/gn --unopt
+ninja -C ../out/host_debug_unopt
 
 # Perform the macOS target build.
-./tools/gn --unopt --mac --no-goma
-autoninja -C ../out/mac_debug_unopt
+./tools/gn --unopt --mac
+ninja -C ../out/mac_debug_unopt
 ```
 Builds are architecture-specific, and can be controlled by specifying
 `--mac-cpu=arm64` or `--mac-cpu=x64` (default) when invoking `gn`.
-
-Googlers can remove `--no-goma` to make use of the Goma distributed compile
-service.
 
 ## Testing
 

--- a/shell/platform/fuchsia/flutter/tests/integration/README.md
+++ b/shell/platform/fuchsia/flutter/tests/integration/README.md
@@ -28,8 +28,6 @@ Command-line options:
 * Add `--runtime-mode debug` or `--runtime-mode profile` to switch between JIT and AOT
   builds.  These correspond to a vanilla Fuchsia build and a `--release` Fuchsia build
   respectively.  The default is debug/JIT builds.
-* For Googlers, add the `--goma` argument when using goma, and add the `--xcode-symlinks`
-  argument when using goma on macOS.
 * Remove `--no-lto` if you care about performance or binary size; unfortunately it results
   in a *much* slower build.
 

--- a/shell/platform/fuchsia/unit_tests.md
+++ b/shell/platform/fuchsia/unit_tests.md
@@ -24,7 +24,6 @@ $ENGINE_DIR/flutter/tools/fuchsia/devshell/run_unit_tests.sh
 
 - Pass `--unopt` to turn off C++ compiler optimizations.
 - Pass `--count N` to do N test runs. Useful for testing for flakes.
-- Pass `--goma` to accelerate the build if you're a Googler.
 - Pass `--package-filter` to run a specific test package instead of all the test packages. For example:
 
   ```sh

--- a/tools/engine_tool/test/build_command_test.dart
+++ b/tools/engine_tool/test/build_command_test.dart
@@ -168,7 +168,7 @@ void main() {
       expect(result, equals(0));
       expect(testEnv.processHistory[0].command[0],
           contains(path.join('tools', 'gn')));
-      expect(testEnv.processHistory[0].command[3], equals('--rbe'));
+      expect(testEnv.processHistory[0].command[2], equals('--rbe'));
       expect(testEnv.processHistory[1].command[0],
           contains(path.join('reclient', 'bootstrap')));
     } finally {
@@ -351,10 +351,11 @@ void main() {
       ]);
       expect(result, equals(0));
       expect(testEnv.processHistory, containsCommand((List<String> command) {
-        return command.length > 5 &&
+        return command.length > 3 &&
             command[0].contains('ninja') &&
+            command[1].contains('-C') &&
             command[2].endsWith('/host_debug') &&
-            command[5] == 'flutter/fml:fml_arc_unittests';
+            command[3] == 'flutter/fml:fml_arc_unittests';
       }));
     } finally {
       testEnv.cleanup();
@@ -378,12 +379,13 @@ void main() {
       ]);
       expect(result, equals(0));
       expect(testEnv.processHistory, containsCommand((List<String> command) {
-        return command.length > 7 &&
+        return command.length > 5 &&
             command[0].contains('ninja') &&
+            command[1].contains('-C') &&
             command[2].endsWith('/host_debug') &&
-            command[5] == 'flutter/display_list:display_list_unittests' &&
-            command[6] == 'flutter/flow:flow_unittests' &&
-            command[7] == 'flutter/fml:fml_arc_unittests';
+            command[3] == 'flutter/display_list:display_list_unittests' &&
+            command[4] == 'flutter/flow:flow_unittests' &&
+            command[5] == 'flutter/fml:fml_arc_unittests';
       }));
     } finally {
       testEnv.cleanup();

--- a/tools/engine_tool/test/fixtures.dart
+++ b/tools/engine_tool/test/fixtures.dart
@@ -21,7 +21,7 @@ String testConfig(String osDimension, String osPlatform) => '''
       "gclient_variables": {
         "variable": false
       },
-      "gn": ["--gn-arg", "--lto", "--goma", "--no-rbe"],
+      "gn": ["--gn-arg", "--lto", "--no-rbe"],
       "name": "ci/build_name",
       "description": "This is a very long description that will test that the help message is wrapped correctly at an appropriate number of characters.",
       "ninja": {
@@ -54,7 +54,7 @@ String testConfig(String osDimension, String osPlatform) => '''
       "drone_dimensions": [
         "os=$osDimension"
       ],
-      "gn": ["--gn-arg", "--lto", "--goma", "--no-rbe"],
+      "gn": ["--gn-arg", "--lto", "--no-rbe"],
       "name": "$osPlatform/host_debug",
       "ninja": {
         "config": "host_debug",
@@ -65,7 +65,7 @@ String testConfig(String osDimension, String osPlatform) => '''
       "drone_dimensions": [
         "os=$osDimension"
       ],
-      "gn": ["--gn-arg", "--lto", "--goma", "--no-rbe"],
+      "gn": ["--gn-arg", "--lto", "--no-rbe"],
       "name": "$osPlatform/android_debug_arm64",
       "ninja": {
         "config": "android_debug_arm64",
@@ -76,7 +76,7 @@ String testConfig(String osDimension, String osPlatform) => '''
       "drone_dimensions": [
         "os=$osDimension"
       ],
-      "gn": ["--gn-arg", "--lto", "--no-goma", "--rbe"],
+      "gn": ["--gn-arg", "--lto", "--rbe"],
       "name": "ci/android_debug_rbe_arm64",
       "ninja": {
         "config": "android_debug_rbe_arm64",
@@ -130,7 +130,7 @@ const String configsToTestNamespacing = '''
       "drone_dimensions": [
         "os=Linux"
       ],
-      "gn": ["--gn-arg", "--lto", "--goma", "--no-rbe"],
+      "gn": ["--gn-arg", "--lto", "--no-rbe"],
       "name": "linux/host_debug",
       "ninja": {
         "config": "local_host_debug",
@@ -141,7 +141,7 @@ const String configsToTestNamespacing = '''
       "drone_dimensions": [
         "os=Linux"
       ],
-      "gn": ["--gn-arg", "--lto", "--goma", "--no-rbe"],
+      "gn": ["--gn-arg", "--lto", "--no-rbe"],
       "name": "ci/host_debug",
       "ninja": {
         "config": "ci/host_debug",

--- a/tools/fuchsia/devshell/build_and_copy_to_fuchsia.sh
+++ b/tools/fuchsia/devshell/build_and_copy_to_fuchsia.sh
@@ -13,7 +13,6 @@
 ###                  Valid values: [x64, arm64]
 ###                  Default value: x64
 ###   --unoptimized: Disables C++ compiler optimizations.
-###   --goma: Speeds up builds for Googlers. sorry. :(
 ###
 ### Any additional arguments are forwarded directly to GN.
 
@@ -28,8 +27,6 @@ ensure_ninja
 runtime_mode="debug"
 compilation_mode="jit"
 fuchsia_cpu="x64"
-goma=0
-goma_flags=""
 ninja_cmd="ninja"
 unoptimized_flags=""
 unoptimized_suffix=""
@@ -63,12 +60,6 @@ while [[ $# -gt 0 ]]; do
         exit 1
       fi
       ;;
-    --goma)
-      goma=1
-      goma_flags="--goma"
-      ninja_cmd="autoninja"
-      shift # past argument
-      ;;
     --unopt|--unoptimized)
       unoptimized_flags="--unoptimized"
       unoptimized_suffix="_unopt"
@@ -92,7 +83,7 @@ then
   engine-warning "If you have already checked out Fuchsia's Flutter Engine commit and then committed some additional changes, please ignore the above warning."
 fi
 
-all_gn_args="--fuchsia --fuchsia-cpu="${fuchsia_cpu}" --runtime-mode="${runtime_mode}" ${goma_flags} ${unoptimized_flags} ${extra_gn_args[@]}"
+all_gn_args="--fuchsia --fuchsia-cpu="${fuchsia_cpu}" --runtime-mode="${runtime_mode}" ${unoptimized_flags} ${extra_gn_args[@]}"
 engine-info "GN args: ${all_gn_args}"
 
 "$ENGINE_DIR"/flutter/tools/gn ${all_gn_args}

--- a/tools/fuchsia/devshell/run_integration_test.sh
+++ b/tools/fuchsia/devshell/run_integration_test.sh
@@ -18,7 +18,6 @@
 ###                  Valid values: [x64, arm64]
 ###                  Default value: x64
 ###   --unoptimized: Disables C++ compiler optimizations.
-###   --goma: Speeds up builds. For Googlers only, sorry. :(
 
 set -e  # Fail on any error.
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"/lib/vars.sh || exit $?
@@ -75,8 +74,6 @@ skip_fuchsia_emu=0
 runtime_mode="debug"
 compilation_mode="jit"
 fuchsia_cpu="x64"
-goma=0
-goma_flags=""
 ninja_cmd="ninja"
 unoptimized_flags=""
 unoptimized_suffix=""
@@ -118,12 +115,6 @@ while [[ $# -gt 0 ]]; do
         exit 1
       fi
       ;;
-    --goma)
-      goma=1
-      goma_flags="--goma"
-      ninja_cmd="autoninja"
-      shift # past argument
-      ;;
     --unopt|--unoptimized)
       unoptimized_flags="--unoptimized"
       unoptimized_suffix="_unopt"
@@ -146,7 +137,7 @@ then
   headless_flags="--headless"
 fi
 
-all_gn_args="--fuchsia --fuchsia-cpu="${fuchsia_cpu}" --runtime-mode="${runtime_mode}" ${goma_flags} ${unoptimized_flags} ${extra_gn_args[@]}"
+all_gn_args="--fuchsia --fuchsia-cpu="${fuchsia_cpu}" --runtime-mode="${runtime_mode}" ${unoptimized_flags} ${extra_gn_args[@]}"
 engine-info "Building Flutter test with GN args: ${all_gn_args}"
 
 "$ENGINE_DIR"/flutter/tools/gn ${all_gn_args}

--- a/tools/fuchsia/devshell/run_unit_tests.sh
+++ b/tools/fuchsia/devshell/run_unit_tests.sh
@@ -13,7 +13,6 @@
 ###   --unoptimized: Disables C++ compiler optimizations.
 ###   --count: Number of times to run the test. By default runs 1 time.
 ###            See `ffx test run --count`.
-###   --goma: Speeds up builds for Googlers. sorry. :(
 
 set -e  # Fail on any error.
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"/lib/vars.sh || exit $?
@@ -26,8 +25,6 @@ ensure_ninja
 runtime_mode="debug"
 compilation_mode="jit"
 fuchsia_cpu="x64"
-goma=0
-goma_flags=""
 ninja_cmd="ninja"
 package_filter="*tests-0.far"
 test_filter_flags=""
@@ -46,12 +43,6 @@ while [[ $# -gt 0 ]]; do
       count_flags="--count $1"
       shift # past value
       ;;
-    --goma)
-      goma=1
-      goma_flags="--goma"
-      ninja_cmd="autoninja"
-      shift # past argument
-      ;;
     --unopt|--unoptimized)
       unoptimized_flags="--unoptimized"
       unoptimized_suffix="_unopt"
@@ -69,7 +60,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-all_gn_args="--fuchsia --no-lto --fuchsia-cpu="${fuchsia_cpu}" --runtime-mode="${runtime_mode}" ${goma_flags} ${unoptimized_flags}"
+all_gn_args="--fuchsia --no-lto --fuchsia-cpu="${fuchsia_cpu}" --runtime-mode="${runtime_mode}" ${unoptimized_flags}"
 engine-info "GN args: ${all_gn_args}"
 
 "${ENGINE_DIR}"/flutter/tools/gn ${all_gn_args}

--- a/tools/fuchsia/devshell/test/test_build_and_copy_to_fuchsia.sh
+++ b/tools/fuchsia/devshell/test/test_build_and_copy_to_fuchsia.sh
@@ -35,8 +35,5 @@ $ENGINE_DIR/flutter/tools/fuchsia/devshell/build_and_copy_to_fuchsia.sh --runtim
 engine-info "Testing build_and_copy_to_fuchsia.sh --fuchsia-cpu arm64..."
 $ENGINE_DIR/flutter/tools/fuchsia/devshell/build_and_copy_to_fuchsia.sh --fuchsia-cpu arm64
 
-engine-info "Testing build_and_copy_to_fuchsia.sh --goma..."
-$ENGINE_DIR/flutter/tools/fuchsia/devshell/build_and_copy_to_fuchsia.sh --goma
-
 engine-info "Testing build_and_copy_to_fuchsia.sh --no-prebuilt-dart-sdk..."
 $ENGINE_DIR/flutter/tools/fuchsia/devshell/build_and_copy_to_fuchsia.sh --no-prebuilt-dart-sdk

--- a/tools/gn
+++ b/tools/gn
@@ -257,78 +257,6 @@ def setup_rbe(args):
   return rbe_gn_args
 
 
-def setup_goma(args):
-  goma_gn_args = {}
-  # If RBE is requested, don't try to use goma.
-  if args.rbe:
-    goma_gn_args['use_goma'] = False
-    goma_gn_args['goma_dir'] = None
-    return goma_gn_args
-
-  # args.goma has three states, True (--goma), False (--no-goma), and
-  # None (default). In True mode, we force GOMA to be used (and fail
-  # if we cannot enable it) unless the selected target definitely does
-  # not support it (in which case we print a warning). In False mode,
-  # we disable GOMA regardless. In None mode, we enable it if we can
-  # autodetect a configuration, and otherwise disable it.
-
-  # When running in CI, the recipes use their own goma install, and take
-  # care of starting and stopping the compiler proxy.
-  running_on_luci = os.environ.get('LUCI_CONTEXT') is not None
-
-  # The GOMA client has no arm64 binary, so run the x64 binary through
-  # Rosetta.
-  buildtools_platform = buildtools_dir()
-  if buildtools_platform == 'mac-arm64':
-    buildtools_platform = 'mac-x64'
-
-  # Prefer the goma fetched by gclient if it exists.
-  cipd_goma_dir = os.path.join(SRC_ROOT, 'flutter', 'buildtools', buildtools_platform, 'goma')
-
-  # Next, if GOMA_DIR is set, use that install.
-  goma_dir = os.environ.get('GOMA_DIR')
-
-  # Finally, look for goma in the install location recommended in our
-  # documentation.
-  goma_home_dir = os.path.join(os.getenv('HOME', ''), 'goma')
-  # GOMA has a different default (home) path on gWindows.
-  if not os.path.exists(goma_home_dir) and sys.platform.startswith(('cygwin', 'win')):
-    goma_home_dir = os.path.join('c:\\', 'src', 'goma', 'goma-win64')
-
-  if args.target_os == 'wasm' or args.web:
-    goma_gn_args['use_goma'] = False
-    goma_gn_args['goma_dir'] = None
-    if args.goma:
-      print('Disabling GOMA for wasm builds, it is not supported yet.')
-  elif args.goma is not False and not running_on_luci and os.path.exists(cipd_goma_dir):
-    goma_gn_args['use_goma'] = True
-    goma_gn_args['goma_dir'] = cipd_goma_dir
-  elif args.goma is not False and goma_dir and os.path.exists(goma_dir):
-    goma_gn_args['use_goma'] = True
-    goma_gn_args['goma_dir'] = goma_dir
-  elif args.goma is not False and os.path.exists(goma_home_dir):
-    goma_gn_args['use_goma'] = True
-    goma_gn_args['goma_dir'] = goma_home_dir
-  elif args.goma:
-    raise Exception(
-        'GOMA was specified but was not found. Set the GOMA_DIR environment '
-        'variable, install goma at $HOME/goma following the instructions at '
-        'https://github.com/flutter/flutter/wiki/Compiling-the-engine, or '
-        'run this script with the --no-goma flag to do a non-goma-enabled '
-        'build.',
-    )
-  else:
-    goma_gn_args['use_goma'] = False
-    goma_gn_args['goma_dir'] = None
-
-  if goma_gn_args['use_goma'] and sys.platform == 'darwin':
-    if (not running_on_luci or args.xcode_symlinks or
-        os.getenv('FLUTTER_GOMA_CREATE_XCODE_SYMLINKS', '0') == '1'):
-      goma_gn_args['create_xcode_symlinks'] = True
-
-  return goma_gn_args
-
-
 # Find the locations of the macOS and iOS SDKs under flutter/prebuilts.
 def setup_apple_sdks():
   sdks_gn_args = {}
@@ -474,8 +402,6 @@ def to_gn_args(args):
 
   gn_args.update(setup_git_versions())
 
-  gn_args.update(setup_goma(args))
-
   gn_args.update(setup_rbe(args))
 
   # If building for WASM, set the GN args using 'to_gn_wasm_args' as most
@@ -566,13 +492,8 @@ def to_gn_args(args):
     gn_args['host_cpu'] = 'x86'
     gn_args['current_cpu'] = 'x86'
 
-  # When building binaries to run on a macOS host (like gen_snapshot), always
-  # use the clang_x64 toolchain, which will run under Rosetta. This is done for
-  # two reasons:
-  #  1. goma currently only supports the clang_x64 toolchain.
-  #  2. gen_snapshot cannot crossbuild from arm64 to x64. Its host architecture
-  #     must be x64 to target x64.
-  # TODO(cbracken): https://github.com/flutter/flutter/issues/103386
+  # TODO(cbracken):
+  # https://github.com/flutter/flutter/issues/103386
   if get_host_os() == 'mac' and not args.force_mac_arm64:
     gn_args['host_cpu'] = 'x64'
 
@@ -1084,7 +1005,7 @@ def parse_args(args):
   parser.add_argument(
       '--xcode-symlinks',
       action='store_true',
-      help='Set to true for builds targeting macOS or iOS when using goma. If '
+      help='Set to true for builds targeting macOS or iOS when using RBE. If '
       'set, symlinks to the Xcode provided sysroot and SDKs will be '
       'created in a generated folder, which will avoid potential backend '
       'errors in Fuchsia RBE. Instead of specifying the flag on each '

--- a/tools/pkg/engine_build_configs/lib/src/build_config_runner.dart
+++ b/tools/pkg/engine_build_configs/lib/src/build_config_runner.dart
@@ -264,7 +264,6 @@ final class BuildRunner extends Runner {
   static const List<(String, String)> _overridableArgs = <(String, String)>[
     ('--lto', '--no-lto'),
     ('--rbe', '--no-rbe'),
-    ('--goma', '--no-goma'),
   ];
 
   // extraGnArgs overrides the build config args.
@@ -416,7 +415,7 @@ final class BuildRunner extends Runner {
         ninjaPath,
         '-C',
         outDir,
-        if (_isGomaOrRbe) ...<String>['-j', '200'],
+        if (_isRbe) ...<String>['-j', '200'],
         ...extraNinjaArgs,
         ...build.ninja.targets,
       ];
@@ -523,9 +522,7 @@ final class BuildRunner extends Runner {
     return true;
   }
 
-  late final bool _isGoma = _mergedGnArgs.contains('--goma');
   late final bool _isRbe = _mergedGnArgs.contains('--rbe');
-  late final bool _isGomaOrRbe = _isGoma || _isRbe;
 
   Future<bool> _runGenerators(RunnerEventHandler eventHandler) async {
     for (final BuildTask task in build.generators) {

--- a/tools/pkg/engine_build_configs/test/build_config_runner_test.dart
+++ b/tools/pkg/engine_build_configs/test/build_config_runner_test.dart
@@ -191,35 +191,6 @@ void main() {
     expect(events[6].command.contains('--extra-test-arg'), isTrue);
   });
 
-  test('GlobalBuildRunner passes large -j for a goma build', () async {
-    final Build targetBuild = buildConfig.builds[0];
-    final BuildRunner buildRunner = BuildRunner(
-      platform: FakePlatform(operatingSystem: Platform.linux),
-      processRunner: ProcessRunner(
-        // dryRun should not try to spawn any processes.
-        processManager: _fakeProcessManager(),
-      ),
-      abi: ffi.Abi.linuxX64,
-      engineSrcDir: engine.srcDir,
-      build: targetBuild,
-      extraGnArgs: <String>['--goma'],
-      dryRun: true,
-    );
-    final List<RunnerEvent> events = <RunnerEvent>[];
-    void handler(RunnerEvent event) => events.add(event);
-    final bool runResult = await buildRunner.run(handler);
-
-    final String buildName = targetBuild.name;
-
-    expect(runResult, isTrue);
-
-    // Check that the events for the Ninja command are correct.
-    expect(events[2] is RunnerStart, isTrue);
-    expect(events[2].name, equals('$buildName: ninja'));
-    expect(events[2].command.contains('-j'), isTrue);
-    expect(events[2].command.contains('200'), isTrue);
-  });
-
   test('GlobalBuildRunner passes large -j for an rbe build', () async {
     final Build targetBuild = buildConfig.builds[0];
     final BuildRunner buildRunner = BuildRunner(
@@ -427,7 +398,7 @@ void main() {
       abi: ffi.Abi.linuxX64,
       engineSrcDir: engine.srcDir,
       build: targetBuild,
-      extraGnArgs: <String>['--no-lto', '--no-goma', '--rbe'],
+      extraGnArgs: <String>['--no-lto', '--rbe'],
       dryRun: true,
     );
     final List<RunnerEvent> events = <RunnerEvent>[];
@@ -443,10 +414,8 @@ void main() {
     expect(events[0].name, equals('$buildName: GN'));
     expect(events[0].command[0], contains('flutter/tools/gn'));
     expect(events[0].command.contains('--no-lto'), isTrue);
-    expect(events[0].command.contains('--no-goma'), isTrue);
     expect(events[0].command.contains('--rbe'), isTrue);
     expect(events[0].command.contains('--lto'), isFalse);
-    expect(events[0].command.contains('--goma'), isFalse);
     expect(events[0].command.contains('--no-rbe'), isFalse);
     expect(events[1] is RunnerResult, isTrue);
     expect(events[1].name, equals('$buildName: GN'));

--- a/tools/pkg/engine_build_configs/test/build_config_test.dart
+++ b/tools/pkg/engine_build_configs/test/build_config_test.dart
@@ -23,7 +23,7 @@ int main() {
     final Build globalBuild = buildConfig.builds[0];
     expect(globalBuild.name, equals('build_name'));
     expect(globalBuild.description, equals('build_description'));
-    expect(globalBuild.gn.length, equals(4));
+    expect(globalBuild.gn.length, equals(3));
     expect(globalBuild.gn[0], equals('--gn-arg'));
     expect(globalBuild.droneDimensions.length, equals(1));
     expect(globalBuild.droneDimensions[0], equals('os=Linux'));

--- a/tools/pkg/engine_build_configs/test/fixtures.dart
+++ b/tools/pkg/engine_build_configs/test/fixtures.dart
@@ -21,7 +21,7 @@ const String buildConfigJson = '''
       "gclient_variables": {
         "variable": false
       },
-      "gn": ["--gn-arg", "--lto", "--goma", "--no-rbe"],
+      "gn": ["--gn-arg", "--lto", "--no-rbe"],
       "name": "build_name",
       "description": "build_description",
       "ninja": {


### PR DESCRIPTION
This removes goma most places except for the arguments to the `gn` script, which are referenced by recipes. This does not remove goma capabilities from the GN build entirely. That requires changes in the buildroot which have to be staged after this change.