### PR TITLE
[fuchsia][sysmem2] move to sysmem2 protocols

### DIFF
--- a/shell/platform/fuchsia/flutter/software_surface.h
+++ b/shell/platform/fuchsia/flutter/software_surface.h
@@ -5,7 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_FLUTTER_SOFTWARE_SURFACE_H_
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_FLUTTER_SOFTWARE_SURFACE_H_
 
-#include <fuchsia/sysmem/cpp/fidl.h>
+#include <fuchsia/sysmem2/cpp/fidl.h>
 #include <fuchsia/ui/composition/cpp/fidl.h>
 #include <lib/async/cpp/wait.h>
 #include <lib/zx/event.h>
@@ -25,7 +25,7 @@ namespace flutter_runner {
 
 class SoftwareSurface final : public SurfaceProducerSurface {
  public:
-  SoftwareSurface(fuchsia::sysmem::AllocatorSyncPtr& sysmem_allocator,
+  SoftwareSurface(fuchsia::sysmem2::AllocatorSyncPtr& sysmem_allocator,
                   fuchsia::ui::composition::AllocatorPtr& flatland_allocator,
                   const SkISize& size);
 
@@ -79,7 +79,7 @@ class SoftwareSurface final : public SurfaceProducerSurface {
                              const zx_packet_signal_t* signal);
 
   bool SetupSkiaSurface(
-      fuchsia::sysmem::AllocatorSyncPtr& sysmem_allocator,
+      fuchsia::sysmem2::AllocatorSyncPtr& sysmem_allocator,
       fuchsia::ui::composition::AllocatorPtr& flatland_allocator,
       const SkISize& size);
 

--- a/shell/platform/fuchsia/flutter/software_surface_producer.cc
+++ b/shell/platform/fuchsia/flutter/software_surface_producer.cc
@@ -49,10 +49,12 @@ zx_koid_t GetCurrentProcessId() {
 
 SoftwareSurfaceProducer::SoftwareSurfaceProducer() {
   zx_status_t status = fdio_service_connect(
-      "/svc/fuchsia.sysmem.Allocator",
+      "/svc/fuchsia.sysmem2.Allocator",
       sysmem_allocator_.NewRequest().TakeChannel().release());
-  sysmem_allocator_->SetDebugClientInfo(GetCurrentProcessName(),
-                                        GetCurrentProcessId());
+  sysmem_allocator_->SetDebugClientInfo(
+      std::move(fuchsia::sysmem2::AllocatorSetDebugClientInfoRequest{}
+                    .set_name(GetCurrentProcessName())
+                    .set_id(GetCurrentProcessId())));
   FML_DCHECK(status == ZX_OK);
 
   status = fdio_service_connect(

--- a/shell/platform/fuchsia/flutter/software_surface_producer.h
+++ b/shell/platform/fuchsia/flutter/software_surface_producer.h
@@ -5,7 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_FLUTTER_SOFTWARE_SURFACE_PRODUCER_H_
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_FLUTTER_SOFTWARE_SURFACE_PRODUCER_H_
 
-#include <fuchsia/sysmem/cpp/fidl.h>
+#include <fuchsia/sysmem2/cpp/fidl.h>
 #include <fuchsia/ui/composition/cpp/fidl.h>
 
 #include <unordered_map>
@@ -54,7 +54,7 @@ class SoftwareSurfaceProducer final : public SurfaceProducer {
 
   void TraceStats();
 
-  fuchsia::sysmem::AllocatorSyncPtr sysmem_allocator_;
+  fuchsia::sysmem2::AllocatorSyncPtr sysmem_allocator_;
   fuchsia::ui::composition::AllocatorPtr flatland_allocator_;
 
   // These surfaces are available for re-use.

--- a/shell/platform/fuchsia/flutter/surface_producer.h
+++ b/shell/platform/fuchsia/flutter/surface_producer.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_FLUTTER_SURFACE_PRODUCER_H_
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_FLUTTER_SURFACE_PRODUCER_H_
 
+#include <fuchsia/sysmem2/cpp/fidl.h>
 #include <fuchsia/ui/composition/cpp/fidl.h>
 #include <lib/zx/event.h>
 

--- a/shell/platform/fuchsia/flutter/tests/integration/embedder/flutter-embedder-test.cc
+++ b/shell/platform/fuchsia/flutter/tests/integration/embedder/flutter-embedder-test.cc
@@ -237,11 +237,7 @@ void FlutterEmbedderTest::SetUpRealmBase() {
                     Protocol{fuchsia::logger::LogSink::Name_},
                     Protocol{fuchsia::inspect::InspectSink::Name_},
                     Protocol{fuchsia::sysmem::Allocator::Name_},
-
-                    // Replace "fuchsia.sysmem2.Allocator" with
-                    // fuchsia::sysmem2::Allocator::Name_
-                    // when available (fuchsia SDK >= 19).
-                    Protocol{"fuchsia.sysmem2.Allocator"},
+                    Protocol{fuchsia::sysmem2::Allocator::Name_},
                     Protocol{fuchsia::tracing::provider::Registry::Name_},
                     Protocol{kVulkanLoaderServiceName},
                 },
@@ -254,11 +250,7 @@ void FlutterEmbedderTest::SetUpRealmBase() {
       .capabilities = {Protocol{fuchsia::logger::LogSink::Name_},
                        Protocol{fuchsia::inspect::InspectSink::Name_},
                        Protocol{fuchsia::sysmem::Allocator::Name_},
-
-                       // Replace "fuchsia.sysmem2.Allocator" with
-                       // fuchsia::sysmem2::Allocator::Name_
-                       // when available (fuchsia SDK >= 19).
-                       Protocol{"fuchsia.sysmem2.Allocator"},
+                       Protocol{fuchsia::sysmem2::Allocator::Name_},
                        Protocol{fuchsia::tracing::provider::Registry::Name_},
                        Protocol{kVulkanLoaderServiceName}},
       .source = ParentRef{},

--- a/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.cc
+++ b/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.cc
@@ -82,11 +82,7 @@ void PortableUITest::SetUpRealmBase() {
       .capabilities = {Protocol{fuchsia::logger::LogSink::Name_},
                        Protocol{fuchsia::inspect::InspectSink::Name_},
                        Protocol{fuchsia::sysmem::Allocator::Name_},
-
-                       // Replace string with
-                       // fuchsia::sysmem2::Allocator::Name_
-                       // when available (fuchsia SDK >= 19).
-                       Protocol{"fuchsia.sysmem2.Allocator"},
+                       Protocol{fuchsia::sysmem2::Allocator::Name_},
                        Protocol{fuchsia::tracing::provider::Registry::Name_},
                        Protocol{fuchsia::ui::input::ImeService::Name_},
                        Protocol{kPosixSocketProviderName},

--- a/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.h
+++ b/shell/platform/fuchsia/flutter/tests/integration/utils/portable_ui_test.h
@@ -5,7 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_FLUTTER_TESTS_INTEGRATION_UTILS_PORTABLE_UI_TEST_H_
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_FLUTTER_TESTS_INTEGRATION_UTILS_PORTABLE_UI_TEST_H_
 
-#include <fuchsia/sysmem/cpp/fidl.h>
+#include <fuchsia/sysmem2/cpp/fidl.h>
 #include <fuchsia/ui/app/cpp/fidl.h>
 #include <fuchsia/ui/composition/cpp/fidl.h>
 #include <fuchsia/ui/display/singleton/cpp/fidl.h>

--- a/shell/platform/fuchsia/flutter/vulkan_surface.h
+++ b/shell/platform/fuchsia/flutter/vulkan_surface.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_FLUTTER_VULKAN_SURFACE_H_
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_FLUTTER_VULKAN_SURFACE_H_
 
+#include <fuchsia/sysmem2/cpp/fidl.h>
 #include <lib/async/cpp/wait.h>
 #include <lib/zx/event.h>
 #include <lib/zx/vmo.h>
@@ -44,7 +45,7 @@ struct VulkanImage {
 class VulkanSurface final : public SurfaceProducerSurface {
  public:
   VulkanSurface(vulkan::VulkanProvider& vulkan_provider,
-                fuchsia::sysmem::AllocatorSyncPtr& sysmem_allocator,
+                fuchsia::sysmem2::AllocatorSyncPtr& sysmem_allocator,
                 fuchsia::ui::composition::AllocatorPtr& flatland_allocator,
                 sk_sp<GrDirectContext> context,
                 const SkISize& size);
@@ -135,7 +136,7 @@ class VulkanSurface final : public SurfaceProducerSurface {
                      const zx_packet_signal_t* signal);
 
   bool AllocateDeviceMemory(
-      fuchsia::sysmem::AllocatorSyncPtr& sysmem_allocator,
+      fuchsia::sysmem2::AllocatorSyncPtr& sysmem_allocator,
       fuchsia::ui::composition::AllocatorPtr& flatland_allocator,
       sk_sp<GrDirectContext> context,
       const SkISize& size);

--- a/shell/platform/fuchsia/flutter/vulkan_surface_pool.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_pool.cc
@@ -35,10 +35,12 @@ VulkanSurfacePool::VulkanSurfacePool(vulkan::VulkanProvider& vulkan_provider,
   FML_CHECK(context_ != nullptr);
 
   zx_status_t status = fdio_service_connect(
-      "/svc/fuchsia.sysmem.Allocator",
+      "/svc/fuchsia.sysmem2.Allocator",
       sysmem_allocator_.NewRequest().TakeChannel().release());
-  sysmem_allocator_->SetDebugClientInfo(GetCurrentProcessName(),
-                                        GetCurrentProcessId());
+  sysmem_allocator_->SetDebugClientInfo(
+      std::move(fuchsia::sysmem2::AllocatorSetDebugClientInfoRequest{}
+                    .set_name(GetCurrentProcessName())
+                    .set_id(GetCurrentProcessId())));
   FML_DCHECK(status == ZX_OK);
 
   status = fdio_service_connect(

--- a/shell/platform/fuchsia/flutter/vulkan_surface_pool.h
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_pool.h
@@ -42,7 +42,7 @@ class VulkanSurfacePool final {
  private:
   vulkan::VulkanProvider& vulkan_provider_;
   sk_sp<GrDirectContext> context_;
-  fuchsia::sysmem::AllocatorSyncPtr sysmem_allocator_;
+  fuchsia::sysmem2::AllocatorSyncPtr sysmem_allocator_;
   fuchsia::ui::composition::AllocatorPtr flatland_allocator_;
   std::vector<std::unique_ptr<VulkanSurface>> available_surfaces_;
   std::unordered_map<uintptr_t, std::unique_ptr<VulkanSurface>>


### PR DESCRIPTION
Switch flutter from sysmem(1) protocols to sysmem2 protocols.

This is part of the overall sysmem(1) to sysmem2 migration.

fixes flutter/flutter#151154