### PR TITLE
[Impeller] Pop AHBs from front of buffer queue instead of back.

### DIFF
--- a/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.cc
+++ b/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.cc
@@ -266,8 +266,7 @@ static TextureType ToTextureType(const AHardwareBuffer_Desc& ahb_desc) {
 }
 
 static TextureDescriptor ToTextureDescriptor(
-    const AHardwareBuffer_Desc& ahb_desc,
-    bool is_swapchain_image) {
+    const AHardwareBuffer_Desc& ahb_desc) {
   const auto ahb_size = ISize{ahb_desc.width, ahb_desc.height};
   TextureDescriptor desc;
   // We are not going to touch hardware buffers on the CPU or use them as
@@ -282,7 +281,8 @@ static TextureDescriptor ToTextureDescriptor(
   desc.mip_count = (ahb_desc.usage & AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE)
                        ? ahb_size.MipCount()
                        : 1u;
-  if (is_swapchain_image) {
+
+  if (ahb_desc.usage & AHARDWAREBUFFER_USAGE_COMPOSER_OVERLAY) {
     desc.usage = TextureUsage::kRenderTarget;
   }
 
@@ -292,9 +292,8 @@ static TextureDescriptor ToTextureDescriptor(
 AHBTextureSourceVK::AHBTextureSourceVK(
     const std::shared_ptr<Context>& p_context,
     struct AHardwareBuffer* ahb,
-    const AHardwareBuffer_Desc& ahb_desc,
-    bool is_swapchain_image)
-    : TextureSourceVK(ToTextureDescriptor(ahb_desc, is_swapchain_image)) {
+    const AHardwareBuffer_Desc& ahb_desc)
+    : TextureSourceVK(ToTextureDescriptor(ahb_desc)) {
   if (!p_context) {
     return;
   }
@@ -377,8 +376,7 @@ AHBTextureSourceVK::AHBTextureSourceVK(
     bool is_swapchain_image)
     : AHBTextureSourceVK(context,
                          backing_store->GetHandle(),
-                         backing_store->GetAndroidDescriptor(),
-                         is_swapchain_image) {
+                         backing_store->GetAndroidDescriptor()) {
   backing_store_ = std::move(backing_store);
   is_swapchain_image_ = is_swapchain_image;
 }

--- a/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.cc
+++ b/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.cc
@@ -266,7 +266,8 @@ static TextureType ToTextureType(const AHardwareBuffer_Desc& ahb_desc) {
 }
 
 static TextureDescriptor ToTextureDescriptor(
-    const AHardwareBuffer_Desc& ahb_desc) {
+    const AHardwareBuffer_Desc& ahb_desc,
+    bool is_swapchain_image) {
   const auto ahb_size = ISize{ahb_desc.width, ahb_desc.height};
   TextureDescriptor desc;
   // We are not going to touch hardware buffers on the CPU or use them as
@@ -281,14 +282,19 @@ static TextureDescriptor ToTextureDescriptor(
   desc.mip_count = (ahb_desc.usage & AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE)
                        ? ahb_size.MipCount()
                        : 1u;
+  if (is_swapchain_image) {
+    desc.usage = TextureUsage::kRenderTarget;
+  }
+
   return desc;
 }
 
 AHBTextureSourceVK::AHBTextureSourceVK(
     const std::shared_ptr<Context>& p_context,
     struct AHardwareBuffer* ahb,
-    const AHardwareBuffer_Desc& ahb_desc)
-    : TextureSourceVK(ToTextureDescriptor(ahb_desc)) {
+    const AHardwareBuffer_Desc& ahb_desc,
+    bool is_swapchain_image)
+    : TextureSourceVK(ToTextureDescriptor(ahb_desc, is_swapchain_image)) {
   if (!p_context) {
     return;
   }
@@ -371,7 +377,8 @@ AHBTextureSourceVK::AHBTextureSourceVK(
     bool is_swapchain_image)
     : AHBTextureSourceVK(context,
                          backing_store->GetHandle(),
-                         backing_store->GetAndroidDescriptor()) {
+                         backing_store->GetAndroidDescriptor(),
+                         is_swapchain_image) {
   backing_store_ = std::move(backing_store);
   is_swapchain_image_ = is_swapchain_image;
 }

--- a/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.h
+++ b/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.h
@@ -36,7 +36,8 @@ class AHBTextureSourceVK final : public TextureSourceVK {
  public:
   AHBTextureSourceVK(const std::shared_ptr<Context>& context,
                      struct AHardwareBuffer* hardware_buffer,
-                     const AHardwareBuffer_Desc& hardware_buffer_desc);
+                     const AHardwareBuffer_Desc& hardware_buffer_desc,
+                     bool is_swapchain_image = false);
 
   AHBTextureSourceVK(const std::shared_ptr<Context>& context,
                      std::unique_ptr<android::HardwareBuffer> backing_store,

--- a/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.h
+++ b/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.h
@@ -36,8 +36,7 @@ class AHBTextureSourceVK final : public TextureSourceVK {
  public:
   AHBTextureSourceVK(const std::shared_ptr<Context>& context,
                      struct AHardwareBuffer* hardware_buffer,
-                     const AHardwareBuffer_Desc& hardware_buffer_desc,
-                     bool is_swapchain_image = false);
+                     const AHardwareBuffer_Desc& hardware_buffer_desc);
 
   AHBTextureSourceVK(const std::shared_ptr<Context>& context,
                      std::unique_ptr<android::HardwareBuffer> backing_store,

--- a/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
@@ -37,17 +37,17 @@ static TextureDescriptor ToSwapchainTextureDescriptor(
 
 std::shared_ptr<AHBSwapchainImplVK> AHBSwapchainImplVK::Create(
     const std::weak_ptr<Context>& context,
-    std::weak_ptr<android::SurfaceControl> surface_control,
+    const std::weak_ptr<android::SurfaceControl>& surface_control,
     const ISize& size,
     bool enable_msaa) {
-  auto impl = std::shared_ptr<AHBSwapchainImplVK>(new AHBSwapchainImplVK(
-      context, std::move(surface_control), size, enable_msaa));
+  auto impl = std::shared_ptr<AHBSwapchainImplVK>(
+      new AHBSwapchainImplVK(context, surface_control, size, enable_msaa));
   return impl->IsValid() ? impl : nullptr;
 }
 
 AHBSwapchainImplVK::AHBSwapchainImplVK(
     const std::weak_ptr<Context>& context,
-    std::weak_ptr<android::SurfaceControl> surface_control,
+    const std::weak_ptr<android::SurfaceControl>& surface_control,
     const ISize& size,
     bool enable_msaa)
     : surface_control_(std::move(surface_control)),
@@ -179,7 +179,7 @@ std::shared_ptr<ExternalFenceVK> AHBSwapchainImplVK::SubmitCompletionSignal(
 
   BarrierVK barrier;
   barrier.cmd_buffer = command_encoder_vk;
-  barrier.new_layout = vk::ImageLayout::eGeneral;
+  barrier.new_layout = vk::ImageLayout::ePresentSrcKHR;
   barrier.src_stage = vk::PipelineStageFlagBits::eColorAttachmentOutput;
   barrier.src_access = vk::AccessFlagBits::eColorAttachmentWrite;
   barrier.dst_stage = vk::PipelineStageFlagBits::eBottomOfPipe;
@@ -208,7 +208,7 @@ std::shared_ptr<ExternalFenceVK> AHBSwapchainImplVK::SubmitCompletionSignal(
 
 void AHBSwapchainImplVK::OnTextureSetOnSurfaceControl(
     const AutoSemaSignaler& signaler,
-    std::shared_ptr<AHBTextureSourceVK> texture) {
+    const std::shared_ptr<AHBTextureSourceVK>& texture) {
   signaler->Reset();
   // The transaction completion indicates that the surface control now
   // references the hardware buffer. We can recycle the previous set buffer

--- a/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
@@ -9,6 +9,7 @@
 #include "impeller/renderer/backend/vulkan/barrier_vk.h"
 #include "impeller/renderer/backend/vulkan/command_buffer_vk.h"
 #include "impeller/renderer/backend/vulkan/command_encoder_vk.h"
+#include "impeller/renderer/backend/vulkan/gpu_tracer_vk.h"
 #include "impeller/renderer/backend/vulkan/swapchain/ahb/ahb_formats.h"
 #include "impeller/renderer/backend/vulkan/swapchain/surface_vk.h"
 #include "impeller/toolkit/android/surface_transaction.h"
@@ -126,6 +127,10 @@ bool AHBSwapchainImplVK::Present(
     VALIDATION_LOG << "Surface control died before swapchain image could be "
                       "presented.";
     return false;
+  }
+  auto context = transients_->GetContext().lock();
+  if (context) {
+    ContextVK::Cast(*context).GetGPUTracer()->MarkFrameEnd();
   }
 
   if (!texture) {

--- a/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
@@ -184,7 +184,7 @@ std::shared_ptr<ExternalFenceVK> AHBSwapchainImplVK::SubmitCompletionSignal(
 
   BarrierVK barrier;
   barrier.cmd_buffer = command_encoder_vk;
-  barrier.new_layout = vk::ImageLayout::ePresentSrcKHR;
+  barrier.new_layout = vk::ImageLayout::eGeneral;
   barrier.src_stage = vk::PipelineStageFlagBits::eColorAttachmentOutput;
   barrier.src_access = vk::AccessFlagBits::eColorAttachmentWrite;
   barrier.dst_stage = vk::PipelineStageFlagBits::eBottomOfPipe;

--- a/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.h
+++ b/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.h
@@ -49,7 +49,7 @@ class AHBSwapchainImplVK final
   ///
   static std::shared_ptr<AHBSwapchainImplVK> Create(
       const std::weak_ptr<Context>& context,
-      std::weak_ptr<android::SurfaceControl> surface_control,
+      const std::weak_ptr<android::SurfaceControl>& surface_control,
       const ISize& size,
       bool enable_msaa);
 
@@ -105,7 +105,7 @@ class AHBSwapchainImplVK final
 
   explicit AHBSwapchainImplVK(
       const std::weak_ptr<Context>& context,
-      std::weak_ptr<android::SurfaceControl> surface_control,
+      const std::weak_ptr<android::SurfaceControl>& surface_control,
       const ISize& size,
       bool enable_msaa);
 
@@ -117,7 +117,7 @@ class AHBSwapchainImplVK final
 
   void OnTextureSetOnSurfaceControl(
       const AutoSemaSignaler& signaler,
-      std::shared_ptr<AHBTextureSourceVK> texture);
+      const std::shared_ptr<AHBTextureSourceVK>& texture);
 };
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_texture_pool_vk.h
+++ b/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_texture_pool_vk.h
@@ -42,11 +42,9 @@ class AHBTexturePoolVK {
   /// @param[in]  max_extry_age  The maximum duration an entry will remain
   ///                            cached in the pool.
   ///
-  explicit AHBTexturePoolVK(
-      std::weak_ptr<Context> context,
-      android::HardwareBufferDescriptor desc,
-      size_t max_entries = 2u,
-      std::chrono::milliseconds max_extry_age = std::chrono::seconds{1});
+  explicit AHBTexturePoolVK(const std::weak_ptr<Context>& context,
+                            android::HardwareBufferDescriptor desc,
+                            size_t max_entries = 2u);
 
   ~AHBTexturePoolVK();
 
@@ -86,7 +84,7 @@ class AHBTexturePoolVK {
   ///
   /// @param[in]  texture  The texture to be returned to the pool.
   ///
-  void Push(std::shared_ptr<AHBTextureSourceVK> texture);
+  void Push(const std::shared_ptr<AHBTextureSourceVK>& texture);
 
   //----------------------------------------------------------------------------
   /// @brief      Perform an explicit GC of the pool items. This happens
@@ -98,17 +96,15 @@ class AHBTexturePoolVK {
 
  private:
   struct PoolEntry {
-    TimePoint last_access_time;
     std::shared_ptr<AHBTextureSourceVK> item;
 
     explicit PoolEntry(std::shared_ptr<AHBTextureSourceVK> p_item)
-        : last_access_time(Clock::now()), item(std::move(p_item)) {}
+        : item(std::move(p_item)) {}
   };
 
   const std::weak_ptr<Context> context_;
   const android::HardwareBufferDescriptor desc_;
   const size_t max_entries_;
-  const std::chrono::milliseconds max_extry_age_;
   bool is_valid_ = false;
   Mutex pool_mutex_;
   std::deque<PoolEntry> pool_ IPLR_GUARDED_BY(pool_mutex_);

--- a/impeller/renderer/backend/vulkan/swapchain/surface_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain/surface_vk.cc
@@ -24,16 +24,7 @@ std::unique_ptr<SurfaceVK> SurfaceVK::WrapSwapchainImage(
   }
 
   const auto enable_msaa = transients->IsMSAAEnabled();
-
   const auto swapchain_tex_desc = swapchain_image->GetTextureDescriptor();
-
-  TextureDescriptor resolve_tex_desc;
-  resolve_tex_desc.type = TextureType::kTexture2D;
-  resolve_tex_desc.format = swapchain_tex_desc.format;
-  resolve_tex_desc.size = swapchain_tex_desc.size;
-  resolve_tex_desc.usage = TextureUsage::kRenderTarget;
-  resolve_tex_desc.sample_count = SampleCount::kCount1;
-  resolve_tex_desc.storage_mode = StorageMode::kDevicePrivate;
 
   std::shared_ptr<Texture> resolve_tex =
       std::make_shared<TextureVK>(context,         //


### PR DESCRIPTION
Fixes visual artifacts rendering on a Pixel 7. I also noticed that the swapchain images were tagged as sampled images but not render targets, so I fixed that and the barrier. THough by itself the barrier was not sufficient to fix the artifacts.

Its possible that external memory barriers don't do anything? Or presentSrcKHR is the wrong state.

Fixes https://github.com/flutter/flutter/issues/147723