### PR TITLE
Adds display list debugger

### DIFF
--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -257,6 +257,7 @@
 ../../../flutter/shell/common/animator_unittests.cc
 ../../../flutter/shell/common/base64_unittests.cc
 ../../../flutter/shell/common/context_options_unittests.cc
+../../../flutter/shell/common/display_list_debugger_unittests.cc
 ../../../flutter/shell/common/dl_op_spy_unittests.cc
 ../../../flutter/shell/common/engine_animator_unittests.cc
 ../../../flutter/shell/common/engine_unittests.cc

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -86,6 +86,8 @@ source_set("common") {
     "animator.h",
     "context_options.cc",
     "context_options.h",
+    "display_list_debugger.cc",
+    "display_list_debugger.h",
     "display_manager.cc",
     "display_manager.h",
     "dl_op_spy.cc",

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -314,6 +314,7 @@ if (enable_unittests) {
       "animator_unittests.cc",
       "base64_unittests.cc",
       "context_options_unittests.cc",
+      "display_list_debugger_unittests.cc",
       "dl_op_spy_unittests.cc",
       "engine_animator_unittests.cc",
       "engine_unittests.cc",

--- a/shell/common/display_list_debugger.cc
+++ b/shell/common/display_list_debugger.cc
@@ -1,0 +1,40 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/common/display_list_debugger.h"
+
+#include <atomic>
+
+#include "flutter/fml/logging.h"
+
+namespace {
+std::atomic<char*> saveDisplayListPath;
+}
+
+namespace flutter {
+void DisplayListDebugger::HandleMessage(
+    std::unique_ptr<PlatformMessage> message) {
+  const fml::MallocMapping& data = message->data();
+  char* old_path = saveDisplayListPath.exchange(
+      strdup(reinterpret_cast<const char*>(data.GetMapping())));
+  if (old_path) {
+    free(old_path);
+  }
+}
+
+void DisplayListDebugger::SaveDisplayList(
+    const sk_sp<DisplayList>& display_list) {
+  if (char* path = saveDisplayListPath.exchange(nullptr)) {
+    fml::UniqueFD dir = fml::OpenDirectory(path, /*create_if_necessary=*/false,
+                                           fml::FilePermission::kWrite);
+    // DisplayList doesn't have an accessor for the byte size of the storage,
+    // adding one may confuse the api so we derive it with bytes().
+    size_t size = display_list->bytes(/*nested=*/false) - sizeof(DisplayList);
+    fml::NonOwnedMapping mapping(display_list->GetStorage().get(), size);
+    bool success = fml::WriteAtomically(dir, "display_list.dat", mapping);
+    FML_LOG(ERROR) << "store display_list (" << success << "):" << path;
+    free(path);
+  }
+}
+}  // namespace flutter

--- a/shell/common/display_list_debugger.cc
+++ b/shell/common/display_list_debugger.cc
@@ -23,7 +23,7 @@ void DisplayListDebugger::HandleMessage(
                 &free);
 }
 
-void DisplayListDebugger::SaveDisplayList(
+fml::Status DisplayListDebugger::SaveDisplayList(
     const sk_sp<DisplayList>& display_list) {
   if (FreePtr<char> path =
           FreePtr<char>(saveDisplayListPath.exchange(nullptr), &free)) {
@@ -35,6 +35,9 @@ void DisplayListDebugger::SaveDisplayList(
     fml::NonOwnedMapping mapping(display_list->GetStorage().get(), size);
     bool success = fml::WriteAtomically(dir, "display_list.dat", mapping);
     FML_LOG(ERROR) << "store display_list (" << success << "):" << path.get();
+    return success ? fml::Status()
+                   : fml::Status(fml::StatusCode::kUnknown, "write failed");
   }
+  return fml::Status(fml::StatusCode::kUnavailable, "unavailable");
 }
 }  // namespace flutter

--- a/shell/common/display_list_debugger.h
+++ b/shell/common/display_list_debugger.h
@@ -1,0 +1,22 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_COMMON_DISPLAY_LIST_DEBUGGER_H_
+#define FLUTTER_SHELL_COMMON_DISPLAY_LIST_DEBUGGER_H_
+
+#include "flutter/display_list/display_list.h"
+#include "flutter/lib/ui/window/platform_message.h"
+
+namespace flutter {
+
+class DisplayListDebugger {
+ public:
+  static constexpr char kChannelName[] = "flutter/display_list";
+  static void HandleMessage(std::unique_ptr<PlatformMessage> message);
+  static void SaveDisplayList(const sk_sp<DisplayList>& display_list);
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_COMMON_DISPLAY_LIST_DEBUGGER_H_

--- a/shell/common/display_list_debugger.h
+++ b/shell/common/display_list_debugger.h
@@ -6,15 +6,17 @@
 #define FLUTTER_SHELL_COMMON_DISPLAY_LIST_DEBUGGER_H_
 
 #include "flutter/display_list/display_list.h"
+#include "flutter/fml/status.h"
 #include "flutter/lib/ui/window/platform_message.h"
 
 namespace flutter {
 
+/// Utility for saving display lists to disk in response to platform messages.
 class DisplayListDebugger {
  public:
   static constexpr char kChannelName[] = "flutter/display_list";
   static void HandleMessage(std::unique_ptr<PlatformMessage> message);
-  static void SaveDisplayList(const sk_sp<DisplayList>& display_list);
+  static fml::Status SaveDisplayList(const sk_sp<DisplayList>& display_list);
 };
 
 }  // namespace flutter

--- a/shell/common/display_list_debugger.h
+++ b/shell/common/display_list_debugger.h
@@ -14,7 +14,7 @@ namespace flutter {
 /// Utility for saving display lists to disk in response to platform messages.
 class DisplayListDebugger {
  public:
-  static constexpr char kChannelName[] = "flutter/display_list";
+  static constexpr char kChannelName[] = "flutter/display_list_debugger";
   static void HandleMessage(std::unique_ptr<PlatformMessage> message);
   static fml::Status SaveDisplayList(const sk_sp<DisplayList>& display_list);
 };

--- a/shell/common/display_list_debugger_unittests.cc
+++ b/shell/common/display_list_debugger_unittests.cc
@@ -1,0 +1,34 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/display_list/dl_builder.h"
+#include "flutter/shell/common/display_list_debugger.h"
+
+#include "gtest/gtest.h"
+
+namespace flutter {
+namespace testing {
+
+TEST(DisplayListDebuggerTest, Noop) {
+  DisplayListBuilder builder;
+  sk_sp<DisplayList> display_list = builder.Build();
+  EXPECT_FALSE(DisplayListDebugger::SaveDisplayList(display_list).ok());
+}
+
+TEST(DisplayListDebuggerTest, Simple) {
+  DisplayListBuilder builder;
+  builder.Scale(0.2, 0.2);
+  sk_sp<DisplayList> display_list = builder.Build();
+  fml::ScopedTemporaryDirectory temp_dir;
+  auto message = std::make_unique<PlatformMessage>(
+      DisplayListDebugger::kChannelName,
+      fml::MallocMapping::Copy(temp_dir.path().c_str(),
+                               temp_dir.path().size() + 1),
+      /*response=*/nullptr);
+  DisplayListDebugger::HandleMessage(std::move(message));
+  EXPECT_TRUE(DisplayListDebugger::SaveDisplayList(display_list).ok());
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -24,6 +24,7 @@
 #include "flutter/fml/trace_event.h"
 #include "flutter/runtime/dart_vm.h"
 #include "flutter/shell/common/base64.h"
+#include "flutter/shell/common/display_list_debugger.h"
 #include "flutter/shell/common/engine.h"
 #include "flutter/shell/common/skia_event_tracer_impl.h"
 #include "flutter/shell/common/switches.h"
@@ -1325,6 +1326,11 @@ void Shell::OnEngineHandlePlatformMessage(
 
   if (message->channel() == kSkiaChannel) {
     HandleEngineSkiaMessage(std::move(message));
+    return;
+  }
+
+  if (message->channel() == DisplayListDebugger::kChannelName) {
+    DisplayListDebugger::HandleMessage(std::move(message));
     return;
   }
 

--- a/shell/gpu/gpu_surface_metal_impeller.mm
+++ b/shell/gpu/gpu_surface_metal_impeller.mm
@@ -129,7 +129,9 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromCAMetalLa
           return false;
         }
 
+#ifndef NDEBUG
         DisplayListDebugger::SaveDisplayList(display_list);
+#endif
 
         if (!disable_partial_repaint && damage) {
           uintptr_t texture = reinterpret_cast<uintptr_t>(last_texture);

--- a/shell/gpu/gpu_surface_metal_impeller.mm
+++ b/shell/gpu/gpu_surface_metal_impeller.mm
@@ -12,8 +12,8 @@
 #include "flutter/fml/mapping.h"
 #include "flutter/fml/paths.h"
 #include "flutter/fml/trace_event.h"
-#include "impeller/display_list/dl_dispatcher.h"
 #include "flutter/shell/common/display_list_debugger.h"
+#include "impeller/display_list/dl_dispatcher.h"
 #include "impeller/renderer/backend/metal/surface_mtl.h"
 #include "impeller/typographer/backends/skia/typographer_context_skia.h"
 

--- a/shell/gpu/gpu_surface_metal_impeller.mm
+++ b/shell/gpu/gpu_surface_metal_impeller.mm
@@ -10,8 +10,10 @@
 #include "flutter/common/settings.h"
 #include "flutter/fml/make_copyable.h"
 #include "flutter/fml/mapping.h"
+#include "flutter/fml/paths.h"
 #include "flutter/fml/trace_event.h"
 #include "impeller/display_list/dl_dispatcher.h"
+#include "flutter/shell/common/display_list_debugger.h"
 #include "impeller/renderer/backend/metal/surface_mtl.h"
 #include "impeller/typographer/backends/skia/typographer_context_skia.h"
 
@@ -126,6 +128,8 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromCAMetalLa
           FML_LOG(ERROR) << "Could not build display list for surface frame.";
           return false;
         }
+
+        DisplayListDebugger::SaveDisplayList(display_list);
 
         if (!disable_partial_repaint && damage) {
           uintptr_t texture = reinterpret_cast<uintptr_t>(last_texture);


### PR DESCRIPTION
Design doc: https://docs.google.com/document/d/17LiGKlt57R5CZMxcWt9wj9Z7eDihhUaUEg3oeGQAKTc/edit#heading=h.kifztz2gx2n3

This is a replacement for the CanvasRecorder.  It just saves out the display list as a blob.  The format is unstable and unsupported but people are allowed to use it for development / debugging purposes.

This won't suffer the same fate as CanvasRecorder since it's just tapping into serialized draw calls we already make as part of rendering.  It's only a couple of lines of code and requires no special compilation.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
