### PR TITLE
Roll FreeType from af4c2d86 to bfc3453f

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -630,7 +630,7 @@ deps = {
    Var('chromium_git') + '/external/github.com/libexpat/libexpat.git' + '@' + '654d2de0da85662fcc7644a7acd7c2dd2cfb21f0',
 
   'src/flutter/third_party/freetype2':
-   Var('flutter_git') + '/third_party/freetype2' + '@' + 'af4c2d86d399b15f31f19aafe49e540578a6be39',
+   Var('flutter_git') + '/third_party/freetype2' + '@' + 'bfc3453fdc85d87b45c896f68bf2e49ebdaeef0a',
 
   'src/flutter/third_party/skia':
    Var('skia_git') + '/skia.git' + '@' +  Var('skia_revision'),


### PR DESCRIPTION
Includes a fix required for building with the latest Clang

See https://github.com/flutter/flutter/issues/143178