### PR TITLE
Remove --trace-gn from ./flutter/tools/gn

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -1216,14 +1216,6 @@ def parse_args(args):
   )
 
   parser.add_argument(
-      '--trace-gn',
-      default=True,
-      action='store_true',
-      help='Write a GN trace log (gn_trace.json) in the Chromium tracing '
-      'format in the build directory.'
-  )
-
-  parser.add_argument(
       '--darwin-extension-safe',
       default=False,
       action='store_true',
@@ -1307,9 +1299,7 @@ def main(argv):
   out_dir = get_out_dir(args)
   command.append(out_dir)
   command.append('--args=%s' % ' '.join(gn_args))
-
-  if args.trace_gn:
-    command.append('--tracelog=%s/gn_trace.json' % out_dir)
+  command.append('--tracelog=%s/gn_trace.json' % out_dir)
 
   if args.verbose:
     command.append('-v')


### PR DESCRIPTION
This flag as originally introduced to see if it made the GN step slower. It did not do so in any measurable manner and the default was flipped to true. AFAICT, no one disables and its good to have tracelogs to debug GN slowdowns. Remove the flag.
