### PR TITLE
macOS fluttertextinputplugin drops selector called if no client

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -438,6 +438,7 @@ static char markerKey;
       _activeModel->EndComposing();
     }
     [_textInputContext discardMarkedText];
+
     _clientID = nil;
     _inputAction = nil;
     _enableDeltaModel = NO;

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -438,7 +438,6 @@ static char markerKey;
       _activeModel->EndComposing();
     }
     [_textInputContext discardMarkedText];
-
     _clientID = nil;
     _inputAction = nil;
     _enableDeltaModel = NO;
@@ -776,6 +775,10 @@ static char markerKey;
     IMP imp = [self methodForSelector:selector];
     void (*func)(id, SEL, id) = reinterpret_cast<void (*)(id, SEL, id)>(imp);
     func(self, selector, nil);
+  }
+  if (self.clientID == nil) {
+    // The macOS may still call selector even if it is no longer a first responder.
+    return;
   }
 
   if (selector == @selector(insertNewline:)) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPluginTest.mm
@@ -1821,15 +1821,9 @@
   NSString* runLoopMode = @"FlutterTestRunLoopMode";
   plugin.customRunLoopMode = runLoopMode;
 
-  // Ensure both selectors are grouped in one platform channel call.
+  // Call selectors without setting a client.
   [plugin doCommandBySelector:@selector(moveUp:)];
   [plugin doCommandBySelector:@selector(moveRightAndModifySelection:)];
-
-  // Clear the client before the CFRunLoop is run.
-  [plugin handleMethodCall:[FlutterMethodCall methodCallWithMethodName:@"TextInput.clearClient"
-                                                             arguments:@[]]
-                    result:^(id){
-                    }];
 
   __block bool done = false;
   CFRunLoopPerformBlock(CFRunLoopGetMain(), (__bridge CFStringRef)runLoopMode, ^{
@@ -1837,7 +1831,6 @@
   });
 
   while (!done) {
-    // Each invocation will handle one source.
     CFRunLoopRunInMode((__bridge CFStringRef)runLoopMode, 0, true);
   }
   // At this point the selectors should be dropped; otherwise, OCMReject will throw.


### PR DESCRIPTION
The observed behavior is that if a keypress both reach framework and flutter textinputplugin selector and the keypress handler in framework causes the the textinputplugin to resign first responder, the selector will still go through even if the textinputplugin has already resigned.

The pr makes it so textinputplugin will ignore these selector call

fixes https://github.com/flutter/flutter/issues/143270

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
