### PR TITLE
Stable/3.19 CP Workaround HardwareRenderer breakage in Android 14 (#52370)

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -578,6 +578,7 @@ import java.util.List;
     ensureAlive();
     if (flutterEngine != null) {
       updateSystemUiOverlays();
+      flutterEngine.getPlatformViewsController().onResume();
     } else {
       Log.w(TAG, "onPostResume() invoked before FlutterFragment was attached to an Activity.");
     }
@@ -921,6 +922,7 @@ import java.util.List;
         flutterEngine.getSystemChannel().sendMemoryPressureWarning();
       }
       flutterEngine.getRenderer().onTrimMemory(level);
+      flutterEngine.getPlatformViewsController().onTrimMemory(level);
     }
   }
 

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -8,6 +8,7 @@ import static android.view.MotionEvent.PointerCoords;
 import static android.view.MotionEvent.PointerProperties;
 
 import android.annotation.TargetApi;
+import android.content.ComponentCallbacks2;
 import android.content.Context;
 import android.content.MutableContextWrapper;
 import android.os.Build;
@@ -1053,6 +1054,24 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
       final int viewId = platformViews.keyAt(0);
       // Dispose deletes the entry from platformViews and clears associated resources.
       channelHandler.dispose(viewId);
+    }
+  }
+
+  // Invoked when the Android system is requesting we reduce memory usage.
+  public void onTrimMemory(int level) {
+    if (level < ComponentCallbacks2.TRIM_MEMORY_BACKGROUND) {
+      return;
+    }
+    for (VirtualDisplayController vdc : vdControllers.values()) {
+      vdc.clearSurface();
+    }
+  }
+
+  // Called after the application has been resumed.
+  // This is where we undo whatever may have been done in onTrimMemory.
+  public void onResume() {
+    for (VirtualDisplayController vdc : vdControllers.values()) {
+      vdc.resetSurface();
     }
   }
 

--- a/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
@@ -261,6 +261,49 @@ class VirtualDisplayController {
     presentation.dispatchTouchEvent(event);
   }
 
+  public void clearSurface() {
+    virtualDisplay.setSurface(null);
+  }
+
+  public void resetSurface() {
+    final int width = getRenderTargetWidth();
+    final int height = getRenderTargetHeight();
+    final boolean isFocused = getView().isFocused();
+    final SingleViewPresentation.PresentationState presentationState = presentation.detachState();
+
+    // We detach the surface to prevent it being destroyed when releasing the vd.
+    virtualDisplay.setSurface(null);
+    virtualDisplay.release();
+    final DisplayManager displayManager =
+        (DisplayManager) context.getSystemService(Context.DISPLAY_SERVICE);
+    int flags = 0;
+    virtualDisplay =
+        displayManager.createVirtualDisplay(
+            "flutter-vd#" + viewId,
+            width,
+            height,
+            densityDpi,
+            renderTarget.getSurface(),
+            flags,
+            callback,
+            null /* handler */);
+    // Create a new SingleViewPresentation and show() it before we cancel() the existing
+    // presentation. Calling show() and cancel() in this order fixes
+    // https://github.com/flutter/flutter/issues/26345 and maintains seamless transition
+    // of the contents of the presentation.
+    SingleViewPresentation newPresentation =
+        new SingleViewPresentation(
+            context,
+            virtualDisplay.getDisplay(),
+            accessibilityEventsDelegate,
+            presentationState,
+            focusChangeListener,
+            isFocused);
+    newPresentation.show();
+    presentation.cancel();
+    presentation = newPresentation;
+  }
+
   static class OneTimeOnDrawListener implements ViewTreeObserver.OnDrawListener {
     static void schedule(View view, Runnable runnable) {
       OneTimeOnDrawListener listener = new OneTimeOnDrawListener(view, runnable);

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -596,7 +596,132 @@ public class FlutterRendererTest {
     // Acquire the new image.
     assertNotNull(texture.acquireLatestImage());
 
-    // We will have no pending readers to close.
-    assertEquals(0, texture.readersToCloseSize());
+    // Acquire first frame.
+    Image produced = texture.acquireLatestImage();
+    assertNotNull(produced);
+    assertEquals(1, produced.getWidth());
+    assertEquals(1, produced.getHeight());
+    assertEquals(2, texture.numImageReaders());
+    assertEquals(2, texture.numImages());
+    // Acquire second frame. This won't result in the first reader being closed because it has
+    // an active image from it.
+    produced = texture.acquireLatestImage();
+    assertNotNull(produced);
+    assertEquals(1, produced.getWidth());
+    assertEquals(1, produced.getHeight());
+    assertEquals(2, texture.numImageReaders());
+    assertEquals(1, texture.numImages());
+    // Acquire third frame. We will now close the first reader.
+    produced = texture.acquireLatestImage();
+    assertNotNull(produced);
+    assertEquals(4, produced.getWidth());
+    assertEquals(4, produced.getHeight());
+    assertEquals(1, texture.numImageReaders());
+    assertEquals(0, texture.numImages());
+
+    // Returns null image when no more images are queued.
+    assertNull(texture.acquireLatestImage());
+    assertEquals(1, texture.numImageReaders());
+    assertEquals(0, texture.numImages());
+  }
+
+  @Test
+  public void ImageReaderSurfaceProducerTrimMemoryCallback() {
+    FlutterRenderer flutterRenderer = new FlutterRenderer(fakeFlutterJNI);
+    FlutterRenderer.ImageReaderSurfaceProducer texture =
+        flutterRenderer.new ImageReaderSurfaceProducer(0);
+    texture.disableFenceForTest();
+
+    // Returns a null image when one hasn't been produced.
+    assertNull(texture.acquireLatestImage());
+
+    // Give the texture an initial size.
+    texture.setSize(1, 1);
+
+    // Grab the surface so we can render a frame at 1x1 after resizing.
+    Surface surface = texture.getSurface();
+    assertNotNull(surface);
+    Canvas canvas = surface.lockHardwareCanvas();
+    canvas.drawARGB(255, 255, 0, 0);
+    surface.unlockCanvasAndPost(canvas);
+
+    // Let callbacks run, this will produce a single frame.
+    shadowOf(Looper.getMainLooper()).idle();
+
+    assertEquals(1, texture.numImageReaders());
+    assertEquals(1, texture.numImages());
+
+    // Invoke the onTrimMemory callback with level 0.
+    // This should do nothing.
+    texture.onTrimMemory(0);
+    shadowOf(Looper.getMainLooper()).idle();
+
+    assertEquals(1, texture.numImageReaders());
+    assertEquals(1, texture.numImages());
+    assertEquals(0, texture.numTrims());
+
+    // Invoke the onTrimMemory callback with level 40.
+    // This should result in a trim.
+    texture.onTrimMemory(40);
+    shadowOf(Looper.getMainLooper()).idle();
+
+    assertEquals(0, texture.numImageReaders());
+    assertEquals(0, texture.numImages());
+    assertEquals(1, texture.numTrims());
+
+    // Request the surface, this should result in a new image reader.
+    surface = texture.getSurface();
+    assertEquals(1, texture.numImageReaders());
+    assertEquals(0, texture.numImages());
+    assertEquals(1, texture.numTrims());
+
+    // Render an image.
+    canvas = surface.lockHardwareCanvas();
+    canvas.drawARGB(255, 255, 0, 0);
+    surface.unlockCanvasAndPost(canvas);
+
+    // Let callbacks run, this will produce a single frame.
+    shadowOf(Looper.getMainLooper()).idle();
+
+    assertEquals(1, texture.numImageReaders());
+    assertEquals(1, texture.numImages());
+    assertEquals(1, texture.numTrims());
+  }
+
+  // A 0x0 ImageReader is a runtime error.
+  @Test
+  public void ImageReaderSurfaceProducerClampsWidthAndHeightTo1() {
+    FlutterRenderer flutterRenderer = new FlutterRenderer(fakeFlutterJNI);
+    FlutterRenderer.ImageReaderSurfaceProducer texture =
+        flutterRenderer.new ImageReaderSurfaceProducer(0);
+
+    // Default values.
+    assertEquals(texture.getWidth(), 1);
+    assertEquals(texture.getHeight(), 1);
+
+    // Try setting width and height to 0.
+    texture.setSize(0, 0);
+
+    // Ensure we can still create/get a surface without an exception being raised.
+    assertNotNull(texture.getSurface());
+
+    // Expect clamp to 1.
+    assertEquals(texture.getWidth(), 1);
+    assertEquals(texture.getHeight(), 1);
+  }
+
+  @Test
+  public void SurfaceTextureSurfaceProducerCreatesAConnectedTexture() {
+    // Force creating a SurfaceTextureSurfaceProducer regardless of Android API version.
+    FlutterRenderer.debugForceSurfaceProducerGlTextures = true;
+
+    FlutterRenderer flutterRenderer = new FlutterRenderer(fakeFlutterJNI);
+    TextureRegistry.SurfaceProducer producer = flutterRenderer.createSurfaceProducer();
+
+    flutterRenderer.startRenderingToSurface(fakeSurface, false);
+
+    // Verify behavior under test.
+    assertEquals(producer.id(), 0);
+    verify(fakeFlutterJNI, times(1)).registerTexture(eq(producer.id()), any());
   }
 }


### PR DESCRIPTION
Fixes cherry pick https://github.com/flutter/flutter/issues/147578

- Destroy ImageReaders on memory trim.
- Unset the VirtualDisplay's surface on memory trim.
- On resume, recreate ImageReaders.
- On resume, do a dumb little dance and then set the VirtualDisplay's surface

Fixes: https://github.com/flutter/flutter/issues/146499
Fixes: https://github.com/flutter/flutter/issues/144219

Internal bug: b/335646931
Android Fix: https://googleplex-android-review.git.corp.google.com/c/platform/frameworks/base/+/27015418

Android 15 will include the fix. Unclear if Android 14 will be patched.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
