### PR TITLE
[Impeller] support requires readback from onscreen texture in experimental canvas.

### DIFF
--- a/impeller/aiks/experimental_canvas.h
+++ b/impeller/aiks/experimental_canvas.h
@@ -20,14 +20,18 @@ namespace impeller {
 
 class ExperimentalCanvas : public Canvas {
  public:
-  ExperimentalCanvas(ContentContext& renderer, RenderTarget& render_target);
+  ExperimentalCanvas(ContentContext& renderer,
+                     RenderTarget& render_target,
+                     bool requires_readback);
 
   ExperimentalCanvas(ContentContext& renderer,
                      RenderTarget& render_target,
+                     bool requires_readback,
                      Rect cull_rect);
 
   ExperimentalCanvas(ContentContext& renderer,
                      RenderTarget& render_target,
+                     bool requires_readback,
                      IRect cull_rect);
 
   ~ExperimentalCanvas() override = default;
@@ -42,16 +46,7 @@ class ExperimentalCanvas : public Canvas {
 
   bool Restore() override;
 
-  void EndReplay() {
-    FML_DCHECK(inline_pass_contexts_.size() == 1u);
-    inline_pass_contexts_.back()->EndPass();
-    render_passes_.clear();
-    inline_pass_contexts_.clear();
-    renderer_.GetRenderTargetCache()->End();
-
-    Reset();
-    Initialize(initial_cull_rect_);
-  }
+  void EndReplay();
 
   void DrawTextFrame(const std::shared_ptr<TextFrame>& text_frame,
                      Point position,
@@ -73,6 +68,7 @@ class ExperimentalCanvas : public Canvas {
 
   ContentContext& renderer_;
   RenderTarget& render_target_;
+  const bool requires_readback_;
   EntityPassClipStack clip_coverage_stack_;
   std::vector<std::unique_ptr<InlinePassContext>> inline_pass_contexts_;
   std::vector<std::unique_ptr<EntityPassTarget>> entity_pass_targets_;
@@ -83,6 +79,7 @@ class ExperimentalCanvas : public Canvas {
 
   void AddRenderEntityToCurrentPass(Entity entity, bool reuse_depth) override;
   void AddClipEntityToCurrentPass(Entity entity) override;
+  bool BlitToOnscreen();
 
   Point GetGlobalPassPosition() {
     if (save_layer_state_.empty()) {

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -1168,8 +1168,9 @@ Canvas& DlDispatcher::GetCanvas() {
 
 ExperimentalDlDispatcher::ExperimentalDlDispatcher(ContentContext& renderer,
                                                    RenderTarget& render_target,
+                                                   bool requires_readback,
                                                    IRect cull_rect)
-    : canvas_(renderer, render_target, cull_rect) {}
+    : canvas_(renderer, render_target, requires_readback, cull_rect) {}
 
 Canvas& ExperimentalDlDispatcher::GetCanvas() {
   return canvas_;

--- a/impeller/display_list/dl_dispatcher.h
+++ b/impeller/display_list/dl_dispatcher.h
@@ -289,6 +289,7 @@ class ExperimentalDlDispatcher : public DlDispatcherBase {
  public:
   ExperimentalDlDispatcher(ContentContext& renderer,
                            RenderTarget& render_target,
+                           bool requires_readback,
                            IRect cull_rect);
 
   ~ExperimentalDlDispatcher() = default;

--- a/shell/gpu/gpu_surface_metal_impeller.mm
+++ b/shell/gpu/gpu_surface_metal_impeller.mm
@@ -164,6 +164,9 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromCAMetalLa
 
         impeller::IRect cull_rect = surface->coverage();
         SkIRect sk_cull_rect = SkIRect::MakeWH(cull_rect.GetWidth(), cull_rect.GetHeight());
+        [[maybe_unused]] auto supports_readback =
+            surface_frame.framebuffer_info().supports_readback;
+
 #if ENABLE_EXPERIMENTAL_CANVAS
         impeller::TextFrameDispatcher collector(aiks_context->GetContentContext(),
                                                 impeller::Matrix());
@@ -173,7 +176,7 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromCAMetalLa
             fml::MakeCopyable([aiks_context, &display_list, &cull_rect,
                                &sk_cull_rect](impeller::RenderTarget& render_target) -> bool {
               impeller::ExperimentalDlDispatcher impeller_dispatcher(
-                  aiks_context->GetContentContext(), render_target, cull_rect);
+                  aiks_context->GetContentContext(), render_target, supports_readback, cull_rect);
               display_list->Dispatch(impeller_dispatcher, sk_cull_rect);
               impeller_dispatcher.FinishRecording();
               aiks_context->GetContentContext().GetTransientsBuffer().Reset();

--- a/shell/gpu/gpu_surface_vulkan_impeller.cc
+++ b/shell/gpu/gpu_surface_vulkan_impeller.cc
@@ -84,11 +84,12 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
 
         auto cull_rect =
             surface->GetTargetRenderPassDescriptor().GetRenderTargetSize();
+        [[maybe_unused]] auto supports_readback =
+            surface_frame.framebuffer_info().supports_readback;
 
         return renderer->Render(
             std::move(surface),
-            fml::MakeCopyable([aiks_context, cull_rect, display_list](
-                                  impeller::RenderTarget& render_target)
+            fml::MakeCopyable([&](impeller::RenderTarget& render_target)
                                   -> bool {
 #if ENABLE_EXPERIMENTAL_CANVAS
               impeller::TextFrameDispatcher collector(
@@ -98,6 +99,7 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
                   SkIRect::MakeWH(cull_rect.width, cull_rect.height));
               impeller::ExperimentalDlDispatcher impeller_dispatcher(
                   aiks_context->GetContentContext(), render_target,
+                  supports_readback,
                   impeller::IRect::RoundOut(
                       impeller::Rect::MakeSize(cull_rect)));
               display_list->Dispatch(

--- a/shell/platform/embedder/embedder_external_view.cc
+++ b/shell/platform/embedder/embedder_external_view.cc
@@ -114,10 +114,10 @@ bool EmbedderExternalView::Render(const EmbedderRenderTarget& render_target,
 
     impeller::TextFrameDispatcher collector(aiks_context->GetContentContext(),
                                             impeller::Matrix());
-    display_list->Dispatch(collector, sk_cull_rect);
 
     impeller::ExperimentalDlDispatcher impeller_dispatcher(
-        aiks_context->GetContentContext(), *impeller_target, cull_rect);
+        aiks_context->GetContentContext(), *impeller_target,
+        /*supports_readback=*/false, cull_rect);
     display_list->Dispatch(impeller_dispatcher, sk_cull_rect);
     impeller_dispatcher.FinishRecording();
     aiks_context->GetContentContext().GetTransientsBuffer().Reset();


### PR DESCRIPTION
This doesn't yet add support for backdrop filters or emulated advanced blends, but will allow them to work if `surface_frame.framebuffer_info().supports_readback` is true.

part of https://github.com/flutter/flutter/issues/142054
