### PR TITLE
[CP][Impeller] relax conditions for SkRRect.isSimple conversion to impell…

### DIFF
--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -814,8 +814,8 @@ void DlDispatcher::drawCircle(const SkPoint& center, SkScalar radius) {
 }
 
 // |flutter::DlOpReceiver|
-void DlDispatcher::drawRRect(const SkRRect& rrect) {
-  if (rrect.isSimple()) {
+void DlDispatcherBase::drawRRect(const SkRRect& rrect) {
+  if (skia_conversions::IsNearlySimpleRRect(rrect)) {
     canvas_.DrawRRect(skia_conversions::ToRect(rrect.rect()),
                       skia_conversions::ToSize(rrect.getSimpleRadii()), paint_);
   } else {

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -814,7 +814,7 @@ void DlDispatcher::drawCircle(const SkPoint& center, SkScalar radius) {
 }
 
 // |flutter::DlOpReceiver|
-void DlDispatcherBase::drawRRect(const SkRRect& rrect) {
+void DlDispatcher::drawRRect(const SkRRect& rrect) {
   if (skia_conversions::IsNearlySimpleRRect(rrect)) {
     canvas_.DrawRRect(skia_conversions::ToRect(rrect.rect()),
                       skia_conversions::ToSize(rrect.getSimpleRadii()), paint_);

--- a/impeller/display_list/skia_conversions.cc
+++ b/impeller/display_list/skia_conversions.cc
@@ -9,6 +9,20 @@
 namespace impeller {
 namespace skia_conversions {
 
+bool IsNearlySimpleRRect(const SkRRect& rr) {
+  auto [a, b] = rr.radii(SkRRect::kUpperLeft_Corner);
+  auto [c, d] = rr.radii(SkRRect::kLowerLeft_Corner);
+  auto [e, f] = rr.radii(SkRRect::kUpperRight_Corner);
+  auto [g, h] = rr.radii(SkRRect::kLowerRight_Corner);
+  return SkScalarNearlyEqual(a, b, kEhCloseEnough) &&
+         SkScalarNearlyEqual(a, c, kEhCloseEnough) &&
+         SkScalarNearlyEqual(a, d, kEhCloseEnough) &&
+         SkScalarNearlyEqual(a, e, kEhCloseEnough) &&
+         SkScalarNearlyEqual(a, f, kEhCloseEnough) &&
+         SkScalarNearlyEqual(a, g, kEhCloseEnough) &&
+         SkScalarNearlyEqual(a, h, kEhCloseEnough);
+}
+
 Rect ToRect(const SkRect& rect) {
   return Rect::MakeLTRB(rect.fLeft, rect.fTop, rect.fRight, rect.fBottom);
 }

--- a/impeller/display_list/skia_conversions.h
+++ b/impeller/display_list/skia_conversions.h
@@ -24,6 +24,13 @@
 namespace impeller {
 namespace skia_conversions {
 
+/// @brief Like SkRRect.isSimple, but allows the corners to differ by
+///        kEhCloseEnough.
+///
+///        An RRect is simple if all corner radii are approximately
+///        equal.
+bool IsNearlySimpleRRect(const SkRRect& rr);
+
 Rect ToRect(const SkRect& rect);
 
 std::optional<Rect> ToRect(const SkRect* rect);

--- a/impeller/display_list/skia_conversions_unittests.cc
+++ b/impeller/display_list/skia_conversions_unittests.cc
@@ -7,6 +7,7 @@
 #include "flutter/testing/testing.h"
 #include "impeller/display_list/skia_conversions.h"
 #include "impeller/geometry/scalar.h"
+#include "include/core/SkRRect.h"
 
 namespace impeller {
 namespace testing {
@@ -172,6 +173,15 @@ TEST(SkiaConversionsTest, GradientConversionNonMonotonic) {
   ASSERT_TRUE(ScalarNearlyEqual(converted_stops[1], 0.5f));
   ASSERT_TRUE(ScalarNearlyEqual(converted_stops[2], 0.5f));
   ASSERT_TRUE(ScalarNearlyEqual(converted_stops[3], 1.0f));
+}
+
+TEST(SkiaConversionsTest, IsNearlySimpleRRect) {
+  EXPECT_TRUE(skia_conversions::IsNearlySimpleRRect(
+      SkRRect::MakeRectXY(SkRect::MakeLTRB(0, 0, 10, 10), 10, 10)));
+  EXPECT_TRUE(skia_conversions::IsNearlySimpleRRect(
+      SkRRect::MakeRectXY(SkRect::MakeLTRB(0, 0, 10, 10), 10, 9.999)));
+  EXPECT_FALSE(skia_conversions::IsNearlySimpleRRect(
+      SkRRect::MakeRectXY(SkRect::MakeLTRB(0, 0, 10, 10), 10, 9)));
 }
 
 }  // namespace testing


### PR DESCRIPTION
…er::RRect. (#53083)

The flickering in https://github.com/flutter/flutter/issues/148412 is caused by us switching between the RRect fast path and a gaussian blur. The reason is that the SkRect.isSimple check doesn't handle fp precision very well. On one of the frames the difference was :

```
D/skia (18362): SkRect::MakeLTRB(74, 179.666672f, 374, 479.666656f);
D/skia (18362): const SkPoint corners[] = {
D/skia (18362): { 150, 149.999969f },
D/skia (18362): { 150, 150 },
D/skia (18362): { 150, 149.999969f },
D/skia (18362): { 150, 150 },
D/skia (18362): };
```

So lets used a relaxed check for RRect.isSimple instead.

Fixes https://github.com/flutter/flutter/issues/148412
