### PR TITLE
[Impeller] initialize ahb swapchain with max entries.

### DIFF
--- a/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.cc
+++ b/impeller/renderer/backend/vulkan/android/ahb_texture_source_vk.cc
@@ -281,6 +281,9 @@ static TextureDescriptor ToTextureDescriptor(
   desc.mip_count = (ahb_desc.usage & AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE)
                        ? ahb_size.MipCount()
                        : 1u;
+  if (ahb_desc.usage & AHARDWAREBUFFER_USAGE_COMPOSER_OVERLAY) {
+    desc.usage = TextureUsage::kRenderTarget;
+  }
   return desc;
 }
 

--- a/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_texture_pool_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_texture_pool_vk.cc
@@ -16,6 +16,9 @@ AHBTexturePoolVK::AHBTexturePoolVK(std::weak_ptr<Context> context,
     VALIDATION_LOG << "Swapchain image is not allocatable.";
     return;
   }
+  for (auto i = 0u; i < max_entries_; i++) {
+    pool_.emplace_back(CreateTexture());
+  }
   is_valid_ = true;
 }
 


### PR DESCRIPTION
The regression on the complex layout app is due to lazily constructing the AHBs on the first few frames:

https://flutter-flutter-perf.skia.org/e/?begin=1712175722&end=1715166324&queries=device_type%3DPixel_7_Pro%26sub_result%3D90th_percentile_frame_rasterizer_time_millis%26sub_result%3D99th_percentile_frame_rasterizer_time_millis%26sub_result%3Daverage_frame_rasterizer_time_millis%26sub_result%3Dworst_frame_rasterizer_time_millis%26test%3Dcomplex_layout_scroll_perf_impeller__timeline_summary&requestType=0&selected=commit%3D40701%26name%3D%252Carch%253Dintel%252Cbranch%253Dmaster%252Cconfig%253Ddefault%252Cdevice_type%253DPixel_7_Pro%252Cdevice_version%253Dnone%252Chost_type%253Dlinux%252Csub_result%253Dworst_frame_rasterizer_time_millis%252Ctest%253Dcomplex_layout_scroll_perf_impeller__timeline_summary%252C

Lets try eager initialization like the KHR swapchain does.
