### PR TITLE
Replace several calls to GrGLMakeNativeInterface with more direct APIs

### DIFF
--- a/lib/web_ui/skwasm/surface.cpp
+++ b/lib/web_ui/skwasm/surface.cpp
@@ -9,6 +9,7 @@
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/skia/include/gpu/ganesh/gl/GrGLBackendSurface.h"
 #include "third_party/skia/include/gpu/ganesh/gl/GrGLDirectContext.h"
+#include "third_party/skia/include/gpu/ganesh/gl/GrGLMakeWebGLInterface.h"
 
 using namespace Skwasm;
 
@@ -101,7 +102,7 @@ void Surface::_init() {
   makeCurrent(_glContext);
   emscripten_webgl_enable_extension(_glContext, "WEBGL_debug_renderer_info");
 
-  _grContext = GrDirectContexts::MakeGL(GrGLMakeNativeInterface());
+  _grContext = GrDirectContexts::MakeGL(GrGLInterfaces::MakeWebGL());
 
   // WebGL should already be clearing the color and stencil buffers, but do it
   // again here to ensure Skia receives them in the expected state.

--- a/shell/gpu/gpu_surface_gl_delegate.cc
+++ b/shell/gpu/gpu_surface_gl_delegate.cc
@@ -4,9 +4,28 @@
 
 #include "flutter/shell/gpu/gpu_surface_gl_delegate.h"
 
+#include "flutter/fml/build_config.h"
+
 #include <cstring>
 
 #include "third_party/skia/include/gpu/gl/GrGLAssembleInterface.h"
+#include "third_party/skia/include/gpu/gl/GrGLInterface.h"
+
+#if defined(FML_OS_ANDROID)
+#include "third_party/skia/include/gpu/ganesh/gl/egl/GrGLMakeEGLInterface.h"
+#endif
+
+#if defined(FML_OS_LINUX)
+#include "third_party/skia/include/gpu/ganesh/gl/glx/GrGLMakeGLXInterface.h"
+#endif
+
+#if defined(FML_OS_MACOSX)
+#include "third_party/skia/include/gpu/ganesh/gl/mac/GrGLMakeMacInterface.h"
+#endif
+
+#if defined(FML_OS_IOS)
+#include "third_party/skia/include/gpu/ganesh/gl/ios/GrGLMakeIOSInterface.h"
+#endif
 
 namespace flutter {
 
@@ -64,9 +83,20 @@ static bool IsProcResolverOpenGLES(
 static sk_sp<const GrGLInterface> CreateGLInterface(
     const GPUSurfaceGLDelegate::GLProcResolver& proc_resolver) {
   if (proc_resolver == nullptr) {
-    // If there is no custom proc resolver, ask Skia to guess the native
+#if defined(FML_OS_ANDROID)
+    return GrGLInterfaces::MakeEGL();
+#elif defined(FML_OS_LINUX)
+    return GrGLInterfaces::MakeGLX();
+#elif defined(FML_OS_IOS)
+    return GrGLInterfaces::MakeIOS();
+#elif defined(FML_OS_MACOSX)
+    return GrGLInterfaces::MakeMac();
+#else
+    // TODO(kjlubick) update this when Skia has a Windows target for making GL
+    // interfaces. For now, ask Skia to guess the native
     // interface. This often leads to interesting results on most platforms.
     return GrGLMakeNativeInterface();
+#endif
   }
 
   struct ProcResolverContext {

--- a/shell/gpu/gpu_surface_gl_delegate.cc
+++ b/shell/gpu/gpu_surface_gl_delegate.cc
@@ -15,7 +15,7 @@
 #include "third_party/skia/include/gpu/ganesh/gl/egl/GrGLMakeEGLInterface.h"
 #endif
 
-#if defined(FML_OS_LINUX)
+#if defined(FML_OS_LINUX) && defined(SK_GLX)
 #include "third_party/skia/include/gpu/ganesh/gl/glx/GrGLMakeGLXInterface.h"
 #endif
 
@@ -86,7 +86,11 @@ static sk_sp<const GrGLInterface> CreateGLInterface(
 #if defined(FML_OS_ANDROID)
     return GrGLInterfaces::MakeEGL();
 #elif defined(FML_OS_LINUX)
+  #if defined(SK_GLX)
     return GrGLInterfaces::MakeGLX();
+  #else
+    return nullptr;
+  #endif
 #elif defined(FML_OS_IOS)
     return GrGLInterfaces::MakeIOS();
 #elif defined(FML_OS_MACOSX)

--- a/shell/gpu/gpu_surface_gl_delegate.cc
+++ b/shell/gpu/gpu_surface_gl_delegate.cc
@@ -86,11 +86,11 @@ static sk_sp<const GrGLInterface> CreateGLInterface(
 #if defined(FML_OS_ANDROID)
     return GrGLInterfaces::MakeEGL();
 #elif defined(FML_OS_LINUX)
-  #if defined(SK_GLX)
+#if defined(SK_GLX)
     return GrGLInterfaces::MakeGLX();
-  #else
+#else
     return nullptr;
-  #endif
+#endif  // defined(SK_GLX)
 #elif defined(FML_OS_IOS)
     return GrGLInterfaces::MakeIOS();
 #elif defined(FML_OS_MACOSX)

--- a/skia/BUILD.gn
+++ b/skia/BUILD.gn
@@ -426,6 +426,7 @@ optional("gpu") {
       if (defined(ndk_api) && ndk_api >= 26) {
         libs += [ "android" ]
       }
+      public_defines += [ "SK_EGL" ]
     } else if (skia_use_webgl) {
       sources += [
         "$_skia_root/src/gpu/ganesh/gl/webgl/GrGLMakeNativeInterface_webgl.cpp",
@@ -436,6 +437,11 @@ optional("gpu") {
         "$_skia_root/src/gpu/ganesh/gl/glx/GrGLMakeNativeInterface_glx.cpp",
       ]
       libs += [ "GL" ]
+      public_defines += [ "SK_GLX" ]
+    } else if (is_mac) {
+      sources += [ "src/gpu/ganesh/gl/mac/GrGLMakeNativeInterface_mac.cpp" ]
+    } else if (is_ios) {
+      sources += [ "src/gpu/ganesh/gl/iOS/GrGLMakeNativeInterface_iOS.cpp" ]
     } else if (is_win) {
       sources += [
         "$_skia_root/src/gpu/ganesh/gl/win/GrGLMakeNativeInterface_win.cpp",

--- a/skia/BUILD.gn
+++ b/skia/BUILD.gn
@@ -439,9 +439,13 @@ optional("gpu") {
       libs += [ "GL" ]
       public_defines += [ "SK_GLX" ]
     } else if (is_mac) {
-      sources += [ "src/gpu/ganesh/gl/mac/GrGLMakeNativeInterface_mac.cpp" ]
+      sources += [
+        "$_skia_root/src/gpu/ganesh/gl/mac/GrGLMakeNativeInterface_mac.cpp",
+      ]
     } else if (is_ios) {
-      sources += [ "src/gpu/ganesh/gl/iOS/GrGLMakeNativeInterface_iOS.cpp" ]
+      sources += [
+        "$_skia_root/src/gpu/ganesh/gl/iOS/GrGLMakeNativeInterface_iOS.cpp",
+      ]
     } else if (is_win) {
       sources += [
         "$_skia_root/src/gpu/ganesh/gl/win/GrGLMakeNativeInterface_win.cpp",


### PR DESCRIPTION
We are restructuring Skia and plan to remove GrGLMakeNativeInterface at some point. This updates as many places as possible to use the direct and explicit instantiation instead of having "Skia guess". This should ideally not be changing behavior - if it does, then the PR should be modified.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
