### PR TITLE
[canvaskit] Fix overlay reorganization for edge case with only 1 overlay

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -504,12 +504,12 @@ class HtmlViewEmbedder {
     }
 
     // Add all the pictures from the deleted canvases to the second-to-last
-    // canvas.
+    // canvas (or the last canvas if there is only one).
     sawLastCanvas = false;
     for (int i = modifiedEntities.length - 1; i > 0; i--) {
       final RenderingEntity entity = modifiedEntities[i];
       if (entity is RenderingRenderCanvas) {
-        if (sawLastCanvas) {
+        if (sawLastCanvas || maximumCanvases == 1) {
           entity.pictures.addAll(picturesForLastCanvas);
           break;
         }

--- a/lib/web_ui/test/canvaskit/embedded_views_test.dart
+++ b/lib/web_ui/test/canvaskit/embedded_views_test.dart
@@ -1315,6 +1315,69 @@ void testMain() {
           .map((RenderingRenderCanvas canvas) => canvas.pictures.length)
           .toList();
       expect(numPicturesPerCanvas, <int>[1, 1, 1, 1, 1, 1, 12, 1]);
+
+      // It should also work when the maximum canvases is just one.
+      debugOverrideJsConfiguration(<String, Object?>{
+        'canvasKitMaximumSurfaces': 1,
+      }.jsify() as JsFlutterConfiguration?);
+
+      // Render scene with 20 pictures. Check that the last canvas contains the
+      // pictures from the canvases that were deleted.
+      await renderTestScene(<int>[
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+      ]);
+      _expectSceneMatches(<_EmbeddedViewMarker>[
+        _platformView,
+        _platformView,
+        _platformView,
+        _platformView,
+        _platformView,
+        _platformView,
+        _platformView,
+        _platformView,
+        _platformView,
+        _platformView,
+        _platformView,
+        _platformView,
+        _platformView,
+        _platformView,
+        _platformView,
+        _platformView,
+        _platformView,
+        _platformView,
+        _overlay,
+        _platformView,
+      ]);
+
+      // The last canvas should have all the pictures.
+      final Rendering secondRendering = CanvasKitRenderer.instance
+          .debugGetRasterizerForView(implicitView)!
+          .viewEmbedder
+          .debugActiveRendering;
+      final List<int> picturesPerCanvasInSecondRendering = secondRendering
+          .canvases
+          .map((RenderingRenderCanvas canvas) => canvas.pictures.length)
+          .toList();
+      expect(picturesPerCanvasInSecondRendering, <int>[19]);
+      debugOverrideJsConfiguration(null);
     });
   });
 }


### PR DESCRIPTION
When there is only 1 overlay, move pictures in the reduced rendering to the last canvas instead of the second-to-last.

Fixes a bug in https://github.com/flutter/engine/pull/51397

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
