### PR TITLE
Delete impeller_golden_tests from beta RC branch

### DIFF
--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -440,7 +440,6 @@
                     "flutter/build/archives:archive_gen_snapshot",
                     "flutter/build/archives:artifacts",
                     "flutter/build/dart:copy_dart_sdk",
-                    "flutter/impeller/golden_tests:impeller_golden_tests",
                     "flutter/shell/platform/darwin/macos:zip_macos_flutter_framework",
                     "flutter/tools/font_subset"
                 ]


### PR DESCRIPTION
In the previous build ([pr](https://github.com/flutter/engine/pull/53148) [build](https://ci.chromium.org/ui/p/dart-internal/builders/flutter/Mac%20Production%20Engine%20Drone/12733/infra)), the impeller golden tests failed (maybe because they were testing against the main branch goldens?), and thus mac release arm64 binaries were never uploaded.

This PR deletes the target from the ci/builders/*.json file so that we can successfully build and upload mac binaries.