### PR TITLE
[web] update version-lock file location

### DIFF
--- a/lib/web_ui/README.md
+++ b/lib/web_ui/README.md
@@ -124,7 +124,7 @@ this option is particularly effective for building on low-powered laptops.
 ### Test browsers
 
 Chromium, Firefox, and Safari for iOS are version-locked using the
-[browser_lock.yaml][3] configuration file. Safari for macOS is supplied by the
+[package_lock.yaml][3] configuration file. Safari for macOS is supplied by the
 computer's operating system. Tests can be run in Edge locally, but Edge is not
 enabled on LUCI. Chromium is used as a proxy for Chrome, Edge, and other
 Chromium-based browsers.
@@ -177,7 +177,7 @@ The available versions of Chrome for Testing available can be found [here](https
 - If not already authenticated with CIPD, run `cipd auth-login` and follow
   instructions (this step requires sufficient privileges; contact
   #hackers-infra-🌡 on [Flutter's Discord server](https://github.com/flutter/flutter/wiki/Chat)).
-- Edit `dev/browser_lock.yaml` and update the following values under `chrome`:
+- Edit `dev/package_lock.yaml` and update the following values under `chrome`:
   - Set `version` to the full four part version number of the build of Chrome 
     for Testing you want to roll (for example, `118.0.5993.70`)
 - Run `dart dev/browser_roller.dart` and make sure it completes successfully.
@@ -193,7 +193,7 @@ If you have questions, contact the Flutter Web team on Flutter Discord on the
 #### Firefox
 
 We test with Firefox on LUCI in the Linux Web Engine builder. The process for
-rolling Firefox is even easier than Chromium. Simply update `browser_lock.yaml`
+rolling Firefox is even easier than Chromium. Simply update `package_lock.yaml`
 with the latest version of Firefox, and run `browser_roller.dart`.
 
 #### .ci.yaml
@@ -232,7 +232,7 @@ In general, the manual process goes like this:
 2. Create CIPD packages for these packages (more documentation is available for
    Googlers at go/cipd-flutter-web)
 3. Update the version in this repo. Do this by changing the related fields in
-   `browser_lock.yaml` file.
+   `package_lock.yaml` file.
 
 Resources:
 
@@ -243,7 +243,7 @@ Resources:
 
 ### Configuration files
 
-`browser_lock.yaml` contains the version of browsers we use to test Flutter for
+`package_lock.yaml` contains the version of browsers we use to test Flutter for
 web. Versions are not automatically updated whenever a new release is available.
 Instead, we update this file manually once in a while.
 
@@ -305,7 +305,7 @@ Once you know the version for the Emscripten SDK, change the line in
 
 [1]: https://github.com/flutter/flutter/wiki/Setting-up-the-Engine-development-environment
 [2]: https://github.com/flutter/flutter/blob/main/lib/web_ui/test/README
-[3]: https://github.com/flutter/engine/blob/main/lib/web_ui/dev/browser_lock.yaml
+[3]: https://github.com/flutter/engine/blob/main/lib/web_ui/dev/package_lock.yaml
 [4]: https://chrome-infra-packages.appspot.com/p/flutter_internal
 [5]: https://cs.opensource.google/flutter/recipes/+/master:recipes/engine/web_engine.py
 [6]: https://chromium.googlesource.com/chromium/src.git/+/main/docs/cipd_and_3pp.md#What-is-CIPD

--- a/lib/web_ui/dev/chrome_installer.dart
+++ b/lib/web_ui/dev/chrome_installer.dart
@@ -21,7 +21,7 @@ const String _chromeExecutableVar = 'CHROME_EXECUTABLE';
 ///
 /// If [requestedVersion] is null, uses the version specified on the
 /// command-line. If not specified on the command-line, uses the version
-/// specified in the "browser_lock.yaml" file.
+/// specified in the "package_lock.yaml" file.
 ///
 /// If [requestedVersion] is not null, installs that version. The value
 /// may be "latest" (the latest available build of Chrome), "system"

--- a/lib/web_ui/dev/firefox_installer.dart
+++ b/lib/web_ui/dev/firefox_installer.dart
@@ -17,7 +17,7 @@ const String _firefoxExecutableVar = 'FIREFOX_EXECUTABLE';
 ///
 /// If [requestedVersion] is null, uses the version specified on the
 /// command-line. If not specified on the command-line, uses the version
-/// specified in the "browser_lock.yaml" file.
+/// specified in the "package_lock.yaml" file.
 ///
 /// If [requestedVersion] is not null, installs that version. The value
 /// may be "latest" (the latest stable Firefox version), "system"


### PR DESCRIPTION
PR #47573 renamed the version-lock file from `browser_lock.yaml` to `package_lock.yaml`. This PR adjusts sources to changes.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
