### PR TITLE
[Flutter GPU] Upload `flutter_gpu.zip` upon successful completion of ci/android_debug.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -283,7 +283,10 @@ if (build_engine_artifacts) {
 group("dist") {
   testonly = true
 
-  deps = [ "//flutter/sky/dist" ]
+  deps = [
+    "//flutter/lib/gpu/dist",
+    "//flutter/sky/dist",
+  ]
 }
 
 if (is_fuchsia && enable_unittests) {

--- a/build/archives/BUILD.gn
+++ b/build/archives/BUILD.gn
@@ -88,10 +88,6 @@ if (build_engine_artifacts && !is_android) {
           destination = "shader_lib"
         },
         {
-          source = "//flutter/lib/gpu"
-          destination = "flutter_gpu"
-        },
-        {
           source = "$root_out_dir/${lib_prefix}path_ops$dll"
           destination = "${lib_prefix}path_ops$dll"
         },

--- a/ci/builders/linux_android_debug_engine.json
+++ b/ci/builders/linux_android_debug_engine.json
@@ -68,7 +68,8 @@
                         "out/ci/android_debug/zip_archives/android-arm/symbols.zip",
                         "out/ci/android_debug/zip_archives/download.flutter.io",
                         "out/ci/android_debug/zip_archives/sky_engine.zip",
-                        "out/ci/android_debug/zip_archives/android-javadoc.zip"
+                        "out/ci/android_debug/zip_archives/android-javadoc.zip",
+                        "out/ci/android_debug/zip_archives/flutter_gpu.zip"
                     ],
                     "realm": "production"
                 }
@@ -96,6 +97,7 @@
                 "targets": [
                     "flutter",
                     "flutter/sky/dist:zip_old_location",
+                    "flutter/lib/gpu/dist:zip_old_location",
                     "flutter/shell/platform/android:embedding_jars",
                     "flutter/shell/platform/android:abi_jars",
                     "flutter/shell/platform/android:robolectric_tests"

--- a/lib/gpu/dist/BUILD.gn
+++ b/lib/gpu/dist/BUILD.gn
@@ -1,0 +1,47 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//flutter/build/zip_bundle.gni")
+
+# Similar to `sky_engine`, zip up the `flutter_gpu` Dart package and upload
+# it to GCS for distribution. This is only done during Android builds on CI.
+#
+# Then, the Flutter tool downloads and extracts `flutter_gpu.zip` into the
+# package cache (`bin/cache/pkg`) during artifact initialization.
+#
+# Note that unlike with `sky_engine`, the `lib/gpu` directory is already a
+# complete Dart package. So no additional build steps are necessary beyond
+# zipping it up.
+
+if (is_android) {
+  zip_bundle("zip") {
+    output = "$android_zip_archive_dir/flutter_gpu.zip"
+    files = [
+      {
+        source = "//flutter/lib/gpu"
+        destination = "flutter_gpu"
+      },
+    ]
+    deps = []
+  }
+
+  zip_bundle("zip_old_location") {
+    # TODO: remove after we migrate the tool to use the new location.
+    # Bug: https://github.com/flutter/flutter/issues/105351
+    output = "flutter_gpu.zip"
+    files = [
+      {
+        source = "//flutter/lib/gpu"
+        destination = "flutter_gpu"
+      },
+    ]
+    deps = []
+  }
+}
+
+group("dist") {
+  if (is_android) {
+    deps = [ ":zip" ]
+  }
+}


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/131711.

Also, stops distributing `flutter_gpu` as part of the host artifacts, since it's not target-specific.

This enables us to use the same distribution mechanism as the `sky_engine` package.

Corresponding framework PR: https://github.com/flutter/flutter/pull/149299