### PR TITLE
[Impeller] allow for one more active swapchain image.

### DIFF
--- a/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
@@ -17,9 +17,11 @@ namespace impeller {
 
 //------------------------------------------------------------------------------
 /// The maximum number of presents pending in the compositor after which the
-/// acquire calls will block.
+/// acquire calls will block. This value is 2 images given to the system
+/// compositor and one for the raster thread, Because the semaphore is acquired
+/// when the CPU Begins working on the texture
 ///
-static constexpr const size_t kMaxPendingPresents = 2u;
+static constexpr const size_t kMaxPendingPresents = 3u;
 
 static TextureDescriptor ToSwapchainTextureDescriptor(
     const android::HardwareBufferDescriptor& ahb_desc) {

--- a/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_texture_pool_vk.h
+++ b/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_texture_pool_vk.h
@@ -45,7 +45,7 @@ class AHBTexturePoolVK {
   explicit AHBTexturePoolVK(
       std::weak_ptr<Context> context,
       android::HardwareBufferDescriptor desc,
-      size_t max_entries = 2u,
+      size_t max_entries = 3u,
       std::chrono::milliseconds max_extry_age = std::chrono::seconds{1});
 
   ~AHBTexturePoolVK();

--- a/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_texture_pool_vk.h
+++ b/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_texture_pool_vk.h
@@ -45,7 +45,7 @@ class AHBTexturePoolVK {
   explicit AHBTexturePoolVK(
       std::weak_ptr<Context> context,
       android::HardwareBufferDescriptor desc,
-      size_t max_entries = 3u,
+      size_t max_entries = 2u,
       std::chrono::milliseconds max_extry_age = std::chrono::seconds{1});
 
   ~AHBTexturePoolVK();


### PR DESCRIPTION
Currently the rendering performance is less stable with this patch: https://flutter-flutter-perf.skia.org/e/?queries=device_type%3DPixel_7_Pro%26sub_result%3D90th_percentile_frame_rasterizer_time_millis%26sub_result%3D99th_percentile_frame_rasterizer_time_millis%26sub_result%3Daverage_frame_rasterizer_time_millis%26sub_result%3Dworst_frame_rasterizer_time_millis%26test%3Dcomplex_layout_scroll_perf_impeller__timeline_summary&selected=commit%3D40592%26name%3D%252Carch%253Dintel%252Cbranch%253Dmaster%252Cconfig%253Ddefault%252Cdevice_type%253DPixel_7_Pro%252Cdevice_version%253Dnone%252Chost_type%253Dlinux%252Csub_result%253D99th_percentile_frame_rasterizer_time_millis%252Ctest%253Dcomplex_layout_scroll_perf_impeller__timeline_summary%252C


The reason I suspect that is that we're signaling the semaphore at the start of the raster thread. This means that we're limiting the actual number of pending presents to 1, as we also need to account for the CPU access. Increase this and the max texture count to 3, to allow 2 pending presents and one image worked on by the CPU.