### PR TITLE
Setup `NativeAssetsApi` during isolate group creation

### DIFF
--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -107,6 +107,7 @@ source_set("runtime") {
     ":test_font",
     "$dart_src/runtime:dart_api",
     "$dart_src/runtime/bin:dart_io_api",
+    "$dart_src/runtime/bin:native_assets_api",
     "//flutter/assets",
     "//flutter/common",
     "//flutter/flow",

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -1175,11 +1175,6 @@ static void* NativeAssetsDlopenRelative(const char* path, char** error) {
                                                  error);
 }
 
-// This code can't live as DartFFI::InitForIsolateGroup in
-// lib/ffi/native_assets.cc with target "//flutter/lib/ffi:ffi", because it
-// would have a cyclic import with "//flutter/runtime:runtime" by using
-// DartIsolateGroupData. Because of the function pointers, it also cannot
-// capture the script_uri in a lambda.
 static void InitDartFFIForIsolateGroup() {
   NativeAssetsApi native_assets;
   memset(&native_assets, 0, sizeof(native_assets));
@@ -1218,9 +1213,9 @@ Dart_Isolate DartIsolate::CreateDartIsolateGroup(
     isolate_data.release();
     // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
 
-    success = InitializeIsolate(embedder_isolate, isolate, error);
-
     InitDartFFIForIsolateGroup();
+
+    success = InitializeIsolate(embedder_isolate, isolate, error);
   }
   if (!success) {
     Dart_ShutdownIsolate();


### PR DESCRIPTION
This initializes the `NativeAssetsApi` for native assets resolution in the isolate group creation callback.

* https://github.com/dart-lang/sdk/issues/55523

## Implementation considerations

The DartIO initialization lives in its own GN target. This doesn't work for the native assets initialization due to it having to look up the `script_uri` in one of the callbacks. Since the callbacks are function pointers, we can't have a lambda that captures the script uri. So instead, the native assets initialization lives in the flutter/runtime target.

The import from dart should probably be `runtime/include/bin/native_assets_api.h` to mirror what we're doing with dart IO, rather than directly importing from `runtime/bin/native_assets.h`.

## Testing

All native asset testing is in flutter_tools, so those tests will only run once this rolls into flutter/flutter. I have done manual testing locally with a Dart branch that removes the fallback: https://dart-review.googlesource.com/c/sdk/+/370740

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
