### PR TITLE
Add host_profile_arm64 and host_release_arm64 local engine configurations.

### DIFF
--- a/ci/builders/local_engine.json
+++ b/ci/builders/local_engine.json
@@ -547,6 +547,68 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
+        "os=Mac-13",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "download_android_deps": false,
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "profile",
+        "--mac-cpu",
+        "arm64",
+        "--xcode-symlinks",
+        "--rbe",
+        "--no-goma"
+      ],
+      "name": "macos/host_profile_arm64",
+      "description": "Builds a profile mode engine for a macOS host on arm64.",
+      "ninja": {
+        "config": "host_profile_arm64",
+        "targets": []
+      },
+      "properties": {
+        "$flutter/osx_sdk": {
+          "sdk_version": "15a240d"
+        }
+      }
+    },
+    {
+      "cas_archive": false,
+      "drone_dimensions": [
+        "os=Mac-13",
+        "device_type=none"
+      ],
+      "gclient_variables": {
+        "download_android_deps": false,
+        "use_rbe": true
+      },
+      "gn": [
+        "--runtime-mode",
+        "release",
+        "--mac-cpu",
+        "arm64",
+        "--xcode-symlinks",
+        "--rbe",
+        "--no-goma"
+      ],
+      "name": "macos/host_release_arm64",
+      "description": "Builds a release mode engine for a macOS host on arm64.",
+      "ninja": {
+        "config": "host_release_arm64",
+        "targets": []
+      },
+      "properties": {
+        "$flutter/osx_sdk": {
+          "sdk_version": "15a240d"
+        }
+      }
+    },
+    {
+      "cas_archive": false,
+      "drone_dimensions": [
         "os=Linux",
         "device_type=none"
       ],


### PR DESCRIPTION
These are used on macOS hosts during local engine development.
