### PR TITLE
[Impeller] correctly map DL non-mipmap sample mode to non-mipmap sample mode.

### DIFF
--- a/impeller/core/sampler_descriptor.h
+++ b/impeller/core/sampler_descriptor.h
@@ -15,12 +15,7 @@ class Context;
 struct SamplerDescriptor final : public Comparable<SamplerDescriptor> {
   MinMagFilter min_filter = MinMagFilter::kNearest;
   MinMagFilter mag_filter = MinMagFilter::kNearest;
-
-  // TODO(https://github.com/flutter/flutter/issues/148253):
-  // `MipFilter::kNearest` is the default value for mip filters, as it
-  // cooresponds with the framework's `FilterQuality.low`. If we ever change the
-  // default filter quality, we should update this function to match.
-  MipFilter mip_filter = MipFilter::kNearest;
+  MipFilter mip_filter = MipFilter::kBase;
 
   SamplerAddressMode width_address_mode = SamplerAddressMode::kClampToEdge;
   SamplerAddressMode height_address_mode = SamplerAddressMode::kClampToEdge;

--- a/impeller/core/sampler_descriptor.h
+++ b/impeller/core/sampler_descriptor.h
@@ -15,7 +15,7 @@ class Context;
 struct SamplerDescriptor final : public Comparable<SamplerDescriptor> {
   MinMagFilter min_filter = MinMagFilter::kNearest;
   MinMagFilter mag_filter = MinMagFilter::kNearest;
-  MipFilter mip_filter = MipFilter::kBase;
+  MipFilter mip_filter = MipFilter::kNearest;
 
   SamplerAddressMode width_address_mode = SamplerAddressMode::kClampToEdge;
   SamplerAddressMode height_address_mode = SamplerAddressMode::kClampToEdge;

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -123,12 +123,11 @@ static impeller::SamplerDescriptor ToSamplerDescriptor(
       desc.label = "Nearest Sampler";
       break;
     case flutter::DlImageSampling::kLinear:
-    // Impeller doesn't support cubic sampling, but linear is closer to correct
-    // than nearest for this case.
-    case flutter::DlImageSampling::kCubic:
       desc.min_filter = desc.mag_filter = impeller::MinMagFilter::kLinear;
+      desc.mip_filter = impeller::MipFilter::kBase;
       desc.label = "Linear Sampler";
       break;
+    case flutter::DlImageSampling::kCubic:
     case flutter::DlImageSampling::kMipmapLinear:
       desc.min_filter = desc.mag_filter = impeller::MinMagFilter::kLinear;
       desc.mip_filter = impeller::MipFilter::kLinear;


### PR DESCRIPTION
Match DL/Skia sampling defaults. This does not change the default SamplerDescriptor value, but that is irrelevant as any draws from the framework will pass through DL conversion.

The SamplerDescriptor default of nearest is generally a good idea.

Fixes https://github.com/flutter/flutter/issues/148253 