### PR TITLE
[display_list] allow applying opacity peephole to single glyph.

### DIFF
--- a/display_list/BUILD.gn
+++ b/display_list/BUILD.gn
@@ -131,6 +131,7 @@ if (enable_unittests) {
       ":display_list",
       ":display_list_fixtures",
       "//flutter/display_list/testing:display_list_testing",
+      "//flutter/impeller/typographer/backends/skia:typographer_skia_backend",
       "//flutter/testing",
       "//flutter/testing:skia",
     ]

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -4333,12 +4333,6 @@ TEST_F(DisplayListTest, DrawDisplayListForwardsBackdropFlag) {
 }
 
 TEST_F(DisplayListTest, TextFrameOpacityPeephole) {
-  // TODO(https://github.com/flutter/flutter/issues/82202): Remove once the
-  // performance overlay can use Fuchsia's font manager instead of the empty
-  // default.
-#if defined(OS_FUCHSIA) || !defined(IMPELLER_SUPPORTS_RENDERING)
-  GTEST_SKIP() << "Rendering comparisons require a valid default font manager";
-#else
   // Single character can have opacity peephole applied.
   {
     std::string message = "A";
@@ -4361,7 +4355,6 @@ TEST_F(DisplayListTest, TextFrameOpacityPeephole) {
     auto dl = builder.Build();
     EXPECT_FALSE(dl->can_apply_group_opacity());
   }
-#endif  // defined(OS_FUCHSIA) || !defined(IMPELLER_SUPPORTS_RENDERING)
 }
 
 }  // namespace testing

--- a/display_list/dl_builder.cc
+++ b/display_list/dl_builder.cc
@@ -1698,7 +1698,11 @@ void DisplayListBuilder::drawTextFrame(
     // they will protect overlapping glyphs from the effects of overdraw
     // so we must make the conservative assessment that this DL layer is
     // not compatible with group opacity inheritance.
-    UpdateLayerOpacityCompatibility(false);
+    // A single glyph can still have the opacity peephole applied (this is
+    // likely a glyph used as an Icon)
+    const bool is_single_glyph = text_frame->GetRunCount() == 1u &&
+                                 text_frame->GetRuns()[0].GetGlyphCount() == 1u;
+    UpdateLayerOpacityCompatibility(is_single_glyph);
     UpdateLayerResult(result);
   }
 }

--- a/display_list/testing/dl_test_snippets.cc
+++ b/display_list/testing/dl_test_snippets.cc
@@ -980,5 +980,12 @@ sk_sp<SkTextBlob> GetTestTextBlob(int index) {
   return blob;
 }
 
+sk_sp<SkTextBlob> CreateTextBlob(std::string& message) {
+  sk_sp<SkTextBlob> blob =
+      SkTextBlob::MakeFromText(message.c_str(), message.size(),
+                               CreateTestFontOfSize(20), SkTextEncoding::kUTF8);
+  return blob;
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/display_list/testing/dl_test_snippets.h
+++ b/display_list/testing/dl_test_snippets.h
@@ -227,6 +227,8 @@ SkFont CreateTestFontOfSize(SkScalar scalar);
 
 sk_sp<SkTextBlob> GetTestTextBlob(int index);
 
+sk_sp<SkTextBlob> CreateTextBlob(std::string& message);
+
 struct DisplayListInvocation {
   // ----------------------------------
   // Required fields for initialization


### PR DESCRIPTION
A single glyph can be opacity peepholed, this is common in the case of Icons.