### PR TITLE
[Impeller] fix emojis with non-solid color sources.

### DIFF
--- a/third_party/txt/BUILD.gn
+++ b/third_party/txt/BUILD.gn
@@ -124,7 +124,7 @@ if (enable_unittests) {
   test_fixtures("txt_fixtures") {
     fixtures = [
       "third_party/fonts/Roboto-Regular.ttf",
-      "//flutter/third_party/txt/third_party/fonts/NotoColorEmoji.ttf",
+      "third_party/fonts/NotoColorEmoji.ttf",
     ]
 
     if (host_os == "mac") {

--- a/third_party/txt/BUILD.gn
+++ b/third_party/txt/BUILD.gn
@@ -122,7 +122,10 @@ source_set("txt") {
 
 if (enable_unittests) {
   test_fixtures("txt_fixtures") {
-    fixtures = [ "third_party/fonts/Roboto-Regular.ttf", "//flutter/third_party/txt/third_party/fonts/NotoColorEmoji.ttf", ]
+    fixtures = [
+      "third_party/fonts/Roboto-Regular.ttf",
+      "//flutter/third_party/txt/third_party/fonts/NotoColorEmoji.ttf",
+    ]
 
     if (host_os == "mac") {
       fixtures += [ "/System/Library/Fonts/Apple Color Emoji.ttc" ]
@@ -180,8 +183,7 @@ if (enable_unittests) {
     # This is needed for //flutter/third_party/googletest for linking zircon
     # symbols.
     if (is_fuchsia) {
-      libs =
-          [ "${fuchsia_arch_root}/sysroot/lib/libzircon.so" ]
+      libs = [ "${fuchsia_arch_root}/sysroot/lib/libzircon.so" ]
     }
   }
 }

--- a/third_party/txt/BUILD.gn
+++ b/third_party/txt/BUILD.gn
@@ -122,7 +122,11 @@ source_set("txt") {
 
 if (enable_unittests) {
   test_fixtures("txt_fixtures") {
-    fixtures = [ "third_party/fonts/Roboto-Regular.ttf" ]
+    fixtures = [ "third_party/fonts/Roboto-Regular.ttf", "//flutter/third_party/txt/third_party/fonts/NotoColorEmoji.ttf", ]
+
+    if (host_os == "mac") {
+      fixtures += [ "/System/Library/Fonts/Apple Color Emoji.ttc" ]
+    }
   }
 
   executable("txt_benchmarks") {

--- a/third_party/txt/src/skia/paragraph_skia.cc
+++ b/third_party/txt/src/skia/paragraph_skia.cc
@@ -87,6 +87,16 @@ class DisplayListParagraphPainter : public skt::ParagraphPainter {
     if (impeller_enabled_) {
       if (ShouldRenderAsPath(dl_paints_[paint_id])) {
         auto path = skia::textlayout::Paragraph::GetPath(blob.get());
+        // If there is no path, this is an emoji and should be drawn as is,
+        // ignoring the color source.
+        if (path.isEmpty()) {
+          builder_->DrawTextFrame(impeller::MakeTextFrameFromTextBlobSkia(
+                                      blob, dl_paints_[paint_id].getColor()),
+                                  x, y, dl_paints_[paint_id]);
+
+          return;
+        }
+
         auto transformed = path.makeTransform(SkMatrix::Translate(
             x + blob->bounds().left(), y + blob->bounds().top()));
         builder_->DrawPath(transformed, dl_paints_[paint_id]);

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -30,7 +30,7 @@ static const std::string kEmojiFontName =
 #if FML_OS_MACOSX
     "Apple Color Emoji";
 #else
-    "NotoColorEmoji";
+    "Noto Color Emoji";
 #endif
 
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/142974

If a text is drawn with a color source but lacks a path, just draw the original text. This ensures emojis render like Skia.