### PR TITLE
Move `Logger.test` to an injected log output versus leaky abstraction.

### DIFF
--- a/tools/engine_tool/lib/src/logger.dart
+++ b/tools/engine_tool/lib/src/logger.dart
@@ -40,7 +40,7 @@ class Logger {
     _setupIoSink(io.stdout);
   }
 
-  /// Constructrs a logger that invokes a [callback] for each log message.
+  /// Constructs a logger that invokes a [callback] for each log message.
   @visibleForTesting
   Logger.test(
     void Function(log.LogRecord) onLog, {

--- a/tools/engine_tool/lib/src/logger.dart
+++ b/tools/engine_tool/lib/src/logger.dart
@@ -8,6 +8,9 @@ import 'dart:io' as io show IOSink, stderr, stdout;
 import 'package:logging/logging.dart' as log;
 import 'package:meta/meta.dart';
 
+// Part of the public API, so it's nicer to provide the symbols directly.
+export 'package:logging/logging.dart' show LogRecord;
+
 // This is where a flutter_tool style progress spinner, color output,
 // ascii art, terminal control for clearing lines or the whole screen, etc.
 // can go. We can just add more methods to Logger using the flutter_tool's
@@ -37,15 +40,16 @@ class Logger {
     _setupIoSink(io.stdout);
   }
 
-  /// A logger for tests.
+  /// Constructrs a logger that invokes a [callback] for each log message.
   @visibleForTesting
-  Logger.test({
+  Logger.test(
+    void Function(log.LogRecord) onLog, {
     log.Level level = statusLevel,
   })
       : _logger = log.Logger.detached('et'),
         _test = true {
     _logger.level = level;
-    _logger.onRecord.listen((log.LogRecord r) => _testLogs.add(r));
+    _logger.onRecord.listen(onLog);
   }
 
   /// The logging level for error messages. These go to stderr.
@@ -101,7 +105,6 @@ class Logger {
   }
 
   final log.Logger _logger;
-  final List<log.LogRecord> _testLogs = <log.LogRecord>[];
   final bool _test;
 
   Spinner? _status;
@@ -259,11 +262,6 @@ class Logger {
     s = s.replaceRange(leftEnd, rightStart, '...');
     return s + maybeNewline;
   }
-
-  /// In a [Logger] constructed by [Logger.test], this list will contain all of
-  /// the [LogRecord]s emitted by the test.
-  @visibleForTesting
-  List<log.LogRecord> get testLogs => _testLogs;
 }
 
 /// A base class for progress spinners, and a no-op implementation that prints

--- a/tools/engine_tool/test/fetch_command_test.dart
+++ b/tools/engine_tool/test/fetch_command_test.dart
@@ -51,7 +51,7 @@ void main() {
   }
 
   test('fetch command invokes gclient sync -D', () async {
-    final Logger logger = Logger.test();
+    final Logger logger = Logger.test((_) {});
     final (Environment env, List<List<String>> runHistory) = linuxEnv(logger);
     final ToolCommandRunner runner = ToolCommandRunner(
       environment: env,
@@ -67,7 +67,7 @@ void main() {
   });
 
   test('fetch command has sync alias', () async {
-    final Logger logger = Logger.test();
+    final Logger logger = Logger.test((_) {});
     final (Environment env, List<List<String>> runHistory) = linuxEnv(logger);
     final ToolCommandRunner runner = ToolCommandRunner(
       environment: env,

--- a/tools/engine_tool/test/format_command_test.dart
+++ b/tools/engine_tool/test/format_command_test.dart
@@ -48,7 +48,7 @@ void main() {
   }
 
   test('--fix is passed to ci/bin/format.dart by default', () async {
-    final Logger logger = Logger.test();
+    final Logger logger = Logger.test((_){ });
     final FakeProcessManager manager = _formatProcessManager(
       expectedFlags: <String>['--fix'],
     );
@@ -64,7 +64,7 @@ void main() {
   });
 
   test('--fix is not passed to ci/bin/format.dart with --dry-run', () async {
-    final Logger logger = Logger.test();
+    final Logger logger = Logger.test((_) {});
     final FakeProcessManager manager = _formatProcessManager(
       expectedFlags: <String>[],
     );
@@ -82,7 +82,7 @@ void main() {
 
   test('exit code is non-zero when ci/bin/format.dart exit code was non zero',
       () async {
-    final Logger logger = Logger.test();
+    final Logger logger = Logger.test((_) {});
     final FakeProcessManager manager = _formatProcessManager(
       expectedFlags: <String>['--fix'],
       exitCode: 1,
@@ -99,7 +99,7 @@ void main() {
   });
 
   test('--all-files is passed to ci/bin/format.dart correctly', () async {
-    final Logger logger = Logger.test();
+    final Logger logger = Logger.test((_){});
     final FakeProcessManager manager = _formatProcessManager(
       expectedFlags: <String>['--fix', '--all-files'],
     );
@@ -116,7 +116,7 @@ void main() {
   });
 
   test('--verbose is passed to ci/bin/format.dart correctly', () async {
-    final Logger logger = Logger.test();
+    final Logger logger = Logger.test((_){});
     final FakeProcessManager manager = _formatProcessManager(
       expectedFlags: <String>['--fix', '--verbose'],
     );
@@ -133,7 +133,8 @@ void main() {
   });
 
   test('--quiet suppresses non-error output', () async {
-    final Logger logger = Logger.test();
+    final List<LogRecord> testLogs = <LogRecord>[];
+    final Logger logger = Logger.test(testLogs.add);
     final FakeProcessManager manager = _formatProcessManager(
       expectedFlags: <String>['--fix'],
       stdout: <String>['many', 'lines', 'of', 'output'].join('\n'),
@@ -149,11 +150,12 @@ void main() {
       '--$quietFlag',
     ]);
     expect(result, equals(0));
-    expect(stringsFromLogs(logger.testLogs), equals(<String>['error\n']));
+    expect(stringsFromLogs(testLogs), equals(<String>['error\n']));
   });
 
   test('Diffs are suppressed by default', () async {
-    final Logger logger = Logger.test();
+    final List<LogRecord> testLogs = <LogRecord>[];
+    final Logger logger = Logger.test(testLogs.add);
     final FakeProcessManager manager = _formatProcessManager(
       expectedFlags: <String>['--fix'],
       stdout: <String>[
@@ -174,11 +176,12 @@ void main() {
       'format',
     ]);
     expect(result, equals(0));
-    expect(stringsFromLogs(logger.testLogs), isEmpty);
+    expect(stringsFromLogs(testLogs), isEmpty);
   });
 
   test('--dry-run disables --fix and prints diffs', () async {
-    final Logger logger = Logger.test();
+    final List<LogRecord> testLogs = <LogRecord>[];
+    final Logger logger = Logger.test(testLogs.add);
     final FakeProcessManager manager = _formatProcessManager(
       expectedFlags: <String>[],
       stdout: <String>[
@@ -201,7 +204,7 @@ void main() {
     ]);
     expect(result, equals(0));
     expect(
-        stringsFromLogs(logger.testLogs),
+        stringsFromLogs(testLogs),
         equals(<String>[
           'To fix, run `et format` or:\n',
           'many\n',
@@ -213,7 +216,8 @@ void main() {
   });
 
   test('progress lines are followed by a carriage return', () async {
-    final Logger logger = Logger.test();
+    final List<LogRecord> testLogs = <LogRecord>[];
+    final Logger logger = Logger.test(testLogs.add);
     const String progressLine = 'diff Jobs:  46% done, 1528/3301 completed,  '
         '7 in progress, 1753 pending,  13 failed.';
     final FakeProcessManager manager = _formatProcessManager(
@@ -229,8 +233,7 @@ void main() {
       'format',
     ]);
     expect(result, equals(0));
-    expect(
-        stringsFromLogs(logger.testLogs), equals(<String>['$progressLine\r']));
+    expect(stringsFromLogs(testLogs), equals(<String>['$progressLine\r']));
   });
 }
 

--- a/tools/engine_tool/test/lint_command_test.dart
+++ b/tools/engine_tool/test/lint_command_test.dart
@@ -78,7 +78,7 @@ void main() {
   }
 
   test('invoked linters', () async {
-    final Logger logger = Logger.test();
+    final Logger logger = Logger.test((_) {});
     final (Environment env, List<List<String>> runHistory) = macEnv(logger);
     final ToolCommandRunner runner = ToolCommandRunner(
       environment: env,

--- a/tools/engine_tool/test/logger_test.dart
+++ b/tools/engine_tool/test/logger_test.dart
@@ -12,72 +12,83 @@ void main() {
   }
 
   test('Setting the level works', () {
-    final Logger logger = Logger.test(level: Logger.infoLevel);
+    final Logger logger = Logger.test((_) {}, level: Logger.infoLevel);
     expect(logger.level, equals(Logger.infoLevel));
   });
 
   test('error messages are recorded at the default log level', () {
-    final Logger logger = Logger.test();
+    final List<LogRecord> testLogs = <LogRecord>[];
+    final Logger logger = Logger.test(testLogs.add);
     logger.error('Error');
-    expect(stringsFromLogs(logger.testLogs), equals(<String>['Error\n']));
+    expect(stringsFromLogs(testLogs), equals(<String>['Error\n']));
   });
 
   test('warning messages are recorded at the default log level', () {
-    final Logger logger = Logger.test();
+    final List<LogRecord> testLogs = <LogRecord>[];
+    final Logger logger = Logger.test(testLogs.add);
     logger.warning('Warning');
-    expect(stringsFromLogs(logger.testLogs), equals(<String>['Warning\n']));
+    expect(stringsFromLogs(testLogs), equals(<String>['Warning\n']));
   });
 
   test('status messages are recorded at the default log level', () {
-    final Logger logger = Logger.test();
+    final List<LogRecord> testLogs = <LogRecord>[];
+    final Logger logger = Logger.test(testLogs.add);
     logger.status('Status');
-    expect(stringsFromLogs(logger.testLogs), equals(<String>['Status\n']));
+    expect(stringsFromLogs(testLogs), equals(<String>['Status\n']));
   });
 
   test('info messages are not recorded at the default log level', () {
-    final Logger logger = Logger.test();
+    final List<LogRecord> testLogs = <LogRecord>[];
+    final Logger logger = Logger.test(testLogs.add);
     logger.info('info');
-    expect(stringsFromLogs(logger.testLogs), equals(<String>[]));
+    expect(stringsFromLogs(testLogs), equals(<String>[]));
   });
 
   test('info messages are recorded at the infoLevel log level', () {
-    final Logger logger = Logger.test(level: Logger.infoLevel);
+    final List<LogRecord> testLogs = <LogRecord>[];
+    final Logger logger = Logger.test(testLogs.add, level: Logger.infoLevel);
     logger.info('info');
-    expect(stringsFromLogs(logger.testLogs), equals(<String>['info\n']));
+    expect(stringsFromLogs(testLogs), equals(<String>['info\n']));
   });
 
   test('indent indents the message', () {
-    final Logger logger = Logger.test();
+    final List<LogRecord> testLogs = <LogRecord>[];
+    final Logger logger = Logger.test(testLogs.add);
     logger.status('Status', indent: 1);
-    expect(stringsFromLogs(logger.testLogs), equals(<String>[' Status\n']));
+    expect(stringsFromLogs(testLogs), equals(<String>[' Status\n']));
   });
 
   test('newlines in error() can be disabled', () {
-    final Logger logger = Logger.test();
+    final List<LogRecord> testLogs = <LogRecord>[];
+    final Logger logger = Logger.test(testLogs.add);
     logger.error('Error', newline: false);
-    expect(stringsFromLogs(logger.testLogs), equals(<String>['Error']));
+    expect(stringsFromLogs(testLogs), equals(<String>['Error']));
   });
 
   test('newlines in warning() can be disabled', () {
-    final Logger logger = Logger.test();
+    final List<LogRecord> testLogs = <LogRecord>[];
+    final Logger logger = Logger.test(testLogs.add);
     logger.warning('Warning', newline: false);
-    expect(stringsFromLogs(logger.testLogs), equals(<String>['Warning']));
+    expect(stringsFromLogs(testLogs), equals(<String>['Warning']));
   });
 
   test('newlines in status() can be disabled', () {
-    final Logger logger = Logger.test();
+    final List<LogRecord> testLogs = <LogRecord>[];
+    final Logger logger = Logger.test(testLogs.add);
     logger.status('Status', newline: false);
-    expect(stringsFromLogs(logger.testLogs), equals(<String>['Status']));
+    expect(stringsFromLogs(testLogs), equals(<String>['Status']));
   });
 
   test('newlines in info() can be disabled', () {
-    final Logger logger = Logger.test(level: Logger.infoLevel);
+    final List<LogRecord> testLogs = <LogRecord>[];
+    final Logger logger = Logger.test(testLogs.add, level: Logger.infoLevel);
     logger.info('info', newline: false);
-    expect(stringsFromLogs(logger.testLogs), equals(<String>['info']));
+    expect(stringsFromLogs(testLogs), equals(<String>['info']));
   });
 
   test('fatal throws exception', () {
-    final Logger logger = Logger.test(level: Logger.infoLevel);
+    final List<LogRecord> testLogs = <LogRecord>[];
+    final Logger logger = Logger.test(testLogs.add, level: Logger.infoLevel);
     bool caught = false;
     try {
       logger.fatal('test', newline: false);
@@ -85,7 +96,7 @@ void main() {
       caught = true;
     }
     expect(caught, equals(true));
-    expect(stringsFromLogs(logger.testLogs), equals(<String>['test']));
+    expect(stringsFromLogs(testLogs), equals(<String>['test']));
   });
 
   test('fitToWidth', () {
@@ -123,7 +134,7 @@ void main() {
   });
 
   test('Spinner calls onFinish callback', () {
-    final Logger logger = Logger.test();
+    final Logger logger = Logger.test((_) {});
     bool called = false;
     final Spinner spinner = logger.startSpinner(
       onFinish: () {

--- a/tools/engine_tool/test/proc_utils_test.dart
+++ b/tools/engine_tool/test/proc_utils_test.dart
@@ -58,7 +58,7 @@ void main() {
   }
 
   test('process queue success', () async {
-    final Logger logger = Logger.test();
+    final Logger logger = Logger.test((_) {});
     final (Environment env, _) = macEnv(logger);
     final WorkerPool wp = WorkerPool(env, NoopWorkerPoolProgressReporter());
     final ProcessTask task =
@@ -72,7 +72,7 @@ void main() {
   });
 
   test('process queue failure', () async {
-    final Logger logger = Logger.test();
+    final Logger logger = Logger.test((_) {});
     final (Environment env, _) = macEnv(logger);
     final WorkerPool wp = WorkerPool(env, NoopWorkerPoolProgressReporter());
     final ProcessTask task =

--- a/tools/engine_tool/test/query_command_test.dart
+++ b/tools/engine_tool/test/query_command_test.dart
@@ -65,7 +65,7 @@ void main() {
       ]);
       expect(result, equals(0));
       expect(
-        stringsFromLogs(env.logger.testLogs),
+        stringsFromLogs(testEnvironment.testLogs),
         equals(<String>[
           'Add --verbose to see detailed information about each builder\n',
           '\n',
@@ -105,7 +105,7 @@ void main() {
       ]);
       expect(result, equals(0));
       expect(
-          stringsFromLogs(env.logger.testLogs),
+          stringsFromLogs(testEnvironment.testLogs),
           equals(<String>[
             'Add --verbose to see detailed information about each builder\n',
             '\n',
@@ -137,7 +137,7 @@ void main() {
       ]);
       expect(result, equals(0));
       expect(
-        env.logger.testLogs.length,
+        testEnvironment.testLogs.length,
         equals(30),
       );
     } finally {
@@ -161,10 +161,10 @@ void main() {
       ]);
       expect(result, equals(0));
       expect(
-        env.logger.testLogs.length,
+        testEnvironment.testLogs.length,
         equals(4),
       );
-      expect(env.logger.testLogs[1].message,
+      expect(testEnvironment.testLogs[1].message,
           startsWith('//flutter/display_list:display_list_unittests'));
     } finally {
       testEnvironment.cleanup();

--- a/tools/engine_tool/test/run_command_test.dart
+++ b/tools/engine_tool/test/run_command_test.dart
@@ -86,7 +86,7 @@ void main() {
   }
 
   test('run command invokes flutter run', () async {
-    final Logger logger = Logger.test();
+    final Logger logger = Logger.test((_) {});
     final (Environment env, List<List<String>> runHistory) = linuxEnv(logger);
     final ToolCommandRunner runner = ToolCommandRunner(
       environment: env,
@@ -101,7 +101,7 @@ void main() {
   });
 
   test('parse devices list', () async {
-    final Logger logger = Logger.test();
+    final Logger logger = Logger.test((_) {});
     final (Environment env, _) = linuxEnv(logger);
     final List<RunTarget> targets =
         parseDevices(env, fixtures.attachedDevices());
@@ -112,7 +112,7 @@ void main() {
   });
 
   test('default device', () async {
-    final Logger logger = Logger.test();
+    final Logger logger = Logger.test((_) {});
     final (Environment env, _) = linuxEnv(logger);
     final List<RunTarget> targets =
         parseDevices(env, fixtures.attachedDevices());
@@ -125,7 +125,7 @@ void main() {
   });
 
   test('device select', () async {
-    final Logger logger = Logger.test();
+    final Logger logger = Logger.test((_) {});
     final (Environment env, _) = linuxEnv(logger);
     RunTarget target = selectRunTarget(env, fixtures.attachedDevices())!;
     expect(target.name, contains('gphone64'));
@@ -134,7 +134,7 @@ void main() {
   });
 
   test('flutter run device select', () async {
-    final Logger logger = Logger.test();
+    final Logger logger = Logger.test((_) {});
     final (Environment env, List<List<String>> runHistory) = linuxEnv(logger);
     final ToolCommandRunner runner = ToolCommandRunner(
       environment: env,

--- a/tools/engine_tool/test/utils.dart
+++ b/tools/engine_tool/test/utils.dart
@@ -59,7 +59,8 @@ class TestEnvironment {
     bool verbose = false,
     this.cannedProcesses = const <CannedProcess>[],
   }) {
-    logger ??= Logger.test();
+    testLogs = <LogRecord>[];
+    logger ??= Logger.test(testLogs.add);
     environment = Environment(
       abi: abi,
       engine: engine,
@@ -137,6 +138,9 @@ class TestEnvironment {
 
   /// A history of all executed processes.
   final List<ExecutedProcess> processHistory = <ExecutedProcess>[];
+
+  /// Test log output.
+  late final List<LogRecord> testLogs;
 }
 
 String _operatingSystemForAbi(ffi.Abi abi) {

--- a/tools/engine_tool/test/worker_pool_test.dart
+++ b/tools/engine_tool/test/worker_pool_test.dart
@@ -100,7 +100,7 @@ void main() {
   }
 
   test('worker pool success', () async {
-    final Logger logger = Logger.test();
+    final Logger logger = Logger.test((_) {});
     final (Environment env, _) = macEnv(logger);
     final TestWorkerPoolProgressReporter reporter =
         TestWorkerPoolProgressReporter();
@@ -114,7 +114,7 @@ void main() {
   });
 
   test('worker pool failure', () async {
-    final Logger logger = Logger.test();
+    final Logger logger = Logger.test((_) {});
     final (Environment env, _) = macEnv(logger);
     final TestWorkerPoolProgressReporter reporter =
         TestWorkerPoolProgressReporter();


### PR DESCRIPTION
Previously, `Logger.test` was a leaky abstraction that stored a `@visibleForTesting` variable that was sometimes unused. It saved a few lines of code for tests, but doesn't seem necessary, so I swapped it out for a callback.