### PR TITLE
[docs] Suggest using same Xcode version as bots

### DIFF
--- a/docs/rbe/rbe.md
+++ b/docs/rbe/rbe.md
@@ -158,11 +158,16 @@ RBE builds can also be slow if your network connection is bandwidth constrained.
 Anecdotally, even with a warm cache, I have noticed slow builds from home due
 to RBE saturating my low-tier Comcast Business connection.
 
-For Googlers on a corp macOS device, both RBE and non-RBE builds can be slow
-due to various background and monitoring processes running. See
-[here](https://buganizer.corp.google.com/issues/324404733#comment16) for how
-to disable some of them. You should also disable Spotlight scanning of the
-engine source directory as described
+For developers on a macOS host device, ensure that you're using the same version
+of Xcode as is in use on the bots. The value of "Build version" returned by
+`xcodebuild -version` should match the `sdk_version` value set in
+`ci/builders/local_engine.json` for the build you're running.
+
+For Googlers on a corp macOS device, both RBE and non-RBE builds can be slow due
+to various background and monitoring processes running. See
+[here](https://buganizer.corp.google.com/issues/324404733#comment16) for how to
+disable some of them. You should also disable Spotlight scanning of the engine
+source directory as described
 [here](go/building-chrome-mac#add-the-source-directory-to-the-spotlight-privacy-list).
 
 When RBE builds are slow, non-RBE builds may be faster, especially incremental


### PR DESCRIPTION
Document that when using RBE, users should ensure the locally installed Xcode toolchain version matches that of the bots, otherwise they're likely to experience slow builds due to cache misses.

Ideally, we should also check the value automatically against the `sdk_version` specified in the relevant `et` build config itself.


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
