### PR TITLE
[icu] Manual roll of icu

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -307,7 +307,7 @@ deps = {
    Var('chromium_git') + '/external/github.com/google/flatbuffers' + '@' + '0a80646371179f8a7a5c1f42c31ee1d44dcf6709',
 
   'src/flutter/third_party/icu':
-   Var('chromium_git') + '/chromium/deps/icu.git' + '@' + 'bad7ddbf921358177e56fd723c2f59f8041a370f',
+   Var('chromium_git') + '/chromium/deps/icu.git' + '@' + '98f2494518c2dbb9c488e83e507b070ea5910e95',
 
    'src/flutter/third_party/gtest-parallel':
    Var('chromium_git') + '/external/github.com/google/gtest-parallel' + '@' + '38191e2733d7cbaeaef6a3f1a942ddeb38a2ad14',

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: b3ce02b496b8b284656eb974794a7b65
+Signature: 44921bea6071222d521ad8c486a1bd58
 

--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -461,14 +461,14 @@ class _RepositoryIcuLicenseFile extends _RepositorySingleLicenseFile {
   _RepositoryIcuLicenseFile._(_RepositoryDirectory parent, fs.TextFile io, this.template, License license)
     : super(parent, io, license);
 
+  // Every paragraph of the license is mentioned. All newlines are disregarded [\n+].
   static final RegExp _pattern = RegExp(
-    r'^(UNICODE, INC\. LICENSE AGREEMENT - DATA FILES AND SOFTWARE\n+' // group
-    r'See Terms of Use (?:.|\n)+?'
-    r'COPYRIGHT AND PERMISSION NOTICE\n+'
-    r'Copyright.+\n'
-    r'Distributed under the Terms of Use in .+\n+'
+    // Starting from ICU 74.1 this has been changed to Unicode License V3.
+    r'^(UNICODE LICENSE V3\n+' // group
+    r'COPYRIGHT AND PERMISSION NOTICE(?:.|\n)+?'
     r')(Permission is hereby granted(?:.|\n)+?)' // template group
     r'\n+-+\n+'
+    // From here onwards should be the same as before 74.1
     r'(Third-Party Software Licenses\n+' // group
     r'This section contains third-party software notices and/or additional\n'
     r'terms for licensed third-party software components included within ICU\n'

--- a/tools/licenses/lib/patterns.dart
+++ b/tools/licenses/lib/patterns.dart
@@ -61,6 +61,11 @@ final RegExp copyrightMentionOkPattern = RegExp(
      r'|const char inflate_copyright\[\] =\n *" inflate 1\.2\.11 Copyright 1995-2017 Mark Adler ";' // found in some freetype files
      r'|" Copyright \(C\) 2016 and later: Unicode, Inc\. and others\. License & terms of use: http://www\.unicode\.org/copyright\.html "'
      r'|"\* / \\\\& ⁊ # % † ‡ ‧ ° © ® ™]"'
+     // It is very likely for copyright-like chars to appear in Unicode
+     // data files in contexts unrelated to copyright.
+     // Imagine that, who would have thought!
+     //                      v--- this one.
+     r'|"\\\\& ⁊ # % † ‡ ‧ ° © ® ™]"'
      r'|" \*   Copyright \(C\) International Business Machines\n"'
      r'|fprintf\(out, "// Copyright \(C\) 2016 and later: Unicode, Inc\. and others\.\\n"\);'
      r'|fprintf\(out, "// License & terms of use: http://www\.unicode\.org/copyright\.html\\n\\n"\);'


### PR DESCRIPTION
Manual roll of the ICU library. This normally happens automatically, but this
time around, ICU folks changed their license, so that needs to be fixed up.
I wish they would stop doing that. :)

This manual change should enable us to turn the auto-roller back on.

https://github.com/flutter/flutter/issues/149684

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
