### PR TITLE
ios_external_view_embedder to ARC

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -120,6 +120,8 @@ source_set("flutter_framework_source_arc") {
     "ios_context_software.mm",
     "ios_external_texture_metal.h",
     "ios_external_texture_metal.mm",
+    "ios_external_view_embedder.h",
+    "ios_external_view_embedder.mm",
     "ios_surface.h",
     "ios_surface.mm",
     "ios_surface_metal_impeller.h",
@@ -181,8 +183,6 @@ source_set("flutter_framework_source") {
     "framework/Source/accessibility_bridge.mm",
     "framework/Source/accessibility_text_entry.h",
     "framework/Source/accessibility_text_entry.mm",
-    "ios_external_view_embedder.h",
-    "ios_external_view_embedder.mm",
     "platform_view_ios.h",
     "platform_view_ios.mm",
   ]

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -2,12 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h"
+
 #include <IOSurface/IOSurfaceObjC.h>
 #include <Metal/Metal.h>
 #include <UIKit/UIKit.h>
 
 #include "flutter/fml/logging.h"
-#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h"
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
+
+FLUTTER_ASSERT_ARC
 
 @interface DisplayLinkManager : NSObject
 @property(class, nonatomic, readonly) BOOL maxRefreshRateEnabledOnIPhone;

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -14,6 +14,9 @@
 #include "flutter/fml/logging.h"
 #include "flutter/fml/memory/task_runner_checker.h"
 #include "flutter/fml/trace_event.h"
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
+
+FLUTTER_ASSERT_ARC
 
 @interface VSyncClient ()
 @property(nonatomic, assign, readonly) double refreshRate;

--- a/shell/platform/darwin/ios/ios_external_view_embedder.mm
+++ b/shell/platform/darwin/ios/ios_external_view_embedder.mm
@@ -6,6 +6,8 @@
 
 #include "flutter/common/constants.h"
 
+FLUTTER_ASSERT_ARC
+
 namespace flutter {
 
 IOSExternalViewEmbedder::IOSExternalViewEmbedder(


### PR DESCRIPTION
`ios_external_view_embedder` is only C++ and there was nothing to migrate.

Also add a few missing `FLUTTER_ASSERT_ARC` macros.

Part of https://github.com/flutter/flutter/issues/137801.
