### PR TITLE
[Impeller] bump image count to 3

### DIFF
--- a/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_texture_pool_vk.h
+++ b/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_texture_pool_vk.h
@@ -57,7 +57,7 @@ class AHBTexturePoolVK {
   ///
   explicit AHBTexturePoolVK(std::weak_ptr<Context> context,
                             android::HardwareBufferDescriptor desc,
-                            size_t max_entries = 2u);
+                            size_t max_entries = 3u);
 
   ~AHBTexturePoolVK();
 


### PR DESCRIPTION
From testing on a Pixel 7 pro, we get constant destruction of buffers at 2, but not at 3, 4, or 5.

I suspect the problem is that when we stop pumping frames, we need to be able to hold all buffers that were in use. Since we support 2 frames in flight while one is encoding, that gives us 3 maximum buffers.