### PR TITLE
Fix et run

### DIFF
--- a/tools/engine_tool/test/run_command_test.dart
+++ b/tools/engine_tool/test/run_command_test.dart
@@ -153,9 +153,9 @@ void main() {
           'flutter',
           'run',
           '--local-engine',
-          'linux/android_debug_arm64',
+          'android_debug_arm64',
           '--local-engine-host',
-          'linux/host_debug',
+          'host_debug',
           '-d',
           'emulator'
         ]));


### PR DESCRIPTION
et run was broken in https://github.com/flutter/engine/pull/51803

this PR adds the missing calls to mangledConfigName before invoking flutter run
