### PR TITLE
[Impeller] require and use backpressure for AHB swapchain.

### DIFF
--- a/impeller/toolkit/android/proc_table.h
+++ b/impeller/toolkit/android/proc_table.h
@@ -60,6 +60,7 @@ namespace impeller::android {
   INVOKE(ASurfaceTransaction_setBuffer, 29)                      \
   INVOKE(ASurfaceTransaction_setColor, 29)                       \
   INVOKE(ASurfaceTransaction_setOnComplete, 29)                  \
+  INVOKE(ASurfaceTransaction_setEnableBackPressure, 31)          \
   INVOKE(ASurfaceTransactionStats_getPreviousReleaseFenceFd, 29) \
   INVOKE(ATrace_isEnabled, 23)                                   \
   INVOKE(eglGetNativeClientBufferANDROID, 0)

--- a/impeller/toolkit/android/surface_control.cc
+++ b/impeller/toolkit/android/surface_control.cc
@@ -5,6 +5,7 @@
 #include "impeller/toolkit/android/surface_control.h"
 
 #include "impeller/base/validation.h"
+#include "impeller/toolkit/android/proc_table.h"
 #include "impeller/toolkit/android/surface_transaction.h"
 
 namespace impeller::android {
@@ -49,7 +50,8 @@ bool SurfaceControl::RemoveFromParent() const {
 
 bool SurfaceControl::IsAvailableOnPlatform() {
   return GetProcTable().IsValid() &&
-         GetProcTable().ASurfaceControl_createFromWindow.IsAvailable();
+         GetProcTable().ASurfaceControl_createFromWindow.IsAvailable() &&
+         GetProcTable().ASurfaceTransaction_setEnableBackPressure.IsAvailable();
 }
 
 }  // namespace impeller::android

--- a/impeller/toolkit/android/surface_transaction.cc
+++ b/impeller/toolkit/android/surface_transaction.cc
@@ -58,7 +58,13 @@ bool SurfaceTransaction::SetContents(const SurfaceControl* control,
     VALIDATION_LOG << "Invalid control or buffer.";
     return false;
   }
-  GetProcTable().ASurfaceTransaction_setBuffer(
+
+  const auto& proc_table = GetProcTable();
+
+  proc_table.ASurfaceTransaction_setEnableBackPressure(
+      transaction_.get(), control->GetHandle(), true);
+
+  proc_table.ASurfaceTransaction_setBuffer(
       transaction_.get(),                                      //
       control->GetHandle(),                                    //
       buffer->GetHandle(),                                     //


### PR DESCRIPTION
I think we might be buffer stuffing on the A02s specifically. Though I don't know if this will just "fix" it by turning off the swapchain for that device.

https://github.com/flutter/flutter/issues/147721