### PR TITLE
[Impeller] made the sqrt conditional in rrect_blur

### DIFF
--- a/impeller/entity/shaders/rrect_blur.frag
+++ b/impeller/entity/shaders/rrect_blur.frag
@@ -53,7 +53,15 @@ float RRectBlurX(vec2 sample_position, vec2 half_size) {
   // The calling function RRectBlur will never provide a Y sample outside
   // of that range, though, so the max(0.0) is mostly a precaution.
   float unit_space_y = space_y / frag_info.corner_radii.y;
-  float unit_space_x = sqrt(max(0.0, 1.0 - unit_space_y * unit_space_y));
+  float unit_space_x_squared = 1.0 - unit_space_y * unit_space_y;
+  float unit_space_x;
+  if (unit_space_x_squared >= 1.0) {
+    unit_space_x = 1.0;
+  } else if (unit_space_x_squared < 0.0) {
+    unit_space_x = 0.0;
+  } else {
+    unit_space_x = sqrt(unit_space_x_squared);
+  }
   float rrect_distance =
       half_size.x - frag_info.corner_radii.x * (1.0 - unit_space_x);
 


### PR DESCRIPTION
issue: https://github.com/flutter/flutter/issues/148496

This eliminates all the `sqrt` calls for when drawing inside of the rect (not the edges).

## before
```
Work registers: 32 (100% used at 100% occupancy)
Uniform registers: 22 (34% used)
Stack spilling: false
16-bit arithmetic: 0%

                                A     FMA     CVT     SFU      LS       V       T    Bound
Total instruction cycles:    0.75    0.41    0.21    0.75    0.00    0.06    0.00   A, SFU
Shortest path cycles:        0.75    0.41    0.21    0.75    0.00    0.06    0.00   A, SFU
Longest path cycles:         0.75    0.41    0.21    0.75    0.00    0.06    0.00   A, SFU

A = Arithmetic, FMA = Arith FMA, CVT = Arith CVT, SFU = Arith SFU,
LS = Load/Store, V = Varying, T = Texture
```
## after
```
Work registers: 19 (59% used at 100% occupancy)
Uniform registers: 22 (34% used)
Stack spilling: false
16-bit arithmetic: 0%

                                A     FMA     CVT     SFU      LS       V       T    Bound
Total instruction cycles:    0.75    0.41    0.40    0.75    0.00    0.06    0.00   A, SFU
Shortest path cycles:        0.62    0.40    0.24    0.62    0.00    0.06    0.00   A, SFU
Longest path cycles:         0.75    0.41    0.40    0.75    0.00    0.06    0.00   A, SFU

A = Arithmetic, FMA = Arith FMA, CVT = Arith CVT, SFU = Arith SFU,
LS = Load/Store, V = Varying, T = Texture
```
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
