### PR TITLE
[Impeller] Move SeparatedVector2 to impeller/geometry.

### DIFF
--- a/impeller/geometry/BUILD.gn
+++ b/impeller/geometry/BUILD.gn
@@ -31,6 +31,8 @@ impeller_component("geometry") {
     "rect.h",
     "saturated_math.h",
     "scalar.h",
+    "separated_vector.cc",
+    "separated_vector.h",
     "shear.cc",
     "shear.h",
     "sigma.cc",

--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -19,6 +19,7 @@
 #include "impeller/geometry/point.h"
 #include "impeller/geometry/rect.h"
 #include "impeller/geometry/scalar.h"
+#include "impeller/geometry/separated_vector.h"
 #include "impeller/geometry/size.h"
 
 // TODO(zanderso): https://github.com/flutter/flutter/issues/127701
@@ -1139,6 +1140,40 @@ TEST(GeometryTest, Vector4Lerp) {
   Vector4 result = p.Lerp({5, 10, 15, 20}, 0.75);
   Vector4 expected(4, 8, 12, 16);
   ASSERT_VECTOR4_NEAR(result, expected);
+}
+
+TEST(GeometryTest, SeparatedVector2NormalizesWithConstructor) {
+  SeparatedVector2 v(Vector2(10, 0));
+  ASSERT_POINT_NEAR(v.direction, Vector2(1, 0));
+  ASSERT_NEAR(v.magnitude, 10, kEhCloseEnough);
+}
+
+TEST(GeometryTest, SeparatedVector2GetVector) {
+  SeparatedVector2 v(Vector2(10, 0));
+  ASSERT_POINT_NEAR(v.GetVector(), Vector2(10, 0));
+}
+
+TEST(GeometryTest, SeparatedVector2GetAlignment) {
+  // Parallel
+  {
+    SeparatedVector2 v(Vector2(10, 0));
+    Scalar actual = v.GetAlignment(SeparatedVector2(Vector2(5, 0)));
+    ASSERT_NEAR(actual, 1, kEhCloseEnough);
+  }
+
+  // Perpendicular
+  {
+    SeparatedVector2 v(Vector2(10, 0));
+    Scalar actual = v.GetAlignment(SeparatedVector2(Vector2(0, 5)));
+    ASSERT_NEAR(actual, 0, kEhCloseEnough);
+  }
+
+  // Opposite parallel
+  {
+    SeparatedVector2 v(Vector2(0, 10));
+    Scalar actual = v.GetAlignment(SeparatedVector2(Vector2(0, -5)));
+    ASSERT_NEAR(actual, -1, kEhCloseEnough);
+  }
 }
 
 TEST(GeometryTest, CanUseVector3AssignmentOperators) {

--- a/impeller/geometry/geometry_unittests.cc
+++ b/impeller/geometry/geometry_unittests.cc
@@ -1176,6 +1176,22 @@ TEST(GeometryTest, SeparatedVector2GetAlignment) {
   }
 }
 
+TEST(GeometryTest, SeparatedVector2AngleTo) {
+  {
+    SeparatedVector2 v(Vector2(10, 0));
+    Radians actual = v.AngleTo(SeparatedVector2(Vector2(5, 0)));
+    Radians expected = Radians{0};
+    ASSERT_NEAR(actual.radians, expected.radians, kEhCloseEnough);
+  }
+
+  {
+    SeparatedVector2 v(Vector2(10, 0));
+    Radians actual = v.AngleTo(SeparatedVector2(Vector2(0, -5)));
+    Radians expected = Radians{-kPi / 2};
+    ASSERT_NEAR(actual.radians, expected.radians, kEhCloseEnough);
+  }
+}
+
 TEST(GeometryTest, CanUseVector3AssignmentOperators) {
   {
     Vector3 p(1, 2, 4);

--- a/impeller/geometry/separated_vector.cc
+++ b/impeller/geometry/separated_vector.cc
@@ -1,0 +1,29 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "separated_vector.h"
+
+namespace impeller {
+
+SeparatedVector2::SeparatedVector2() = default;
+
+SeparatedVector2::SeparatedVector2(Vector2 direction, Scalar magnitude)
+    : direction(direction), magnitude(magnitude){};
+
+SeparatedVector2::SeparatedVector2(Vector2 vector)
+    : direction(vector.Normalize()), magnitude(vector.GetLength()){};
+
+Vector2 SeparatedVector2::GetVector() const {
+  return direction * magnitude;
+}
+
+Scalar SeparatedVector2::GetAlignment(const SeparatedVector2& other) const {
+  return direction.Dot(other.direction);
+}
+
+Radians SeparatedVector2::AngleTo(const SeparatedVector2& other) const {
+  return direction.AngleTo(other.direction);
+}
+
+}  // namespace impeller

--- a/impeller/geometry/separated_vector.h
+++ b/impeller/geometry/separated_vector.h
@@ -1,0 +1,51 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_GEOMETRY_SEPARATED_VECTOR_H_
+#define FLUTTER_IMPELLER_GEOMETRY_SEPARATED_VECTOR_H_
+
+#include "impeller/geometry/point.h"
+
+#include "impeller/geometry/scalar.h"
+
+namespace impeller {
+
+/// @brief  A Vector2, broken down as a separate magnitude and direction.
+///         Assumes that the direction given is normalized.
+///
+///         This is a simple convenience struct for handling polyline offset
+///         values when generating stroke geometry. For performance reasons,
+///         it's sometimes adventageous to track the direction and magnitude
+///         for offsets separately.
+struct SeparatedVector2 {
+  /// The normalized direction of the ray.
+  Vector2 direction;
+
+  /// The magnitude of the ray.
+  Scalar magnitude = 0.0;
+
+  SeparatedVector2();
+  SeparatedVector2(Vector2 direction, Scalar magnitude);
+  explicit SeparatedVector2(Vector2 vector);
+
+  /// Returns the vector representation of the ray.
+  Vector2 GetVector() const;
+
+  /// Returns the scalar alignment of the two vectors.
+  /// In other words, the dot product of the two normalized vectors.
+  ///
+  /// Range: [-1, 1]
+  /// A value of 1 indicates the directions are parallel and pointing in the
+  /// same direction. A value of -1 indicates the vectors are parallel and
+  /// pointing in opposite directions. A value of 0 indicates the vectors are
+  /// perpendicular.
+  Scalar GetAlignment(const SeparatedVector2& other) const;
+
+  /// Returns the scalar angle between the two rays.
+  Radians AngleTo(const SeparatedVector2& other) const;
+};
+
+#endif  // FLUTTER_IMPELLER_GEOMETRY_SEPARATED_VECTOR_H_
+
+}  // namespace impeller

--- a/impeller/geometry/separated_vector.h
+++ b/impeller/geometry/separated_vector.h
@@ -19,17 +19,17 @@ namespace impeller {
 ///         it's sometimes adventageous to track the direction and magnitude
 ///         for offsets separately.
 struct SeparatedVector2 {
-  /// The normalized direction of the ray.
+  /// The normalized direction of the vector.
   Vector2 direction;
 
-  /// The magnitude of the ray.
+  /// The magnitude of the vector.
   Scalar magnitude = 0.0;
 
   SeparatedVector2();
   SeparatedVector2(Vector2 direction, Scalar magnitude);
   explicit SeparatedVector2(Vector2 vector);
 
-  /// Returns the vector representation of the ray.
+  /// Returns the vector representation of the vector.
   Vector2 GetVector() const;
 
   /// Returns the scalar alignment of the two vectors.


### PR DESCRIPTION
Follow-up for https://github.com/flutter/engine/pull/53210.

Also rename from `Ray` to `SeparatedVector2`, which is a more accurate name for what it is.