### PR TITLE
[CP][Impeller] Round out subpass coverage. (#52973)

### DIFF
--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -735,6 +735,22 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
       // right thing.
       return EntityPass::EntityResult::Failure();
     }
+
+    // Round the subpass texture position for pixel alignment with the parent
+    // pass render target. By default, we draw subpass textures with nearest
+    // sampling, so aligning here is important for avoiding visual nearest
+    // sampling errors caused by limited floating point precision when
+    // straddling a half pixel boundary.
+    //
+    // We do this in lieu of expanding/rounding out the subpass coverage in
+    // order to keep the bounds wrapping consistently tight around subpass
+    // elements. Which is necessary to avoid intense flickering in cases
+    // where a subpass texture has a large blur filter with clamp sampling.
+    //
+    // See also this bug: https://github.com/flutter/flutter/issues/144213
+    Point subpass_texture_position =
+        (subpass_coverage->GetOrigin() - global_pass_position).Round();
+
     Entity element_entity;
     Capture subpass_texture_capture =
         capture.CreateChild("Entity (Subpass texture)");
@@ -743,10 +759,8 @@ EntityPass::EntityResult EntityPass::GetEntityForElement(
     element_entity.SetContents(std::move(offscreen_texture_contents));
     element_entity.SetClipDepth(subpass->clip_depth_);
     element_entity.SetBlendMode(subpass->blend_mode_);
-    element_entity.SetTransform(subpass_texture_capture.AddMatrix(
-        "Transform",
-        Matrix::MakeTranslation(
-            Vector3(subpass_coverage->GetOrigin() - global_pass_position))));
+    element_entity.SetTransform(
+        Matrix::MakeTranslation(Vector3(subpass_texture_position)));
 
     return EntityPass::EntityResult::Success(std::move(element_entity));
   }


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/146967

I added a detailed comment inline explaining why we need this. The visual issues in the reported issue were due to nearest sampling while straddling a half pixel offset.

Before:
![image](https://github.com/flutter/engine/assets/919017/ccd89a87-4643-4e4d-9e24-56f28f317e2f)

After:
<img width="964" alt="image" src="https://github.com/flutter/engine/assets/919017/0be88453-1014-443b-bc80-6df459adb075">

