### PR TITLE
When `et` is not attached to a terminal, still split lines for status updates.

### DIFF
--- a/tools/engine_tool/lib/src/logger.dart
+++ b/tools/engine_tool/lib/src/logger.dart
@@ -169,6 +169,8 @@ class Logger {
   /// and emits a carriage return.
   void clearLine() {
     if (!io.stdout.hasTerminal || _test) {
+      // Just write a newline if we're not in a terminal.
+      _ioSinkWrite(io.stdout, '\n');
       return;
     }
     _status?.pause();

--- a/tools/engine_tool/lib/src/logger.dart
+++ b/tools/engine_tool/lib/src/logger.dart
@@ -166,9 +166,9 @@ class Logger {
   }
 
   /// Functionally ends and starts a new line.
-  /// 
+  ///
   /// How that is done depends on the terminal capabilities:
-  /// 
+  ///
   /// - If we are not in a terminal, just write a newline.
   /// - If we are in a a terminal, any spinners are temporarily paused, the
   ///   current line is cleared, and spinners are resumed. If ANSI escapes are

--- a/tools/engine_tool/lib/src/logger.dart
+++ b/tools/engine_tool/lib/src/logger.dart
@@ -165,8 +165,16 @@ class Logger {
     _emitLog(infoLevel, message, indent, newline, fit);
   }
 
-  /// Writes a number of spaces to stdout equal to the width of the terminal
-  /// and emits a carriage return.
+  /// Functionally ends and starts a new line.
+  /// 
+  /// How that is done depends on the terminal capabilities:
+  /// 
+  /// - If we are not in a terminal, just write a newline.
+  /// - If we are in a a terminal, any spinners are temporarily paused, the
+  ///   current line is cleared, and spinners are resumed. If ANSI escapes are
+  ///   supported, the cursor is moved to the start of the line and the line is
+  ///   cleared. Otherwise, the line is cleared by writing spaces to the width
+  ///   of the terminal, then moving the cursor back to the start of the line.
   void clearLine() {
     if (!io.stdout.hasTerminal || _test) {
       // Just write a newline if we're not in a terminal.


### PR DESCRIPTION
For illustrative purposes:

```sh
$ et build | grep '.*'
```

... should still get line-per-line status updates, but it does not without this patch.

It's hard to write tests because of global state, so I've declined to do so at the moment.

Closes https://github.com/flutter/flutter/issues/147903.