### PR TITLE
[Impeller] use smaller SkFont size for determining glyph bounds.

### DIFF
--- a/impeller/typographer/backends/skia/text_frame_skia.cc
+++ b/impeller/typographer/backends/skia/text_frame_skia.cc
@@ -36,7 +36,7 @@ static Rect ToRect(const SkRect& rect) {
   return Rect::MakeLTRB(rect.fLeft, rect.fTop, rect.fRight, rect.fBottom);
 }
 
-static constexpr Scalar kScaleSize = 100000.0f;
+static constexpr Scalar kScaleSize = 64.0f;
 
 std::shared_ptr<TextFrame> MakeTextFrameFromTextBlobSkia(
     const sk_sp<SkTextBlob>& blob) {
@@ -59,7 +59,8 @@ std::shared_ptr<TextFrame> MakeTextFrameFromTextBlobSkia(
         // For some platforms (including Android), `SkFont::getBounds()` snaps
         // the computed bounds to integers. And so we scale up the font size
         // prior to fetching the bounds to ensure that the returned bounds are
-        // always precise enough.
+        // always precise enough. Scaling too large will cause Skia to use
+        // path rendering and potentially inaccurate glyph sizes.
         font.setSize(kScaleSize);
         font.getBounds(glyphs, glyph_count, glyph_bounds.data(), nullptr);
 


### PR DESCRIPTION
Applies the fix that @jason-simmons  previously suggested in https://github.com/flutter/flutter/issues/128624#issuecomment-1846473830 

I'm not sure if these results are better or not ... but I think we try and make this change to see if things are improved anyway? Leaving up golden diffs for others to look at.