### PR TITLE
Replace several NSAssert with FML_CHECK/DCHECK to unblock the build

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderExternalTextureTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderExternalTextureTest.mm
@@ -59,7 +59,7 @@
   CVPixelBufferRef pxbuffer = NULL;
   CVReturn status = CVPixelBufferCreate(kCFAllocatorDefault, _width, _width, _pixelFormatType,
                                         (__bridge CFDictionaryRef)options, &pxbuffer);
-  FML_DCHECK(status == kCVReturnSuccess && pxbuffer != nullptr) << "Failed to create pixel buffer";
+  FML_CHECK(status == kCVReturnSuccess && pxbuffer != nullptr) << "Failed to create pixel buffer";
   return pxbuffer;
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderExternalTextureTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderExternalTextureTest.mm
@@ -60,6 +60,7 @@
   CVReturn status = CVPixelBufferCreate(kCFAllocatorDefault, _width, _width, _pixelFormatType,
                                         (__bridge CFDictionaryRef)options, &pxbuffer);
   NSAssert(status == kCVReturnSuccess && pxbuffer != NULL, @"Failed to create pixel buffer.");
+  FML_DCHECK(status == kCVReturnSuccess && pxbuffer != nullptr) << "Failed to create pixel buffer";
   return pxbuffer;
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderExternalTextureTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderExternalTextureTest.mm
@@ -59,7 +59,6 @@
   CVPixelBufferRef pxbuffer = NULL;
   CVReturn status = CVPixelBufferCreate(kCFAllocatorDefault, _width, _width, _pixelFormatType,
                                         (__bridge CFDictionaryRef)options, &pxbuffer);
-  NSAssert(status == kCVReturnSuccess && pxbuffer != NULL, @"Failed to create pixel buffer.");
   FML_DCHECK(status == kCVReturnSuccess && pxbuffer != nullptr) << "Failed to create pixel buffer";
   return pxbuffer;
 }

--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.mm
@@ -167,9 +167,10 @@ static uint64_t GetLogicalKeyForEvent(NSEvent* event, uint64_t physicalKey) {
     uint32_t* keyLabel = DecodeUtf16(keyLabelUtf16, &keyLabelLength);
     if (keyLabelLength == 1) {
       uint32_t keyLabelChar = *keyLabel;
-      NSCAssert(!IsControlCharacter(keyLabelChar) && !IsUnprintableKey(keyLabelChar),
-                @"Unexpected control or unprintable keylabel 0x%x", keyLabelChar);
-      NSCAssert(keyLabelChar <= 0x10FFFF, @"Out of range keylabel 0x%x", keyLabelChar);
+      FML_DCHECK(!IsControlCharacter(keyLabelChar) && !IsUnprintableKey(keyLabelChar))
+          << "Unexpected control or unprintable keylabel 0x" << std::hex << keyLabelChar;
+      FML_DCHECK(keyLabelChar <= 0x10FFFF)
+          << "Out of range keylabel 0x" << std::hex << keyLabelChar;
       character = keyLabelChar;
     }
     delete[] keyLabel;


### PR DESCRIPTION
In https://github.com/flutter/buildroot/pull/860, disabling `NSAssert` in release build was added, and https://github.com/flutter/engine/pull/53005 tries to roll the change into the engine. However, the change is blocked due to several compilation errors in the engine.

This is due to the fact that Google's `DCHECK`(in flutter engine, `FML_DCHECK`) does not make unused variable warning even in release build, while traditional assertion macro like `assert` or `NSAssert` does. For example, the following code will be expanded like this:
code:
```c++
FML_DCHECK(status == kCVReturnSuccess && pxbuffer != nullptr) <<
   "Failed to create pixel buffer";
```
expanded code:
```c++
true || (status == kCVReturnSuccess && pxbuffer != nullptr)
    ? (void)0 ::
    : fml::LogMessageVoidify() &
          ::fml::LogMessage(::fml::kLogFatal, 0, 0, nullptr).stream()
```

However, equivalent code with `NSAssert` will make unused variable warning, since the expanded code doesn't have any reference to the variable:
code:
```c++
NSAssert(status == kCVReturnSuccess && pxbuffer != NULL, @"Failed to create pixel buffer.");
```

expanded code:
```c++
do {
} while (0)
```
To unblock the build, this CL replaces several `NSAssert` with `FML_DCHECK` in the engine codebase. This CL isn't aimed to replace all `NSAssert` with `FML_DCHECK` since discussions in https://github.com/flutter/buildroot/pull/860 are not finalized whether to replace all `NSAssert` with `FML_DCHECK` or not.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
