### PR TITLE
Re-add `MipFilter::kBase`, but keep `kNearest` as the default.

### DIFF
--- a/impeller/core/formats.h
+++ b/impeller/core/formats.h
@@ -9,7 +9,6 @@
 #include <functional>
 #include <memory>
 #include <string>
-#include <type_traits>
 
 #include "flutter/fml/hash_combine.h"
 #include "flutter/fml/logging.h"
@@ -404,19 +403,32 @@ struct Viewport {
   }
 };
 
+/// @brief      Describes how the texture should be sampled when the texture
+///             is being shrunk (minified) or expanded (magnified) to fit to
+///             the sample point.
 enum class MinMagFilter {
   /// Select nearest to the sample point. Most widely supported.
   kNearest,
+
   /// Select two points and linearly interpolate between them. Some formats
   /// may not support this.
   kLinear,
 };
 
+/// @brief      Options for selecting and filtering between mipmap levels.
 enum class MipFilter {
-  /// Sample from the nearest mip level.
+  /// @brief    The texture is sampled as if it only had a single mipmap level.
+  ///
+  ///           All samples are read from level 0.
+  kBase,
+
+  /// @brief    The nearst mipmap level is selected.
   kNearest,
-  /// Sample from the two nearest mip levels and linearly interpolate between
-  /// them.
+
+  /// @brief    Sample from the two nearest mip levels and linearly interpolate.
+  ///
+  ///           If the filter falls between levels, both levels are sampled, and
+  ///           their results linearly interpolated between levels.
   kLinear,
 };
 

--- a/impeller/core/sampler_descriptor.h
+++ b/impeller/core/sampler_descriptor.h
@@ -15,6 +15,11 @@ class Context;
 struct SamplerDescriptor final : public Comparable<SamplerDescriptor> {
   MinMagFilter min_filter = MinMagFilter::kNearest;
   MinMagFilter mag_filter = MinMagFilter::kNearest;
+
+  // TODO(https://github.com/flutter/flutter/issues/148253):
+  // `MipFilter::kNearest` is the default value for mip filters, as it
+  // cooresponds with the framework's `FilterQuality.low`. If we ever change the
+  // default filter quality, we should update this function to match.
   MipFilter mip_filter = MipFilter::kNearest;
 
   SamplerAddressMode width_address_mode = SamplerAddressMode::kClampToEdge;

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -119,6 +119,7 @@ static impeller::SamplerDescriptor ToSamplerDescriptor(
   switch (options) {
     case flutter::DlImageSampling::kNearestNeighbor:
       desc.min_filter = desc.mag_filter = impeller::MinMagFilter::kNearest;
+      desc.mip_filter = impeller::MipFilter::kBase;
       desc.label = "Nearest Sampler";
       break;
     case flutter::DlImageSampling::kLinear:

--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -125,6 +125,11 @@ bool TextContents::Render(const ContentContext& renderer,
     sampler_desc.min_filter = MinMagFilter::kLinear;
     sampler_desc.mag_filter = MinMagFilter::kLinear;
   }
+
+  // TODO(https://github.com/flutter/flutter/issues/148253):
+  // `MipFilter::kNearest` is the default value for mip filters, as it
+  // cooresponds with the framework's `FilterQuality.low`. If we ever change the
+  // default filter quality, we should update this function to match.
   sampler_desc.mip_filter = MipFilter::kNearest;
 
   FS::BindGlyphAtlasSampler(

--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -126,11 +126,8 @@ bool TextContents::Render(const ContentContext& renderer,
     sampler_desc.mag_filter = MinMagFilter::kLinear;
   }
 
-  // TODO(https://github.com/flutter/flutter/issues/148253):
-  // `MipFilter::kNearest` is the default value for mip filters, as it
-  // cooresponds with the framework's `FilterQuality.low`. If we ever change the
-  // default filter quality, we should update this function to match.
-  sampler_desc.mip_filter = MipFilter::kNearest;
+  // No mipmaps for glyph atlas (glyphs are generated at exact scales).
+  sampler_desc.mip_filter = MipFilter::kBase;
 
   FS::BindGlyphAtlasSampler(
       pass,                 // command

--- a/impeller/renderer/backend/gles/sampler_gles.cc
+++ b/impeller/renderer/backend/gles/sampler_gles.cc
@@ -94,7 +94,8 @@ bool SamplerGLES::ConfigureBoundTexture(const TextureGLES& texture,
 
   gl.TexParameteri(*target, GL_TEXTURE_MIN_FILTER,
                    ToParam(desc.min_filter, mip_filter));
-  gl.TexParameteri(*target, GL_TEXTURE_MAG_FILTER, ToParam(desc.mag_filter));
+  gl.TexParameteri(*target, GL_TEXTURE_MAG_FILTER,
+                   ToParam(desc.mag_filter, MipFilter::kBase));
 
   const auto supports_decal_mode =
       gl.GetCapabilities()->SupportsDecalSamplerAddressMode();

--- a/impeller/renderer/backend/gles/sampler_gles.cc
+++ b/impeller/renderer/backend/gles/sampler_gles.cc
@@ -4,7 +4,6 @@
 
 #include "impeller/renderer/backend/gles/sampler_gles.h"
 
-#include "GLES3/gl3.h"
 #include "impeller/base/validation.h"
 #include "impeller/core/formats.h"
 #include "impeller/renderer/backend/gles/formats_gles.h"

--- a/impeller/renderer/backend/gles/sampler_gles.cc
+++ b/impeller/renderer/backend/gles/sampler_gles.cc
@@ -87,7 +87,7 @@ bool SamplerGLES::ConfigureBoundTexture(const TextureGLES& texture,
   // `MipFilter::kNearest` is the default value for mip filters, as it
   // cooresponds with the framework's `FilterQuality.low`. If we ever change the
   // default filter quality, we should update this function to match.
-  MipFilter mip_filter = MipFilter::kBase;
+  MipFilter mip_filter = MipFilter::kNearest;
   if (texture.GetTextureDescriptor().mip_count > 1) {
     mip_filter = desc.mip_filter;
   }

--- a/impeller/renderer/backend/gles/sampler_gles.cc
+++ b/impeller/renderer/backend/gles/sampler_gles.cc
@@ -16,19 +16,20 @@ SamplerGLES::SamplerGLES(SamplerDescriptor desc) : Sampler(std::move(desc)) {}
 
 SamplerGLES::~SamplerGLES() = default;
 
+// TODO(https://github.com/flutter/flutter/issues/148253): `MipFilter::kNearest`
+// is the default value for mip filters, as it cooresponds with the framework's
+// `FilterQuality.low`. If we ever change the default filter quality, we should
+// update this function to match.
 static GLint ToParam(MinMagFilter minmag_filter,
-                     std::optional<MipFilter> mip_filter = std::nullopt) {
-  if (!mip_filter.has_value()) {
-    switch (minmag_filter) {
-      case MinMagFilter::kNearest:
-        return GL_NEAREST;
-      case MinMagFilter::kLinear:
-        return GL_LINEAR;
-    }
-    FML_UNREACHABLE();
-  }
-
-  switch (mip_filter.value()) {
+                     MipFilter mip_filter = MipFilter::kNearest) {
+  switch (mip_filter) {
+    case MipFilter::kBase:
+      switch (minmag_filter) {
+        case MinMagFilter::kNearest:
+          return GL_NEAREST;
+        case MinMagFilter::kLinear:
+          return GL_LINEAR;
+      }
     case MipFilter::kNearest:
       switch (minmag_filter) {
         case MinMagFilter::kNearest:
@@ -82,7 +83,11 @@ bool SamplerGLES::ConfigureBoundTexture(const TextureGLES& texture,
   }
   const auto& desc = GetDescriptor();
 
-  std::optional<MipFilter> mip_filter = std::nullopt;
+  // TODO(https://github.com/flutter/flutter/issues/148253):
+  // `MipFilter::kNearest` is the default value for mip filters, as it
+  // cooresponds with the framework's `FilterQuality.low`. If we ever change the
+  // default filter quality, we should update this function to match.
+  MipFilter mip_filter = MipFilter::kBase;
   if (texture.GetTextureDescriptor().mip_count > 1) {
     mip_filter = desc.mip_filter;
   }

--- a/impeller/renderer/backend/metal/formats_mtl.h
+++ b/impeller/renderer/backend/metal/formats_mtl.h
@@ -342,6 +342,8 @@ constexpr MTLSamplerMinMagFilter ToMTLSamplerMinMagFilter(MinMagFilter filter) {
 
 constexpr MTLSamplerMipFilter ToMTLSamplerMipFilter(MipFilter filter) {
   switch (filter) {
+    case MipFilter::kBase:
+      return MTLSamplerMipFilterNotMipmapped;
     case MipFilter::kNearest:
       return MTLSamplerMipFilterNearest;
     case MipFilter::kLinear:

--- a/impeller/renderer/backend/vulkan/formats_vk.h
+++ b/impeller/renderer/backend/vulkan/formats_vk.h
@@ -222,6 +222,7 @@ constexpr vk::Filter ToVKSamplerMinMagFilter(MinMagFilter filter) {
 
 constexpr vk::SamplerMipmapMode ToVKSamplerMipmapMode(MipFilter filter) {
   switch (filter) {
+    case MipFilter::kBase:
     case MipFilter::kNearest:
       return vk::SamplerMipmapMode::eNearest;
     case MipFilter::kLinear:

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -781,8 +781,9 @@ TEST_P(RendererTest, CanGenerateMipmaps) {
   bool first_frame = true;
   auto host_buffer = HostBuffer::Create(context->GetResourceAllocator());
   Renderer::RenderCallback callback = [&](RenderTarget& render_target) {
-    const char* mip_filter_names[] = {"Nearest", "Linear"};
-    const MipFilter mip_filters[] = {MipFilter::kNearest, MipFilter::kLinear};
+    const char* mip_filter_names[] = {"Base", "Nearest", "Linear"};
+    const MipFilter mip_filters[] = {MipFilter::kBase, MipFilter::kNearest,
+                                     MipFilter::kLinear};
     const char* min_filter_names[] = {"Nearest", "Linear"};
     const MinMagFilter min_filters[] = {MinMagFilter::kNearest,
                                         MinMagFilter::kLinear};


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/147259.

Changes:
- Make sure the default of `kNearest` is used consistently
- Partial revert of https://github.com/flutter/engine/pull/40491, re-adding `kBase`
- Added some documentation about relevant enums, and why the default is `kNearest`
- Wired up `kBase` in the Metal, Vulkan, and OpenGLES backends

Expecting an update to the `dart_ui_filter_quality_none` golden file:

> ![Screenshot 2024-05-13 at 2 47 49 PM](https://github.com/flutter/engine/assets/168174/68df4c1a-9b2b-4201-9a6c-f78361a5aa30)

For breadcrumbs around the mapping, see https://github.com/flutter/flutter/issues/148253.