### PR TITLE
[Impeller] eagerly bootstrap content context.

### DIFF
--- a/shell/platform/android/android_surface_vulkan_impeller.cc
+++ b/shell/platform/android/android_surface_vulkan_impeller.cc
@@ -24,6 +24,8 @@ AndroidSurfaceVulkanImpeller::AndroidSurfaceVulkanImpeller(
   auto& context_vk =
       impeller::ContextVK::Cast(*android_context->GetImpellerContext());
   surface_context_vk_ = context_vk.CreateSurfaceContext();
+  eager_gpu_surface_ =
+      std::make_unique<GPUSurfaceVulkanImpeller>(surface_context_vk_);
 }
 
 AndroidSurfaceVulkanImpeller::~AndroidSurfaceVulkanImpeller() = default;
@@ -44,6 +46,14 @@ std::unique_ptr<Surface> AndroidSurfaceVulkanImpeller::CreateGPUSurface(
 
   if (!native_window_ || !native_window_->IsValid()) {
     return nullptr;
+  }
+
+  if (eager_gpu_surface_) {
+    auto gpu_surface = std::move(eager_gpu_surface_);
+    if (!gpu_surface->IsValid()) {
+      return nullptr;
+    }
+    return gpu_surface;
   }
 
   std::unique_ptr<GPUSurfaceVulkanImpeller> gpu_surface =

--- a/shell/platform/android/android_surface_vulkan_impeller.h
+++ b/shell/platform/android/android_surface_vulkan_impeller.h
@@ -11,6 +11,7 @@
 #include "flutter/shell/platform/android/android_context_vulkan_impeller.h"
 #include "flutter/shell/platform/android/surface/android_native_window.h"
 #include "flutter/shell/platform/android/surface/android_surface.h"
+#include "shell/gpu/gpu_surface_vulkan_impeller.h"
 
 namespace flutter {
 
@@ -49,6 +50,11 @@ class AndroidSurfaceVulkanImpeller : public AndroidSurface {
  private:
   std::shared_ptr<impeller::SurfaceContextVK> surface_context_vk_;
   fml::RefPtr<AndroidNativeWindow> native_window_;
+  // The first GPU Surface is initialized as soon as the
+  // AndroidSurfaceVulkanImpeller is created. This ensures that the pipelines
+  // are bootstrapped as early as possible.
+  std::unique_ptr<GPUSurfaceVulkanImpeller> eager_gpu_surface_;
+
   bool is_valid_ = false;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AndroidSurfaceVulkanImpeller);


### PR DESCRIPTION
![image](https://github.com/flutter/engine/assets/8975114/5238d169-a68b-4905-848b-3ee7a7972de8)


Work around for https://github.com/flutter/flutter/issues/143540 by running shader bootstrap as early as possible. I was looking at this code for unrelated reasons (include removal) and realized it would be a trivial change.

If we're using the KHR swapchain instead of the AHB swapchain, in theory the pixel format could change but since we hash the pixel format the only bad thing would be the wasted work.