### PR TITLE
fix: TapTextFieldTapRegion not working on ios safari/chrome/webview

### DIFF
--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -3080,10 +3080,11 @@ extension DomScreenOrientationExtension on DomScreenOrientation {
 // remove the listener.
 class DomSubscription {
   DomSubscription(
-      this.target, String typeString, DartDomEventListener dartListener)
+      this.target, String typeString, DartDomEventListener dartListener,
+      {bool userCapture = false})
       : type = typeString.toJS,
         listener = createDomEventListener(dartListener) {
-    target._addEventListener1(type, listener);
+    target.addEventListener(typeString, listener, userCapture);
   }
 
   final JSString type;

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1707,7 +1707,7 @@ class IOSTextEditingStrategy extends GloballyPositionedTextEditingStrategy {
     subscriptions.add(DomSubscription(activeDomElement, 'blur',
             (_) {
               final bool isFastCallback = blurWatch.elapsed < _blurFastCallbackInterval;
-              if (windowHasFocus && isFastCallback) {
+              if (windowHasFocus || isFastCallback) {
                 activeDomElement.focus();
               } else {
                 owner.sendTextConnectionClosedToFrameworkIfAny();

--- a/lib/web_ui/test/engine/text_editing_test.dart
+++ b/lib/web_ui/test/engine/text_editing_test.dart
@@ -929,6 +929,15 @@ Future<void> testMain() async {
           textEditing!.strategy.domElement, 'abcd', 2, 3);
       expect(textEditing!.isEditing, isTrue);
 
+      // touchstart event is dispatched to the DOM element.
+      domDocument.dispatchEvent(createDomEvent('Event', 'touchstart'));
+      // No connection close message sent.
+      expect(spy.messages, hasLength(0));
+      await Future<void>.delayed(Duration.zero);
+      // DOM element still keeps the focus.
+      expect(defaultTextEditingRoot.ownerDocument?.activeElement,
+          textEditing!.strategy.domElement);
+
       // Delay for not to be a fast callback with blur.
       await Future<void>.delayed(const Duration(milliseconds: 200));
       // DOM element is blurred.


### PR DESCRIPTION
For [this issue](https://github.com/flutter/flutter/issues/143384) and [this](https://github.com/flutter/flutter/issues/149685)

https://github.com/flutter/engine/blob/47b15dfba1daefe63490f6ca0f374d79311f5913/lib/web_ui/lib/src/engine/text_editing/text_editing.dart#L1710

There should be use `||` instead of `&&`. The fourth comment above, if `isFastCallback` will remain the focus, so we call `activeDomElement.focus()`. 

If it is not fast callback >= 200ms and `windowHasFocus` is true, we also call `activeDomElement.focus()` to remain focused to wait for the framework to manage the focus change. In this case, if the user taps the `TapTextFieldTapRegion`, the active element should not lose focus. If we use `&&`, in this case, the `engine` sends `TextConnectionClose` to the `framework` to lose focus. So, the `framework` has no chance to manage the focus.