### PR TITLE
Cleanup propagation of codecvt warning suppression in FML.

### DIFF
--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -289,6 +289,13 @@ source_set("command_line") {
   ]
 }
 
+config("string_conversion_config") {
+  if (is_win) {
+    # TODO(50053): Replace codecvt usage.
+    defines = [ "_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING" ]
+  }
+}
+
 source_set("string_conversion") {
   sources = [
     "string_conversion.cc",
@@ -304,14 +311,12 @@ source_set("string_conversion") {
       "platform/win/wstring_conversion.cc",
       "platform/win/wstring_conversion.h",
     ]
-
-    # TODO(cbracken): https://github.com/flutter/flutter/issues/50053
-    defines += [ "_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING" ]
   }
 
   deps = [ ":build_config" ]
 
   public_configs = [
+    ":string_conversion_config",
     "//flutter:config",
     "//flutter/common:flutter_config",
   ]

--- a/impeller/BUILD.gn
+++ b/impeller/BUILD.gn
@@ -30,13 +30,6 @@ config("impeller_public_config") {
     defines += [ "IMPELLER_ENABLE_VULKAN=1" ]
   }
 
-  if (is_win) {
-    defines += [
-      # TODO(dnfield): https://github.com/flutter/flutter/issues/50053
-      "_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING",
-    ]
-  }
-
   if (impeller_enable_3d) {
     defines += [ "IMPELLER_ENABLE_3D" ]
   }


### PR DESCRIPTION
Previously, because the suppression was local, every user of the the header had to manually add the flag. Now the flag will be propagated to the targets automatically. This linked issue still needs to be fixed but the fix can now be more isolated.
