### PR TITLE
[web] enable always_specify_types for web_ui

### DIFF
--- a/lib/web_ui/analysis_options.yaml
+++ b/lib/web_ui/analysis_options.yaml
@@ -8,6 +8,7 @@ include: ../../analysis_options.yaml
 
 linter:
   rules:
+    always_specify_types: true # avoid_dynamic_calls needs to be cleaned up before we can start relying on type inference
     avoid_dynamic_calls: false
     avoid_print: false
     avoid_setters_without_getters: false


### PR DESCRIPTION
`always_specify_types: false` and `avoid_dynamic_calls: false` is a dangerous combination. Let's clean up `avoid_dynamic_calls` before disabling `always_specify_types`.