### PR TITLE
Fix another instance of platform view breakage on Android 14

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -9,6 +9,7 @@ import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.DEFAULT_
 
 import android.annotation.TargetApi;
 import android.app.Activity;
+import android.content.ComponentCallbacks2;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -645,6 +646,12 @@ import java.util.List;
     // See https://github.com/flutter/flutter/issues/93276
     previousVisibility = flutterView.getVisibility();
     flutterView.setVisibility(View.GONE);
+      if (flutterEngine != null) {
+        // When an Activity is stopped it won't have its onTrimMemory callback invoked. Normally,
+        // this isn't a problem but because of a bug in some builds of Android 14 we must act as
+        // if the onTrimMemory callback has been called.
+        flutterEngine.getRenderer().onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_BACKGROUND);
+      }
   }
 
   /**


### PR DESCRIPTION
When you background an activity via the back-gesture the onTrimMemory callback is not invoked but the buggy Android behaviour still occurs.

Workaround this by faking an onTrimMemory callback in the `Activity#onStop` callback.

Fixes [#148662](https://github.com/flutter/flutter/issues/148662)
Related [#146499](https://github.com/flutter/flutter/issues/146499)

Tested manually on a Pixel 7 Pro running Android 14.