### PR TITLE
[et] Work around flutter/flutter#145158

### DIFF
--- a/tools/engine_tool/lib/src/run_utils.dart
+++ b/tools/engine_tool/lib/src/run_utils.dart
@@ -115,8 +115,9 @@ RunTarget? selectRunTarget(Environment env, String flutterDevicesMachine,
 /// Detects available targets and then selects one.
 Future<RunTarget?> detectAndSelectRunTarget(Environment env,
     [String? idPrefix]) async {
-  final ProcessRunnerResult result = await env.processRunner
-      .runProcess(<String>['flutter', 'devices', '--machine']);
+  final ProcessRunnerResult result = await env.processRunner.runProcess(
+    <String>['flutter', '--no-version-check', 'devices', '--machine'],
+  );
   if (result.exitCode != 0) {
     env.logger.error('flutter devices --machine failed:\n'
         'EXIT_CODE:${result.exitCode}\n'

--- a/tools/engine_tool/test/run_command_test.dart
+++ b/tools/engine_tool/test/run_command_test.dart
@@ -68,7 +68,7 @@ void main() {
           processManager: FakeProcessManager(onStart: (List<String> command) {
             runHistory.add(command);
             switch (command) {
-              case ['flutter', 'devices', '--machine']:
+              case ['flutter', '--no-version-check', 'devices', '--machine']:
                 return FakeProcess(stdout: fixtures.attachedDevices());
               default:
                 return FakeProcess();


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/145158 is a bit mysterious since the appropriate guards already appear to be in place in the code. The tools team does not currently have bandwidth to look into this, so in the near term this flag may help `et` work around the issue.