### PR TITLE
[flutter_releases] beta 3.23 release engine - actually delete impeller tests

### DIFF
--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -238,7 +238,20 @@
                 "$flutter/osx_sdk": {
                     "sdk_version": "15a240d"
                 }
-            }
+            },
+            "tests": [
+                {
+                    "language": "python3",
+                    "name": "Impeller-golden, dart and engine tests for host_release",
+                    "script": "flutter/testing/run_tests.py",
+                    "parameters": [
+                        "--variant",
+                        "ci/host_release",
+                        "--type",
+                        "dart,dart-host,engine"
+                    ]
+                }
+            ]
         },
         {
             "archives": [

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -238,20 +238,7 @@
                 "$flutter/osx_sdk": {
                     "sdk_version": "15a240d"
                 }
-            },
-            "tests": [
-                {
-                    "language": "python3",
-                    "name": "Impeller-golden, dart and engine tests for host_release",
-                    "script": "flutter/testing/run_tests.py",
-                    "parameters": [
-                        "--variant",
-                        "ci/host_release",
-                        "--type",
-                        "dart,dart-host,engine"
-                    ]
-                }
-            ]
+            }
         },
         {
             "archives": [
@@ -464,20 +451,7 @@
                 "$flutter/osx_sdk": {
                     "sdk_version": "15a240d"
                 }
-            },
-            "tests": [
-                {
-                    "language": "python3",
-                    "name": "Impeller-golden for host_release",
-                    "script": "flutter/testing/run_tests.py",
-                    "parameters": [
-                        "--variant",
-                        "ci/mac_release_arm64",
-                        "--type",
-                        "impeller-golden"
-                    ]
-                }
-            ]
+            }
         }
     ],
     "generators": {


### PR DESCRIPTION
This is a follow up to https://github.com/flutter/engine/pull/53163, where I deleted the ninja target to build the golden tests, however I forgot to delete the commands to actually run the tests. In post-submit, the tests ran again and failed: https://ci.chromium.org/ui/p/dart-internal/builders/flutter/Mac%20Production%20Engine%20Drone/12733/infra

This PR actually deletes the scripts to run the tests.