### PR TITLE
[Impeller] Disable aging in the AHB swapchains and use FILO.

### DIFF
--- a/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_texture_pool_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_texture_pool_vk.cc
@@ -78,7 +78,6 @@ void AHBTexturePoolVK::PerformGC() {
 }
 
 void AHBTexturePoolVK::PerformGCLocked() {
-  auto now = Clock::now();
   while (!pool_.empty() && (pool_.size() > max_entries_)) {
     // Buffers are pushed to the back of the queue and popped from the front.
     // The ones at the back should be given the most time for their fences to

--- a/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_texture_pool_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_texture_pool_vk.cc
@@ -10,12 +10,8 @@ namespace impeller {
 
 AHBTexturePoolVK::AHBTexturePoolVK(std::weak_ptr<Context> context,
                                    android::HardwareBufferDescriptor desc,
-                                   size_t max_entries,
-                                   std::chrono::milliseconds max_extry_age)
-    : context_(std::move(context)),
-      desc_(desc),
-      max_entries_(max_entries),
-      max_extry_age_(max_extry_age) {
+                                   size_t max_entries)
+    : context_(std::move(context)), desc_(desc), max_entries_(max_entries) {
   if (!desc_.IsAllocatable()) {
     VALIDATION_LOG << "Swapchain image is not allocatable.";
     return;
@@ -29,8 +25,10 @@ AHBTexturePoolVK::PoolEntry AHBTexturePoolVK::Pop() {
   {
     Lock lock(pool_mutex_);
     if (!pool_.empty()) {
-      auto entry = pool_.back();
-      pool_.pop_back();
+      // Buffers are pushed to the back of the queue. To give the ready fences
+      // the most time to signal, pick a buffer from the front of the queue.
+      auto entry = pool_.front();
+      pool_.pop_front();
       return entry;
     }
   }
@@ -80,13 +78,13 @@ void AHBTexturePoolVK::PerformGC() {
 }
 
 void AHBTexturePoolVK::PerformGCLocked() {
-  // Push-Pop operations happen at the back of the deque so the front ages as
-  // much as possible. So that's where we collect entries.
   auto now = Clock::now();
-  while (!pool_.empty() &&
-         (pool_.size() > max_entries_ ||
-          now - pool_.front().last_access_time > max_extry_age_)) {
-    pool_.pop_front();
+  while (!pool_.empty() && (pool_.size() > max_entries_)) {
+    // Buffers are pushed to the back of the queue and popped from the front.
+    // The ones at the back should be given the most time for their fences to
+    // signal. If we are going to get rid of textures, they might as well be the
+    // newest ones since their fences will take the longest to signal.
+    pool_.pop_back();
   }
 }
 

--- a/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_texture_pool_vk.h
+++ b/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_texture_pool_vk.h
@@ -19,8 +19,7 @@ namespace impeller {
 ///             sources that can be used as swapchain images.
 ///
 ///             The number of cached entries in the texture pool is capped to a
-///             caller specified value. Within this cap, no entry may be older
-///             than the caller specified duration.
+///             caller specified value.
 ///
 ///             If a previously cached entry cannot be obtained from the pool, a
 ///             new entry is created. The only case where a valid texture source
@@ -55,14 +54,10 @@ class AHBTexturePoolVK {
   ///                            the texture sources.
   /// @param[in]  max_entries    The maximum entries that will remain cached
   ///                            in the pool.
-  /// @param[in]  max_extry_age  The maximum duration an entry will remain
-  ///                            cached in the pool.
   ///
-  explicit AHBTexturePoolVK(
-      std::weak_ptr<Context> context,
-      android::HardwareBufferDescriptor desc,
-      size_t max_entries = 2u,
-      std::chrono::milliseconds max_extry_age = std::chrono::seconds{1});
+  explicit AHBTexturePoolVK(std::weak_ptr<Context> context,
+                            android::HardwareBufferDescriptor desc,
+                            size_t max_entries = 2u);
 
   ~AHBTexturePoolVK();
 
@@ -117,7 +112,6 @@ class AHBTexturePoolVK {
   const std::weak_ptr<Context> context_;
   const android::HardwareBufferDescriptor desc_;
   const size_t max_entries_;
-  const std::chrono::milliseconds max_extry_age_;
   bool is_valid_ = false;
   Mutex pool_mutex_;
   std::deque<PoolEntry> pool_ IPLR_GUARDED_BY(pool_mutex_);


### PR DESCRIPTION
The aging was causing elevated 9x percentile times after a long duration where no frames were rendered. The FILO queue behavior gives the fences the most time possible to signal and cause fewer GPU stalls. There are already no CPU stalls.
