### PR TITLE
[DisplayList] remove legacy DisplayListMatrixClipTracker

### DIFF
--- a/display_list/utils/dl_matrix_clip_tracker.cc
+++ b/display_list/utils/dl_matrix_clip_tracker.cc
@@ -9,7 +9,7 @@
 
 namespace flutter {
 
-bool DisplayListMatrixClipTracker::is_3x3(const SkM44& m) {
+bool DisplayListMatrixClipState::is_3x3(const SkM44& m) {
   // clang-format off
   return (                                      m.rc(0, 2) == 0 &&
                                                 m.rc(1, 2) == 0 &&
@@ -44,60 +44,6 @@ DisplayListMatrixClipState::DisplayListMatrixClipState(const SkRect& cull_rect,
 DisplayListMatrixClipState::DisplayListMatrixClipState(const SkRect& cull_rect,
                                                        const SkM44& matrix)
     : cull_rect_(ProtectEmpty(cull_rect)), matrix_(ToDlMatrix(matrix)) {}
-
-DisplayListMatrixClipTracker::DisplayListMatrixClipTracker(
-    const DlRect& cull_rect,
-    const DlMatrix& matrix) {
-  saved_.emplace_back(cull_rect, matrix);
-  current_ = &saved_.back();
-  save();  // saved_[0] will always be the initial settings
-}
-
-DisplayListMatrixClipTracker::DisplayListMatrixClipTracker(
-    const SkRect& cull_rect,
-    const SkMatrix& matrix) {
-  saved_.emplace_back(cull_rect, matrix);
-  current_ = &saved_.back();
-  save();  // saved_[0] will always be the initial settings
-}
-
-DisplayListMatrixClipTracker::DisplayListMatrixClipTracker(
-    const SkRect& cull_rect,
-    const SkM44& m44) {
-  saved_.emplace_back(cull_rect, m44);
-  current_ = &saved_.back();
-  save();  // saved_[0] will always be the initial settings
-}
-
-void DisplayListMatrixClipTracker::save() {
-  saved_.emplace_back(*current_);
-  current_ = &saved_.back();
-}
-
-void DisplayListMatrixClipTracker::restore() {
-  if (saved_.size() > 2) {
-    saved_.pop_back();
-    current_ = &saved_.back();
-  }
-}
-
-void DisplayListMatrixClipTracker::reset() {
-  while (saved_.size() > 1) {
-    saved_.pop_back();
-    current_ = &saved_.back();
-  }
-  save();  // saved_[0] will always be the initial settings
-}
-
-void DisplayListMatrixClipTracker::restoreToCount(int restore_count) {
-  FML_DCHECK(restore_count <= getSaveCount());
-  if (restore_count < 1) {
-    restore_count = 1;
-  }
-  while (restore_count < getSaveCount()) {
-    restore();
-  }
-}
 
 bool DisplayListMatrixClipState::inverseTransform(
     const DisplayListMatrixClipState& tracker) {

--- a/display_list/utils/dl_matrix_clip_tracker.h
+++ b/display_list/utils/dl_matrix_clip_tracker.h
@@ -32,6 +32,8 @@ class DisplayListMatrixClipState {
   DisplayListMatrixClipState(const SkRect& cull_rect, const SkM44& matrix);
   DisplayListMatrixClipState(const DisplayListMatrixClipState& other) = default;
 
+  static bool is_3x3(const SkM44& m44);
+
   // This method should almost never be used as it breaks the encapsulation
   // of the enclosing clips. However it is needed for practical purposes in
   // some rare cases - such as when a saveLayer is collecting rendering
@@ -145,147 +147,6 @@ class DisplayListMatrixClipState {
   DlMatrix matrix_;
 
   void adjustCullRect(const DlRect& clip, ClipOp op, bool is_aa);
-
-  friend class DisplayListMatrixClipTracker;
-};
-
-class DisplayListMatrixClipTracker {
- private:
-  using ClipOp = DlCanvas::ClipOp;
-  using DlRect = impeller::Rect;
-  using DlMatrix = impeller::Matrix;
-
- public:
-  DisplayListMatrixClipTracker(const DlRect& cull_rect, const DlMatrix& matrix);
-  DisplayListMatrixClipTracker(const SkRect& cull_rect, const SkMatrix& matrix);
-  DisplayListMatrixClipTracker(const SkRect& cull_rect, const SkM44& matrix);
-
-  // These methods should almost never be used as they breaks the encapsulation
-  // of the enclosing clips. However they are needed for practical purposes in
-  // some rare cases - such as when a saveLayer is collecting rendering
-  // operations prior to applying a filter on the entire layer bounds and
-  // some of those operations fall outside the enclosing clip, but their
-  // filtered content will spread out from where they were rendered on the
-  // layer into the enclosing clipped area.
-  // Omitting the |cull_rect| argument, or passing nullptr, will restore the
-  // cull rect to the initial value it had when the tracker was constructed.
-  void resetDeviceCullRect(const DlRect* cull_rect = nullptr) {
-    if (cull_rect) {
-      current_->resetDeviceCullRect(*cull_rect);
-    } else {
-      current_->resetDeviceCullRect(saved_[0].cull_rect_);
-    }
-  }
-  void resetDeviceCullRect(const SkRect* cull_rect = nullptr) {
-    if (cull_rect) {
-      current_->resetDeviceCullRect(*cull_rect);
-    } else {
-      current_->resetDeviceCullRect(saved_[0].cull_rect_);
-    }
-  }
-  void resetLocalCullRect(const DlRect* cull_rect = nullptr) {
-    if (cull_rect) {
-      current_->resetLocalCullRect(*cull_rect);
-    } else {
-      current_->resetDeviceCullRect(saved_[0].cull_rect_);
-    }
-  }
-  void resetLocalCullRect(const SkRect* cull_rect = nullptr) {
-    if (cull_rect) {
-      current_->resetLocalCullRect(*cull_rect);
-    } else {
-      current_->resetDeviceCullRect(saved_[0].cull_rect_);
-    }
-  }
-
-  static bool is_3x3(const SkM44& m44);
-
-  SkRect base_device_cull_rect() const { return saved_[0].device_cull_rect(); }
-
-  bool using_4x4_matrix() const { return current_->using_4x4_matrix(); }
-
-  DlMatrix matrix() const { return current_->matrix(); }
-  SkM44 matrix_4x4() const { return current_->matrix_4x4(); }
-  SkMatrix matrix_3x3() const { return current_->matrix_3x3(); }
-  SkRect local_cull_rect() const { return current_->local_cull_rect(); }
-  SkRect device_cull_rect() const { return current_->device_cull_rect(); }
-  bool content_culled(const SkRect& content_bounds) const {
-    return current_->content_culled(content_bounds);
-  }
-  bool is_cull_rect_empty() const { return current_->is_cull_rect_empty(); }
-
-  void save();
-  void restore();
-  void reset();
-  int getSaveCount() {
-    // saved_[0] is always the untouched initial conditions
-    // saved_[1] is the first editable stack entry
-    return saved_.size() - 1;
-  }
-  void restoreToCount(int restore_count);
-
-  void translate(SkScalar tx, SkScalar ty) { current_->translate(tx, ty); }
-  void scale(SkScalar sx, SkScalar sy) { current_->scale(sx, sy); }
-  void skew(SkScalar skx, SkScalar sky) { current_->skew(skx, sky); }
-  void rotate(SkScalar degrees) { current_->rotate(degrees); }
-  void transform(const DlMatrix& matrix) { current_->transform(matrix); }
-  void transform(const SkM44& m44) { current_->transform(m44); }
-  void transform(const SkMatrix& matrix) { current_->transform(matrix); }
-  // clang-format off
-  void transform2DAffine(
-      SkScalar mxx, SkScalar mxy, SkScalar mxt,
-      SkScalar myx, SkScalar myy, SkScalar myt) {
-    current_->transform2DAffine(mxx, mxy, mxt, myx, myy, myt);
-  }
-  void transformFullPerspective(
-      SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
-      SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
-      SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
-      SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) {
-    current_->transformFullPerspective(
-        mxx, mxy, mxz, mxt,
-        myx, myy, myz, myt,
-        mzx, mzy, mzz, mzt,
-        mwx, mwy, mwz, mwt
-    );
-  }
-  // clang-format on
-  void setTransform(const DlMatrix& matrix) { current_->setTransform(matrix); }
-  void setTransform(const SkMatrix& matrix) { current_->setTransform(matrix); }
-  void setTransform(const SkM44& m44) { current_->setTransform(m44); }
-  void setIdentity() { current_->setIdentity(); }
-  // If the matrix in |other_tracker| is invertible then transform this
-  // tracker by the inverse of its matrix and return true. Otherwise,
-  // return false and leave this tracker unmodified.
-  bool inverseTransform(const DisplayListMatrixClipTracker& other_tracker) {
-    return current_->inverseTransform(*other_tracker.current_);
-  }
-
-  bool mapRect(DlRect* rect) const { return current_->mapRect(*rect, rect); }
-  bool mapRect(const DlRect& src, DlRect* mapped) {
-    return current_->mapRect(src, mapped);
-  }
-  bool mapRect(SkRect* rect) const { return current_->mapRect(*rect, rect); }
-  bool mapRect(const SkRect& src, SkRect* mapped) {
-    return current_->mapRect(src, mapped);
-  }
-
-  void clipRect(const DlRect& rect, ClipOp op, bool is_aa) {
-    current_->clipRect(rect, op, is_aa);
-  }
-  void clipRect(const SkRect& rect, ClipOp op, bool is_aa) {
-    current_->clipRect(rect, op, is_aa);
-  }
-  void clipRRect(const SkRRect& rrect, ClipOp op, bool is_aa) {
-    current_->clipRRect(rrect, op, is_aa);
-  }
-  void clipPath(const SkPath& path, ClipOp op, bool is_aa) {
-    current_->clipPath(path, op, is_aa);
-  }
-
- private:
-  DisplayListMatrixClipState* current_;
-  std::vector<DisplayListMatrixClipState> saved_;
 };
 
 }  // namespace flutter

--- a/display_list/utils/dl_matrix_clip_tracker_unittests.cc
+++ b/display_list/utils/dl_matrix_clip_tracker_unittests.cc
@@ -9,40 +9,6 @@
 namespace flutter {
 namespace testing {
 
-TEST(DisplayListMatrixClipTracker, Constructor) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
-  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
-  const SkMatrix matrix = SkMatrix::Scale(4, 4);
-  const SkM44 m44 = SkM44::Scale(4, 4);
-  const DlMatrix dl_matrix = DlMatrix::MakeScale({4.0, 4.0, 1.0});
-  const SkRect local_cull_rect = SkRect::MakeLTRB(5, 10, 15, 20);
-
-  DisplayListMatrixClipTracker tracker1(cull_rect, matrix);
-  DisplayListMatrixClipTracker tracker2(cull_rect, m44);
-  DisplayListMatrixClipTracker tracker3(dl_cull_rect, dl_matrix);
-
-  EXPECT_FALSE(tracker1.using_4x4_matrix());
-  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker1.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker1.matrix_3x3(), matrix);
-  EXPECT_EQ(tracker1.matrix_4x4(), m44);
-  EXPECT_EQ(tracker1.matrix(), dl_matrix);
-
-  EXPECT_FALSE(tracker2.using_4x4_matrix());
-  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker2.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker2.matrix_3x3(), matrix);
-  EXPECT_EQ(tracker2.matrix_4x4(), m44);
-  EXPECT_EQ(tracker2.matrix(), dl_matrix);
-
-  EXPECT_FALSE(tracker3.using_4x4_matrix());
-  EXPECT_EQ(tracker3.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker3.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker3.matrix_3x3(), matrix);
-  EXPECT_EQ(tracker3.matrix_4x4(), m44);
-  EXPECT_EQ(tracker3.matrix(), dl_matrix);
-}
-
 TEST(DisplayListMatrixClipState, Constructor) {
   const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
   const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
@@ -77,37 +43,6 @@ TEST(DisplayListMatrixClipState, Constructor) {
   EXPECT_EQ(state3.matrix(), dl_matrix);
 }
 
-TEST(DisplayListMatrixClipTracker, Constructor4x4) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
-  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
-  // clang-format off
-  const SkM44 m44 = SkM44(4, 0, 0.5, 0,
-                          0, 4, 0.5, 0,
-                          0, 0, 4.0, 0,
-                          0, 0, 0.0, 1);
-  const DlMatrix dl_matrix = DlMatrix::MakeRow(4, 0, 0.5, 0,
-                                               0, 4, 0.5, 0,
-                                               0, 0, 4.0, 0,
-                                               0, 0, 0.0, 1);
-  // clang-format on
-  const SkRect local_cull_rect = SkRect::MakeLTRB(5, 10, 15, 20);
-
-  DisplayListMatrixClipTracker tracker1(cull_rect, m44);
-  DisplayListMatrixClipTracker tracker2(dl_cull_rect, dl_matrix);
-
-  EXPECT_TRUE(tracker1.using_4x4_matrix());
-  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker1.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker1.matrix_4x4(), m44);
-  EXPECT_EQ(tracker1.matrix(), dl_matrix);
-
-  EXPECT_TRUE(tracker2.using_4x4_matrix());
-  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker2.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker2.matrix_4x4(), m44);
-  EXPECT_EQ(tracker2.matrix(), dl_matrix);
-}
-
 TEST(DisplayListMatrixClipState, Constructor4x4) {
   const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
   const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
@@ -139,41 +74,6 @@ TEST(DisplayListMatrixClipState, Constructor4x4) {
   EXPECT_EQ(state2.matrix(), dl_matrix);
 }
 
-TEST(DisplayListMatrixClipTracker, TransformTo4x4) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
-  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
-  // clang-format off
-  const SkM44 m44 = SkM44(4, 0, 0.5, 0,
-                          0, 4, 0.5, 0,
-                          0, 0, 4.0, 0,
-                          0, 0, 0.0, 1);
-  const DlMatrix dl_matrix = DlMatrix::MakeRow(4, 0, 0.5, 0,
-                                               0, 4, 0.5, 0,
-                                               0, 0, 4.0, 0,
-                                               0, 0, 0.0, 1);
-  // clang-format on
-  const SkRect local_cull_rect = SkRect::MakeLTRB(5, 10, 15, 20);
-
-  DisplayListMatrixClipTracker tracker1(cull_rect, SkMatrix::I());
-  DisplayListMatrixClipTracker tracker2(dl_cull_rect, DlMatrix());
-  EXPECT_FALSE(tracker1.using_4x4_matrix());
-  EXPECT_FALSE(tracker2.using_4x4_matrix());
-
-  tracker1.transform(m44);
-  EXPECT_TRUE(tracker1.using_4x4_matrix());
-  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker1.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker1.matrix_4x4(), m44);
-  EXPECT_EQ(tracker1.matrix(), dl_matrix);
-
-  tracker2.transform(dl_matrix);
-  EXPECT_TRUE(tracker2.using_4x4_matrix());
-  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker2.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker2.matrix_4x4(), m44);
-  EXPECT_EQ(tracker2.matrix(), dl_matrix);
-}
-
 TEST(DisplayListMatrixClipState, TransformTo4x4) {
   const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
   const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
@@ -189,8 +89,8 @@ TEST(DisplayListMatrixClipState, TransformTo4x4) {
   // clang-format on
   const SkRect local_cull_rect = SkRect::MakeLTRB(5, 10, 15, 20);
 
-  DisplayListMatrixClipTracker state1(cull_rect, SkMatrix::I());
-  DisplayListMatrixClipTracker state2(dl_cull_rect, DlMatrix());
+  DisplayListMatrixClipState state1(cull_rect, SkMatrix::I());
+  DisplayListMatrixClipState state2(dl_cull_rect, DlMatrix());
   EXPECT_FALSE(state1.using_4x4_matrix());
   EXPECT_FALSE(state2.using_4x4_matrix());
 
@@ -207,41 +107,6 @@ TEST(DisplayListMatrixClipState, TransformTo4x4) {
   EXPECT_EQ(state2.local_cull_rect(), local_cull_rect);
   EXPECT_EQ(state2.matrix_4x4(), m44);
   EXPECT_EQ(state2.matrix(), dl_matrix);
-}
-
-TEST(DisplayListMatrixClipTracker, SetTo4x4) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
-  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
-  // clang-format off
-  const SkM44 m44 = SkM44(4, 0, 0.5, 0,
-                          0, 4, 0.5, 0,
-                          0, 0, 4.0, 0,
-                          0, 0, 0.0, 1);
-  const DlMatrix dl_matrix = DlMatrix::MakeRow(4, 0, 0.5, 0,
-                                               0, 4, 0.5, 0,
-                                               0, 0, 4.0, 0,
-                                               0, 0, 0.0, 1);
-  // clang-format on
-  const SkRect local_cull_rect = SkRect::MakeLTRB(5, 10, 15, 20);
-
-  DisplayListMatrixClipTracker tracker1(cull_rect, SkMatrix::I());
-  DisplayListMatrixClipTracker tracker2(dl_cull_rect, DlMatrix());
-  EXPECT_FALSE(tracker1.using_4x4_matrix());
-  EXPECT_FALSE(tracker2.using_4x4_matrix());
-
-  tracker1.setTransform(m44);
-  EXPECT_TRUE(tracker1.using_4x4_matrix());
-  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker1.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker1.matrix_4x4(), m44);
-  EXPECT_EQ(tracker1.matrix(), dl_matrix);
-
-  tracker2.setTransform(dl_matrix);
-  EXPECT_TRUE(tracker2.using_4x4_matrix());
-  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker2.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker2.matrix_4x4(), m44);
-  EXPECT_EQ(tracker2.matrix(), dl_matrix);
 }
 
 TEST(DisplayListMatrixClipState, SetTo4x4) {
@@ -277,105 +142,6 @@ TEST(DisplayListMatrixClipState, SetTo4x4) {
   EXPECT_EQ(state2.local_cull_rect(), local_cull_rect);
   EXPECT_EQ(state2.matrix_4x4(), m44);
   EXPECT_EQ(state2.matrix(), dl_matrix);
-}
-
-TEST(DisplayListMatrixClipTracker, UpgradeTo4x4SaveAndRestore) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
-  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
-  // clang-format off
-  const SkM44 m44 = SkM44(4, 0, 0.5, 0,
-                          0, 4, 0.5, 0,
-                          0, 0, 4.0, 0,
-                          0, 0, 0.0, 1);
-  const DlMatrix dl_matrix = DlMatrix::MakeRow(4, 0, 0.5, 0,
-                                               0, 4, 0.5, 0,
-                                               0, 0, 4.0, 0,
-                                               0, 0, 0.0, 1);
-  // clang-format on
-  const SkRect local_cull_rect = SkRect::MakeLTRB(5, 10, 15, 20);
-
-  DisplayListMatrixClipTracker tracker1(cull_rect, SkMatrix::I());
-  DisplayListMatrixClipTracker tracker2(dl_cull_rect, DlMatrix());
-  EXPECT_FALSE(tracker1.using_4x4_matrix());
-  EXPECT_FALSE(tracker2.using_4x4_matrix());
-
-  tracker1.save();
-  tracker2.save();
-  EXPECT_FALSE(tracker1.using_4x4_matrix());
-  EXPECT_FALSE(tracker2.using_4x4_matrix());
-
-  tracker1.transform(m44);
-  EXPECT_TRUE(tracker1.using_4x4_matrix());
-  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker1.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker1.matrix_4x4(), m44);
-  EXPECT_EQ(tracker1.matrix(), dl_matrix);
-
-  tracker1.restore();
-  EXPECT_FALSE(tracker1.using_4x4_matrix());
-  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker1.local_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker1.matrix_4x4(), SkM44());
-  EXPECT_EQ(tracker1.matrix(), DlMatrix());
-
-  tracker2.transform(dl_matrix);
-  EXPECT_TRUE(tracker2.using_4x4_matrix());
-  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker2.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker2.matrix_4x4(), m44);
-  EXPECT_EQ(tracker2.matrix(), dl_matrix);
-
-  tracker2.restore();
-  EXPECT_FALSE(tracker2.using_4x4_matrix());
-  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker2.local_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker2.matrix_4x4(), SkM44());
-  EXPECT_EQ(tracker2.matrix(), DlMatrix());
-}
-
-// No "State" version of UpgradeTo4x4SaveAndRestore since the State objects
-// do not have save and restore semantics.
-
-TEST(DisplayListMatrixClipTracker, Translate) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
-  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
-  const SkMatrix matrix = SkMatrix::Scale(4, 4);
-  const SkM44 m44 = SkM44::Scale(4, 4);
-  const DlMatrix dl_matrix = DlMatrix::MakeScale({4.0, 4.0, 1.0});
-  const SkMatrix translated_matrix =
-      SkMatrix::Concat(matrix, SkMatrix::Translate(5, 1));
-  const SkM44 translated_m44 = SkM44(translated_matrix);
-  const DlMatrix dl_translated_matrix =
-      dl_matrix * DlMatrix::MakeTranslation({5.0, 1.0});
-  const SkRect local_cull_rect = SkRect::MakeLTRB(0, 9, 10, 19);
-
-  DisplayListMatrixClipTracker tracker1(cull_rect, matrix);
-  DisplayListMatrixClipTracker tracker2(cull_rect, m44);
-  DisplayListMatrixClipTracker tracker3(dl_cull_rect, dl_matrix);
-  tracker1.translate(5, 1);
-  tracker2.translate(5, 1);
-  tracker3.translate(5, 1);
-
-  EXPECT_FALSE(tracker1.using_4x4_matrix());
-  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker1.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker1.matrix_3x3(), translated_matrix);
-  EXPECT_EQ(tracker1.matrix_4x4(), translated_m44);
-  EXPECT_EQ(tracker1.matrix(), dl_translated_matrix);
-
-  EXPECT_FALSE(tracker2.using_4x4_matrix());
-  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker2.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker2.matrix_3x3(), translated_matrix);
-  EXPECT_EQ(tracker2.matrix_4x4(), translated_m44);
-  EXPECT_EQ(tracker2.matrix(), dl_translated_matrix);
-
-  EXPECT_FALSE(tracker3.using_4x4_matrix());
-  EXPECT_EQ(tracker3.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker3.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker3.matrix_3x3(), translated_matrix);
-  EXPECT_EQ(tracker3.matrix_4x4(), translated_m44);
-  EXPECT_EQ(tracker3.matrix(), dl_translated_matrix);
 }
 
 TEST(DisplayListMatrixClipState, Translate) {
@@ -418,49 +184,6 @@ TEST(DisplayListMatrixClipState, Translate) {
   EXPECT_EQ(state3.matrix_3x3(), translated_matrix);
   EXPECT_EQ(state3.matrix_4x4(), translated_m44);
   EXPECT_EQ(state3.matrix(), dl_translated_matrix);
-}
-
-TEST(DisplayListMatrixClipTracker, Scale) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
-  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
-  const SkMatrix matrix = SkMatrix::Scale(4, 4);
-  const SkM44 m44 = SkM44::Scale(4, 4);
-  const DlMatrix dl_matrix = DlMatrix::MakeScale({4.0, 4.0, 1.0});
-  // Scale factor carefully chosen to multiply cleanly and invert
-  // without any non-binary-power-of-2 approximation errors.
-  const SkMatrix scaled_matrix =
-      SkMatrix::Concat(matrix, SkMatrix::Scale(0.5, 2));
-  const SkM44 scaled_m44 = SkM44(scaled_matrix);
-  const DlMatrix scaled_dl_matrix = dl_matrix.Scale({0.5, 2, 1});
-  const SkRect local_cull_rect = SkRect::MakeLTRB(10, 5, 30, 10);
-
-  DisplayListMatrixClipTracker tracker1(cull_rect, matrix);
-  DisplayListMatrixClipTracker tracker2(cull_rect, m44);
-  DisplayListMatrixClipTracker tracker3(dl_cull_rect, dl_matrix);
-  tracker1.scale(0.5, 2);
-  tracker2.scale(0.5, 2);
-  tracker3.scale(0.5, 2);
-
-  EXPECT_FALSE(tracker1.using_4x4_matrix());
-  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker1.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker1.matrix_3x3(), scaled_matrix);
-  EXPECT_EQ(tracker1.matrix_4x4(), scaled_m44);
-  EXPECT_EQ(tracker1.matrix(), scaled_dl_matrix);
-
-  EXPECT_FALSE(tracker2.using_4x4_matrix());
-  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker2.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker2.matrix_3x3(), scaled_matrix);
-  EXPECT_EQ(tracker2.matrix_4x4(), scaled_m44);
-  EXPECT_EQ(tracker2.matrix(), scaled_dl_matrix);
-
-  EXPECT_FALSE(tracker3.using_4x4_matrix());
-  EXPECT_EQ(tracker3.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker3.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker3.matrix_3x3(), scaled_matrix);
-  EXPECT_EQ(tracker3.matrix_4x4(), scaled_m44);
-  EXPECT_EQ(tracker3.matrix(), scaled_dl_matrix);
 }
 
 TEST(DisplayListMatrixClipState, Scale) {
@@ -506,47 +229,6 @@ TEST(DisplayListMatrixClipState, Scale) {
   EXPECT_EQ(state3.matrix(), scaled_dl_matrix);
 }
 
-TEST(DisplayListMatrixClipTracker, Skew) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
-  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
-  const SkMatrix matrix = SkMatrix::Scale(4, 4);
-  const SkM44 m44 = SkM44::Scale(4, 4);
-  const DlMatrix dl_matrix = DlMatrix::MakeScale({4, 4, 1});
-  const SkMatrix skewed_matrix =
-      SkMatrix::Concat(matrix, SkMatrix::Skew(.25, 0));
-  const SkM44 skewed_m44 = SkM44(skewed_matrix);
-  const DlMatrix skewed_dl_matrix = dl_matrix * DlMatrix::MakeSkew(0.25, 0);
-  const SkRect local_cull_rect = SkRect::MakeLTRB(0, 10, 12.5, 20);
-
-  DisplayListMatrixClipTracker tracker1(cull_rect, matrix);
-  DisplayListMatrixClipTracker tracker2(cull_rect, m44);
-  DisplayListMatrixClipTracker tracker3(dl_cull_rect, dl_matrix);
-  tracker1.skew(.25, 0);
-  tracker2.skew(.25, 0);
-  tracker3.skew(.25, 0);
-
-  EXPECT_FALSE(tracker1.using_4x4_matrix());
-  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker1.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker1.matrix_3x3(), skewed_matrix);
-  EXPECT_EQ(tracker1.matrix_4x4(), skewed_m44);
-  EXPECT_EQ(tracker1.matrix(), skewed_dl_matrix);
-
-  EXPECT_FALSE(tracker2.using_4x4_matrix());
-  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker2.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker2.matrix_3x3(), skewed_matrix);
-  EXPECT_EQ(tracker2.matrix_4x4(), skewed_m44);
-  EXPECT_EQ(tracker2.matrix(), skewed_dl_matrix);
-
-  EXPECT_FALSE(tracker3.using_4x4_matrix());
-  EXPECT_EQ(tracker3.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker3.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker3.matrix_3x3(), skewed_matrix);
-  EXPECT_EQ(tracker3.matrix_4x4(), skewed_m44);
-  EXPECT_EQ(tracker3.matrix(), skewed_dl_matrix);
-}
-
 TEST(DisplayListMatrixClipState, Skew) {
   const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
   const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
@@ -586,48 +268,6 @@ TEST(DisplayListMatrixClipState, Skew) {
   EXPECT_EQ(state3.matrix_3x3(), skewed_matrix);
   EXPECT_EQ(state3.matrix_4x4(), skewed_m44);
   EXPECT_EQ(state3.matrix(), skewed_dl_matrix);
-}
-
-TEST(DisplayListMatrixClipTracker, Rotate) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
-  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
-  const SkMatrix matrix = SkMatrix::Scale(4, 4);
-  const SkM44 m44 = SkM44::Scale(4, 4);
-  const DlMatrix dl_matrix = DlMatrix::MakeScale({4, 4, 1});
-  const SkMatrix rotated_matrix =
-      SkMatrix::Concat(matrix, SkMatrix::RotateDeg(90));
-  const SkM44 rotated_m44 = SkM44(rotated_matrix);
-  const DlMatrix rotated_dl_matrix =
-      dl_matrix * DlMatrix::MakeRotationZ(DlDegrees(90));
-  const SkRect local_cull_rect = SkRect::MakeLTRB(10, -15, 20, -5);
-
-  DisplayListMatrixClipTracker tracker1(cull_rect, matrix);
-  DisplayListMatrixClipTracker tracker2(cull_rect, m44);
-  DisplayListMatrixClipTracker tracker3(dl_cull_rect, dl_matrix);
-  tracker1.rotate(90);
-  tracker2.rotate(90);
-  tracker3.rotate(90);
-
-  EXPECT_FALSE(tracker1.using_4x4_matrix());
-  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker1.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker1.matrix_3x3(), rotated_matrix);
-  EXPECT_EQ(tracker1.matrix_4x4(), rotated_m44);
-  EXPECT_EQ(tracker1.matrix(), rotated_dl_matrix);
-
-  EXPECT_FALSE(tracker2.using_4x4_matrix());
-  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker2.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker2.matrix_3x3(), rotated_matrix);
-  EXPECT_EQ(tracker2.matrix_4x4(), rotated_m44);
-  EXPECT_EQ(tracker2.matrix(), rotated_dl_matrix);
-
-  EXPECT_FALSE(tracker3.using_4x4_matrix());
-  EXPECT_EQ(tracker3.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker3.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker3.matrix_3x3(), rotated_matrix);
-  EXPECT_EQ(tracker3.matrix_4x4(), rotated_m44);
-  EXPECT_EQ(tracker3.matrix(), rotated_dl_matrix);
 }
 
 TEST(DisplayListMatrixClipState, Rotate) {
@@ -670,57 +310,6 @@ TEST(DisplayListMatrixClipState, Rotate) {
   EXPECT_EQ(state3.matrix_3x3(), rotated_matrix);
   EXPECT_EQ(state3.matrix_4x4(), rotated_m44);
   EXPECT_EQ(state3.matrix(), rotated_dl_matrix);
-}
-
-TEST(DisplayListMatrixClipTracker, Transform2DAffine) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
-  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
-  const SkMatrix matrix = SkMatrix::Scale(4, 4);
-  const SkM44 m44 = SkM44::Scale(4, 4);
-  const DlMatrix dl_matrix = DlMatrix::MakeScale({4, 4, 1});
-
-  const SkMatrix transformed_matrix =
-      SkMatrix::Concat(matrix, SkMatrix::MakeAll(2, 0, 5,  //
-                                                 0, 2, 6,  //
-                                                 0, 0, 1));
-  const SkM44 transformed_m44 = SkM44(transformed_matrix);
-  const DlMatrix transformed_dl_matrix =
-      dl_matrix * DlMatrix::MakeRow(2, 0, 0, 5,  //
-                                    0, 2, 0, 6,  //
-                                    0, 0, 1, 0,  //
-                                    0, 0, 0, 1);
-  const SkRect local_cull_rect = SkRect::MakeLTRB(0, 2, 5, 7);
-
-  DisplayListMatrixClipTracker tracker1(cull_rect, matrix);
-  DisplayListMatrixClipTracker tracker2(cull_rect, m44);
-  DisplayListMatrixClipTracker tracker3(dl_cull_rect, dl_matrix);
-  tracker1.transform2DAffine(2, 0, 5,  //
-                             0, 2, 6);
-  tracker2.transform2DAffine(2, 0, 5,  //
-                             0, 2, 6);
-  tracker3.transform2DAffine(2, 0, 5,  //
-                             0, 2, 6);
-
-  EXPECT_FALSE(tracker1.using_4x4_matrix());
-  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker1.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker1.matrix_3x3(), transformed_matrix);
-  EXPECT_EQ(tracker1.matrix_4x4(), transformed_m44);
-  EXPECT_EQ(tracker1.matrix(), transformed_dl_matrix);
-
-  EXPECT_FALSE(tracker2.using_4x4_matrix());
-  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker2.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker2.matrix_3x3(), transformed_matrix);
-  EXPECT_EQ(tracker2.matrix_4x4(), transformed_m44);
-  EXPECT_EQ(tracker2.matrix(), transformed_dl_matrix);
-
-  EXPECT_FALSE(tracker3.using_4x4_matrix());
-  EXPECT_EQ(tracker3.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker3.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker3.matrix_3x3(), transformed_matrix);
-  EXPECT_EQ(tracker3.matrix_4x4(), transformed_m44);
-  EXPECT_EQ(tracker3.matrix(), transformed_dl_matrix);
 }
 
 TEST(DisplayListMatrixClipState, Transform2DAffine) {
@@ -772,63 +361,6 @@ TEST(DisplayListMatrixClipState, Transform2DAffine) {
   EXPECT_EQ(state3.matrix_3x3(), transformed_matrix);
   EXPECT_EQ(state3.matrix_4x4(), transformed_m44);
   EXPECT_EQ(state3.matrix(), transformed_dl_matrix);
-}
-
-TEST(DisplayListMatrixClipTracker, TransformFullPerspectiveUsing3x3Matrix) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
-  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
-  const SkMatrix matrix = SkMatrix::Scale(4, 4);
-  const SkM44 m44 = SkM44::Scale(4, 4);
-  const DlMatrix dl_matrix = DlMatrix::MakeScale({4, 4, 1});
-
-  const SkMatrix transformed_matrix =
-      SkMatrix::Concat(matrix, SkMatrix::MakeAll(2, 0, 5,  //
-                                                 0, 2, 6,  //
-                                                 0, 0, 1));
-  const SkM44 transformed_m44 = SkM44(transformed_matrix);
-  const DlMatrix transformed_dl_matrix =
-      dl_matrix * DlMatrix::MakeRow(2, 0, 0, 5,  //
-                                    0, 2, 0, 6,  //
-                                    0, 0, 1, 0,  //
-                                    0, 0, 0, 1);
-  const SkRect local_cull_rect = SkRect::MakeLTRB(0, 2, 5, 7);
-
-  DisplayListMatrixClipTracker tracker1(cull_rect, matrix);
-  DisplayListMatrixClipTracker tracker2(cull_rect, m44);
-  DisplayListMatrixClipTracker tracker3(dl_cull_rect, dl_matrix);
-  tracker1.transformFullPerspective(2, 0, 0, 5,  //
-                                    0, 2, 0, 6,  //
-                                    0, 0, 1, 0,  //
-                                    0, 0, 0, 1);
-  tracker2.transformFullPerspective(2, 0, 0, 5,  //
-                                    0, 2, 0, 6,  //
-                                    0, 0, 1, 0,  //
-                                    0, 0, 0, 1);
-  tracker3.transformFullPerspective(2, 0, 0, 5,  //
-                                    0, 2, 0, 6,  //
-                                    0, 0, 1, 0,  //
-                                    0, 0, 0, 1);
-
-  EXPECT_FALSE(tracker1.using_4x4_matrix());
-  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker1.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker1.matrix_3x3(), transformed_matrix);
-  EXPECT_EQ(tracker1.matrix_4x4(), transformed_m44);
-  EXPECT_EQ(tracker1.matrix(), transformed_dl_matrix);
-
-  EXPECT_FALSE(tracker2.using_4x4_matrix());
-  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker2.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker2.matrix_3x3(), transformed_matrix);
-  EXPECT_EQ(tracker2.matrix_4x4(), transformed_m44);
-  EXPECT_EQ(tracker2.matrix(), transformed_dl_matrix);
-
-  EXPECT_FALSE(tracker3.using_4x4_matrix());
-  EXPECT_EQ(tracker3.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker3.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker3.matrix_3x3(), transformed_matrix);
-  EXPECT_EQ(tracker3.matrix_4x4(), transformed_m44);
-  EXPECT_EQ(tracker3.matrix(), transformed_dl_matrix);
 }
 
 TEST(DisplayListMatrixClipState, TransformFullPerspectiveUsing3x3Matrix) {
@@ -888,59 +420,6 @@ TEST(DisplayListMatrixClipState, TransformFullPerspectiveUsing3x3Matrix) {
   EXPECT_EQ(state3.matrix(), transformed_dl_matrix);
 }
 
-TEST(DisplayListMatrixClipTracker, TransformFullPerspectiveUsing4x4Matrix) {
-  const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
-  const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
-  const SkMatrix matrix = SkMatrix::Scale(4, 4);
-  const SkM44 m44 = SkM44::Scale(4, 4);
-  const DlMatrix dl_matrix = DlMatrix::MakeScale({4, 4, 1});
-
-  const SkM44 transformed_m44 = SkM44(m44, SkM44(2, 0, 0, 5,  //
-                                                 0, 2, 0, 6,  //
-                                                 0, 0, 1, 7,  //
-                                                 0, 0, 0, 1));
-  const DlMatrix transformed_dl_matrix =
-      dl_matrix * DlMatrix::MakeRow(2, 0, 0, 5,  //
-                                    0, 2, 0, 6,  //
-                                    0, 0, 1, 7,  //
-                                    0, 0, 0, 1);
-  const SkRect local_cull_rect = SkRect::MakeLTRB(0, 2, 5, 7);
-
-  DisplayListMatrixClipTracker tracker1(cull_rect, matrix);
-  DisplayListMatrixClipTracker tracker2(cull_rect, m44);
-  DisplayListMatrixClipTracker tracker3(dl_cull_rect, dl_matrix);
-  tracker1.transformFullPerspective(2, 0, 0, 5,  //
-                                    0, 2, 0, 6,  //
-                                    0, 0, 1, 7,  //
-                                    0, 0, 0, 1);
-  tracker2.transformFullPerspective(2, 0, 0, 5,  //
-                                    0, 2, 0, 6,  //
-                                    0, 0, 1, 7,  //
-                                    0, 0, 0, 1);
-  tracker3.transformFullPerspective(2, 0, 0, 5,  //
-                                    0, 2, 0, 6,  //
-                                    0, 0, 1, 7,  //
-                                    0, 0, 0, 1);
-
-  EXPECT_TRUE(tracker1.using_4x4_matrix());
-  EXPECT_EQ(tracker1.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker1.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker1.matrix_4x4(), transformed_m44);
-  EXPECT_EQ(tracker1.matrix(), transformed_dl_matrix);
-
-  EXPECT_TRUE(tracker2.using_4x4_matrix());
-  EXPECT_EQ(tracker2.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker2.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker2.matrix_4x4(), transformed_m44);
-  EXPECT_EQ(tracker2.matrix(), transformed_dl_matrix);
-
-  EXPECT_TRUE(tracker3.using_4x4_matrix());
-  EXPECT_EQ(tracker3.device_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker3.local_cull_rect(), local_cull_rect);
-  EXPECT_EQ(tracker3.matrix_4x4(), transformed_m44);
-  EXPECT_EQ(tracker3.matrix(), transformed_dl_matrix);
-}
-
 TEST(DisplayListMatrixClipState, TransformFullPerspectiveUsing4x4Matrix) {
   const SkRect cull_rect = SkRect::MakeLTRB(20, 40, 60, 80);
   const DlRect dl_cull_rect = DlRect::MakeLTRB(20, 40, 60, 80);
@@ -994,28 +473,11 @@ TEST(DisplayListMatrixClipState, TransformFullPerspectiveUsing4x4Matrix) {
   EXPECT_EQ(state3.matrix(), transformed_dl_matrix);
 }
 
-TEST(DisplayListMatrixClipTracker, ClipDifference) {
+TEST(DisplayListMatrixClipState, ClipDifference) {
   SkRect cull_rect = SkRect::MakeLTRB(20, 20, 40, 40);
 
   auto non_reducing = [&cull_rect](const SkRect& diff_rect,
                                    const std::string& label) {
-    {
-      DisplayListMatrixClipTracker tracker(cull_rect, SkMatrix::I());
-      tracker.clipRect(diff_rect, DlCanvas::ClipOp::kDifference, false);
-      EXPECT_EQ(tracker.device_cull_rect(), cull_rect) << label;
-    }
-    {
-      DisplayListMatrixClipTracker tracker(cull_rect, SkMatrix::I());
-      const SkRRect diff_rrect = SkRRect::MakeRect(diff_rect);
-      tracker.clipRRect(diff_rrect, DlCanvas::ClipOp::kDifference, false);
-      EXPECT_EQ(tracker.device_cull_rect(), cull_rect) << label << " (RRect)";
-    }
-    {
-      DisplayListMatrixClipTracker tracker(cull_rect, SkMatrix::I());
-      const SkPath diff_path = SkPath().addRect(diff_rect);
-      tracker.clipPath(diff_path, DlCanvas::ClipOp::kDifference, false);
-      EXPECT_EQ(tracker.device_cull_rect(), cull_rect) << label << " (RRect)";
-    }
     {
       DisplayListMatrixClipState state(cull_rect, SkMatrix::I());
       state.clipRect(diff_rect, DlCanvas::ClipOp::kDifference, false);
@@ -1039,23 +501,6 @@ TEST(DisplayListMatrixClipTracker, ClipDifference) {
                                const SkRect& result_rect,
                                const std::string& label) {
     EXPECT_TRUE(result_rect.isEmpty() || cull_rect.contains(result_rect));
-    {
-      DisplayListMatrixClipTracker tracker(cull_rect, SkMatrix::I());
-      tracker.clipRect(diff_rect, DlCanvas::ClipOp::kDifference, false);
-      EXPECT_EQ(tracker.device_cull_rect(), result_rect) << label;
-    }
-    {
-      DisplayListMatrixClipTracker tracker(cull_rect, SkMatrix::I());
-      const SkRRect diff_rrect = SkRRect::MakeRect(diff_rect);
-      tracker.clipRRect(diff_rrect, DlCanvas::ClipOp::kDifference, false);
-      EXPECT_EQ(tracker.device_cull_rect(), result_rect) << label << " (RRect)";
-    }
-    {
-      DisplayListMatrixClipTracker tracker(cull_rect, SkMatrix::I());
-      const SkPath diff_path = SkPath().addRect(diff_rect);
-      tracker.clipPath(diff_path, DlCanvas::ClipOp::kDifference, false);
-      EXPECT_EQ(tracker.device_cull_rect(), result_rect) << label << " (RRect)";
-    }
     {
       DisplayListMatrixClipState state(cull_rect, SkMatrix::I());
       state.clipRect(diff_rect, DlCanvas::ClipOp::kDifference, false);
@@ -1129,17 +574,6 @@ TEST(DisplayListMatrixClipTracker, ClipDifference) {
   reducing(SkRect::MakeLTRB(15, 15, 45, 45), SkRect::MakeEmpty(), "Smothering");
 }
 
-TEST(DisplayListMatrixClipTracker, ClipPathWithInvertFillType) {
-  SkRect cull_rect = SkRect::MakeLTRB(0, 0, 100.0, 100.0);
-  DisplayListMatrixClipTracker tracker(cull_rect, SkMatrix::I());
-  SkPath clip = SkPath().addCircle(10.2, 11.3, 2).addCircle(20.4, 25.7, 2);
-  clip.setFillType(SkPathFillType::kInverseWinding);
-  tracker.clipPath(clip, DlCanvas::ClipOp::kIntersect, false);
-
-  EXPECT_EQ(tracker.local_cull_rect(), cull_rect);
-  EXPECT_EQ(tracker.device_cull_rect(), cull_rect);
-}
-
 TEST(DisplayListMatrixClipState, ClipPathWithInvertFillType) {
   SkRect cull_rect = SkRect::MakeLTRB(0, 0, 100.0, 100.0);
   DisplayListMatrixClipState state(cull_rect, SkMatrix::I());
@@ -1149,19 +583,6 @@ TEST(DisplayListMatrixClipState, ClipPathWithInvertFillType) {
 
   EXPECT_EQ(state.local_cull_rect(), cull_rect);
   EXPECT_EQ(state.device_cull_rect(), cull_rect);
-}
-
-TEST(DisplayListMatrixClipTracker, DiffClipPathWithInvertFillType) {
-  SkRect cull_rect = SkRect::MakeLTRB(0, 0, 100.0, 100.0);
-  DisplayListMatrixClipTracker tracker(cull_rect, SkMatrix::I());
-
-  SkPath clip = SkPath().addCircle(10.2, 11.3, 2).addCircle(20.4, 25.7, 2);
-  clip.setFillType(SkPathFillType::kInverseWinding);
-  SkRect clip_bounds = SkRect::MakeLTRB(8.2, 9.3, 22.4, 27.7);
-  tracker.clipPath(clip, DlCanvas::ClipOp::kDifference, false);
-
-  EXPECT_EQ(tracker.local_cull_rect(), clip_bounds);
-  EXPECT_EQ(tracker.device_cull_rect(), clip_bounds);
 }
 
 TEST(DisplayListMatrixClipState, DiffClipPathWithInvertFillType) {

--- a/flow/diff_context.h
+++ b/flow/diff_context.h
@@ -223,8 +223,8 @@ class DiffContext {
     // when starting subtree to paint layer children).
     bool integral_transform = false;
 
-    // Used to restoring clip tracker when popping state.
-    int clip_tracker_save_count = 0;
+    // Current transform and clip for the layer
+    DisplayListMatrixClipState matrix_clip;
 
     // Whether this subtree has filter bounds adjustment function. If so,
     // it will need to be removed from stack when subtree is closed.
@@ -234,9 +234,8 @@ class DiffContext {
     bool has_texture = false;
   };
 
-  void MakeCurrentTransformIntegral();
+  void MakeTransformIntegral(DisplayListMatrixClipState& matrix_clip);
 
-  DisplayListMatrixClipTracker clip_tracker_;
   std::shared_ptr<std::vector<SkRect>> rects_;
   State state_;
   SkISize frame_size_;

--- a/flow/layers/layer_state_stack.cc
+++ b/flow/layers/layer_state_stack.cc
@@ -137,65 +137,67 @@ class DlCanvasDelegate : public LayerStateStack::Delegate {
 
 class PrerollDelegate : public LayerStateStack::Delegate {
  public:
-  PrerollDelegate(const SkRect& cull_rect, const SkMatrix& matrix)
-      : tracker_(cull_rect, matrix) {}
+  PrerollDelegate(const SkRect& cull_rect, const SkMatrix& matrix) {
+    save_stack_.emplace_back(cull_rect, matrix);
+  }
 
   void decommission() override {}
 
-  SkM44 matrix_4x4() const override { return tracker_.matrix_4x4(); }
-  SkMatrix matrix_3x3() const override { return tracker_.matrix_3x3(); }
-  SkRect local_cull_rect() const override { return tracker_.local_cull_rect(); }
+  SkM44 matrix_4x4() const override { return state().matrix_4x4(); }
+  SkMatrix matrix_3x3() const override { return state().matrix_3x3(); }
+  SkRect local_cull_rect() const override { return state().local_cull_rect(); }
   SkRect device_cull_rect() const override {
-    return tracker_.device_cull_rect();
+    return state().device_cull_rect();
   }
   bool content_culled(const SkRect& content_bounds) const override {
-    return tracker_.content_culled(content_bounds);
+    return state().content_culled(content_bounds);
   }
 
-  void save() override { tracker_.save(); }
+  void save() override { save_stack_.emplace_back(state()); }
   void saveLayer(const SkRect& bounds,
                  LayerStateStack::RenderingAttributes& attributes,
                  DlBlendMode blend,
                  const DlImageFilter* backdrop) override {
-    tracker_.save();
+    save_stack_.emplace_back(state());
   }
-  void restore() override { tracker_.restore(); }
+  void restore() override { save_stack_.pop_back(); }
 
   void translate(SkScalar tx, SkScalar ty) override {
-    tracker_.translate(tx, ty);
+    state().translate(tx, ty);
   }
-  void transform(const SkM44& m44) override { tracker_.transform(m44); }
-  void transform(const SkMatrix& matrix) override {
-    tracker_.transform(matrix);
-  }
+  void transform(const SkM44& m44) override { state().transform(m44); }
+  void transform(const SkMatrix& matrix) override { state().transform(matrix); }
   void integralTransform() override {
-    if (tracker_.using_4x4_matrix()) {
+    if (state().using_4x4_matrix()) {
       SkM44 integral;
-      if (RasterCacheUtil::ComputeIntegralTransCTM(tracker_.matrix_4x4(),
+      if (RasterCacheUtil::ComputeIntegralTransCTM(state().matrix_4x4(),
                                                    &integral)) {
-        tracker_.setTransform(integral);
+        state().setTransform(integral);
       }
     } else {
       SkMatrix integral;
-      if (RasterCacheUtil::ComputeIntegralTransCTM(tracker_.matrix_3x3(),
+      if (RasterCacheUtil::ComputeIntegralTransCTM(state().matrix_3x3(),
                                                    &integral)) {
-        tracker_.setTransform(integral);
+        state().setTransform(integral);
       }
     }
   }
 
   void clipRect(const SkRect& rect, ClipOp op, bool is_aa) override {
-    tracker_.clipRect(rect, op, is_aa);
+    state().clipRect(rect, op, is_aa);
   }
   void clipRRect(const SkRRect& rrect, ClipOp op, bool is_aa) override {
-    tracker_.clipRRect(rrect, op, is_aa);
+    state().clipRRect(rrect, op, is_aa);
   }
   void clipPath(const SkPath& path, ClipOp op, bool is_aa) override {
-    tracker_.clipPath(path, op, is_aa);
+    state().clipPath(path, op, is_aa);
   }
 
  private:
-  DisplayListMatrixClipTracker tracker_;
+  DisplayListMatrixClipState& state() { return save_stack_.back(); }
+  const DisplayListMatrixClipState& state() const { return save_stack_.back(); }
+
+  std::vector<DisplayListMatrixClipState> save_stack_;
 };
 
 // ==============================================================
@@ -579,7 +581,7 @@ void MutatorContext::transform(const SkMatrix& matrix) {
 }
 
 void MutatorContext::transform(const SkM44& m44) {
-  if (DisplayListMatrixClipTracker::is_3x3(m44)) {
+  if (DisplayListMatrixClipState::is_3x3(m44)) {
     transform(m44.asM33());
   } else {
     layer_state_stack_->maybe_save_layer_for_transform(save_needed_);

--- a/testing/mock_canvas.h
+++ b/testing/mock_canvas.h
@@ -286,7 +286,8 @@ class MockCanvas final : public DlCanvas {
   void Flush() override;
 
  private:
-  DisplayListMatrixClipTracker tracker_;
+  SkISize base_layer_size_;
+  std::vector<DisplayListMatrixClipState> state_stack_;
   std::vector<DrawCall> draw_calls_;
   int current_layer_;
 };


### PR DESCRIPTION
The MatrixClipTracker was nothing more than a vector of MatrixClipState objects and a whole lot of duplicate delegation methods. It provided little value since nearly every use of it already had a state stack that was kept in synch with it's internal stack and so it was just adding an extra layer of delegation and extra allocations.