### PR TITLE
[Impeller] remove Android CPU affinity.

### DIFF
--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -145,9 +145,6 @@ void ContextVK::Setup(Settings settings) {
   raster_message_loop_ = fml::ConcurrentMessageLoop::Create(
       ChooseThreadCountForWorkers(std::thread::hardware_concurrency()));
   raster_message_loop_->PostTaskToAllWorkers([]() {
-    // Currently we only use the worker task pool for small parts of a frame
-    // workload, if this changes this setting may need to be adjusted.
-    fml::RequestAffinity(fml::CpuAffinity::kNotPerformance);
 #ifdef FML_OS_ANDROID
     if (::setpriority(PRIO_PROCESS, gettid(), -5) != 0) {
       FML_LOG(ERROR) << "Failed to set Workers task runner priority";

--- a/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
+++ b/impeller/renderer/backend/vulkan/fence_waiter_vk.cc
@@ -92,9 +92,6 @@ static std::vector<vk::Fence> GetFencesForWaitSet(const WaitSet& set) {
 void FenceWaiterVK::Main() {
   fml::Thread::SetCurrentThreadName(
       fml::Thread::ThreadConfig{"IplrVkFenceWait"});
-  // Since this thread mostly waits on fences, it doesn't need to be fast.
-  fml::RequestAffinity(fml::CpuAffinity::kEfficiency);
-
   while (true) {
     // We'll read the terminate_ flag within the lock below.
     bool terminate = false;

--- a/impeller/renderer/backend/vulkan/resource_manager_vk.cc
+++ b/impeller/renderer/backend/vulkan/resource_manager_vk.cc
@@ -39,9 +39,6 @@ void ResourceManagerVK::Start() {
   // ... so no FML_DCHECK here.
 
   fml::Thread::SetCurrentThreadName(fml::Thread::ThreadConfig{"IplrVkResMgr"});
-  // While this code calls destructors it doesn't need to be particularly fast
-  // with them, as long as it doesn't interrupt raster thread.
-  fml::RequestAffinity(fml::CpuAffinity::kEfficiency);
 
   bool should_exit = false;
   while (!should_exit) {

--- a/shell/platform/android/android_shell_holder.cc
+++ b/shell/platform/android/android_shell_holder.cc
@@ -42,21 +42,18 @@ static void AndroidPlatformThreadConfigSetter(
   // set thread priority
   switch (config.priority) {
     case fml::Thread::ThreadPriority::kBackground: {
-      fml::RequestAffinity(fml::CpuAffinity::kEfficiency);
       if (::setpriority(PRIO_PROCESS, 0, 10) != 0) {
         FML_LOG(ERROR) << "Failed to set IO task runner priority";
       }
       break;
     }
     case fml::Thread::ThreadPriority::kDisplay: {
-      fml::RequestAffinity(fml::CpuAffinity::kPerformance);
       if (::setpriority(PRIO_PROCESS, 0, -1) != 0) {
         FML_LOG(ERROR) << "Failed to set UI task runner priority";
       }
       break;
     }
     case fml::Thread::ThreadPriority::kRaster: {
-      fml::RequestAffinity(fml::CpuAffinity::kPerformance);
       // Android describes -8 as "most important display threads, for
       // compositing the screen and retrieving input events". Conservatively
       // set the raster thread to slightly lower priority than it.
@@ -70,7 +67,6 @@ static void AndroidPlatformThreadConfigSetter(
       break;
     }
     default:
-      fml::RequestAffinity(fml::CpuAffinity::kNotPerformance);
       if (::setpriority(PRIO_PROCESS, 0, 0) != 0) {
         FML_LOG(ERROR) << "Failed to set priority";
       }


### PR DESCRIPTION
the CPU affinity APIs are causing kernel panics in samsung devices, due to modifications of the linux kernel that were not well thought out.