### PR TITLE
Log Vulkan loader errors if the instance failed creation on Fuchsia

### DIFF
--- a/vulkan/vulkan_application.h
+++ b/vulkan/vulkan_application.h
@@ -44,12 +44,16 @@ class VulkanApplication {
   std::unique_ptr<VulkanDevice> AcquireFirstCompatibleLogicalDevice() const;
 
  private:
-  VulkanProcTable& vk_;
-  VulkanHandle<VkInstance> instance_;
-  uint32_t api_version_;
-  std::unique_ptr<VulkanDebugReport> debug_report_;
+  // Located at the beginning so it outlives instance_.
+  std::string initialization_logs_;
+  bool initialization_logs_enabled_ = true;
   bool valid_;
   bool enable_validation_layers_;
+  uint8_t padding_;
+  uint32_t api_version_;
+  VulkanProcTable& vk_;
+  VulkanHandle<VkInstance> instance_;
+  std::unique_ptr<VulkanDebugReport> debug_report_;
 
   std::vector<VkPhysicalDevice> GetPhysicalDevices() const;
   std::vector<VkExtensionProperties> GetSupportedInstanceExtensions(
@@ -57,6 +61,15 @@ class VulkanApplication {
   bool ExtensionSupported(
       const std::vector<VkExtensionProperties>& supported_extensions,
       const std::string& extension_name);
+  static VKAPI_ATTR VkBool32 DebugReportCallback(
+      VkDebugReportFlagsEXT flags,
+      VkDebugReportObjectTypeEXT objectType,
+      uint64_t object,
+      size_t location,
+      int32_t messageCode,
+      const char* pLayerPrefix,
+      const char* pMessage,
+      void* pUserData);
 
   FML_DISALLOW_COPY_AND_ASSIGN(VulkanApplication);
 };


### PR DESCRIPTION
Log Vulkan loader errors if the instance failed creation on Fuchsia
The vulkan loader can output logs to help us debug why instance creation
fails. To catch these logs, we need to pass a debug report callback to
vkCreateInstance (since the only other debug report callback is set up
after the instance is created).

Outputting logs is currently only enabled on Fuchsia, since other
platforms may have fallbacks and wouldn't want the error logspam.

Fixes https://github.com/flutter/flutter/issues/82928

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
