### PR TITLE
Add a host_debug_unopt_arm64 macOS configuration.

### DIFF
--- a/ci/builders/local_engine.json
+++ b/ci/builders/local_engine.json
@@ -482,6 +482,38 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
+        "os=Mac-13",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "download_android_deps": false,
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "debug",
+        "--unopt",
+        "--mac-cpu",
+        "arm64",
+        "--xcode-symlinks",
+        "--rbe",
+        "--no-goma"
+      ],
+      "name": "macos/host_debug_unopt_arm64",
+      "description": "Builds a debug mode engine for a macOS host on arm64.",
+      "ninja": {
+        "config": "host_debug_unopt_arm64",
+        "targets": []
+      },
+      "properties": {
+        "$flutter/osx_sdk": {
+          "sdk_version": "15a240d"
+        }
+      }
+    },
+    {
+      "cas_archive": false,
+      "drone_dimensions": [
         "os=Linux",
         "device_type=none"
       ],


### PR DESCRIPTION
This is the default development configuration for local engine host builds on the corp M1 macOS boxes.