### PR TITLE
[et] Print reproxy stats when RBE shuts down

### DIFF
--- a/tools/pkg/engine_build_configs/lib/src/build_config_runner.dart
+++ b/tools/pkg/engine_build_configs/lib/src/build_config_runner.dart
@@ -76,7 +76,13 @@ final class RunnerProgress extends RunnerEvent {
 
 /// A [RunnerEvent] representing the result of a command.
 final class RunnerResult extends RunnerEvent {
-  RunnerResult(super.name, super.command, super.timestamp, this.result);
+  RunnerResult(
+    super.name,
+    super.command,
+    super.timestamp,
+    this.result, {
+    this.okMessage = 'OK',
+  });
 
   /// The resuilt of running the command.
   final ProcessRunnerResult result;
@@ -84,10 +90,13 @@ final class RunnerResult extends RunnerEvent {
   /// Whether the command was successful.
   late final bool ok = result.exitCode == 0;
 
+  /// The message to print on a successful result. The default is 'OK'.
+  final String okMessage;
+
   @override
   String toString() {
     if (ok) {
-      return '[${_timestamp(timestamp)}][$name]: OK';
+      return '[${_timestamp(timestamp)}][$name]: $okMessage';
     }
     final StringBuffer buffer = StringBuffer();
     buffer.writeln('[$timestamp][$name]: FAILED');
@@ -331,6 +340,38 @@ final class BuildRunner extends Runner {
     return p.join(engineSrcDir.path, 'flutter', 'buildtools', platformDir);
   }();
 
+  // Returns the second line of output from reproxystatus, which contains
+  // RBE statistics, or null if something goes wrong.
+  Future<String?> _reproxystatus() async {
+    final String reclientPath = p.join(_buildtoolsPath, 'reclient');
+    final String exe = platform.isWindows ? '.exe' : '';
+    final String restatsPath = p.join(reclientPath, 'reproxystatus$exe');
+    final ProcessRunnerResult restatsResult;
+    if (dryRun) {
+      restatsResult = ProcessRunnerResult(
+        0,                       // exit code.
+        utf8.encode('OK\nOK\n'), // stdout.
+        <int>[],                 // stderr.
+        utf8.encode('OK\nOK\n'), // combined,
+        pid: 0,                  // pid.
+      );
+    } else {
+      restatsResult = await processRunner.runProcess(
+        <String>[restatsPath, '-color', 'off'],
+        failOk: true,
+      );
+    }
+    if (restatsResult.exitCode != 0) {
+      return null;
+    }
+    // The second line of output has the stats.
+    final List<String> lines = restatsResult.stdout.split('\n');
+    if (lines.length < 2) {
+      return null;
+    }
+    return lines[1];
+  }
+
   Future<bool> _bootstrapRbe(
     RunnerEventHandler eventHandler, {
     bool shutdown = false,
@@ -382,11 +423,16 @@ final class BuildRunner extends Runner {
         failOk: true,
       );
     }
+    String okMessage = bootstrapResult.stdout.trim();
+    if (shutdown) {
+      okMessage = await _reproxystatus() ?? okMessage;
+    }
     eventHandler(RunnerResult(
       '${build.name}: RBE ${shutdown ? 'shutdown' : 'startup'}',
       bootstrapCommand,
       DateTime.now(),
       bootstrapResult,
+      okMessage: okMessage,
     ));
     return bootstrapResult.exitCode == 0;
   }

--- a/tools/pkg/engine_build_configs/test/build_config_runner_test.dart
+++ b/tools/pkg/engine_build_configs/test/build_config_runner_test.dart
@@ -230,6 +230,7 @@ void main() {
     expect(events[6].name, equals('$buildName: RBE shutdown'));
     expect(events[7] is RunnerResult, isTrue);
     expect(events[7].name, equals('$buildName: RBE shutdown'));
+    expect((events[7] as RunnerResult).okMessage, equals('OK'));
   });
 
   test('GlobalBuildRunner skips GN when runGn is false', () async {


### PR DESCRIPTION
```
$ bin/et build -c ci/android_release_arm64                                                                                      ─╯
[2024-05-14T11:28:40.856][ci/android_release_arm64: GN]: OK
[2024-05-14T11:28:42.527][ci/android_release_arm64: RBE startup]: Proxy started successfully.
[2024-05-14T11:31:14.869][ci/android_release_arm64: ninja]: 100.0% (1096/1096) STAMP obj/flutter/lib/snapshot/snapshot.stamp
[2024-05-14T11:31:14.871][ci/android_release_arm64: ninja]: OK
[2024-05-14T11:31:15.182][ci/android_release_arm64: RBE shutdown]: Actions completed: 1021 (569 racing locals, 452 racing remotes)
```