### PR TITLE
[web] Set the correct href on semantic links

### DIFF
--- a/lib/web_ui/lib/src/engine/semantics/incrementable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/incrementable.dart
@@ -28,7 +28,10 @@ class Incrementable extends PrimaryRoleManager {
     // the one being focused on, but the internal `<input>` element.
     addLiveRegion();
     addRouteName();
-    addLabelAndValue(preferredRepresentation: LabelRepresentation.ariaLabel);
+    addLabelAndValue(
+      preferredRepresentation: LabelRepresentation.ariaLabel,
+      labelSources: _incrementableLabelSources,
+    );
 
     append(_element);
     _element.type = 'range';
@@ -59,6 +62,12 @@ class Incrementable extends PrimaryRoleManager {
     EngineSemantics.instance.addGestureModeListener(_gestureModeListener);
     _focusManager.manage(semanticsObject.id, _element);
   }
+
+  // The incrementable role manager has custom reporting of the semantics value.
+  // We do not need to also render it as a label.
+  static final Set<LabelSource> _incrementableLabelSources = LabelAndValue
+      .allLabelSources
+      .difference(<LabelSource>{LabelSource.value});
 
   @override
   bool focusAsRouteDefault() {

--- a/lib/web_ui/lib/src/engine/semantics/link.dart
+++ b/lib/web_ui/lib/src/engine/semantics/link.dart
@@ -18,9 +18,8 @@ class Link extends PrimaryRoleManager {
   @override
   DomElement createElement() {
     final DomElement element = domDocument.createElement('a');
-    // TODO(chunhtai): Fill in the real link once the framework sends entire uri.
-    // https://github.com/flutter/flutter/issues/102535.
-    element.setAttribute('href', '#');
+    // TODO: The <a> element has `aria-label={value}`. We should stop that!
+    element.setAttribute('href', semanticsObject.hasValue ? semanticsObject.value! : '#');
     element.style.display = 'block';
     return element;
   }

--- a/lib/web_ui/lib/src/engine/semantics/link.dart
+++ b/lib/web_ui/lib/src/engine/semantics/link.dart
@@ -11,9 +11,15 @@ class Link extends PrimaryRoleManager {
     PrimaryRole.link,
     semanticsObject,
     preferredLabelRepresentation: LabelRepresentation.domText,
+    labelSources: _linkLabelSources,
   ) {
     addTappable();
   }
+
+  // The semantics value is consumed by the [Link] role manager, so there's no
+  // need to also render it as a label.
+  static final Set<LabelSource> _linkLabelSources = LabelAndValue.allLabelSources
+      .difference(<LabelSource>{LabelSource.value});
 
   @override
   DomElement createElement() {

--- a/lib/web_ui/lib/src/engine/semantics/link.dart
+++ b/lib/web_ui/lib/src/engine/semantics/link.dart
@@ -24,8 +24,9 @@ class Link extends PrimaryRoleManager {
   @override
   DomElement createElement() {
     final DomElement element = domDocument.createElement('a');
-    // TODO: The <a> element has `aria-label={value}`. We should stop that!
-    element.setAttribute('href', semanticsObject.hasValue ? semanticsObject.value! : '#');
+    if (semanticsObject.hasValue) {
+      element.setAttribute('href', semanticsObject.value!);
+    }
     element.style.display = 'block';
     return element;
   }

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -480,6 +480,10 @@ abstract class PrimaryRoleManager {
       ..overflow = 'visible';
     element.setAttribute('id', 'flt-semantic-node-${semanticsObject.id}');
 
+    if (semanticsObject.hasIdentifier) {
+      element.setAttribute('semantic-identifier', semanticsObject.identifier!);
+    }
+
     // The root node has some properties that other nodes do not.
     if (semanticsObject.id == 0 && !configuration.debugShowSemanticsNodes) {
       // Make all semantics transparent. Use `filter` instead of `opacity`
@@ -1097,6 +1101,21 @@ class SemanticsObject {
     _dirtyFields |= _platformViewIdIndex;
   }
 
+  /// See [ui.SemanticsUpdateBuilder.updateNode].
+  String? get identifier => _identifier;
+  String? _identifier;
+
+  bool get hasIdentifier => _identifier != null && _identifier!.isNotEmpty;
+
+  static const int _identifierIndex = 1 << 24;
+
+  /// Whether the [identifier] field has been updated but has not been
+  /// applied to the DOM yet.
+  bool get isIdentifierDirty => _isDirty(_identifierIndex);
+  void _markIdentifierDirty() {
+    _dirtyFields |= _identifierIndex;
+  }
+
   /// A unique permanent identifier of the semantics node in the tree.
   final int id;
 
@@ -1251,6 +1270,11 @@ class SemanticsObject {
     if (_flags != update.flags) {
       _flags = update.flags;
       _markFlagsDirty();
+    }
+
+    if (_identifier != update.identifier) {
+      _identifier = update.identifier;
+      _markIdentifierDirty();
     }
 
     if (_value != update.value) {

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -434,12 +434,20 @@ abstract class PrimaryRoleManager {
   ///
   /// If `labelRepresentation` is true, configures the [LabelAndValue] role with
   /// [LabelAndValue.labelRepresentation] set to true.
-  PrimaryRoleManager.withBasics(this.role, this.semanticsObject, { required LabelRepresentation preferredLabelRepresentation }) {
+  PrimaryRoleManager.withBasics(
+    this.role,
+    this.semanticsObject, {
+    required LabelRepresentation preferredLabelRepresentation,
+    Set<LabelSource> labelSources = LabelAndValue.allLabelSources,
+  }) {
     element = _initElement(createElement(), semanticsObject);
     addFocusManagement();
     addLiveRegion();
     addRouteName();
-    addLabelAndValue(preferredRepresentation: preferredLabelRepresentation);
+    addLabelAndValue(
+      preferredRepresentation: preferredLabelRepresentation,
+      labelSources: labelSources,
+    );
   }
 
   /// Initializes a blank role for a [semanticsObject].
@@ -566,8 +574,16 @@ abstract class PrimaryRoleManager {
   LabelAndValue? _labelAndValue;
 
   /// Adds generic label features.
-  void addLabelAndValue({ required LabelRepresentation preferredRepresentation }) {
-    addSecondaryRole(_labelAndValue = LabelAndValue(semanticsObject, this, preferredRepresentation: preferredRepresentation));
+  void addLabelAndValue({
+    required LabelRepresentation preferredRepresentation,
+    Set<LabelSource> labelSources = LabelAndValue.allLabelSources,
+  }) {
+    addSecondaryRole(_labelAndValue = LabelAndValue(
+      semanticsObject,
+      this,
+      preferredRepresentation: preferredRepresentation,
+      labelSources: labelSources,
+    ));
   }
 
   /// Adds generic functionality for handling taps and clicks.


### PR DESCRIPTION
- Use the semantics `value` as the `href` attribute for links.
- Omit the `href` attribute when `value` is empty (prevents unwanted navigation).
- For links and incrementables, do not derive the label attribute from the semantics `value`.

Part of https://github.com/flutter/flutter/issues/102535
Fixes https://github.com/flutter/flutter/issues/146291