### PR TITLE
[Impeller] Round out subpass coverage.

### DIFF
--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -629,6 +629,18 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
       return EntityPass::EntityResult::Skip();
     }
 
+    // RoundOut the subpass coverage to ensure the new subpass texture will be
+    // perfectly pixel aligned in the common case. By default, we draw subpass
+    // textures with nearest sampling, perfectly aligned with the parent pass
+    // render target. So integer aligning the subpass coverage rectangle is
+    // important for:
+    // 1. Correct visual subpixel placement/antialiasing of subpass elements.
+    // 2. Avoiding visual nearest sampling errors caused by limited floating
+    //    point precision when straddling a half pixel boundary.
+    if (subpass_coverage.has_value()) {
+      subpass_coverage = Rect::RoundOut(subpass_coverage.value());
+    }
+
     auto subpass_size = ISize(subpass_coverage->GetSize());
     if (subpass_size.IsEmpty()) {
       return EntityPass::EntityResult::Skip();


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/146967

I added a detailed comment inline explaining why we need this. The visual issues in the reported issue were due to nearest sampling while straddling a half pixel offset.

Before:
![image](https://github.com/flutter/engine/assets/919017/ccd89a87-4643-4e4d-9e24-56f28f317e2f)

After:
<img width="964" alt="image" src="https://github.com/flutter/engine/assets/919017/0be88453-1014-443b-bc80-6df459adb075">
