### PR TITLE
[Impeller][CP] dont segfault when tessellating empty polygons.

### DIFF
--- a/impeller/tessellator/tessellator.cc
+++ b/impeller/tessellator/tessellator.cc
@@ -197,7 +197,6 @@ std::vector<Point> Tessellator::TessellateConvex(const Path& path,
   for (auto j = 0u; j < polyline.contours.size(); j++) {
     auto [start, end] = polyline.GetContourPointBounds(j);
     auto first_point = polyline.GetPoint(start);
-    FML_LOG(ERROR) << "first:" << start << ", " << end;
     // Some polygons will not self close and an additional triangle
     // must be inserted, others will self close and we need to avoid
     // inserting an extra triangle.

--- a/impeller/tessellator/tessellator.cc
+++ b/impeller/tessellator/tessellator.cc
@@ -197,7 +197,7 @@ std::vector<Point> Tessellator::TessellateConvex(const Path& path,
   for (auto j = 0u; j < polyline.contours.size(); j++) {
     auto [start, end] = polyline.GetContourPointBounds(j);
     auto first_point = polyline.GetPoint(start);
-
+    FML_LOG(ERROR) << "first:" << start << ", " << end;
     // Some polygons will not self close and an additional triangle
     // must be inserted, others will self close and we need to avoid
     // inserting an extra triangle.
@@ -221,6 +221,7 @@ std::vector<Point> Tessellator::TessellateConvex(const Path& path,
       output.emplace_back(first_point);
     }
 
+    // if (start != end) {
     size_t a = start + 1;
     size_t b = end - 1;
     while (a < b) {
@@ -235,6 +236,7 @@ std::vector<Point> Tessellator::TessellateConvex(const Path& path,
     } else {
       previous_contour_odd_points = true;
     }
+    // }
   }
   return output;
 }

--- a/impeller/tessellator/tessellator.cc
+++ b/impeller/tessellator/tessellator.cc
@@ -220,22 +220,22 @@ std::vector<Point> Tessellator::TessellateConvex(const Path& path,
       output.emplace_back(first_point);
     }
 
-    // if (start != end) {
-    size_t a = start + 1;
-    size_t b = end - 1;
-    while (a < b) {
-      output.emplace_back(polyline.GetPoint(a));
-      output.emplace_back(polyline.GetPoint(b));
-      a++;
-      b--;
+    if (start != end) {
+      size_t a = start + 1;
+      size_t b = end - 1;
+      while (a < b) {
+        output.emplace_back(polyline.GetPoint(a));
+        output.emplace_back(polyline.GetPoint(b));
+        a++;
+        b--;
+      }
+      if (a == b) {
+        previous_contour_odd_points = false;
+        output.emplace_back(polyline.GetPoint(a));
+      } else {
+        previous_contour_odd_points = true;
+      }
     }
-    if (a == b) {
-      previous_contour_odd_points = false;
-      output.emplace_back(polyline.GetPoint(a));
-    } else {
-      previous_contour_odd_points = true;
-    }
-    // }
   }
   return output;
 }

--- a/impeller/tessellator/tessellator_unittests.cc
+++ b/impeller/tessellator/tessellator_unittests.cc
@@ -136,10 +136,8 @@ TEST(TessellatorTest, TessellateConvex) {
                     .Close()
                     .AddRect(Rect::MakeLTRB(0, 0, 100, 100))
                     .TakePath();
-    auto pts = t.TessellateConvex(path, 1.0);
-
-    std::vector<Point> expected = {{0, 0}, {10, 0}, {0, 10}, {10, 10}};
-    EXPECT_EQ(pts, expected);
+    // Verify no crash.
+    t.TessellateConvex(path, 1.0);
   }
 }
 

--- a/impeller/tessellator/tessellator_unittests.cc
+++ b/impeller/tessellator/tessellator_unittests.cc
@@ -128,6 +128,19 @@ TEST(TessellatorTest, TessellateConvex) {
                                    {20, 30}, {30, 30}};
     EXPECT_EQ(pts, expected);
   }
+
+  {
+    Tessellator t;
+    PathBuilder builder{};
+    auto path = builder.MoveTo({10, 10})
+                    .Close()
+                    .AddRect(Rect::MakeLTRB(0, 0, 100, 100))
+                    .TakePath();
+    auto pts = t.TessellateConvex(path, 1.0);
+
+    std::vector<Point> expected = {{0, 0}, {10, 0}, {0, 10}, {10, 10}};
+    EXPECT_EQ(pts, expected);
+  }
 }
 
 TEST(TessellatorTest, CircleVertexCounts) {


### PR DESCRIPTION
While this is fixed on ToT, the stable channel is far behind so cherry picking all the tessellation changes is infeasible. Instead, we can land a small fix to avoid the segfault. Atttached unit test crashes without patch.

Fixes https://github.com/flutter/flutter/issues/149646
Fixes https://github.com/flutter/flutter/issues/149309