### PR TITLE
Remove use of --nnbd-agnostic

### DIFF
--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -238,7 +238,7 @@ compile_platform("strong_platform") {
       flutter_runtime_mode == "release" || flutter_runtime_mode == "jit_release"
   args = [
     "--enable-experiment=generic-metadata",
-    "--nnbd-agnostic",
+    "--nnbd-strong",
     "--target=flutter",
     "-Ddart.vm.product=$is_runtime_mode_release",
     "-Ddart.isVM=true",

--- a/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
@@ -20,7 +20,7 @@ compile_platform("kernel_platform_files") {
   ]
 
   args = [
-    "--nnbd-agnostic",
+    "--nnbd-strong",
     "--target=dart_runner",
     "dart:core",
   ]

--- a/shell/platform/fuchsia/flutter/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/kernel/BUILD.gn
@@ -20,7 +20,7 @@ compile_platform("kernel_platform_files") {
   ]
 
   args = [
-    "--nnbd-agnostic",
+    "--nnbd-strong",
     "--target=flutter_runner",
     "dart:core",
   ]


### PR DESCRIPTION
The Dart VM no longer supports unsound null safety, so we don't need to generate the platform in agnostic mode.

