### PR TITLE
[Impeller] remove image upload from IO thread, limit concurrent worker threads.

### DIFF
--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -2310,6 +2310,8 @@ TEST_F(EmbedderTest, CanPostTaskToAllNativeThreads) {
   ASSERT_EQ(captures.render_threads_count, 1u);
   ASSERT_EQ(captures.ui_threads_count, 1u);
   ASSERT_EQ(captures.worker_threads_count, worker_count + 1u /* for IO */);
+  EXPECT_GE(captures.worker_threads_count - 1, 2);
+  EXPECT_LE(captures.worker_threads_count - 1, 4);
 
   platform_task_runner->PostTask([&]() {
     engine.reset();

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -2310,8 +2310,8 @@ TEST_F(EmbedderTest, CanPostTaskToAllNativeThreads) {
   ASSERT_EQ(captures.render_threads_count, 1u);
   ASSERT_EQ(captures.ui_threads_count, 1u);
   ASSERT_EQ(captures.worker_threads_count, worker_count + 1u /* for IO */);
-  EXPECT_GE(captures.worker_threads_count - 1, 2);
-  EXPECT_LE(captures.worker_threads_count - 1, 4);
+  EXPECT_GE(captures.worker_threads_count - 1, 2u);
+  EXPECT_LE(captures.worker_threads_count - 1, 4u);
 
   platform_task_runner->PostTask([&]() {
     engine.reset();


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/123058
Fixes https://github.com/flutter/flutter/issues/135443


We're currently using the IO thread to bottleneck image uploads. Instead, just use fewer concurrent worker threads - and cap the limit at something small. For a Pixel device, this should use about 2 threads maximum, instead of  5 (4 worker and 1 IO).