### PR TITLE
Update format.dart to point to new google-java-format location

### DIFF
--- a/ci/bin/format.dart
+++ b/ci/bin/format.dart
@@ -475,6 +475,7 @@ class JavaFormatChecker extends FormatChecker {
       path.absolute(
         path.join(
           srcDir.absolute.path,
+          'flutter',
           'third_party',
           'android_tools',
           'google-java-format',


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/149319
Caused by https://github.com/flutter/engine/pull/52582

Follow up required to add a flag that fails on missing jar files instead of skipping missing jar files. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
