### PR TITLE
Revert "Widen CPU affinity set."

### DIFF
--- a/fml/cpu_affinity.cc
+++ b/fml/cpu_affinity.cc
@@ -58,8 +58,6 @@ CPUSpeedTracker::CPUSpeedTracker(std::vector<CpuIndexAndSpeed> data)
     }
     if (data.speed == min_speed_value) {
       efficiency_.push_back(data.index);
-    } else {
-      not_efficiency_.push_back(data.index);
     }
   }
 
@@ -79,8 +77,6 @@ const std::vector<size_t>& CPUSpeedTracker::GetIndices(
       return efficiency_;
     case CpuAffinity::kNotPerformance:
       return not_performance_;
-    case CpuAffinity::kNotEfficiency:
-      return not_efficiency_;
   }
 }
 

--- a/fml/cpu_affinity.h
+++ b/fml/cpu_affinity.h
@@ -26,9 +26,6 @@ enum class CpuAffinity {
 
   /// @brief Request affinity for all non-performance cores.
   kNotPerformance,
-
-  /// @brief Request affinity for all non-efficiency cores.
-  kNotEfficiency,
 };
 
 /// @brief Request count of efficiency cores.
@@ -82,7 +79,6 @@ class CPUSpeedTracker {
   std::vector<size_t> efficiency_;
   std::vector<size_t> performance_;
   std::vector<size_t> not_performance_;
-  std::vector<size_t> not_efficiency_;
 };
 
 /// @note Visible for testing.

--- a/fml/cpu_affinity_unittests.cc
+++ b/fml/cpu_affinity_unittests.cc
@@ -29,9 +29,6 @@ TEST(CpuAffinity, NormalSlowMedFastCores) {
   ASSERT_EQ(tracker.GetIndices(CpuAffinity::kNotPerformance).size(), 2u);
   ASSERT_EQ(tracker.GetIndices(CpuAffinity::kNotPerformance)[0], 0u);
   ASSERT_EQ(tracker.GetIndices(CpuAffinity::kNotPerformance)[1], 1u);
-  ASSERT_EQ(tracker.GetIndices(CpuAffinity::kNotEfficiency).size(), 2u);
-  ASSERT_EQ(tracker.GetIndices(CpuAffinity::kNotEfficiency)[0], 1u);
-  ASSERT_EQ(tracker.GetIndices(CpuAffinity::kNotEfficiency)[1], 2u);
 }
 
 TEST(CpuAffinity, NoCpuData) {

--- a/shell/platform/android/android_shell_holder.cc
+++ b/shell/platform/android/android_shell_holder.cc
@@ -49,14 +49,14 @@ static void AndroidPlatformThreadConfigSetter(
       break;
     }
     case fml::Thread::ThreadPriority::kDisplay: {
-      fml::RequestAffinity(fml::CpuAffinity::kNotEfficiency);
+      fml::RequestAffinity(fml::CpuAffinity::kPerformance);
       if (::setpriority(PRIO_PROCESS, 0, -1) != 0) {
         FML_LOG(ERROR) << "Failed to set UI task runner priority";
       }
       break;
     }
     case fml::Thread::ThreadPriority::kRaster: {
-      fml::RequestAffinity(fml::CpuAffinity::kNotEfficiency);
+      fml::RequestAffinity(fml::CpuAffinity::kPerformance);
       // Android describes -8 as "most important display threads, for
       // compositing the screen and retrieving input events". Conservatively
       // set the raster thread to slightly lower priority than it.


### PR DESCRIPTION
Reverts flutter/engine#53136

b/345642546 shows some massive performance regressions on this patch. i'll rework it so the conditions are only loosened on phones with one fast core.