### PR TITLE
Run tests on macOS 13 or 14

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -30,7 +30,7 @@ platform_properties:
           {"dependency": "open_jdk", "version": "version:17"}
         ]
       device_type: none
-      os: Mac-13
+      os: Mac-13|Mac-14
       $flutter/osx_sdk : >-
         {
           "sdk_version": "15a240d"
@@ -363,7 +363,7 @@ targets:
           "sdk_version": "15a240d"
         }
     drone_dimensions:
-      - os=Mac-13
+      - os=Mac-13|Mac-14
 
   - name: Linux mac_clangd
     recipe: engine_v2/engine_v2
@@ -392,7 +392,7 @@ targets:
           "sdk_version": "15a240d"
         }
     drone_dimensions:
-      - os=Mac-13
+      - os=Mac-13|Mac-14
       - cpu=x86
 
   - name: Mac impeller-cmake-example

--- a/ci/builders/linux_web_engine.json
+++ b/ci/builders/linux_web_engine.json
@@ -1131,7 +1131,7 @@
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "cpu=arm64"
       ],
       "gclient_variables": {
@@ -1164,7 +1164,7 @@
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "cpu=arm64"
       ],
       "gclient_variables": {
@@ -1197,7 +1197,7 @@
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "cpu=arm64"
       ],
       "gclient_variables": {
@@ -1230,7 +1230,7 @@
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "cpu=arm64"
       ],
       "gclient_variables": {
@@ -1263,7 +1263,7 @@
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "cpu=arm64"
       ],
       "gclient_variables": {
@@ -1296,7 +1296,7 @@
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "cpu=arm64"
       ],
       "gclient_variables": {

--- a/ci/builders/local_engine.json
+++ b/ci/builders/local_engine.json
@@ -3,7 +3,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -35,7 +35,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -68,7 +68,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -100,7 +100,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -132,7 +132,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -165,7 +165,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -199,7 +199,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -310,7 +310,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -343,7 +343,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -427,7 +427,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -511,7 +511,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -542,7 +542,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -574,7 +574,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -606,7 +606,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -714,7 +714,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -795,7 +795,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "device_type=none"
       ],
       "gclient_variables": {

--- a/ci/builders/mac_android_aot_engine.json
+++ b/ci/builders/mac_android_aot_engine.json
@@ -14,7 +14,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -71,7 +71,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -130,7 +130,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -189,7 +189,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -246,7 +246,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -305,7 +305,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=x86"
             ],
             "gclient_variables": {

--- a/ci/builders/mac_clang_tidy.json
+++ b/ci/builders/mac_clang_tidy.json
@@ -3,7 +3,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -31,7 +31,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -64,7 +64,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -114,7 +114,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -164,7 +164,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -214,7 +214,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -264,7 +264,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=arm64"
             ],
             "gclient_variables": {

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -15,7 +15,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=x86",
                 "mac_model=Macmini8,1"
             ],
@@ -100,7 +100,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=x86",
                 "mac_model=Macmini8,1"
             ],
@@ -180,7 +180,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=x86",
                 "mac_model=Macmini8,1"
             ],
@@ -268,7 +268,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -337,7 +337,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -409,7 +409,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=arm64"
             ],
             "gclient_variables": {

--- a/ci/builders/mac_impeller_cmake_example.json
+++ b/ci/builders/mac_impeller_cmake_example.json
@@ -7,7 +7,7 @@
             "archives": [],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=arm64"
             ],
             "gclient_variables": {

--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -3,7 +3,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -49,7 +49,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13"
+                "os=Mac-13|Mac-14"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -96,7 +96,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13"
+                "os=Mac-13|Mac-14"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -140,7 +140,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13"
+                "os=Mac-13|Mac-14"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -185,7 +185,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13"
+                "os=Mac-13|Mac-14"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -230,7 +230,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -278,7 +278,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13"
+                "os=Mac-13|Mac-14"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -327,7 +327,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13"
+                "os=Mac-13|Mac-14"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -373,7 +373,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13"
+                "os=Mac-13|Mac-14"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -420,7 +420,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13"
+                "os=Mac-13|Mac-14"
             ],
             "gclient_variables": {
                 "download_android_deps": false,

--- a/ci/builders/mac_unopt.json
+++ b/ci/builders/mac_unopt.json
@@ -3,7 +3,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=x86",
                 "mac_model=Macmini8,1"
             ],
@@ -66,7 +66,7 @@
             },
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -121,7 +121,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -183,7 +183,7 @@
             },
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -250,7 +250,7 @@
             },
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -310,7 +310,7 @@
             "cas_archive": false,
             "drone_dimensions":
             [
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "device_type=none"
             ],
             "gclient_variables":
@@ -350,7 +350,7 @@
             "cas_archive": false,
             "drone_dimensions":
             [
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "device_type=none"
             ],
             "gclient_variables":

--- a/ci/builders/mac_unopt_debug_no_rbe.json
+++ b/ci/builders/mac_unopt_debug_no_rbe.json
@@ -11,7 +11,7 @@
     {
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "cpu=x86",
         "mac_model=Macmini8,1"
       ],

--- a/lib/web_ui/dev/generate_builder_json.dart
+++ b/lib/web_ui/dev/generate_builder_json.dart
@@ -113,10 +113,7 @@ Iterable<dynamic> _getAllTestSteps(List<TestSuite> suites) {
       suite.runConfig.browser == BrowserName.chrome ||
       suite.runConfig.browser == BrowserName.firefox
     ),
-    // TODO(jacksongardner): Stop filtering to Mac-12 after macOS 13 issues are fixed:
-    // https://github.com/flutter/flutter/issues/136274,
-    // https://github.com/flutter/flutter/issues/136279
-    ..._getTestStepsForPlatform(suites, 'Mac', specificOS: 'Mac-13', cpu: 'arm64', (TestSuite suite) =>
+    ..._getTestStepsForPlatform(suites, 'Mac', specificOS: 'Mac-13|Mac-14', cpu: 'arm64', (TestSuite suite) =>
       suite.runConfig.browser == BrowserName.safari
     ),
     ..._getTestStepsForPlatform(suites, 'Windows', (TestSuite suite) =>


### PR DESCRIPTION
In preparation of upgrading our fleet to macOS 14, allow tests to run on either macOS 13 or 14.

Fixes https://github.com/flutter/flutter/issues/148879.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
