### PR TITLE
[Impeller] remove CPU clear of atlas.

### DIFF
--- a/impeller/renderer/backend/gles/blit_command_gles.cc
+++ b/impeller/renderer/backend/gles/blit_command_gles.cc
@@ -276,7 +276,7 @@ bool BlitCopyBufferToTextureCommandGLES::Encode(
                   0u,                          // border
                   data.external_format,        // external format
                   data.type,                   // type
-                  tex_data                     // data
+                  nullptr                      // data
     );
     texture_gles.MarkSliceInitialized(slice);
   }

--- a/impeller/renderer/blit_pass.cc
+++ b/impeller/renderer/blit_pass.cc
@@ -136,7 +136,8 @@ bool BlitPass::AddCopy(BufferView source,
       destination_region_value.GetY() < 0 ||
       destination_region_value.GetRight() > destination_size.width ||
       destination_region_value.GetBottom() > destination_size.height) {
-    VALIDATION_LOG << "Blit region cannot be larger than destination texture.";
+    VALIDATION_LOG << "Blit region cannot be larger than destination texture."
+                   << destination_region_value << " " << destination_size;
     return false;
   }
 

--- a/impeller/renderer/blit_pass.cc
+++ b/impeller/renderer/blit_pass.cc
@@ -136,8 +136,7 @@ bool BlitPass::AddCopy(BufferView source,
       destination_region_value.GetY() < 0 ||
       destination_region_value.GetRight() > destination_size.width ||
       destination_region_value.GetBottom() > destination_size.height) {
-    VALIDATION_LOG << "Blit region cannot be larger than destination texture."
-                   << destination_region_value << " " << destination_size;
+    VALIDATION_LOG << "Blit region cannot be larger than destination texture.";
     return false;
   }
 

--- a/impeller/renderer/blit_pass_unittests.cc
+++ b/impeller/renderer/blit_pass_unittests.cc
@@ -104,5 +104,29 @@ TEST_P(BlitPassTest, ChecksInvalidSliceParameters) {
                                  std::nullopt, "", /*slice=*/0));
 }
 
+TEST_P(BlitPassTest, CanBlitSmallRegionToUninitializedTexture) {
+  auto context = GetContext();
+  auto cmd_buffer = context->CreateCommandBuffer();
+  auto blit_pass = cmd_buffer->CreateBlitPass();
+
+  TextureDescriptor dst_format;
+  dst_format.storage_mode = StorageMode::kDevicePrivate;
+  dst_format.format = PixelFormat::kR8G8B8A8UNormInt;
+  dst_format.size = {1000, 1000};
+  auto dst = context->GetResourceAllocator()->CreateTexture(dst_format);
+
+  DeviceBufferDescriptor src_format;
+  src_format.size = 4;
+  src_format.storage_mode = StorageMode::kHostVisible;
+  auto src = context->GetResourceAllocator()->CreateBuffer(src_format);
+
+  ASSERT_TRUE(dst);
+
+  EXPECT_TRUE(blit_pass->AddCopy(DeviceBuffer::AsBufferView(src), dst,
+                                 IRect::MakeLTRB(0, 0, 1, 1), "", /*slice=*/0));
+  EXPECT_TRUE(blit_pass->EncodeCommands(GetContext()->GetResourceAllocator()));
+  EXPECT_TRUE(context->GetCommandQueue()->Submit({std::move(cmd_buffer)}).ok());
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/typographer/backends/skia/typographer_context_skia.cc
+++ b/impeller/typographer/backends/skia/typographer_context_skia.cc
@@ -196,7 +196,6 @@ static bool CanAppendToExistingAtlas(
 
 static ISize OptimumAtlasSizeForFontGlyphPairs(
     const std::vector<FontGlyphPair>& pairs,
-    std::vector<Rect>& glyph_positions,
     const std::shared_ptr<GlyphAtlasContext>& atlas_context,
     GlyphAtlas::Type type,
     const ISize& max_texture_size) {
@@ -209,6 +208,7 @@ static ISize OptimumAtlasSizeForFontGlyphPairs(
                            ? ISize(kMinAlphaBitmapSize, kMinAlphaBitmapSize)
                            : ISize(kMinAtlasSize, kMinAtlasSize);
   size_t total_pairs = pairs.size() + 1;
+  std::vector<Rect> glyph_positions;
   do {
     auto rect_packer = std::shared_ptr<RectanglePacker>(
         RectanglePacker::Factory(current_size.width, current_size.height));
@@ -239,7 +239,7 @@ static void DrawGlyph(SkCanvas* canvas,
                       bool has_color) {
   const auto& metrics = scaled_font.font.GetMetrics();
   const auto position =
-      SkPoint::Make(1 / scaled_font.scale, 1 / scaled_font.scale);
+      SkPoint::Make(1.0f / scaled_font.scale, 1.0f / scaled_font.scale);
   SkGlyphID glyph_id = glyph.index;
 
   SkFont sk_font(
@@ -307,7 +307,6 @@ static bool UpdateAtlasBitmap(const GlyphAtlas& atlas,
     DrawGlyph(canvas, pair.scaled_font, pair.glyph, has_color);
 
     // Note: the position is shifted by (1, 1) to include the padding pixels.
-    // Glyphs will never be positioned at (0, 0).
     if (!blit_pass->AddCopy(
             allocator.TakeBufferView(), texture,
             IRect::MakeXYWH(pos->GetLeft() - 1, pos->GetTop() - 1, size.width,
@@ -416,7 +415,6 @@ std::shared_ptr<GlyphAtlas> TypographerContextSkia::CreateGlyphAtlas(
   std::shared_ptr<GlyphAtlas> glyph_atlas = std::make_shared<GlyphAtlas>(type);
   ISize atlas_size = OptimumAtlasSizeForFontGlyphPairs(
       font_glyph_pairs,                                             //
-      glyph_positions,                                              //
       atlas_context,                                                //
       type,                                                         //
       context.GetResourceAllocator()->GetMaxTextureSizeSupported()  //

--- a/impeller/typographer/backends/skia/typographer_context_skia.cc
+++ b/impeller/typographer/backends/skia/typographer_context_skia.cc
@@ -284,6 +284,8 @@ static bool UpdateAtlasBitmap(const GlyphAtlas& atlas,
     if (size.IsEmpty()) {
       continue;
     }
+
+    FML_DCHECK(pos->GetOrigin() != Point(0, 0));
     // Add 1px of padding around glyph so that linearly sampled skew/rotate
     // glyphs do not sample uninitialized data.
     size.width += 2;

--- a/impeller/typographer/backends/skia/typographer_context_skia.cc
+++ b/impeller/typographer/backends/skia/typographer_context_skia.cc
@@ -426,15 +426,6 @@ std::shared_ptr<GlyphAtlas> TypographerContextSkia::CreateGlyphAtlas(
   if (atlas_size.IsEmpty()) {
     return nullptr;
   }
-  // ---------------------------------------------------------------------------
-  // Step 4b: Find location of font-glyph pairs in the atlas. We have this from
-  // the last step. So no need to do create another rect packer. But just do a
-  // sanity check of counts. This could also be just an assertion as only a
-  // construction issue would cause such a failure.
-  // ---------------------------------------------------------------------------
-  if (glyph_positions.size() != font_glyph_pairs.size()) {
-    return nullptr;
-  }
 
   // ---------------------------------------------------------------------------
   // Step 5b: Record the positions in the glyph atlas.


### PR DESCRIPTION
Linearly sampled glyphs can grab pixels outside of the glyph bounds. if we're only updating smaller regions of the glyph atlas, that texture data could be uninitialized - and the resulting junk would leak into glyphs. 

One way to solve this would be to initialize each glyph atlas texture in a render pass. However, there are restrictions in OpenGLES about what formats can be a color attachment.

To solve this initially, I just uploaded a big empy buffer. However, I think we can work around this by placing the padding pixels around the glyph and uploading those too. The padding pixels would then be initialized to transparent.

Before: Glyph is in the top left of its rect, with padding pixels below and to the right.

```
_______
| A _ _
| _ _ _
| _ _ _
```

After: Glyph is centered in its rect, with padding pixels around.

```
_______
| _ _ _
| _ A _
| _ _ _
```

So all pixels that are linearly sampled should at most include the padding pixels which are guaranteed to be initialized.
