### PR TITLE
[dart:ui] expose renderer selection for Impeller.

### DIFF
--- a/lib/ui/natives.dart
+++ b/lib/ui/natives.dart
@@ -108,8 +108,9 @@ typedef _ScheduleImmediateClosure = void Function(void Function());
 @pragma('vm:entry-point')
 _ScheduleImmediateClosure _getScheduleMicrotaskClosure() => _scheduleMicrotask;
 
-// Used internally to indicate whether the Engine is using Impeller for
-// rendering.
+/// Whether the Engine is using the Impeller rendering engine.
+bool get isImpellerEnabled => _impellerEnabled;
+
 @pragma('vm:entry-point')
 bool _impellerEnabled = false;
 


### PR DESCRIPTION
We'd like to conditionally switch to more accurate/expensive rendering if impeller is enabled, as we've actually been able to improve performance of the zoom page transition.

Requires:
 * https://github.com/flutter/flutter/pull/147648
 * https://github.com/flutter/engine/pull/52087
 
 Allows fixing https://github.com/flutter/flutter/issues/136510