### PR TITLE
[Impeller] Expand fast gradient to all shapes.

### DIFF
--- a/impeller/entity/contents/color_source_contents.h
+++ b/impeller/entity/contents/color_source_contents.h
@@ -141,11 +141,12 @@ class ColorSourceContents : public Contents {
     GeometryResult::Mode geometry_mode = GetGeometry()->GetResultMode();
     Geometry& geometry = *GetGeometry();
 
-    const bool is_stencil_then_cover =
+    bool is_stencil_then_cover =
         geometry_mode == GeometryResult::Mode::kNonZero ||
         geometry_mode == GeometryResult::Mode::kEvenOdd;
     if (!is_stencil_then_cover && force_stencil) {
       geometry_mode = GeometryResult::Mode::kNonZero;
+      is_stencil_then_cover = true;
     }
 
     if (is_stencil_then_cover) {

--- a/impeller/entity/contents/color_source_contents.h
+++ b/impeller/entity/contents/color_source_contents.h
@@ -12,6 +12,7 @@
 #include "impeller/entity/geometry/geometry.h"
 #include "impeller/entity/geometry/rect_geometry.h"
 #include "impeller/geometry/matrix.h"
+#include "impeller/renderer/render_pass.h"
 
 namespace impeller {
 
@@ -111,6 +112,19 @@ class ColorSourceContents : public Contents {
   using PipelineBuilderCallback =
       std::function<std::shared_ptr<Pipeline<PipelineDescriptor>>(
           ContentContextOptions)>;
+  using CreateGeometryCallback =
+      std::function<GeometryResult(const ContentContext& renderer,
+                                   const Entity& entity,
+                                   RenderPass& pass,
+                                   const Geometry& geom)>;
+
+  static GeometryResult DefaultCreateGeometryCallback(
+      const ContentContext& renderer,
+      const Entity& entity,
+      RenderPass& pass,
+      const Geometry& geom) {
+    return geom.GetPositionBuffer(renderer, entity, pass);
+  }
 
   template <typename VertexShaderT>
   bool DrawGeometry(const ContentContext& renderer,
@@ -118,7 +132,10 @@ class ColorSourceContents : public Contents {
                     RenderPass& pass,
                     const PipelineBuilderCallback& pipeline_callback,
                     typename VertexShaderT::FrameInfo frame_info,
-                    const BindFragmentCallback& bind_fragment_callback) const {
+                    const BindFragmentCallback& bind_fragment_callback,
+                    bool force_stencil = false,
+                    const CreateGeometryCallback& create_geom_callback =
+                        DefaultCreateGeometryCallback) const {
     auto options = OptionsFromPassAndEntity(pass, entity);
 
     GeometryResult::Mode geometry_mode = GetGeometry()->GetResultMode();
@@ -127,6 +144,10 @@ class ColorSourceContents : public Contents {
     const bool is_stencil_then_cover =
         geometry_mode == GeometryResult::Mode::kNonZero ||
         geometry_mode == GeometryResult::Mode::kEvenOdd;
+    if (!is_stencil_then_cover && force_stencil) {
+      geometry_mode = GeometryResult::Mode::kNonZero;
+    }
+
     if (is_stencil_then_cover) {
       pass.SetStencilReference(0);
 
@@ -178,7 +199,7 @@ class ColorSourceContents : public Contents {
     }
 
     GeometryResult geometry_result =
-        geometry.GetPositionBuffer(renderer, entity, pass);
+        create_geom_callback(renderer, entity, pass, geometry);
     if (geometry_result.vertex_buffer.vertex_count == 0u) {
       return true;
     }

--- a/impeller/entity/contents/color_source_contents.h
+++ b/impeller/entity/contents/color_source_contents.h
@@ -175,6 +175,12 @@ class ColorSourceContents : public Contents {
               ContentContextOptions::StencilMode::kStencilEvenOddFill;
           break;
         default:
+          if (force_stencil) {
+            pass.SetCommandLabel("Stencil preparation (NonZero)");
+            options.stencil_mode =
+                ContentContextOptions::StencilMode::kStencilNonZeroFill;
+            break;
+          }
           FML_UNREACHABLE();
       }
       pass.SetPipeline(renderer.GetClipPipeline(options));

--- a/impeller/entity/contents/linear_gradient_contents.cc
+++ b/impeller/entity/contents/linear_gradient_contents.cc
@@ -8,6 +8,7 @@
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/entity/contents/gradient_generator.h"
 #include "impeller/entity/entity.h"
+#include "impeller/entity/geometry/geometry.h"
 #include "impeller/geometry/scalar.h"
 #include "impeller/renderer/render_pass.h"
 #include "impeller/renderer/vertex_buffer_builder.h"
@@ -56,8 +57,7 @@ bool LinearGradientContents::IsOpaque() const {
 }
 
 bool LinearGradientContents::CanApplyFastGradient() const {
-  if (!GetGeometry()->IsAxisAlignedRect() ||
-      !GetInverseEffectTransform().IsIdentity()) {
+  if (!GetInverseEffectTransform().IsIdentity()) {
     return false;
   }
   std::optional<Rect> maybe_rect = GetGeometry()->GetCoverage(Matrix());
@@ -107,69 +107,82 @@ bool LinearGradientContents::FastLinearGradient(const ContentContext& renderer,
   using VS = FastGradientPipeline::VertexShader;
   using FS = FastGradientPipeline::FragmentShader;
 
-  auto options = OptionsFromPassAndEntity(pass, entity);
-  options.primitive_type = PrimitiveType::kTriangle;
   Geometry& geometry = *GetGeometry();
+  bool force_stencil = !geometry.IsAxisAlignedRect();
 
-  // We already know this is an axis aligned rectangle, so the coverage will
-  // be approximately the same as the geometry. For non axis-algined rectangles,
-  // we can force stencil then cover (not done here). We give an identity
-  // transform to avoid double transforming the gradient.
-  std::optional<Rect> maybe_rect = geometry.GetCoverage(Matrix());
-  if (!maybe_rect.has_value()) {
-    return false;
-  }
-  Rect rect = maybe_rect.value();
-  bool horizontal_axis = start_point_.y == end_point_.y;
+  auto geom_callback = [&](const ContentContext& renderer, const Entity& entity,
+                           RenderPass& pass,
+                           const Geometry& geometry) -> GeometryResult {
+    // We already know this is an axis aligned rectangle, so the coverage will
+    // be approximately the same as the geometry. For non axis-algined
+    // rectangles, we can force stencil then cover (not done here). We give an
+    // identity transform to avoid double transforming the gradient.
+    std::optional<Rect> maybe_rect = geometry.GetCoverage(Matrix());
+    if (!maybe_rect.has_value()) {
+      return {};
+    }
+    Rect rect = maybe_rect.value();
+    bool horizontal_axis = start_point_.y == end_point_.y;
 
-  // Compute the locations of each breakpoint along the primary axis, then
-  // create a rectangle that joins each segment. There will be two triangles
-  // between each pair of points.
-  VertexBufferBuilder<VS::PerVertexData> vtx_builder;
-  vtx_builder.Reserve(6 * (stops_.size() - 1));
-  Point prev = start_point_;
-  for (auto i = 1u; i < stops_.size(); i++) {
-    Scalar t = stops_[i];
-    Point current = (1.0 - t) * start_point_ + t * end_point_;
-    Rect section = horizontal_axis
-                       ? Rect::MakeXYWH(prev.x, rect.GetY(), current.x - prev.x,
-                                        rect.GetHeight())
+    // Compute the locations of each breakpoint along the primary axis, then
+    // create a rectangle that joins each segment. There will be two triangles
+    // between each pair of points.
+    VertexBufferBuilder<VS::PerVertexData> vtx_builder;
+    vtx_builder.Reserve(6 * (stops_.size() - 1));
+    Point prev = start_point_;
+    for (auto i = 1u; i < stops_.size(); i++) {
+      Scalar t = stops_[i];
+      Point current = (1.0 - t) * start_point_ + t * end_point_;
+      Rect section = horizontal_axis
+                         ? Rect::MakeXYWH(prev.x, rect.GetY(),
+                                          current.x - prev.x, rect.GetHeight())
 
-                       : Rect::MakeXYWH(rect.GetX(), prev.y, rect.GetWidth(),
-                                        current.y - prev.y);
-    vtx_builder.AddVertices({
-        {section.GetLeftTop(), colors_[i - 1]},
-        {section.GetRightTop(), horizontal_axis ? colors_[i] : colors_[i - 1]},
-        {section.GetLeftBottom(),
-         horizontal_axis ? colors_[i - 1] : colors_[i]},
-        {section.GetRightTop(), horizontal_axis ? colors_[i] : colors_[i - 1]},
-        {section.GetLeftBottom(),
-         horizontal_axis ? colors_[i - 1] : colors_[i]},
-        {section.GetRightBottom(), colors_[i]},
-    });
-    prev = current;
-  }
-  auto& host_buffer = renderer.GetTransientsBuffer();
+                         : Rect::MakeXYWH(rect.GetX(), prev.y, rect.GetWidth(),
+                                          current.y - prev.y);
+      vtx_builder.AddVertices({
+          {section.GetLeftTop(), colors_[i - 1]},
+          {section.GetRightTop(),
+           horizontal_axis ? colors_[i] : colors_[i - 1]},
+          {section.GetLeftBottom(),
+           horizontal_axis ? colors_[i - 1] : colors_[i]},
+          {section.GetRightTop(),
+           horizontal_axis ? colors_[i] : colors_[i - 1]},
+          {section.GetLeftBottom(),
+           horizontal_axis ? colors_[i - 1] : colors_[i]},
+          {section.GetRightBottom(), colors_[i]},
+      });
+      prev = current;
+    }
+    return GeometryResult{
+        .type = PrimitiveType::kTriangle,
+        .vertex_buffer =
+            vtx_builder.CreateVertexBuffer(renderer.GetTransientsBuffer()),
+        .transform = entity.GetShaderTransform(pass),
+    };
+  };
 
   pass.SetLabel("LinearGradient");
-  pass.SetVertexBuffer(vtx_builder.CreateVertexBuffer(host_buffer));
-  pass.SetPipeline(renderer.GetFastGradientPipeline(options));
-  pass.SetStencilReference(0);
 
-  // Take the pre-populated vertex shader uniform struct and set managed
-  // values.
   VS::FrameInfo frame_info;
-  frame_info.mvp = entity.GetShaderTransform(pass);
 
-  VS::BindFrameInfo(pass, host_buffer.EmplaceUniform(frame_info));
+  PipelineBuilderCallback pipeline_callback =
+      [&renderer](ContentContextOptions options) {
+        return renderer.GetFastGradientPipeline(options);
+      };
+  return ColorSourceContents::DrawGeometry<VS>(
+      renderer, entity, pass, pipeline_callback, frame_info,
+      [this, &renderer, &entity](RenderPass& pass) {
+        auto& host_buffer = renderer.GetTransientsBuffer();
 
-  FS::FragInfo frag_info;
-  frag_info.alpha =
-      GetOpacityFactor() * GetGeometry()->ComputeAlphaCoverage(entity);
+        FS::FragInfo frag_info;
+        frag_info.alpha =
+            GetOpacityFactor() * GetGeometry()->ComputeAlphaCoverage(entity);
 
-  FS::BindFragInfo(pass, host_buffer.EmplaceUniform(frag_info));
+        FS::BindFragInfo(pass, host_buffer.EmplaceUniform(frag_info));
 
-  return pass.Draw().ok();
+        return true;
+      },
+      /*force_stencil=*/force_stencil, geom_callback);
 }
 
 bool LinearGradientContents::Render(const ContentContext& renderer,


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/148651

allows the fast gradient to apply to non-rect shapes where the start/end are still on the coverage rect. Goldens are slightly different but seem close enough?
