### PR TITLE
Move setting the logging level into the `Logger` constructor, refactor.

### DIFF
--- a/tools/engine_tool/lib/main.dart
+++ b/tools/engine_tool/lib/main.dart
@@ -60,12 +60,18 @@ void main(List<String> args) async {
     io.exitCode = 1;
   }
 
+  final Logger logger;
+  if (verbose) {
+    logger = Logger(level: Logger.infoLevel);
+  } else {
+    logger = Logger();
+  }
   final Environment environment = Environment(
     abi: ffi.Abi.current(),
     engine: engine,
     platform: const LocalPlatform(),
     processRunner: ProcessRunner(),
-    logger: Logger(),
+    logger: logger,
     verbose: verbose,
   );
 

--- a/tools/engine_tool/lib/src/commands/command_runner.dart
+++ b/tools/engine_tool/lib/src/commands/command_runner.dart
@@ -6,7 +6,6 @@ import 'package:args/command_runner.dart';
 import 'package:engine_build_configs/engine_build_configs.dart';
 
 import '../environment.dart';
-import '../logger.dart';
 import 'build_command.dart';
 import 'fetch_command.dart';
 import 'flags.dart';

--- a/tools/engine_tool/lib/src/commands/command_runner.dart
+++ b/tools/engine_tool/lib/src/commands/command_runner.dart
@@ -94,9 +94,6 @@ final class ToolCommandRunner extends CommandRunner<int> {
 
   @override
   Future<int> run(Iterable<String> args) async {
-    if (environment.verbose) {
-      environment.logger.level = Logger.infoLevel;
-    }
     try {
       return await runCommand(parse(args)) ?? 0;
     } on FormatException catch (e) {

--- a/tools/engine_tool/lib/src/logger.dart
+++ b/tools/engine_tool/lib/src/logger.dart
@@ -26,10 +26,12 @@ import 'package:meta/meta.dart';
 /// which can be inspected by unit tetss.
 class Logger {
   /// Constructs a logger for use in the tool.
-  Logger()
+  Logger({
+    log.Level level = statusLevel,
+  })
       : _logger = log.Logger.detached('et'),
         _test = false {
-    _logger.level = statusLevel;
+    _logger.level = level;
     _logger.onRecord.listen(_handler);
     _setupIoSink(io.stderr);
     _setupIoSink(io.stdout);
@@ -37,10 +39,12 @@ class Logger {
 
   /// A logger for tests.
   @visibleForTesting
-  Logger.test()
+  Logger.test({
+    log.Level level = statusLevel,
+  })
       : _logger = log.Logger.detached('et'),
         _test = true {
-    _logger.level = statusLevel;
+    _logger.level = level;
     _logger.onRecord.listen((log.LogRecord r) => _testLogs.add(r));
   }
 
@@ -104,11 +108,6 @@ class Logger {
 
   /// Get the current logging level.
   log.Level get level => _logger.level;
-
-  /// Set the current logging level.
-  set level(log.Level l) {
-    _logger.level = l;
-  }
 
   /// Record a log message level [Logger.error] and throw a FatalError.
   /// This should only be called when the program has entered an impossible

--- a/tools/engine_tool/test/logger_test.dart
+++ b/tools/engine_tool/test/logger_test.dart
@@ -12,8 +12,7 @@ void main() {
   }
 
   test('Setting the level works', () {
-    final Logger logger = Logger.test();
-    logger.level = Logger.infoLevel;
+    final Logger logger = Logger.test(level: Logger.infoLevel);
     expect(logger.level, equals(Logger.infoLevel));
   });
 
@@ -42,8 +41,7 @@ void main() {
   });
 
   test('info messages are recorded at the infoLevel log level', () {
-    final Logger logger = Logger.test();
-    logger.level = Logger.infoLevel;
+    final Logger logger = Logger.test(level: Logger.infoLevel);
     logger.info('info');
     expect(stringsFromLogs(logger.testLogs), equals(<String>['info\n']));
   });
@@ -73,15 +71,13 @@ void main() {
   });
 
   test('newlines in info() can be disabled', () {
-    final Logger logger = Logger.test();
-    logger.level = Logger.infoLevel;
+    final Logger logger = Logger.test(level: Logger.infoLevel);
     logger.info('info', newline: false);
     expect(stringsFromLogs(logger.testLogs), equals(<String>['info']));
   });
 
   test('fatal throws exception', () {
-    final Logger logger = Logger.test();
-    logger.level = Logger.infoLevel;
+    final Logger logger = Logger.test(level: Logger.infoLevel);
     bool caught = false;
     try {
       logger.fatal('test', newline: false);


### PR DESCRIPTION
Based on @zanderso's feedback here: https://github.com/flutter/engine/pull/52619#discussion_r1592868979.

I think this is the most succinct way to setup logging, it also doesn't seem to make sense to allow the level to be configured at runtime, so boom. 