### PR TITLE
[fuchsia] route fuchsia.sysmem2.Allocator pt 2

### DIFF
--- a/shell/platform/fuchsia/flutter/tests/integration/embedder/flutter-embedder-test.cc
+++ b/shell/platform/fuchsia/flutter/tests/integration/embedder/flutter-embedder-test.cc
@@ -237,6 +237,11 @@ void FlutterEmbedderTest::SetUpRealmBase() {
                     Protocol{fuchsia::logger::LogSink::Name_},
                     Protocol{fuchsia::inspect::InspectSink::Name_},
                     Protocol{fuchsia::sysmem::Allocator::Name_},
+
+                    // Replace "fuchsia.sysmem2.Allocator" with
+                    // fuchsia::sysmem2::Allocator::Name_
+                    // when available (fuchsia SDK >= 19).
+                    Protocol{"fuchsia.sysmem2.Allocator"},
                     Protocol{fuchsia::tracing::provider::Registry::Name_},
                     Protocol{kVulkanLoaderServiceName},
                 },
@@ -249,6 +254,11 @@ void FlutterEmbedderTest::SetUpRealmBase() {
       .capabilities = {Protocol{fuchsia::logger::LogSink::Name_},
                        Protocol{fuchsia::inspect::InspectSink::Name_},
                        Protocol{fuchsia::sysmem::Allocator::Name_},
+
+                       // Replace "fuchsia.sysmem2.Allocator" with
+                       // fuchsia::sysmem2::Allocator::Name_
+                       // when available (fuchsia SDK >= 19).
+                       Protocol{"fuchsia.sysmem2.Allocator"},
                        Protocol{fuchsia::tracing::provider::Registry::Name_},
                        Protocol{kVulkanLoaderServiceName}},
       .source = ParentRef{},


### PR DESCRIPTION
Fuchsia's fake-display will be migrating to sysmem2, which requires fuchsia.sysmem2.Allocator to be routed.

fixes https://github.com/flutter/flutter/issues/146858

- [y] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [y] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [na] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [y] I listed at least one issue that this PR fixes in the description above.
- [fixes to existing tests] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [na] I updated/added relevant documentation (doc comments with `///`).
- [na / googler] I signed the [CLA].
- [y] All existing and new tests are passing.
