### PR TITLE
Use dart.library.html to distinguish dart2wasm from dart2js/ddc in conditional imports

### DIFF
--- a/lib/web_ui/lib/src/engine/renderer.dart
+++ b/lib/web_ui/lib/src/engine/renderer.dart
@@ -7,7 +7,7 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:ui/src/engine.dart';
-import 'package:ui/src/engine/skwasm/skwasm_stub.dart' if (dart.library.ffi) 'package:ui/src/engine/skwasm/skwasm_impl.dart';
+import 'package:ui/src/engine/skwasm/skwasm_impl.dart' if (dart.library.html) 'package:ui/src/engine/skwasm/skwasm_stub.dart';
 import 'package:ui/ui.dart' as ui;
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 

--- a/lib/web_ui/lib/ui_web/src/ui_web/browser_detection.dart
+++ b/lib/web_ui/lib/ui_web/src/ui_web/browser_detection.dart
@@ -195,10 +195,7 @@ class BrowserDetection {
   bool get isEdge => userAgent.contains('Edg/');
 
   /// Whether we are running from a wasm module compiled with dart2wasm.
-  ///
-  /// Note: Currently the ffi library is available from dart2wasm but not dart2js
-  /// or dartdevc.
-  bool get isWasm => const bool.fromEnvironment('dart.library.ffi');
+  bool get isWasm => const bool.fromEnvironment('dart.tool.dart2wasm');
 }
 
 /// A short-hand accessor to the [BrowserDetection.instance] singleton.

--- a/lib/web_ui/lib/ui_web/src/ui_web/browser_detection.dart
+++ b/lib/web_ui/lib/ui_web/src/ui_web/browser_detection.dart
@@ -195,7 +195,7 @@ class BrowserDetection {
   bool get isEdge => userAgent.contains('Edg/');
 
   /// Whether we are running from a wasm module compiled with dart2wasm.
-  bool get isWasm => const bool.fromEnvironment('dart.tool.dart2wasm');
+  bool get isWasm => !const bool.fromEnvironment('dart.library.html');
 }
 
 /// A short-hand accessor to the [BrowserDetection.instance] singleton.

--- a/lib/web_ui/test/ui/utils.dart
+++ b/lib/web_ui/test/ui/utils.dart
@@ -5,8 +5,7 @@
 import 'dart:async';
 
 import 'package:ui/src/engine.dart';
-import 'package:ui/src/engine/skwasm/skwasm_stub.dart'
-    if (dart.library.ffi) 'package:ui/src/engine/skwasm/skwasm_impl.dart';
+import 'package:ui/src/engine/skwasm/skwasm_impl.dart' if (dart.library.html) 'package:ui/src/engine/skwasm/skwasm_stub.dart';
 import 'package:ui/ui.dart';
 
 import '../common/rendering.dart';

--- a/web_sdk/sdk_rewriter.dart
+++ b/web_sdk/sdk_rewriter.dart
@@ -102,7 +102,7 @@ const Set<String> rootLibraryNames = <String>{
 };
 
 final Map<Pattern, String> extraImportsMap = <Pattern, String>{
-  RegExp('skwasm_(stub|impl)'): "import 'dart:_skwasm_stub' if (dart.library.ffi) 'dart:_skwasm_impl';",
+  RegExp('skwasm_(stub|impl)'): "import 'dart:_skwasm_impl' if (dart.library.html) 'dart:_skwasm_stub';",
   'ui_web': "import 'dart:ui_web' as ui_web;",
   'engine': "import 'dart:_engine';",
   'web_unicode': "import 'dart:_web_unicode';",

--- a/web_sdk/test/sdk_rewriter_test.dart
+++ b/web_sdk/test/sdk_rewriter_test.dart
@@ -165,7 +165,7 @@ void printSomething() {
   test('gets correct extra imports', () {
     // Root libraries.
     expect(getExtraImportsForLibrary('engine'), <String>[
-      "import 'dart:_skwasm_stub' if (dart.library.ffi) 'dart:_skwasm_impl';",
+      "import 'dart:_skwasm_impl' if (dart.library.html) 'dart:_skwasm_stub';",
       "import 'dart:ui_web' as ui_web;",
       "import 'dart:_web_unicode';",
       "import 'dart:_web_test_fonts';",


### PR DESCRIPTION
Users of packages that have specialized code for the VM (which supports FFI) use conditional imports based on `dart.library.ffi`. We don't want the VM-specific code to be used for web in dart2wasm.

As a result we're going to make `dart.library.ffi` be false in conditional imports (as well as in
`const bool.fromEnvironment('dart.library.ffi')`).

Issue https://github.com/dart-lang/sdk/issues/55948
Issue https://github.com/flutter/flutter/issues/149984