### PR TITLE
[Impeller] AHB swapchain mark frame start for tracer.

### DIFF
--- a/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
@@ -103,6 +103,11 @@ std::unique_ptr<Surface> AHBSwapchainImplVK::AcquireNextDrawable() {
     return nullptr;
   }
 
+  auto context = transients_->GetContext().lock();
+  if (context) {
+    ContextVK::Cast(*context).GetGPUTracer()->MarkFrameStart();
+  }
+
   auto surface = SurfaceVK::WrapSwapchainImage(
       transients_, texture,
       [signaler = auto_sema_signaler, weak = weak_from_this(), texture]() {


### PR DESCRIPTION
https://flutter-flutter-perf.skia.org/e/?begin=1713561746&end=1715051005&queries=device_type%3DPixel_7_Pro%26sub_result%3Daverage_gpu_frame_time%26test%3Dnew_gallery_impeller__transition_perf&requestType=0&selected=commit%3D40670%26name%3D%252Carch%253Dintel%252Cbranch%253Dmaster%252Cconfig%253Ddefault%252Cdevice_type%253DPixel_7_Pro%252Cdevice_version%253Dnone%252Chost_type%253Dlinux%252Csub_result%253Daverage_gpu_frame_time%252Ctest%253Dnew_gallery_impeller__transition_perf%252C 

still not fixed because I also forgot the start
