### PR TITLE
Migrate androidx.window to 1.1.0 stable

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -381,8 +381,8 @@ embedding_dependencies_jars = [
   "//third_party/android_embedding_dependencies/lib/tracing-1.0.0.jar",
   "//third_party/android_embedding_dependencies/lib/versionedparcelable-1.1.1.jar",
   "//third_party/android_embedding_dependencies/lib/viewpager-1.0.0.jar",
-  "//third_party/android_embedding_dependencies/lib/window-1.0.0-beta04.jar",
-  "//third_party/android_embedding_dependencies/lib/window-java-1.0.0-beta04.jar",
+  "//third_party/android_embedding_dependencies/lib/window-1.0.0.jar",
+  "//third_party/android_embedding_dependencies/lib/window-java-1.0.0.jar",
 ]
 
 action("check_imports") {

--- a/tools/androidx/files.json
+++ b/tools/androidx/files.json
@@ -67,9 +67,9 @@
     ]
   },
   {
-    "url": "https://maven.google.com/androidx/window/window-java/1.0.0-beta04/window-java-1.0.0-beta04.aar",
+    "url": "https://maven.google.com/androidx/window/window-java/1.0.0/window-java-1.0.0.aar",
     "out_file_name": "androidx_window_java.aar",
-    "maven_dependency": "androidx.window:window-java:1.0.0-beta04",
+    "maven_dependency": "androidx.window:window-java:1.0.0",
     "provides": [
       "androidx.window.java.layout.WindowInfoRepositoryCallbackAdapter",
       "androidx.window.layout.DisplayFeature",


### PR DESCRIPTION
Updates the androidx.window dependency from 1.1.0-beta04 to 1.1.0-stable.

Note that since androidx.window is a maven dependency (and not a CIPD dependency), step 7 and 8 of the android_embedding_bundle/README.md were skipped.

Issue: 129307
Test: et build -c android_debug_arm64
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [test-exempt] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
