### PR TITLE
Migrate FlutterDartProject and FlutterPluginAppLifeCycleDelegate to ARC

### DIFF
--- a/shell/platform/darwin/common/framework/Headers/FlutterDartProject.h
+++ b/shell/platform/darwin/common/framework/Headers/FlutterDartProject.h
@@ -6,7 +6,6 @@
 #define FLUTTER_SHELL_PLATFORM_DARWIN_COMMON_FRAMEWORK_HEADERS_FLUTTERDARTPROJECT_H_
 
 #import <Foundation/Foundation.h>
-#import <TargetConditionals.h>
 
 #import "FlutterMacros.h"
 

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -63,6 +63,8 @@ source_set("flutter_framework_source_arc") {
     "framework/Source/FlutterCallbackCache_Internal.h",
     "framework/Source/FlutterChannelKeyResponder.h",
     "framework/Source/FlutterChannelKeyResponder.mm",
+    "framework/Source/FlutterDartProject.mm",
+    "framework/Source/FlutterDartProject_Internal.h",
     "framework/Source/FlutterDartVMServicePublisher.h",
     "framework/Source/FlutterDartVMServicePublisher.mm",
     "framework/Source/FlutterEmbedderKeyResponder.h",
@@ -78,6 +80,7 @@ source_set("flutter_framework_source_arc") {
     "framework/Source/FlutterPlatformViews.mm",
     "framework/Source/FlutterPlatformViews_Internal.h",
     "framework/Source/FlutterPlatformViews_Internal.mm",
+    "framework/Source/FlutterPluginAppLifeCycleDelegate.mm",
     "framework/Source/FlutterRestorationPlugin.h",
     "framework/Source/FlutterRestorationPlugin.mm",
     "framework/Source/FlutterSpellCheckPlugin.h",
@@ -162,15 +165,12 @@ source_set("flutter_framework_source") {
     # New files are highly encouraged to be in ARC.
     # To add new files in ARC, add them to the `flutter_framework_source_arc` target.
     "framework/Source/FlutterAppDelegate.mm",
-    "framework/Source/FlutterDartProject.mm",
-    "framework/Source/FlutterDartProject_Internal.h",
     "framework/Source/FlutterEngine.mm",
     "framework/Source/FlutterEngineGroup.mm",
     "framework/Source/FlutterEngine_Internal.h",
     "framework/Source/FlutterHeadlessDartRunner.mm",
     "framework/Source/FlutterPlatformPlugin.h",
     "framework/Source/FlutterPlatformPlugin.mm",
-    "framework/Source/FlutterPluginAppLifeCycleDelegate.mm",
     "framework/Source/FlutterSemanticsScrollView.h",
     "framework/Source/FlutterSemanticsScrollView.mm",
     "framework/Source/FlutterViewController.mm",
@@ -195,19 +195,14 @@ source_set("flutter_framework_source") {
   }
 
   deps += [
-    ":ios_gpu_configuration",
     "//flutter/common",
-    "//flutter/flow",
     "//flutter/fml",
     "//flutter/runtime",
-    "//flutter/runtime:libdart",
     "//flutter/shell/common",
-    "//flutter/shell/platform/common:common_cpp_input",
     "//flutter/shell/platform/darwin/common",
     "//flutter/shell/platform/darwin/common:framework_common",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//flutter/shell/profiling:profiling",
-    "//flutter/skia",
     "//flutter/third_party/spring_animation",
   ]
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -8,22 +8,12 @@
 
 #include <syslog.h>
 
-#import <Metal/Metal.h>
-#include <sstream>
-#include <string>
-
 #include "flutter/common/constants.h"
-#include "flutter/common/task_runners.h"
-#include "flutter/fml/mapping.h"
-#include "flutter/fml/message_loop.h"
-#include "flutter/fml/platform/darwin/scoped_nsobject.h"
-#include "flutter/runtime/dart_vm.h"
-#include "flutter/shell/common/shell.h"
 #include "flutter/shell/common/switches.h"
 #import "flutter/shell/platform/darwin/common/command_line.h"
-#import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterView.h"
 
-FLUTTER_ASSERT_NOT_ARC
+FLUTTER_ASSERT_ARC
 
 extern "C" {
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
@@ -47,7 +37,6 @@ static BOOL DoesHardwareSupportWideGamut() {
       // A9/A10 on iOS 10+
       result = [device supportsFeatureSet:MTLFeatureSet_iOS_GPUFamily3_v2];
     }
-    [device release];
   });
   return result;
 }
@@ -62,7 +51,7 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
   // 4. Settings from the main NSBundle and default values.
 
   NSBundle* mainBundle = FLTGetApplicationBundle();
-  NSBundle* engineBundle = [NSBundle bundleForClass:[FlutterViewController class]];
+  NSBundle* engineBundle = [NSBundle bundleForClass:[FlutterView class]];
 
   bool hasExplicitBundle = bundle != nil;
   if (bundle == nil) {
@@ -369,18 +358,17 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
 
 + (NSString*)domainNetworkPolicy:(NSDictionary*)appTransportSecurity {
   // https://developer.apple.com/documentation/bundleresources/information_property_list/nsapptransportsecurity/nsexceptiondomains
-  NSDictionary* exceptionDomains = [appTransportSecurity objectForKey:@"NSExceptionDomains"];
+  NSDictionary* exceptionDomains = appTransportSecurity[@"NSExceptionDomains"];
   if (exceptionDomains == nil) {
     return @"";
   }
-  NSMutableArray* networkConfigArray = [[[NSMutableArray alloc] init] autorelease];
+  NSMutableArray* networkConfigArray = [[NSMutableArray alloc] init];
   for (NSString* domain in exceptionDomains) {
-    NSDictionary* domainConfiguration = [exceptionDomains objectForKey:domain];
+    NSDictionary* domainConfiguration = exceptionDomains[domain];
     // Default value is false.
-    bool includesSubDomains =
-        [[domainConfiguration objectForKey:@"NSIncludesSubdomains"] boolValue];
+    bool includesSubDomains = [domainConfiguration[@"NSIncludesSubdomains"] boolValue];
     bool allowsCleartextCommunication =
-        [[domainConfiguration objectForKey:@"NSExceptionAllowsInsecureHTTPLoads"] boolValue];
+        [domainConfiguration[@"NSExceptionAllowsInsecureHTTPLoads"] boolValue];
     [networkConfigArray addObject:@[
       domain, includesSubDomains ? @YES : @NO, allowsCleartextCommunication ? @YES : @NO
     ]];
@@ -388,11 +376,11 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
   NSData* jsonData = [NSJSONSerialization dataWithJSONObject:networkConfigArray
                                                      options:0
                                                        error:NULL];
-  return [[[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding] autorelease];
+  return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
 }
 
 + (bool)allowsArbitraryLoads:(NSDictionary*)appTransportSecurity {
-  return [[appTransportSecurity objectForKey:@"NSAllowsArbitraryLoads"] boolValue];
+  return [appTransportSecurity[@"NSAllowsArbitraryLoads"] boolValue];
 }
 
 + (NSString*)lookupKeyForAsset:(NSString*)asset {

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -6,12 +6,14 @@
 
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterDartProject_Internal.h"
 
+#import <Metal/Metal.h>
+#import <UIKit/UIKit.h>
+
 #include <syslog.h>
 
 #include "flutter/common/constants.h"
 #include "flutter/shell/common/switches.h"
 #import "flutter/shell/platform/darwin/common/command_line.h"
-#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterView.h"
 
 FLUTTER_ASSERT_ARC
 
@@ -51,7 +53,7 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
   // 4. Settings from the main NSBundle and default values.
 
   NSBundle* mainBundle = FLTGetApplicationBundle();
-  NSBundle* engineBundle = [NSBundle bundleForClass:[FlutterView class]];
+  NSBundle* engineBundle = [NSBundle bundleForClass:[FlutterDartProject class]];
 
   bool hasExplicitBundle = bundle != nil;
   if (bundle == nil) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
@@ -7,8 +7,9 @@
 #include "flutter/fml/logging.h"
 #include "flutter/fml/paths.h"
 #include "flutter/lib/ui/plugins/callback_cache.h"
-#import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterCallbackCache_Internal.h"
+
+FLUTTER_ASSERT_ARC
 
 static const char* kCallbackCacheSubDir = "Library/Caches/";
 
@@ -43,7 +44,7 @@ static const SEL kSelectorsHandledByPlugins[] = {
   dispatch_block_t unsubscribe = ^{
     [[NSNotificationCenter defaultCenter] removeObserver:blockSelf name:name object:nil];
   };
-  [_notificationUnsubscribers addObject:[[unsubscribe copy] autorelease]];
+  [_notificationUnsubscribers addObject:[unsubscribe copy]];
 }
 
 - (instancetype)init {
@@ -63,7 +64,7 @@ static const SEL kSelectorsHandledByPlugins[] = {
     [self addObserverFor:UIApplicationWillTerminateNotification
                 selector:@selector(handleWillTerminate:)];
 #endif
-    _delegates = [[NSPointerArray weakObjectsPointerArray] retain];
+    _delegates = [NSPointerArray weakObjectsPointerArray];
     _debugBackgroundTask = UIBackgroundTaskInvalid;
   }
   return self;
@@ -73,9 +74,6 @@ static const SEL kSelectorsHandledByPlugins[] = {
   for (dispatch_block_t unsubscribe in _notificationUnsubscribers) {
     unsubscribe();
   }
-  [_notificationUnsubscribers release];
-  [_delegates release];
-  [super dealloc];
 }
 
 static BOOL IsPowerOfTwo(NSUInteger x) {


### PR DESCRIPTION
- Migrate `FlutterDartProject` and `FlutterPluginAppLifeCycleDelegate` from MRC to ARC.  
- Swap a few dictionary `objectForKey:` to subscripting.
- Header cleanup.
- Cleanup build DEPS.

Part of https://github.com/flutter/flutter/issues/137801.