### PR TITLE
[Impeller] allow cloning a rectangle packer with an increased size.

### DIFF
--- a/impeller/typographer/backends/skia/typographer_context_skia.cc
+++ b/impeller/typographer/backends/skia/typographer_context_skia.cc
@@ -61,7 +61,7 @@ static size_t PairsFitInAtlasOfSize(
     const auto glyph_size =
         ISize::Ceil(pair.glyph.bounds.GetSize() * pair.scaled_font.scale);
     IPoint16 location_in_atlas;
-    if (!rect_packer->addRect(glyph_size.width + kPadding,   //
+    if (!rect_packer->AddRect(glyph_size.width + kPadding,   //
                               glyph_size.height + kPadding,  //
                               &location_in_atlas             //
                               )) {
@@ -99,7 +99,7 @@ static bool CanAppendToExistingAtlas(
     const auto glyph_size =
         ISize::Ceil(pair.glyph.bounds.GetSize() * pair.scaled_font.scale);
     IPoint16 location_in_atlas;
-    if (!rect_packer->addRect(glyph_size.width + kPadding,   //
+    if (!rect_packer->AddRect(glyph_size.width + kPadding,   //
                               glyph_size.height + kPadding,  //
                               &location_in_atlas             //
                               )) {

--- a/impeller/typographer/backends/stb/typographer_context_stb.cc
+++ b/impeller/typographer/backends/stb/typographer_context_stb.cc
@@ -79,7 +79,7 @@ static size_t PairsFitInAtlasOfSize(
     }
 
     IPoint16 location_in_atlas;
-    if (!rect_packer->addRect(glyph_size.width + kPadding,   //
+    if (!rect_packer->AddRect(glyph_size.width + kPadding,   //
                               glyph_size.height + kPadding,  //
                               &location_in_atlas             //
                               )) {
@@ -136,7 +136,7 @@ static bool CanAppendToExistingAtlas(
     }
 
     IPoint16 location_in_atlas;
-    if (!rect_packer->addRect(glyph_size.width + kPadding,   //
+    if (!rect_packer->AddRect(glyph_size.width + kPadding,   //
                               glyph_size.height + kPadding,  //
                               &location_in_atlas             //
                               )) {

--- a/impeller/typographer/rectangle_packer.cc
+++ b/impeller/typographer/rectangle_packer.cc
@@ -33,6 +33,8 @@ class SkylineRectanglePacker final : public RectanglePacker {
     return area_so_far_ / ((float)this->width() * this->height());
   }
 
+  std::unique_ptr<RectanglePacker> CloneWithSize(int width, int height) final;
+
  private:
   struct SkylineSegment {
     int x_;
@@ -164,6 +166,19 @@ void SkylineRectanglePacker::addSkylineLevel(int skylineIndex,
       --i;
     }
   }
+}
+
+std::unique_ptr<RectanglePacker> SkylineRectanglePacker::CloneWithSize(
+    int width,
+    int height) {
+  FML_DCHECK(width >= this->width() && height >= this->height());
+  auto packer = std::make_unique<SkylineRectanglePacker>(width, height);
+  for (SkylineSegment segment : skyline_) {
+    packer->skyline_.push_back(segment);
+  }
+  packer->area_so_far_ = area_so_far_;
+
+  return packer;
 }
 
 std::unique_ptr<RectanglePacker> RectanglePacker::Factory(int width,

--- a/impeller/typographer/rectangle_packer.cc
+++ b/impeller/typographer/rectangle_packer.cc
@@ -33,7 +33,7 @@ class SkylineRectanglePacker final : public RectanglePacker {
     return area_so_far_ / ((float)this->width() * this->height());
   }
 
-  std::unique_ptr<RectanglePacker> CloneWithSize(int width, int height) final;
+  std::unique_ptr<RectanglePacker> Clone(int scale) final;
 
  private:
   struct SkylineSegment {
@@ -131,13 +131,13 @@ void SkylineRectanglePacker::addSkylineLevel(int skylineIndex,
   newSegment.width_ = width;
   skyline_.insert(std::next(skyline_.begin(), skylineIndex), newSegment);
 
-  FML_DCHECK(newSegment.x_ + newSegment.width_ <= this->width());
-  FML_DCHECK(newSegment.y_ <= this->height());
+  FML_CHECK(newSegment.x_ + newSegment.width_ <= this->width());
+  FML_CHECK(newSegment.y_ <= this->height());
 
   // delete width of the new skyline segment from following ones
   for (int i = skylineIndex + 1; i < (int)skyline_.size(); ++i) {
     // The new segment subsumes all or part of skyline_[i]
-    FML_DCHECK(skyline_[i - 1].x_ <= skyline_[i].x_);
+    FML_CHECK(skyline_[i - 1].x_ <= skyline_[i].x_);
 
     if (skyline_[i].x_ < skyline_[i - 1].x_ + skyline_[i - 1].width_) {
       int shrink = skyline_[i - 1].x_ + skyline_[i - 1].width_ - skyline_[i].x_;
@@ -168,11 +168,10 @@ void SkylineRectanglePacker::addSkylineLevel(int skylineIndex,
   }
 }
 
-std::unique_ptr<RectanglePacker> SkylineRectanglePacker::CloneWithSize(
-    int width,
-    int height) {
-  FML_DCHECK(width >= this->width() && height >= this->height());
-  auto packer = std::make_unique<SkylineRectanglePacker>(width, height);
+std::unique_ptr<RectanglePacker> SkylineRectanglePacker::Clone(int scale) {
+  FML_DCHECK(scale >= 0);
+  auto packer =
+      std::make_unique<SkylineRectanglePacker>(width(), height() * scale);
   for (SkylineSegment segment : skyline_) {
     packer->skyline_.push_back(segment);
   }

--- a/impeller/typographer/rectangle_packer.cc
+++ b/impeller/typographer/rectangle_packer.cc
@@ -16,24 +16,24 @@ namespace impeller {
 class SkylineRectanglePacker final : public RectanglePacker {
  public:
   SkylineRectanglePacker(int w, int h) : RectanglePacker(w, h) {
-    this->reset();
+    this->Reset();
   }
 
   ~SkylineRectanglePacker() final {}
 
-  void reset() final {
+  void Reset() final {
     area_so_far_ = 0;
     skyline_.clear();
     skyline_.push_back(SkylineSegment{0, 0, this->width()});
   }
 
-  bool addRect(int w, int h, IPoint16* loc) final;
+  bool AddRect(int w, int h, IPoint16* loc) final;
 
-  float percentFull() const final {
+  Scalar PercentFull() const final {
     return area_so_far_ / ((float)this->width() * this->height());
   }
 
-  std::unique_ptr<RectanglePacker> Clone(int scale) final;
+  std::unique_ptr<RectanglePacker> Clone(uint32_t scale) final;
 
  private:
   struct SkylineSegment {
@@ -56,7 +56,7 @@ class SkylineRectanglePacker final : public RectanglePacker {
   void addSkylineLevel(int skylineIndex, int x, int y, int width, int height);
 };
 
-bool SkylineRectanglePacker::addRect(int width, int height, IPoint16* loc) {
+bool SkylineRectanglePacker::AddRect(int width, int height, IPoint16* loc) {
   if ((unsigned)width > (unsigned)this->width() ||
       (unsigned)height > (unsigned)this->height()) {
     return false;
@@ -168,8 +168,8 @@ void SkylineRectanglePacker::addSkylineLevel(int skylineIndex,
   }
 }
 
-std::unique_ptr<RectanglePacker> SkylineRectanglePacker::Clone(int scale) {
-  FML_DCHECK(scale >= 0);
+std::unique_ptr<RectanglePacker> SkylineRectanglePacker::Clone(uint32_t scale) {
+  FML_DCHECK(scale != 0);
   auto packer =
       std::make_unique<SkylineRectanglePacker>(width(), height() * scale);
   for (SkylineSegment segment : skyline_) {

--- a/impeller/typographer/rectangle_packer.cc
+++ b/impeller/typographer/rectangle_packer.cc
@@ -131,13 +131,13 @@ void SkylineRectanglePacker::addSkylineLevel(int skylineIndex,
   newSegment.width_ = width;
   skyline_.insert(std::next(skyline_.begin(), skylineIndex), newSegment);
 
-  FML_CHECK(newSegment.x_ + newSegment.width_ <= this->width());
-  FML_CHECK(newSegment.y_ <= this->height());
+  FML_DCHECK(newSegment.x_ + newSegment.width_ <= this->width());
+  FML_DCHECK(newSegment.y_ <= this->height());
 
   // delete width of the new skyline segment from following ones
   for (int i = skylineIndex + 1; i < (int)skyline_.size(); ++i) {
     // The new segment subsumes all or part of skyline_[i]
-    FML_CHECK(skyline_[i - 1].x_ <= skyline_[i].x_);
+    FML_DCHECK(skyline_[i - 1].x_ <= skyline_[i].x_);
 
     if (skyline_[i].x_ < skyline_[i - 1].x_ + skyline_[i - 1].width_) {
       int shrink = skyline_[i - 1].x_ + skyline_[i - 1].width_ - skyline_[i].x_;

--- a/impeller/typographer/rectangle_packer.h
+++ b/impeller/typographer/rectangle_packer.h
@@ -51,6 +51,16 @@ class RectanglePacker {
   virtual float percentFull() const = 0;
 
   //----------------------------------------------------------------------------
+  /// @brief     Create a new rectangle packer with a different (larger) size
+  ///            and initialize its contents to the current packer.
+  ///
+  /// @return    A new rectangle packer.
+  ///
+  ///            This method is used for growing the glyph atlas while keeping
+  ///            existing glyphs in place.
+  virtual std::unique_ptr<RectanglePacker> CloneWithSize(int width, int height);
+
+  //----------------------------------------------------------------------------
   /// @brief     Empty out all previously added rectangles.
   ///
   virtual void reset() = 0;

--- a/impeller/typographer/rectangle_packer.h
+++ b/impeller/typographer/rectangle_packer.h
@@ -51,14 +51,17 @@ class RectanglePacker {
   virtual float percentFull() const = 0;
 
   //----------------------------------------------------------------------------
-  /// @brief     Create a new rectangle packer with a different (larger) size
-  ///            and initialize its contents to the current packer.
+  /// @brief     Create a new rectangle packer with a larger scaled height
+  ///            scaled and initialize its contents to the current packer.
+  ///
+  /// @param[in] scale  The scaling factor to be applied to the new height.
   ///
   /// @return    A new rectangle packer.
   ///
   ///            This method is used for growing the glyph atlas while keeping
-  ///            existing glyphs in place.
-  virtual std::unique_ptr<RectanglePacker> CloneWithSize(int width, int height);
+  ///            existing glyphs in place. The width of the rectangle packer
+  ///            cannot be increased.
+  virtual std::unique_ptr<RectanglePacker> Clone(int scale);
 
   //----------------------------------------------------------------------------
   /// @brief     Empty out all previously added rectangles.

--- a/impeller/typographer/rectangle_packer.h
+++ b/impeller/typographer/rectangle_packer.h
@@ -6,6 +6,7 @@
 #define FLUTTER_IMPELLER_TYPOGRAPHER_RECTANGLE_PACKER_H_
 
 #include "flutter/fml/logging.h"
+#include "impeller/geometry/scalar.h"
 
 #include <cstdint>
 
@@ -41,14 +42,14 @@ class RectanglePacker {
   ///
   /// @return     Return true on success; false on failure.
   ///
-  virtual bool addRect(int width, int height, IPoint16* loc) = 0;
+  virtual bool AddRect(int width, int height, IPoint16* loc) = 0;
 
   //----------------------------------------------------------------------------
   /// @brief     Returns how much area has been filled with rectangles.
   ///
   /// @return    Percentage as a decimal between 0.0 and 1.0
   ///
-  virtual float percentFull() const = 0;
+  virtual Scalar PercentFull() const = 0;
 
   //----------------------------------------------------------------------------
   /// @brief     Create a new rectangle packer with a larger scaled height
@@ -59,14 +60,14 @@ class RectanglePacker {
   /// @return    A new rectangle packer.
   ///
   ///            This method is used for growing the glyph atlas while keeping
-  ///            existing glyphs in place. The width of the rectangle packer
+  ///            existing rects in place. The width of the rectangle packer
   ///            cannot be increased.
-  virtual std::unique_ptr<RectanglePacker> Clone(int scale) = 0;
+  virtual std::unique_ptr<RectanglePacker> Clone(uint32_t scale) = 0;
 
   //----------------------------------------------------------------------------
   /// @brief     Empty out all previously added rectangles.
   ///
-  virtual void reset() = 0;
+  virtual void Reset() = 0;
 
  protected:
   RectanglePacker(int width, int height) : width_(width), height_(height) {

--- a/impeller/typographer/typographer_unittests.cc
+++ b/impeller/typographer/typographer_unittests.cc
@@ -375,6 +375,60 @@ TEST_P(TypographerTest,
   ASSERT_NE(old_packer, new_packer);
 }
 
+TEST(TypographerTest, CanCloneRectanglePackerEmpty) {
+  auto skyline = RectanglePacker::Factory(256, 256);
+
+  EXPECT_EQ(skyline->percentFull(), 0);
+
+  auto skyline_2 = skyline->CloneWithSize(512, 512);
+
+  EXPECT_EQ(skyline->percentFull(), 0);
+}
+
+TEST(TypographerTest, CanCloneRectanglePackerAndPreservePositions) {
+  auto skyline = RectanglePacker::Factory(256, 256);
+  IPoint16 loc;
+  EXPECT_TRUE(skyline->addRect(100, 100, &loc));
+
+  EXPECT_EQ(loc.x(), 0);
+  EXPECT_EQ(loc.y(), 0);
+  auto percent = skyline->percentFull();
+
+  auto skyline_2 = skyline->CloneWithSize(512, 512);
+
+  EXPECT_LT(skyline_2->percentFull(), percent);
+}
+
+TEST(TypographerTest, CanCloneRectanglePackerWhileFull) {
+  auto skyline = RectanglePacker::Factory(256, 256);
+  IPoint16 loc;
+  // Add a rectangle the size of the entire area.
+  EXPECT_TRUE(skyline->addRect(256, 256, &loc));
+  // Packer is now full.
+  EXPECT_FALSE(skyline->addRect(256, 256, &loc));
+
+  auto skyline_2 = skyline->CloneWithSize(512, 512);
+
+  // Can now fit three more
+  EXPECT_TRUE(skyline_2->addRect(256, 256, &loc));
+  EXPECT_TRUE(skyline_2->addRect(256, 256, &loc));
+  EXPECT_TRUE(skyline_2->addRect(256, 256, &loc));
+}
+
+TEST(TypographerTest, CloneToSameSizePreservesContents) {
+  auto skyline = RectanglePacker::Factory(256, 256);
+  IPoint16 loc;
+  // Add a rectangle the size of the entire area.
+  EXPECT_TRUE(skyline->addRect(256, 256, &loc));
+  // Packer is now full.
+  EXPECT_FALSE(skyline->addRect(256, 256, &loc));
+
+  auto skyline_2 = skyline->CloneWithSize(256, 256);
+
+  // Packer is still full.
+  EXPECT_FALSE(skyline->addRect(256, 256, &loc));
+}
+
 }  // namespace testing
 }  // namespace impeller
 

--- a/impeller/typographer/typographer_unittests.cc
+++ b/impeller/typographer/typographer_unittests.cc
@@ -380,7 +380,7 @@ TEST(TypographerTest, CanCloneRectanglePackerEmpty) {
 
   EXPECT_EQ(skyline->percentFull(), 0);
 
-  auto skyline_2 = skyline->CloneWithSize(512, 512);
+  auto skyline_2 = skyline->Clone(/*scale=*/2);
 
   EXPECT_EQ(skyline->percentFull(), 0);
 }
@@ -394,7 +394,7 @@ TEST(TypographerTest, CanCloneRectanglePackerAndPreservePositions) {
   EXPECT_EQ(loc.y(), 0);
   auto percent = skyline->percentFull();
 
-  auto skyline_2 = skyline->CloneWithSize(512, 512);
+  auto skyline_2 = skyline->Clone(/*scale=*/2);
 
   EXPECT_LT(skyline_2->percentFull(), percent);
 }
@@ -407,11 +407,9 @@ TEST(TypographerTest, CanCloneRectanglePackerWhileFull) {
   // Packer is now full.
   EXPECT_FALSE(skyline->addRect(256, 256, &loc));
 
-  auto skyline_2 = skyline->CloneWithSize(512, 512);
+  auto skyline_2 = skyline->Clone(/*scale=*/2);
 
-  // Can now fit three more
-  EXPECT_TRUE(skyline_2->addRect(256, 256, &loc));
-  EXPECT_TRUE(skyline_2->addRect(256, 256, &loc));
+  // Can now fit one more
   EXPECT_TRUE(skyline_2->addRect(256, 256, &loc));
 }
 
@@ -423,7 +421,7 @@ TEST(TypographerTest, CloneToSameSizePreservesContents) {
   // Packer is now full.
   EXPECT_FALSE(skyline->addRect(256, 256, &loc));
 
-  auto skyline_2 = skyline->CloneWithSize(256, 256);
+  auto skyline_2 = skyline->Clone(/*scale=*/1);
 
   // Packer is still full.
   EXPECT_FALSE(skyline->addRect(256, 256, &loc));

--- a/impeller/typographer/typographer_unittests.cc
+++ b/impeller/typographer/typographer_unittests.cc
@@ -297,12 +297,12 @@ TEST_P(TypographerTest, MaybeHasOverlapping) {
 TEST_P(TypographerTest, RectanglePackerAddsNonoverlapingRectangles) {
   auto packer = RectanglePacker::Factory(200, 100);
   ASSERT_NE(packer, nullptr);
-  ASSERT_EQ(packer->percentFull(), 0);
+  ASSERT_EQ(packer->PercentFull(), 0);
 
   const SkIRect packer_area = SkIRect::MakeXYWH(0, 0, 200, 100);
 
   IPoint16 first_output = {-1, -1};  // Fill with sentinel values
-  ASSERT_TRUE(packer->addRect(20, 20, &first_output));
+  ASSERT_TRUE(packer->AddRect(20, 20, &first_output));
   // Make sure the rectangle is placed such that it is inside the bounds of
   // the packer's area.
   const SkIRect first_rect =
@@ -311,10 +311,10 @@ TEST_P(TypographerTest, RectanglePackerAddsNonoverlapingRectangles) {
 
   // Initial area was 200 x 100 = 20_000
   // We added 20x20 = 400. 400 / 20_000 == 0.02 == 2%
-  ASSERT_TRUE(flutter::testing::NumberNear(packer->percentFull(), 0.02));
+  ASSERT_TRUE(flutter::testing::NumberNear(packer->PercentFull(), 0.02));
 
   IPoint16 second_output = {-1, -1};
-  ASSERT_TRUE(packer->addRect(140, 90, &second_output));
+  ASSERT_TRUE(packer->AddRect(140, 90, &second_output));
   const SkIRect second_rect =
       SkIRect::MakeXYWH(second_output.x(), second_output.y(), 140, 90);
   // Make sure the rectangle is placed such that it is inside the bounds of
@@ -324,18 +324,18 @@ TEST_P(TypographerTest, RectanglePackerAddsNonoverlapingRectangles) {
 
   // We added another 90 x 140 = 12_600 units, now taking us to 13_000
   // 13_000 / 20_000 == 0.65 == 65%
-  ASSERT_TRUE(flutter::testing::NumberNear(packer->percentFull(), 0.65));
+  ASSERT_TRUE(flutter::testing::NumberNear(packer->PercentFull(), 0.65));
 
   // There's enough area to add this rectangle, but no space big enough for
   // the 50 units of width.
   IPoint16 output;
-  ASSERT_FALSE(packer->addRect(50, 50, &output));
+  ASSERT_FALSE(packer->AddRect(50, 50, &output));
   // Should be unchanged.
-  ASSERT_TRUE(flutter::testing::NumberNear(packer->percentFull(), 0.65));
+  ASSERT_TRUE(flutter::testing::NumberNear(packer->PercentFull(), 0.65));
 
-  packer->reset();
+  packer->Reset();
   // Should be empty now.
-  ASSERT_EQ(packer->percentFull(), 0);
+  ASSERT_EQ(packer->PercentFull(), 0);
 }
 
 TEST_P(TypographerTest,
@@ -378,53 +378,53 @@ TEST_P(TypographerTest,
 TEST(TypographerTest, CanCloneRectanglePackerEmpty) {
   auto skyline = RectanglePacker::Factory(256, 256);
 
-  EXPECT_EQ(skyline->percentFull(), 0);
+  EXPECT_EQ(skyline->PercentFull(), 0);
 
   auto skyline_2 = skyline->Clone(/*scale=*/2);
 
-  EXPECT_EQ(skyline->percentFull(), 0);
+  EXPECT_EQ(skyline->PercentFull(), 0);
 }
 
 TEST(TypographerTest, CanCloneRectanglePackerAndPreservePositions) {
   auto skyline = RectanglePacker::Factory(256, 256);
   IPoint16 loc;
-  EXPECT_TRUE(skyline->addRect(100, 100, &loc));
+  EXPECT_TRUE(skyline->AddRect(100, 100, &loc));
 
   EXPECT_EQ(loc.x(), 0);
   EXPECT_EQ(loc.y(), 0);
-  auto percent = skyline->percentFull();
+  auto percent = skyline->PercentFull();
 
   auto skyline_2 = skyline->Clone(/*scale=*/2);
 
-  EXPECT_LT(skyline_2->percentFull(), percent);
+  EXPECT_LT(skyline_2->PercentFull(), percent);
 }
 
 TEST(TypographerTest, CanCloneRectanglePackerWhileFull) {
   auto skyline = RectanglePacker::Factory(256, 256);
   IPoint16 loc;
   // Add a rectangle the size of the entire area.
-  EXPECT_TRUE(skyline->addRect(256, 256, &loc));
+  EXPECT_TRUE(skyline->AddRect(256, 256, &loc));
   // Packer is now full.
-  EXPECT_FALSE(skyline->addRect(256, 256, &loc));
+  EXPECT_FALSE(skyline->AddRect(256, 256, &loc));
 
   auto skyline_2 = skyline->Clone(/*scale=*/2);
 
   // Can now fit one more
-  EXPECT_TRUE(skyline_2->addRect(256, 256, &loc));
+  EXPECT_TRUE(skyline_2->AddRect(256, 256, &loc));
 }
 
 TEST(TypographerTest, CloneToSameSizePreservesContents) {
   auto skyline = RectanglePacker::Factory(256, 256);
   IPoint16 loc;
   // Add a rectangle the size of the entire area.
-  EXPECT_TRUE(skyline->addRect(256, 256, &loc));
+  EXPECT_TRUE(skyline->AddRect(256, 256, &loc));
   // Packer is now full.
-  EXPECT_FALSE(skyline->addRect(256, 256, &loc));
+  EXPECT_FALSE(skyline->AddRect(256, 256, &loc));
 
   auto skyline_2 = skyline->Clone(/*scale=*/1);
 
   // Packer is still full.
-  EXPECT_FALSE(skyline->addRect(256, 256, &loc));
+  EXPECT_FALSE(skyline->AddRect(256, 256, &loc));
 }
 
 }  // namespace testing


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/138798

Allow cloning a rectangle packer with all existing skylines preserved, but the size increased. This will allow us to preserve the positioning and state of all glyphs when the atlas size is increased, which is necessary for the "blit contents to top right of new texture" approach for improving append performance.
EDIT: I mean top left!