### PR TITLE
[web] scale semantic text elements to match the desired focus ring size

### DIFF
--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -589,6 +589,14 @@ extension DomElementExtension on DomElement {
   external JSNumber get _clientWidth;
   double get clientWidth => _clientWidth.toDartDouble;
 
+  @JS('offsetHeight')
+  external JSNumber get _offsetHeight;
+  double get offsetHeight => _offsetHeight.toDartDouble;
+
+  @JS('offsetWidth')
+  external JSNumber get _offsetWidth;
+  double get offsetWidth => _offsetWidth.toDartDouble;
+
   @JS('id')
   external JSString get _id;
   String get id => _id.toDart;

--- a/lib/web_ui/lib/src/engine/semantics/checkable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/checkable.dart
@@ -55,7 +55,7 @@ class Checkable extends PrimaryRoleManager {
         super.withBasics(
           PrimaryRole.checkable,
           semanticsObject,
-          labelRepresentation: LabelRepresentation.ariaLabel,
+          preferredLabelRepresentation: LabelRepresentation.ariaLabel,
         ) {
     addTappable();
   }

--- a/lib/web_ui/lib/src/engine/semantics/checkable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/checkable.dart
@@ -55,7 +55,7 @@ class Checkable extends PrimaryRoleManager {
         super.withBasics(
           PrimaryRole.checkable,
           semanticsObject,
-          labelRepresentation: LeafLabelRepresentation.ariaLabel,
+          labelRepresentation: LabelRepresentation.ariaLabel,
         ) {
     addTappable();
   }

--- a/lib/web_ui/lib/src/engine/semantics/incrementable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/incrementable.dart
@@ -28,7 +28,7 @@ class Incrementable extends PrimaryRoleManager {
     // the one being focused on, but the internal `<input>` element.
     addLiveRegion();
     addRouteName();
-    addLabelAndValue(labelRepresentation: LeafLabelRepresentation.ariaLabel);
+    addLabelAndValue(labelRepresentation: LabelRepresentation.ariaLabel);
 
     append(_element);
     _element.type = 'range';

--- a/lib/web_ui/lib/src/engine/semantics/incrementable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/incrementable.dart
@@ -28,7 +28,7 @@ class Incrementable extends PrimaryRoleManager {
     // the one being focused on, but the internal `<input>` element.
     addLiveRegion();
     addRouteName();
-    addLabelAndValue(labelRepresentation: LabelRepresentation.ariaLabel);
+    addLabelAndValue(preferredRepresentation: LabelRepresentation.ariaLabel);
 
     append(_element);
     _element.type = 'range';

--- a/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
+++ b/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
@@ -50,9 +50,9 @@ enum LabelRepresentation {
   /// Creates the behavior for this label representation.
   LabelRepresentationBehavior createBehavior(PrimaryRoleManager owner) {
     return switch (this) {
-      LabelRepresentation.ariaLabel => AriaLabelRepresentation._(owner),
-      LabelRepresentation.domText => DomTextRepresentation._(owner),
-      LabelRepresentation.sizedSpan => SizedSpanRepresentation._(owner),
+      ariaLabel => AriaLabelRepresentation._(owner),
+      domText => DomTextRepresentation._(owner),
+      sizedSpan => SizedSpanRepresentation._(owner),
     };
   }
 }

--- a/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
+++ b/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
@@ -285,7 +285,7 @@ class LabelAndValue extends RoleManager {
       : preferredRepresentation;
 
     LabelRepresentationBehavior? representation = _representation;
-    if (representation == null || representation.runtimeType != effectiveRepresentation.runtimeType) {
+    if (representation == null || representation.runtimeType != effectiveRepresentation.implementation) {
       representation?.cleanUp();
       _representation = representation = switch (effectiveRepresentation) {
         LabelRepresentation.ariaLabel => AriaLabelRepresentation._(owner),

--- a/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
+++ b/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
@@ -246,10 +246,9 @@ final class SizedSpanRepresentation extends LabelRepresentationBehavior {
 /// interactive controls. In such case the value is reported via that element's
 /// `value` attribute rather than rendering it separately.
 class LabelAndValue extends RoleManager {
-  LabelAndValue(SemanticsObject semanticsObject, PrimaryRoleManager owner, { required this.labelRepresentation })
+  LabelAndValue(SemanticsObject semanticsObject, PrimaryRoleManager owner, { required this.preferredRepresentation })
       : super(Role.labelAndValue, semanticsObject, owner);
 
-  // TODO(yjbanov): rename to `preferredRepresentation` because it's not guaranteed.
   /// The preferred representation of the label in the DOM.
   ///
   /// This value may be changed. Calling [update] after changing it will apply
@@ -257,7 +256,7 @@ class LabelAndValue extends RoleManager {
   ///
   /// If the node contains children, [LabelRepresentation.ariaLabel] is used
   /// instead.
-  LabelRepresentation labelRepresentation;
+  LabelRepresentation preferredRepresentation;
 
   @override
   void update() {
@@ -283,7 +282,7 @@ class LabelAndValue extends RoleManager {
   LabelRepresentationBehavior _getEffectiveRepresentation() {
     final LabelRepresentation effectiveRepresentation = semanticsObject.hasChildren
       ? LabelRepresentation.ariaLabel
-      : labelRepresentation;
+      : preferredRepresentation;
 
     LabelRepresentationBehavior? representation = _representation;
     if (representation == null || representation.runtimeType != effectiveRepresentation.runtimeType) {

--- a/lib/web_ui/lib/src/engine/semantics/link.dart
+++ b/lib/web_ui/lib/src/engine/semantics/link.dart
@@ -10,7 +10,7 @@ class Link extends PrimaryRoleManager {
   Link(SemanticsObject semanticsObject) : super.withBasics(
     PrimaryRole.link,
     semanticsObject,
-    labelRepresentation: LabelRepresentation.domText,
+    preferredLabelRepresentation: LabelRepresentation.domText,
   ) {
     addTappable();
   }

--- a/lib/web_ui/lib/src/engine/semantics/link.dart
+++ b/lib/web_ui/lib/src/engine/semantics/link.dart
@@ -10,7 +10,7 @@ class Link extends PrimaryRoleManager {
   Link(SemanticsObject semanticsObject) : super.withBasics(
     PrimaryRole.link,
     semanticsObject,
-    labelRepresentation: LeafLabelRepresentation.domText,
+    labelRepresentation: LabelRepresentation.domText,
   ) {
     addTappable();
   }

--- a/lib/web_ui/lib/src/engine/semantics/platform_view.dart
+++ b/lib/web_ui/lib/src/engine/semantics/platform_view.dart
@@ -25,7 +25,7 @@ class PlatformViewRoleManager extends PrimaryRoleManager {
       : super.withBasics(
           PrimaryRole.platformView,
           semanticsObject,
-          labelRepresentation: LeafLabelRepresentation.ariaLabel,
+          labelRepresentation: LabelRepresentation.ariaLabel,
         );
 
   @override

--- a/lib/web_ui/lib/src/engine/semantics/platform_view.dart
+++ b/lib/web_ui/lib/src/engine/semantics/platform_view.dart
@@ -25,7 +25,7 @@ class PlatformViewRoleManager extends PrimaryRoleManager {
       : super.withBasics(
           PrimaryRole.platformView,
           semanticsObject,
-          labelRepresentation: LabelRepresentation.ariaLabel,
+          preferredLabelRepresentation: LabelRepresentation.ariaLabel,
         );
 
   @override

--- a/lib/web_ui/lib/src/engine/semantics/scrollable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/scrollable.dart
@@ -27,7 +27,7 @@ class Scrollable extends PrimaryRoleManager {
       : super.withBasics(
           PrimaryRole.scrollable,
           semanticsObject,
-          labelRepresentation: LabelRepresentation.ariaLabel,
+          preferredLabelRepresentation: LabelRepresentation.ariaLabel,
         );
 
   /// Disables browser-driven scrolling in the presence of pointer events.

--- a/lib/web_ui/lib/src/engine/semantics/scrollable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/scrollable.dart
@@ -28,14 +28,7 @@ class Scrollable extends PrimaryRoleManager {
           PrimaryRole.scrollable,
           semanticsObject,
           labelRepresentation: LeafLabelRepresentation.ariaLabel,
-        ) {
-    _scrollOverflowElement.style
-      ..position = 'absolute'
-      ..transformOrigin = '0 0 0'
-      // Ignore pointer events since this is a dummy element.
-      ..pointerEvents = 'none';
-    append(_scrollOverflowElement);
-  }
+        );
 
   /// Disables browser-driven scrolling in the presence of pointer events.
   GestureModeCallback? _gestureModeListener;
@@ -95,6 +88,20 @@ class Scrollable extends PrimaryRoleManager {
         }
       }
     }
+  }
+
+  @override
+  void initState() {
+    // Scrolling is controlled by setting overflow-y/overflow-x to 'scroll`. The
+    // default overflow = "visible" needs to be unset.
+    semanticsObject.element.style.overflow = '';
+
+    _scrollOverflowElement.style
+      ..position = 'absolute'
+      ..transformOrigin = '0 0 0'
+      // Ignore pointer events since this is a dummy element.
+      ..pointerEvents = 'none';
+    append(_scrollOverflowElement);
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/semantics/scrollable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/scrollable.dart
@@ -27,7 +27,7 @@ class Scrollable extends PrimaryRoleManager {
       : super.withBasics(
           PrimaryRole.scrollable,
           semanticsObject,
-          labelRepresentation: LeafLabelRepresentation.ariaLabel,
+          labelRepresentation: LabelRepresentation.ariaLabel,
         );
 
   /// Disables browser-driven scrolling in the presence of pointer events.

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -715,19 +715,9 @@ final class GenericRole extends PrimaryRoleManager {
       return false;
     }
 
-    // Case 3: current node is visual/informational. Move just the
-    // accessibility focus.
-
-    // Plain text nodes should not be focusable via keyboard or mouse. They are
-    // only focusable for the purposes of focusing the screen reader. To achieve
-    // this the -1 value is used.
-    //
-    // See also:
-    //
-    // https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex
-    // TODO(yjbanov): if <span> is used, it should be focused, not the parent element
-    element.tabIndex = -1;
-    element.focus();
+    // Case 3: current node is visual/informational. Move just the accessibility
+    // focus.
+    labelAndValue!.focusAsRouteDefault();
     return true;
   }
 }

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -434,12 +434,12 @@ abstract class PrimaryRoleManager {
   ///
   /// If `labelRepresentation` is true, configures the [LabelAndValue] role with
   /// [LabelAndValue.labelRepresentation] set to true.
-  PrimaryRoleManager.withBasics(this.role, this.semanticsObject, { required LabelRepresentation labelRepresentation }) {
+  PrimaryRoleManager.withBasics(this.role, this.semanticsObject, { required LabelRepresentation preferredLabelRepresentation }) {
     element = _initElement(createElement(), semanticsObject);
     addFocusManagement();
     addLiveRegion();
     addRouteName();
-    addLabelAndValue(labelRepresentation: labelRepresentation);
+    addLabelAndValue(preferredRepresentation: preferredLabelRepresentation);
   }
 
   /// Initializes a blank role for a [semanticsObject].
@@ -562,8 +562,8 @@ abstract class PrimaryRoleManager {
   LabelAndValue? _labelAndValue;
 
   /// Adds generic label features.
-  void addLabelAndValue({ required LabelRepresentation labelRepresentation }) {
-    addSecondaryRole(_labelAndValue = LabelAndValue(semanticsObject, this, labelRepresentation: labelRepresentation));
+  void addLabelAndValue({ required LabelRepresentation preferredRepresentation }) {
+    addSecondaryRole(_labelAndValue = LabelAndValue(semanticsObject, this, preferredRepresentation: preferredRepresentation));
   }
 
   /// Adds generic functionality for handling taps and clicks.
@@ -647,7 +647,7 @@ final class GenericRole extends PrimaryRoleManager {
     // Prefer sized span because if this is a leaf it is frequently a Text widget.
     // But if it turns out to be a container, then LabelAndValue will automatically
     // switch to `aria-label`.
-    labelRepresentation: LabelRepresentation.sizedSpan,
+    preferredLabelRepresentation: LabelRepresentation.sizedSpan,
   ) {
     // Typically a tappable widget would have a more specific role, such as
     // "link", "button", "checkbox", etc. However, there are situations when a
@@ -683,13 +683,13 @@ final class GenericRole extends PrimaryRoleManager {
     //   it. Previously, role="text" was used, but it was only supported by
     //   Safari, and it was removed starting Safari 17.
     if (semanticsObject.hasChildren) {
-      labelAndValue!.labelRepresentation = LabelRepresentation.ariaLabel;
+      labelAndValue!.preferredRepresentation = LabelRepresentation.ariaLabel;
       setAriaRole('group');
     } else if (semanticsObject.hasFlag(ui.SemanticsFlag.isHeader)) {
-      labelAndValue!.labelRepresentation = LabelRepresentation.domText;
+      labelAndValue!.preferredRepresentation = LabelRepresentation.domText;
       setAriaRole('heading');
     } else {
-      labelAndValue!.labelRepresentation = LabelRepresentation.sizedSpan;
+      labelAndValue!.preferredRepresentation = LabelRepresentation.sizedSpan;
       removeAttribute('role');
     }
 

--- a/lib/web_ui/lib/src/engine/semantics/tappable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/tappable.dart
@@ -10,7 +10,7 @@ class Button extends PrimaryRoleManager {
   Button(SemanticsObject semanticsObject) : super.withBasics(
     PrimaryRole.button,
     semanticsObject,
-    labelRepresentation: LabelRepresentation.domText,
+    preferredLabelRepresentation: LabelRepresentation.domText,
   ) {
     addTappable();
     setAriaRole('button');

--- a/lib/web_ui/lib/src/engine/semantics/tappable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/tappable.dart
@@ -10,7 +10,7 @@ class Button extends PrimaryRoleManager {
   Button(SemanticsObject semanticsObject) : super.withBasics(
     PrimaryRole.button,
     semanticsObject,
-    labelRepresentation: LeafLabelRepresentation.domText,
+    labelRepresentation: LabelRepresentation.domText,
   ) {
     addTappable();
     setAriaRole('button');

--- a/lib/web_ui/test/engine/matchers_test.dart
+++ b/lib/web_ui/test/engine/matchers_test.dart
@@ -44,6 +44,53 @@ Specifically:
     );
   });
 
+  test('trivial equal text content', () {
+    expectDom(
+      '<div>hello</div>',
+      hasHtml('<div>hello</div>'),
+    );
+  });
+
+  test('trivial unequal text content', () {
+    expectDom(
+      '<div>hello</div>',
+      expectMismatch(
+        hasHtml('<div>world</div>'),
+        '''
+The following DOM structure did not match the expected pattern:
+<div>hello</div>
+
+Specifically:
+ - @div: expected text content "world", but found "hello".''',
+      ),
+    );
+  });
+
+  test('white space between elements', () {
+    expectDom(
+      '<a> <b> </b> </a>',
+      hasHtml('<a><b> </b></a>'),
+    );
+
+    expectDom(
+      '<a><b> </b></a>',
+      hasHtml('<a> <b> </b> </a>'),
+    );
+
+    expectDom(
+      '<a><b> </b></a>',
+      expectMismatch(
+        hasHtml('<a><b>   </b></a>'),
+        '''
+The following DOM structure did not match the expected pattern:
+<a><b> </b></a>
+
+Specifically:
+ - @a > b: expected text content "   ", but found " ".''',
+      ),
+    );
+  });
+
   test('trivial equal attributes', () {
     expectDom(
       '<div id="hello"></div>',
@@ -192,7 +239,7 @@ The following DOM structure did not match the expected pattern:
 <div><span></span><p></p></div>
 
 Specifically:
- - @div: expected 3 children, but found 2.''',
+ - @div: expected 3 child nodes, but found 2.''',
       ),
     );
   });
@@ -207,7 +254,7 @@ The following DOM structure did not match the expected pattern:
 <div><span></span><waldo></waldo><p></p></div>
 
 Specifically:
- - @div: expected 2 children, but found 3.''',
+ - @div: expected 2 child nodes, but found 3.''',
       ),
     );
   });

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -3277,9 +3277,24 @@ void _testDialog() {
     expect(capturedActions, isEmpty);
 
     // However, the element should have gotten the focus.
-    final DomElement element = owner().debugSemanticsTree![2]!.element;
-    expect(element.tabIndex, -1);
-    expect(domDocument.activeElement, element);
+
+    tester.expectSemantics('''
+<flt-semantics>
+  <flt-semantics-container>
+    <flt-semantics>
+      <flt-semantics-container>
+        <flt-semantics id="flt-semantic-node-2">
+          <span tabindex="-1">Heading</span>
+        </flt-semantics>
+        <flt-semantics role="button" tabindex="0" flt-tappable="">Click me!</flt-semantics>
+      </flt-semantics-container>
+    </flt-semantics>
+  </flt-semantics-container>
+</flt-semantics>''');
+
+    final DomElement span = owner().debugSemanticsTree![2]!.element.querySelectorAll('span').single;
+    expect(span.tabIndex, -1);
+    expect(domDocument.activeElement, span);
 
     semantics().semanticsEnabled = false;
   });

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -123,7 +123,7 @@ void _testRoleManagerLifecycle() {
       );
       tester.apply();
 
-      tester.expectSemantics('<sem role="button" style="$rootSemanticStyle"></sem>');
+      tester.expectSemantics('<sem role="button"></sem>');
 
       final SemanticsObject node = owner().debugSemanticsTree![0]!;
       expect(node.primaryRole?.role, PrimaryRole.button);
@@ -146,7 +146,7 @@ void _testRoleManagerLifecycle() {
       );
       tester.apply();
 
-      tester.expectSemantics('<sem role="button" style="$rootSemanticStyle">a label</sem>');
+      tester.expectSemantics('<sem role="button">a label</sem>');
 
       final SemanticsObject node = owner().debugSemanticsTree![0]!;
       expect(node.primaryRole?.role, PrimaryRole.button);
@@ -320,6 +320,30 @@ void _testEngineSemanticsOwner() {
     expect(copy.reduceMotion, true);
   });
 
+  test('makes the semantic DOM tree invisible', () {
+    semantics()
+      ..debugOverrideTimestampFunction(() => _testTime)
+      ..semanticsEnabled = true;
+
+    final SemanticsTester tester = SemanticsTester(owner());
+    tester.updateNode(
+      id: 0,
+      label: 'I am root',
+      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+    );
+    tester.apply();
+
+    expectSemanticsTree(
+      owner(),
+      '''
+<sem style="filter: opacity(0%); color: rgba(0, 0, 0, 0)">
+  <span>I am root</span>
+</sem>''',
+    );
+
+    semantics().semanticsEnabled = false;
+  });
+
   void renderSemantics({String? label, String? tooltip, Set<ui.SemanticsFlag> flags = const <ui.SemanticsFlag>{}}) {
     int flagValues = 0;
     for (final ui.SemanticsFlag flag in flags) {
@@ -363,9 +387,9 @@ void _testEngineSemanticsOwner() {
     expect(tree[1]!.label, 'Hello');
 
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
+<sem>
   <sem-c>
-    <sem role="text">Hello</sem>
+    <sem><span>Hello</span></sem>
   </sem-c>
 </sem>''');
 
@@ -373,9 +397,9 @@ void _testEngineSemanticsOwner() {
     renderLabel('World');
 
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
+<sem>
   <sem-c>
-    <sem role="text">World</sem>
+    <sem><span>World</span></sem>
   </sem-c>
 </sem>''');
 
@@ -383,9 +407,9 @@ void _testEngineSemanticsOwner() {
     renderLabel('');
 
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
+<sem>
   <sem-c>
-    <sem role="text"></sem>
+    <sem></sem>
   </sem-c>
 </sem>''');
 
@@ -406,9 +430,9 @@ void _testEngineSemanticsOwner() {
     final DomElement existingParent = tree[1]!.element.parent!;
 
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
+<sem>
   <sem-c>
-    <sem role="text">Hello</sem>
+    <sem><span>Hello</span></sem>
   </sem-c>
 </sem>''');
 
@@ -421,7 +445,7 @@ void _testEngineSemanticsOwner() {
     expect(tree[1]!.label, 'Hello');
     expect(tree[1]!.element.tagName.toLowerCase(), 'a');
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
+<sem>
   <sem-c>
     <a style="display: block;">Hello</a>
   </sem-c>
@@ -445,9 +469,9 @@ void _testEngineSemanticsOwner() {
     expect(tree[1]!.tooltip, 'tooltip');
 
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
+<sem>
   <sem-c>
-    <sem>tooltip</sem>
+    <sem><span>tooltip</span></sem>
   </sem-c>
 </sem>''');
 
@@ -455,9 +479,9 @@ void _testEngineSemanticsOwner() {
     renderSemantics(label: 'Hello', tooltip: 'tooltip');
 
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
+<sem>
   <sem-c>
-    <sem role="text">tooltip\nHello</sem>
+    <sem><span>tooltip<br>Hello</span></sem>
   </sem-c>
 </sem>''');
 
@@ -465,9 +489,9 @@ void _testEngineSemanticsOwner() {
     renderSemantics();
 
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
+<sem>
   <sem-c>
-    <sem role="text"></sem>
+    <sem></sem>
   </sem-c>
 </sem>''');
 
@@ -660,7 +684,7 @@ void _testHeader() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem role="heading" style="$rootSemanticStyle">Header of the page</sem>
+<sem role="heading">Header of the page</sem>
 ''');
 
     semantics().semanticsEnabled = false;
@@ -696,7 +720,7 @@ void _testHeader() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem role="group" aria-label="Header of the page" style="$rootSemanticStyle"><sem-c><sem></sem></sem-c></sem>
+<sem role="group" aria-label="Header of the page"><sem-c><sem></sem></sem-c></sem>
 ''');
 
     semantics().semanticsEnabled = false;
@@ -764,7 +788,7 @@ void _testText() {
 
     expectSemanticsTree(
       owner(),
-      '''<sem role="text" style="$rootSemanticStyle">plain text</sem>''',
+      '''<sem><span>plain text</span></sem>''',
     );
 
     final SemanticsObject node = owner().debugSemanticsTree![0]!;
@@ -797,7 +821,7 @@ void _testText() {
 
     expectSemanticsTree(
       owner(),
-      '''<sem flt-tappable="" role="text" style="$rootSemanticStyle">tappable text</sem>''',
+      '''<sem flt-tappable=""><span>tappable text</span></sem>''',
     );
 
     final SemanticsObject node = owner().debugSemanticsTree![0]!;
@@ -925,7 +949,7 @@ void _testContainer() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
+<sem>
   <sem-c>
     <sem></sem>
   </sem-c>
@@ -976,7 +1000,7 @@ void _testContainer() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
+<sem>
   <sem-c>
     <sem></sem>
   </sem-c>
@@ -1021,7 +1045,7 @@ void _testContainer() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
+<sem>
   <sem-c>
     <sem></sem>
   </sem-c>
@@ -1072,7 +1096,7 @@ void _testContainer() {
 
       owner().updateSemantics(builder.build());
       expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
+<sem>
   <sem-c>
     <sem style="z-index: 4"></sem>
     <sem style="z-index: 2"></sem>
@@ -1092,7 +1116,7 @@ void _testContainer() {
       );
       owner().updateSemantics(builder.build());
       expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
+<sem>
   <sem-c>
     <sem style="z-index: 4"></sem>
     <sem style="z-index: 3"></sem>
@@ -1112,7 +1136,7 @@ void _testContainer() {
       );
       owner().updateSemantics(builder.build());
       expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
+<sem>
   <sem-c>
     <sem style="z-index: 1"></sem>
     <sem style="z-index: 3"></sem>
@@ -1132,7 +1156,7 @@ void _testContainer() {
       );
       owner().updateSemantics(builder.build());
       expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
+<sem>
   <sem-c>
     <sem style="z-index: 2"></sem>
     <sem style="z-index: 4"></sem>
@@ -1163,7 +1187,7 @@ void _testContainer() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
+<sem>
   <sem-c>
     <sem style="z-index: 2"></sem>
     <sem style="z-index: 1"></sem>
@@ -1215,7 +1239,7 @@ void _testContainer() {
 
       owner().updateSemantics(builder.build());
       expectSemanticsTree(owner(), '''
-  <sem style="$rootSemanticStyle">
+  <sem>
     <sem-c>
       <sem style="z-index: 2">
         <sem-c>
@@ -1252,7 +1276,7 @@ void _testContainer() {
 
       owner().updateSemantics(builder.build());
       expectSemanticsTree(owner(), '''
-  <sem style="$rootSemanticStyle">
+  <sem>
     <sem-c>
       <sem style="z-index: 2">
         <sem-c>
@@ -1287,7 +1311,7 @@ void _testVerticalScrolling() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle; touch-action: none; overflow-y: scroll">
+<sem style="touch-action: none; overflow-y: scroll">
 <flt-semantics-scroll-overflow></flt-semantics-scroll-overflow>
 </sem>''');
 
@@ -1319,7 +1343,7 @@ void _testVerticalScrolling() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle; touch-action: none; overflow-y: scroll">
+<sem style="touch-action: none; overflow-y: scroll">
 <flt-semantics-scroll-overflow></flt-semantics-scroll-overflow>
   <sem-c>
     <sem></sem>
@@ -1376,7 +1400,7 @@ void _testVerticalScrolling() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle; touch-action: none; overflow-y: scroll">
+<sem style="touch-action: none; overflow-y: scroll">
   <flt-semantics-scroll-overflow></flt-semantics-scroll-overflow>
   <sem-c>
     <sem style="z-index: 3"></sem>
@@ -1440,7 +1464,7 @@ void _testHorizontalScrolling() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle; touch-action: none; overflow-x: scroll">
+<sem style="touch-action: none; overflow-x: scroll">
 <flt-semantics-scroll-overflow></flt-semantics-scroll-overflow>
 </sem>''');
 
@@ -1470,7 +1494,7 @@ void _testHorizontalScrolling() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle; touch-action: none; overflow-x: scroll">
+<sem style="touch-action: none; overflow-x: scroll">
 <flt-semantics-scroll-overflow></flt-semantics-scroll-overflow>
   <sem-c>
     <sem></sem>
@@ -1527,7 +1551,7 @@ void _testHorizontalScrolling() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle; touch-action: none; overflow-x: scroll">
+<sem style="touch-action: none; overflow-x: scroll">
   <flt-semantics-scroll-overflow></flt-semantics-scroll-overflow>
   <sem-c>
     <sem style="z-index: 3"></sem>
@@ -1591,7 +1615,7 @@ void _testIncrementables() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
+<sem>
   <input role="slider" aria-valuenow="1" aria-valuetext="d" aria-valuemax="1" aria-valuemin="1">
 </sem>''');
 
@@ -1624,7 +1648,7 @@ void _testIncrementables() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
+<sem>
   <input role="slider" aria-valuenow="1" aria-valuetext="d" aria-valuemax="2" aria-valuemin="1">
 </sem>''');
 
@@ -1657,7 +1681,7 @@ void _testIncrementables() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
+<sem>
   <input role="slider" aria-valuenow="1" aria-valuetext="d" aria-valuemax="1" aria-valuemin="0">
 </sem>''');
 
@@ -1692,7 +1716,7 @@ void _testIncrementables() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
+<sem>
   <input role="slider" aria-valuenow="1" aria-valuetext="d" aria-valuemax="2" aria-valuemin="0">
 </sem>''');
 
@@ -1770,7 +1794,7 @@ void _testTextField() {
     owner().updateSemantics(builder.build());
 
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
+<sem>
   <input />
 </sem>''');
 
@@ -1856,7 +1880,7 @@ void _testCheckables() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem aria-label="test label" flt-tappable role="switch" aria-checked="true" style="$rootSemanticStyle"></sem>
+<sem aria-label="test label" flt-tappable role="switch" aria-checked="true"></sem>
 ''');
 
     final SemanticsObject node = owner().debugSemanticsTree![0]!;
@@ -1889,7 +1913,7 @@ void _testCheckables() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem role="switch" aria-disabled="true" aria-checked="true" style="$rootSemanticStyle"></sem>
+<sem role="switch" aria-disabled="true" aria-checked="true"></sem>
 ''');
 
     semantics().semanticsEnabled = false;
@@ -1914,7 +1938,7 @@ void _testCheckables() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem role="switch" flt-tappable aria-checked="false" style="$rootSemanticStyle"></sem>
+<sem role="switch" flt-tappable aria-checked="false"></sem>
 ''');
 
     semantics().semanticsEnabled = false;
@@ -1940,7 +1964,7 @@ void _testCheckables() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem role="checkbox" flt-tappable aria-checked="true" style="$rootSemanticStyle"></sem>
+<sem role="checkbox" flt-tappable aria-checked="true"></sem>
 ''');
 
     semantics().semanticsEnabled = false;
@@ -1965,7 +1989,7 @@ void _testCheckables() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem role="checkbox" aria-disabled="true" aria-checked="true" style="$rootSemanticStyle"></sem>
+<sem role="checkbox" aria-disabled="true" aria-checked="true"></sem>
 ''');
 
     semantics().semanticsEnabled = false;
@@ -1990,7 +2014,7 @@ void _testCheckables() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem role="checkbox" flt-tappable aria-checked="false" style="$rootSemanticStyle"></sem>
+<sem role="checkbox" flt-tappable aria-checked="false"></sem>
 ''');
 
     semantics().semanticsEnabled = false;
@@ -2017,7 +2041,7 @@ void _testCheckables() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem role="radio" flt-tappable aria-checked="true" style="$rootSemanticStyle"></sem>
+<sem role="radio" flt-tappable aria-checked="true"></sem>
 ''');
 
     semantics().semanticsEnabled = false;
@@ -2043,7 +2067,7 @@ void _testCheckables() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem role="radio" aria-disabled="true" aria-checked="true" style="$rootSemanticStyle"></sem>
+<sem role="radio" aria-disabled="true" aria-checked="true"></sem>
 ''');
 
     semantics().semanticsEnabled = false;
@@ -2069,7 +2093,7 @@ void _testCheckables() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem role="radio" flt-tappable aria-checked="false" style="$rootSemanticStyle"></sem>
+<sem role="radio" flt-tappable aria-checked="false"></sem>
 ''');
 
     semantics().semanticsEnabled = false;
@@ -2154,7 +2178,7 @@ void _testTappable() {
     tester.apply();
 
     expectSemanticsTree(owner(), '''
-<sem role="button" flt-tappable style="$rootSemanticStyle"></sem>
+<sem role="button" flt-tappable></sem>
 ''');
 
     final SemanticsObject node = owner().debugSemanticsTree![0]!;
@@ -2186,7 +2210,7 @@ void _testTappable() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem role="button" aria-disabled="true" style="$rootSemanticStyle"></sem>
+<sem role="button" aria-disabled="true"></sem>
 ''');
 
     semantics().semanticsEnabled = false;
@@ -2213,25 +2237,25 @@ void _testTappable() {
     updateTappable(enabled: false);
     expectSemanticsTree(
       owner(),
-      '<sem role="button" aria-disabled="true" style="$rootSemanticStyle"></sem>'
+      '<sem role="button" aria-disabled="true"></sem>'
     );
 
     updateTappable(enabled: true);
     expectSemanticsTree(
       owner(),
-      '<sem role="button" flt-tappable style="$rootSemanticStyle"></sem>',
+      '<sem role="button" flt-tappable></sem>',
     );
 
     updateTappable(enabled: false);
     expectSemanticsTree(
       owner(),
-      '<sem role="button" aria-disabled="true" style="$rootSemanticStyle"></sem>',
+      '<sem role="button" aria-disabled="true"></sem>',
     );
 
     updateTappable(enabled: true);
     expectSemanticsTree(
       owner(),
-      '<sem role="button" flt-tappable style="$rootSemanticStyle"></sem>',
+      '<sem role="button" flt-tappable></sem>',
     );
 
     semantics().semanticsEnabled = false;
@@ -2349,7 +2373,7 @@ void _testTappable() {
     tester.apply();
 
     expectSemanticsTree(owner(), '''
-<sem flt-tappable role="button" style="$rootSemanticStyle">
+<sem flt-tappable role="button">
   <sem-c>
     <sem flt-tappable role="button"></sem>
   </sem-c>
@@ -2411,7 +2435,7 @@ void _testImage() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem role="img" aria-label="Test Image Label" style="$rootSemanticStyle"></sem>
+<sem role="img" aria-label="Test Image Label"></sem>
 ''');
 
     semantics().semanticsEnabled = false;
@@ -2441,9 +2465,8 @@ void _testImage() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
-  <sem-img role="img" aria-label="Test Image Label">
-  </sem-img>
+<sem>
+  <sem-img role="img" aria-label="Test Image Label"></sem-img>
   <sem-c>
     <sem></sem>
   </sem-c>
@@ -2468,7 +2491,7 @@ void _testImage() {
     owner().updateSemantics(builder.build());
     expectSemanticsTree(
       owner(),
-      '<sem role="img" style="$rootSemanticStyle"></sem>',
+      '<sem role="img"></sem>',
     );
 
     semantics().semanticsEnabled = false;
@@ -2497,9 +2520,8 @@ void _testImage() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
-  <sem-img role="img">
-  </sem-img>
+<sem>
+  <sem-img role="img"></sem-img>
   <sem-c>
     <sem></sem>
   </sem-c>
@@ -2632,7 +2654,7 @@ void _testPlatformView() {
       owner().updateSemantics(builder.build());
       expectSemanticsTree(
         owner(),
-        '<sem aria-owns="flt-pv-5" style="$rootSemanticStyle"></sem>',
+        '<sem aria-owns="flt-pv-5"></sem>',
       );
     }
 
@@ -2647,7 +2669,7 @@ void _testPlatformView() {
       owner().updateSemantics(builder.build());
       expectSemanticsTree(
         owner(),
-        '<sem aria-owns="flt-pv-42" style="$rootSemanticStyle"></sem>',
+        '<sem aria-owns="flt-pv-42"></sem>',
       );
     }
 
@@ -2669,7 +2691,7 @@ void _testPlatformView() {
 
     expectSemanticsTree(
       owner(),
-      '<sem aria-owns="flt-pv-5" style="$rootSemanticStyle"></sem>',
+      '<sem aria-owns="flt-pv-5"></sem>',
     );
     final DomElement element = owner().semanticsHost.querySelector('flt-semantics')!;
     expect(element.style.pointerEvents, 'none');
@@ -2751,7 +2773,7 @@ void _testPlatformView() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
+<sem>
   <sem-c>
     <sem style="z-index: 3"></sem>
     <sem style="z-index: 2" aria-owns="flt-pv-0"></sem>
@@ -2855,7 +2877,7 @@ void _testGroup() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-<sem role="group" aria-label="this is a label for a group of elements" style="$rootSemanticStyle"><sem-c><sem></sem></sem-c></sem>
+<sem role="group" aria-label="this is a label for a group of elements"><sem-c><sem></sem></sem-c></sem>
 ''');
 
     semantics().semanticsEnabled = false;
@@ -2887,7 +2909,7 @@ void _testDialog() {
 
     owner().updateSemantics(builder.build());
     expectSemanticsTree(owner(), '''
-      <sem role="dialog" aria-label="this is a dialog label" style="$rootSemanticStyle"><sem-c><sem></sem></sem-c></sem>
+      <sem role="dialog" aria-label="this is a dialog label"><sem-c><sem></sem></sem-c></sem>
     ''');
 
     expect(
@@ -2932,7 +2954,7 @@ void _testDialog() {
 
     // But still sets the dialog role.
     expectSemanticsTree(owner(), '''
-      <sem role="dialog" aria-label="" style="$rootSemanticStyle"><sem-c><sem></sem></sem-c></sem>
+      <sem role="dialog" aria-label=""><sem-c><sem></sem></sem-c></sem>
     ''');
 
     expect(
@@ -2970,11 +2992,11 @@ void _testDialog() {
       tester.apply();
 
       expectSemanticsTree(owner(), '''
-        <sem role="dialog" aria-describedby="flt-semantic-node-2" style="$rootSemanticStyle">
+        <sem role="dialog" aria-describedby="flt-semantic-node-2">
           <sem-c>
             <sem>
               <sem-c>
-                <sem role="text">$label</sem>
+                <sem><span>$label</span></sem>
               </sem-c>
             </sem>
           </sem-c>
@@ -3019,7 +3041,7 @@ void _testDialog() {
     tester.apply();
 
     expectSemanticsTree(owner(), '''
-      <sem style="$rootSemanticStyle"></sem>
+      <sem></sem>
     ''');
 
     expect(
@@ -3059,11 +3081,11 @@ void _testDialog() {
     tester.apply();
 
     expectSemanticsTree(owner(), '''
-      <sem style="$rootSemanticStyle">
+      <sem>
         <sem-c>
           <sem>
             <sem-c>
-              <sem role="text">Hello</sem>
+              <sem><span>Hello</span></sem>
             </sem-c>
           </sem>
         </sem-c>
@@ -3420,9 +3442,9 @@ void _testFocusable() {
     }
 
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
+<sem>
   <sem-c>
-    <sem role="text">focusable text</sem>
+    <sem><span>focusable text</span></sem>
   </sem-c>
 </sem>
 ''');

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -481,7 +481,7 @@ void _testEngineSemanticsOwner() {
     expectSemanticsTree(owner(), '''
 <sem>
   <sem-c>
-    <sem><span>tooltip<br>Hello</span></sem>
+    <sem><span>tooltip\nHello</span></sem>
   </sem-c>
 </sem>''');
 

--- a/lib/web_ui/test/engine/semantics/semantics_tester.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_tester.dart
@@ -13,11 +13,6 @@ import 'package:ui/ui.dart' as ui;
 
 import '../../common/matchers.dart';
 
-/// CSS style applied to the root of the semantics tree.
-// TODO(yjbanov): this should be handled internally by [expectSemanticsTree].
-//                No need for every test to inject it.
-const String rootSemanticStyle = 'filter: opacity(0%); color: rgba(0, 0, 0, 0)';
-
 /// A convenience wrapper of the semantics API for building and inspecting the
 /// semantics tree in unit tests.
 class SemanticsTester {

--- a/lib/web_ui/test/engine/semantics/semantics_text_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_text_test.dart
@@ -14,7 +14,6 @@ import '../../common/rendering.dart';
 import '../../common/test_initialization.dart';
 import 'semantics_tester.dart';
 
-const String _rootStyle = 'style="filter: opacity(0%); color: rgba(0, 0, 0, 0)"';
 DateTime _testTime = DateTime(2023, 2, 17);
 EngineSemantics semantics() => EngineSemantics.instance;
 EngineSemanticsOwner owner() => EnginePlatformDispatcher.instance.implicitView!.semantics;
@@ -46,7 +45,7 @@ Future<void> testMain() async {
       tester.apply();
 
       expectSemanticsTree(owner(), '''
-        <sem role="text" $_rootStyle>Hello</sem>'''
+        <sem><span>Hello</span></sem>'''
       );
 
       final SemanticsObject node = owner().debugSemanticsTree![0]!;
@@ -58,7 +57,7 @@ Future<void> testMain() async {
       );
     }
 
-    // Change label - expect both <span> and aria-label to be updated.
+    // Change label - expect the <span> to be updated.
     {
       final SemanticsTester tester = SemanticsTester(owner());
       tester.updateNode(
@@ -70,7 +69,7 @@ Future<void> testMain() async {
       tester.apply();
 
       expectSemanticsTree(owner(), '''
-        <sem role="text" $_rootStyle>World</sem>'''
+        <sem><span>World</span></sem>'''
       );
     }
 
@@ -85,7 +84,7 @@ Future<void> testMain() async {
       );
       tester.apply();
 
-      expectSemanticsTree(owner(), '<sem role="text" $_rootStyle></sem>');
+      expectSemanticsTree(owner(), '<sem></sem>');
     }
 
     semantics().semanticsEnabled = false;
@@ -114,9 +113,9 @@ Future<void> testMain() async {
     tester.apply();
 
     expectSemanticsTree(owner(), '''
-      <sem aria-label="I am a parent" role="group" $_rootStyle>
+      <sem aria-label="I am a parent" role="group">
         <sem-c>
-          <sem role="text">I am a child</sem>
+          <sem><span>I am a child</span></sem>
         </sem-c>
       </sem>'''
     );
@@ -141,7 +140,7 @@ Future<void> testMain() async {
       tester.apply();
 
       expectSemanticsTree(owner(), '''
-        <sem role="text" $_rootStyle>I am a leaf</sem>'''
+        <sem><span>I am a leaf</span></sem>'''
       );
     }
 
@@ -165,9 +164,9 @@ Future<void> testMain() async {
       tester.apply();
 
       expectSemanticsTree(owner(), '''
-        <sem aria-label="I am a parent" role="group" $_rootStyle>
+        <sem aria-label="I am a parent" role="group">
           <sem-c>
-            <sem role="text">I am a child</sem>
+            <sem><span>I am a child</span></sem>
           </sem-c>
         </sem>'''
       );
@@ -185,7 +184,7 @@ Future<void> testMain() async {
       tester.apply();
 
       expectSemanticsTree(owner(), '''
-        <sem role="text" $_rootStyle>I am a leaf again</sem>'''
+        <sem><span>I am a leaf again</span></sem>'''
       );
     }
 

--- a/lib/web_ui/test/engine/semantics/semantics_text_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_text_test.dart
@@ -190,4 +190,99 @@ Future<void> testMain() async {
 
     semantics().semanticsEnabled = false;
   });
+
+  test('focusAsRouteDefault focuses on <span> when sized span is used', () async {
+    semantics()
+      ..debugOverrideTimestampFunction(() => _testTime)
+      ..semanticsEnabled = true;
+
+    final SemanticsTester tester = SemanticsTester(owner());
+    tester.updateNode(
+      id: 0,
+      label: 'Hello',
+      transform: Matrix4.identity().toFloat64(),
+      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+    );
+    tester.apply();
+
+    expectSemanticsTree(owner(), '''
+      <sem><span>Hello</span></sem>'''
+    );
+
+    final SemanticsObject node = owner().debugSemanticsTree![0]!;
+    final DomElement span = node.element.querySelector('span')!;
+
+    expect(span.getAttribute('tabindex'), isNull);
+    node.primaryRole!.focusAsRouteDefault();
+    expect(span.getAttribute('tabindex'), '-1');
+    expect(domDocument.activeElement, span);
+
+    semantics().semanticsEnabled = false;
+  });
+
+  test('focusAsRouteDefault focuses on <flt-semantics> when DOM text is used', () async {
+    semantics()
+      ..debugOverrideTimestampFunction(() => _testTime)
+      ..semanticsEnabled = true;
+
+    final SemanticsTester tester = SemanticsTester(owner());
+    tester.updateNode(
+      id: 0,
+      label: 'Hello',
+      transform: Matrix4.identity().toFloat64(),
+      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+    );
+    tester.apply();
+
+    final SemanticsObject node = owner().debugSemanticsTree![0]!;
+
+    // Set DOM text as preferred representation
+    final LabelAndValue lav = node.primaryRole!.labelAndValue!;
+    lav.preferredRepresentation = LabelRepresentation.domText;
+    lav.update();
+
+    expectSemanticsTree(owner(), '''
+      <sem>Hello</sem>'''
+    );
+
+    expect(node.element.getAttribute('tabindex'), isNull);
+    node.primaryRole!.focusAsRouteDefault();
+    expect(node.element.getAttribute('tabindex'), '-1');
+    expect(domDocument.activeElement, node.element);
+
+    semantics().semanticsEnabled = false;
+  });
+
+  test('focusAsRouteDefault focuses on <flt-semantics> when aria-label is used', () async {
+    semantics()
+      ..debugOverrideTimestampFunction(() => _testTime)
+      ..semanticsEnabled = true;
+
+    final SemanticsTester tester = SemanticsTester(owner());
+    tester.updateNode(
+      id: 0,
+      label: 'Hello',
+      transform: Matrix4.identity().toFloat64(),
+      rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
+    );
+    tester.apply();
+
+    final SemanticsObject node = owner().debugSemanticsTree![0]!;
+
+    // Set DOM text as preferred representation
+    final LabelAndValue lav = node.primaryRole!.labelAndValue!;
+    lav.preferredRepresentation = LabelRepresentation.ariaLabel;
+    lav.update();
+
+    expectSemanticsTree(owner(), '''
+      <sem aria-label="Hello"></sem>'''
+    );
+
+    expect(node.element.getAttribute('tabindex'), isNull);
+    node.primaryRole!.focusAsRouteDefault();
+    expect(node.element.getAttribute('tabindex'), '-1');
+    expect(domDocument.activeElement, node.element);
+
+    semantics().semanticsEnabled = false;
+  });
 }

--- a/lib/web_ui/test/engine/semantics/text_field_test.dart
+++ b/lib/web_ui/test/engine/semantics/text_field_test.dart
@@ -93,7 +93,7 @@ void testMain() {
     createTextFieldSemantics(value: 'hello');
 
     expectSemanticsTree(owner(), '''
-<sem style="$rootSemanticStyle">
+<sem>
   <input />
 </sem>''');
 


### PR DESCRIPTION
Due to https://g-issues.chromium.org/issues/40875151?pli=1&authuser=0 and a lack of an ARIA role for plain text nodes (after the removal of `role="text"` in WebKit recently), there is no way to customize the size of the screen reader focus ring for a plain text element. The focus ring always tightly hugs the text itself.

A workaround implemented in this PR is to match the size of the text exactly to the desired focus ring size. This is done by measuring the size of the text in the DOM, then scaling it both vertically and horizontally to match the size requested by the framework for the corresponding semantics node.

To avoid serious performance penalty, the following optimizations were included:

- Nodes that are satisfiable by just an `aria-label` do not need this workaround, and are skipped.
- Nodes that must use DOM text (e.g. links, buttons) but have ARIA roles that size them based on the element, do not need this workaround, and are skipped.
- Nodes that do need the workaround are first measured in a single batch, incurring only one page reflow. Then they are all updated in a single batch without taking any further DOM measurements. This ensures that no matter how many text spans are rendered, only one reflow is needed to measure them all.
- Nodes that need the workaround cache the previous label and size, and if they do not change, the size is not updated.

Other changes:

- Rename `LeafLabelRepresentation` to `LabelRepresentation`, because labels also apply to non-leaf nodes (e.g. `aria-label` may be applied to a container).
- Rename `labelRepresentation` to `preferredLabelRepresentation`, because a particular label representation cannot be guaranteed. A node that currently looks like a leaf text node may turn out to be an empty container, and after adding children to it must switch from using DOM text to an `aria-label`. Therefore, role manager only specify a preference, but `LabelAndValue` ultimately decides which representation is usable.
- Introduce `void initState()` in `PrimaryRoleManager` to be used for one-time initialization of state and DOM structure after all objects that are in a one-to-one relationship with each other create all the references needed to establish that relationship (`PrimaryRoleManager`, `SemanticsObject`, `element`, `owner`, etc). This is not available at the time the constructors are called.

Fixes https://github.com/flutter/flutter/issues/146774.