### PR TITLE
[skwasm] Change default `FilterQuality` to `None` for image shaders.

### DIFF
--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/shaders.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/shaders.dart
@@ -186,7 +186,7 @@ class SkwasmImageShader extends SkwasmNativeShader implements ui.ImageShader {
           image.handle,
           tmx.index,
           tmy.index,
-          (filterQuality ?? ui.FilterQuality.medium).index,
+          (filterQuality ?? ui.FilterQuality.none).index,
           localMatrix,
         ));
       });
@@ -195,7 +195,7 @@ class SkwasmImageShader extends SkwasmNativeShader implements ui.ImageShader {
         image.handle,
         tmx.index,
         tmy.index,
-        (filterQuality ?? ui.FilterQuality.medium).index,
+        (filterQuality ?? ui.FilterQuality.none).index,
         nullptr,
       ));
     }

--- a/lib/web_ui/test/ui/image_golden_test.dart
+++ b/lib/web_ui/test/ui/image_golden_test.dart
@@ -11,7 +11,6 @@ import 'dart:typed_data';
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
-import 'package:ui/src/engine/canvaskit/canvaskit_api.dart';
 
 import 'package:ui/ui.dart' as ui;
 import 'package:web_engine_tester/golden_tester.dart';

--- a/lib/web_ui/test/ui/image_golden_test.dart
+++ b/lib/web_ui/test/ui/image_golden_test.dart
@@ -238,7 +238,6 @@ Future<void> testMain() async {
           ui.TileMode.decal,
           ui.TileMode.decal,
           matrix,
-          filterQuality: ui.FilterQuality.medium,
         );
 
         // Draw an octagon

--- a/lib/web_ui/test/ui/image_golden_test.dart
+++ b/lib/web_ui/test/ui/image_golden_test.dart
@@ -273,7 +273,7 @@ Future<void> testMain() async {
         await drawPictureUsingCurrentRenderer(recorder.endRecording());
 
         await matchGoldenFile('${name}_drawVertices_imageShader.png', region: drawRegion);
-      });
+      }, skip: isHtml); // https://github.com/flutter/flutter/issues/127454;
 
       test('toByteData_rgba', () async {
         final ui.Image image = await generateImage();

--- a/lib/web_ui/test/ui/image_golden_test.dart
+++ b/lib/web_ui/test/ui/image_golden_test.dart
@@ -86,17 +86,23 @@ Future<void> testMain() async {
   // `imageGenerator` should produce an image that is 150x150 pixels.
   void emitImageTests(String name, Future<ui.Image> Function() imageGenerator) {
     group(name, () {
-      late ui.Image image;
-      setUp(() async {
-        image = await imageGenerator();
-      });
+      final List<ui.Image> images = <ui.Image>[];
+
+      Future<ui.Image> generateImage() async {
+        final ui.Image image = await imageGenerator();
+        images.add(image);
+        return image;
+      }
 
       tearDown(() {
-        image.dispose();
+        for (final ui.Image image in images) {
+          image.dispose();
+        }
+        images.clear();
       });
 
       test('drawImage', () async {
-        final ui.Image image = await imageGenerator();
+        final ui.Image image = await generateImage();
 
         final ui.PictureRecorder recorder = ui.PictureRecorder();
         final ui.Canvas canvas = ui.Canvas(recorder, drawRegion);
@@ -111,7 +117,7 @@ Future<void> testMain() async {
       });
 
       test('drawImageRect', () async {
-        final ui.Image image = await imageGenerator();
+        final ui.Image image = await generateImage();
 
         final ui.PictureRecorder recorder = ui.PictureRecorder();
         final ui.Canvas canvas = ui.Canvas(recorder, drawRegion);
@@ -147,7 +153,7 @@ Future<void> testMain() async {
       });
 
       test('drawImageNine', () async {
-        final ui.Image image = await imageGenerator();
+        final ui.Image image = await generateImage();
 
         final ui.PictureRecorder recorder = ui.PictureRecorder();
         final ui.Canvas canvas = ui.Canvas(recorder, drawRegion);
@@ -168,7 +174,7 @@ Future<void> testMain() async {
         final ui.Canvas canvas = ui.Canvas(recorder, drawRegion);
         final Float64List matrix = Matrix4.rotationZ(pi / 6).toFloat64();
         Future<void> drawOvalWithShader(ui.Rect rect, ui.FilterQuality quality) async {
-          final ui.Image image = await imageGenerator();
+          final ui.Image image = await generateImage();
           final ui.ImageShader shader = ui.ImageShader(
             image,
             ui.TileMode.repeated,
@@ -199,7 +205,7 @@ Future<void> testMain() async {
       });
 
       test('fragment_shader_sampler', () async {
-        final ui.Image image = await imageGenerator();
+        final ui.Image image = await generateImage();
 
         final ui.FragmentProgram program = await renderer.createFragmentProgram('glitch_shader');
         final ui.FragmentShader shader = program.fragmentShader();
@@ -224,7 +230,7 @@ Future<void> testMain() async {
       }, skip: isHtml); // HTML doesn't support fragment shaders
 
       test('drawVertices with image shader', () async {
-        final ui.Image image = await imageGenerator();
+        final ui.Image image = await generateImage();
 
         final Float64List matrix = Matrix4.rotationZ(pi / 6).toFloat64();
         final ui.ImageShader shader = ui.ImageShader(
@@ -270,7 +276,7 @@ Future<void> testMain() async {
       });
 
       test('toByteData_rgba', () async {
-        final ui.Image image = await imageGenerator();
+        final ui.Image image = await generateImage();
 
         final ByteData? rgbaData = await image.toByteData();
         expect(rgbaData, isNotNull);
@@ -278,7 +284,7 @@ Future<void> testMain() async {
       });
 
       test('toByteData_png', () async {
-        final ui.Image image = await imageGenerator();
+        final ui.Image image = await generateImage();
 
         final ByteData? pngData = await image.toByteData(format: ui.ImageByteFormat.png);
         expect(pngData, isNotNull);


### PR DESCRIPTION
This brings the behavior in line with the CanvasKit renderer, which also uses `None` for the default image shader quality.

I added a few unit tests to cover different filter qualities. It turns out, there is a skia issue that manifests both in CanvasKit and Skwasm when a lazy image is rendered with medium quality. See https://g-issues.skia.org/issues/338095525