### PR TITLE
[Impeller] disabling the color write mask seems to improve performance on iOS compared to just the blend options.

### DIFF
--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -40,6 +40,7 @@ void ContentContextOptions::ApplyToPipelineDescriptor(
   color0.format = color_attachment_pixel_format;
   color0.alpha_blend_op = BlendOperation::kAdd;
   color0.color_blend_op = BlendOperation::kAdd;
+  color0.write_mask = ColorWriteMaskBits::kAll;
 
   switch (pipeline_blend) {
     case BlendMode::kClear:

--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -69,6 +69,7 @@ void ContentContextOptions::ApplyToPipelineDescriptor(
       color0.dst_color_blend_factor = BlendFactor::kOne;
       color0.src_alpha_blend_factor = BlendFactor::kZero;
       color0.src_color_blend_factor = BlendFactor::kZero;
+      color0.write_mask = ColorWriteMaskBits::kNone;
       break;
     case BlendMode::kSourceOver:
       color0.dst_alpha_blend_factor = BlendFactor::kOneMinusSourceAlpha;


### PR DESCRIPTION
Otherwise should be semantically equivalent/no-op.