### PR TITLE
Revert "Fixed constness of display list storage."

### DIFF
--- a/display_list/display_list.cc
+++ b/display_list/display_list.cc
@@ -51,7 +51,7 @@ DisplayList::DisplayList(DisplayListStorage&& storage,
       rtree_(std::move(rtree)) {}
 
 DisplayList::~DisplayList() {
-  const uint8_t* ptr = storage_.get();
+  uint8_t* ptr = storage_.get();
   DisposeOps(ptr, ptr + byte_count_);
 }
 
@@ -142,7 +142,7 @@ class VectorCuller final : public Culler {
 };
 
 void DisplayList::Dispatch(DlOpReceiver& receiver) const {
-  const uint8_t* ptr = storage_.get();
+  uint8_t* ptr = storage_.get();
   Dispatch(receiver, ptr, ptr + byte_count_, NopCuller::instance);
 }
 
@@ -162,7 +162,7 @@ void DisplayList::Dispatch(DlOpReceiver& receiver,
   }
   const DlRTree* rtree = this->rtree().get();
   FML_DCHECK(rtree != nullptr);
-  const uint8_t* ptr = storage_.get();
+  uint8_t* ptr = storage_.get();
   std::vector<int> rect_indices;
   rtree->search(cull_rect, &rect_indices);
   VectorCuller culler(rtree, rect_indices);
@@ -170,8 +170,8 @@ void DisplayList::Dispatch(DlOpReceiver& receiver,
 }
 
 void DisplayList::Dispatch(DlOpReceiver& receiver,
-                           const uint8_t* ptr,
-                           const uint8_t* end,
+                           uint8_t* ptr,
+                           uint8_t* end,
                            Culler& culler) const {
   DispatchContext context = {
       .receiver = receiver,
@@ -207,7 +207,7 @@ void DisplayList::Dispatch(DlOpReceiver& receiver,
   }
 }
 
-void DisplayList::DisposeOps(const uint8_t* ptr, const uint8_t* end) {
+void DisplayList::DisposeOps(uint8_t* ptr, uint8_t* end) {
   while (ptr < end) {
     auto op = reinterpret_cast<const DLOp*>(ptr);
     ptr += op->size;
@@ -234,15 +234,15 @@ void DisplayList::DisposeOps(const uint8_t* ptr, const uint8_t* end) {
   }
 }
 
-static bool CompareOps(const uint8_t* ptrA,
-                       const uint8_t* endA,
-                       const uint8_t* ptrB,
-                       const uint8_t* endB) {
+static bool CompareOps(uint8_t* ptrA,
+                       uint8_t* endA,
+                       uint8_t* ptrB,
+                       uint8_t* endB) {
   // These conditions are checked by the caller...
   FML_DCHECK((endA - ptrA) == (endB - ptrB));
   FML_DCHECK(ptrA != ptrB);
-  const uint8_t* bulk_start_a = ptrA;
-  const uint8_t* bulk_start_b = ptrB;
+  uint8_t* bulk_start_a = ptrA;
+  uint8_t* bulk_start_b = ptrB;
   while (ptrA < endA && ptrB < endB) {
     auto opA = reinterpret_cast<const DLOp*>(ptrA);
     auto opB = reinterpret_cast<const DLOp*>(ptrB);
@@ -310,8 +310,8 @@ bool DisplayList::Equals(const DisplayList* other) const {
   if (byte_count_ != other->byte_count_ || op_count_ != other->op_count_) {
     return false;
   }
-  const uint8_t* ptr = storage_.get();
-  const uint8_t* o_ptr = other->storage_.get();
+  uint8_t* ptr = storage_.get();
+  uint8_t* o_ptr = other->storage_.get();
   if (ptr == o_ptr) {
     return true;
   }

--- a/display_list/display_list.h
+++ b/display_list/display_list.h
@@ -237,9 +237,7 @@ class DisplayListStorage {
   DisplayListStorage() = default;
   DisplayListStorage(DisplayListStorage&&) = default;
 
-  uint8_t* get() { return ptr_.get(); }
-
-  const uint8_t* get() const { return ptr_.get(); }
+  uint8_t* get() const { return ptr_.get(); }
 
   void realloc(size_t count) {
     ptr_.reset(static_cast<uint8_t*>(std::realloc(ptr_.release(), count)));
@@ -311,8 +309,6 @@ class DisplayList : public SkRefCnt {
     return modifies_transparent_black_;
   }
 
-  const DisplayListStorage& GetStorage() const { return storage_; }
-
  private:
   DisplayList(DisplayListStorage&& ptr,
               size_t byte_count,
@@ -328,7 +324,7 @@ class DisplayList : public SkRefCnt {
 
   static uint32_t next_unique_id();
 
-  static void DisposeOps(const uint8_t* ptr, const uint8_t* end);
+  static void DisposeOps(uint8_t* ptr, uint8_t* end);
 
   const DisplayListStorage storage_;
   const size_t byte_count_;
@@ -349,8 +345,8 @@ class DisplayList : public SkRefCnt {
   const sk_sp<const DlRTree> rtree_;
 
   void Dispatch(DlOpReceiver& ctx,
-                const uint8_t* ptr,
-                const uint8_t* end,
+                uint8_t* ptr,
+                uint8_t* end,
                 Culler& culler) const;
 
   friend class DisplayListBuilder;


### PR DESCRIPTION
Reverts flutter/engine#52705

The PR exposed internal storage information which is neither useful nor supported.

View comments on the PR for more specific reasons.