### PR TITLE
[engine] null check texture registry in OnPlatformViewMarkTextureFrameAvailable.

### DIFF
--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1186,6 +1186,9 @@ void Shell::OnPlatformViewMarkTextureFrameAvailable(int64_t texture_id) {
   // Tell the rasterizer that one of its textures has a new frame available.
   task_runners_.GetRasterTaskRunner()->PostTask(
       [rasterizer = rasterizer_->GetWeakPtr(), texture_id]() {
+        if (rasterizer) {
+          return;
+        }
         auto registry = rasterizer->GetTextureRegistry();
 
         if (!registry) {

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1186,7 +1186,7 @@ void Shell::OnPlatformViewMarkTextureFrameAvailable(int64_t texture_id) {
   // Tell the rasterizer that one of its textures has a new frame available.
   task_runners_.GetRasterTaskRunner()->PostTask(
       [rasterizer = rasterizer_->GetWeakPtr(), texture_id]() {
-        if (rasterizer) {
+        if (!rasterizer) {
           return;
         }
         auto registry = rasterizer->GetTextureRegistry();


### PR DESCRIPTION
From the issue, it looks like an NPE in this closure, we're not sure what else it could be besides the weak ptr - which could be null.

Fixes https://github.com/flutter/flutter/issues/149895