### PR TITLE
Revert "[web] switch from .didGain/LoseAccessibilityFocus to .focus (…

### DIFF
--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -2737,30 +2737,6 @@ DomCompositionEvent createDomCompositionEvent(String type,
   }
 }
 
-/// This is a pseudo-type for DOM elements that have the boolean `disabled`
-/// property.
-///
-/// This type cannot be part of the actual type hierarchy because each DOM type
-/// defines its `disabled` property ad hoc, without inheriting it from a common
-/// type, e.g. [DomHTMLInputElement] and [DomHTMLTextAreaElement].
-///
-/// To use, simply cast any element known to have the `disabled` property to
-/// this type using `as DomElementWithDisabledProperty`, then read and write
-/// this property as normal.
-@JS()
-@staticInterop
-class DomElementWithDisabledProperty extends DomHTMLElement {}
-
-extension DomElementWithDisabledPropertyExtension on DomElementWithDisabledProperty {
-  @JS('disabled')
-  external JSBoolean? get _disabled;
-  bool? get disabled => _disabled?.toDart;
-
-  @JS('disabled')
-  external set _disabled(JSBoolean? value);
-  set disabled(bool? value) => _disabled = value?.toJS;
-}
-
 @JS()
 @staticInterop
 class DomHTMLInputElement extends DomHTMLElement {}

--- a/lib/web_ui/lib/src/engine/semantics/text_field.dart
+++ b/lib/web_ui/lib/src/engine/semantics/text_field.dart
@@ -257,7 +257,6 @@ class TextField extends PrimaryRoleManager {
     editableElement = semanticsObject.hasFlag(ui.SemanticsFlag.isMultiline)
         ? createDomHTMLTextAreaElement()
         : createDomHTMLInputElement();
-    _updateEnabledState();
 
     // On iOS, even though the semantic text field is transparent, the cursor
     // and text highlighting are still visible. The cursor and text selection
@@ -311,7 +310,16 @@ class TextField extends PrimaryRoleManager {
           }
 
           EnginePlatformDispatcher.instance.invokeOnSemanticsAction(
-              semanticsObject.id, ui.SemanticsAction.focus, null);
+              semanticsObject.id, ui.SemanticsAction.didGainAccessibilityFocus, null);
+        }));
+    activeEditableElement.addEventListener('blur',
+        createDomEventListener((DomEvent event) {
+          if (EngineSemantics.instance.gestureMode != GestureMode.browserGestures) {
+            return;
+          }
+
+          EnginePlatformDispatcher.instance.invokeOnSemanticsAction(
+              semanticsObject.id, ui.SemanticsAction.didLoseAccessibilityFocus, null);
         }));
   }
 
@@ -425,19 +433,20 @@ class TextField extends PrimaryRoleManager {
     // and wait for a tap event before invoking the iOS workaround and creating
     // the editable element.
     if (editableElement != null) {
-      _updateEnabledState();
       activeEditableElement.style
         ..width = '${semanticsObject.rect!.width}px'
         ..height = '${semanticsObject.rect!.height}px';
 
       if (semanticsObject.hasFocus) {
-        if (domDocument.activeElement != activeEditableElement && semanticsObject.isEnabled) {
+        if (domDocument.activeElement !=
+            activeEditableElement) {
           semanticsObject.owner.addOneTimePostUpdateCallback(() {
             activeEditableElement.focus();
           });
         }
         SemanticsTextEditingStrategy._instance?.activate(this);
-      } else if (domDocument.activeElement == activeEditableElement) {
+      } else if (domDocument.activeElement ==
+          activeEditableElement) {
         if (!isIosSafari) {
           SemanticsTextEditingStrategy._instance?.deactivate(this);
           // Only apply text, because this node is not focused.
@@ -455,16 +464,6 @@ class TextField extends PrimaryRoleManager {
     } else {
       element.removeAttribute('aria-label');
     }
-  }
-
-  void _updateEnabledState() {
-    final DomElement? element = editableElement;
-
-    if (element == null) {
-      return;
-    }
-
-    (element as DomElementWithDisabledProperty).disabled = !semanticsObject.isEnabled;
   }
 
   @override

--- a/lib/web_ui/test/engine/semantics/semantics_tester.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_tester.dart
@@ -75,7 +75,6 @@ class SemanticsTester {
     bool? hasPaste,
     bool? hasDidGainAccessibilityFocus,
     bool? hasDidLoseAccessibilityFocus,
-    bool? hasFocus,
     bool? hasCustomAction,
     bool? hasDismiss,
     bool? hasMoveCursorForwardByWord,
@@ -242,9 +241,6 @@ class SemanticsTester {
     }
     if (hasDidLoseAccessibilityFocus ?? false) {
       actions |= ui.SemanticsAction.didLoseAccessibilityFocus.index;
-    }
-    if (hasFocus ?? false) {
-      actions |= ui.SemanticsAction.focus.index;
     }
     if (hasCustomAction ?? false) {
       actions |= ui.SemanticsAction.customAction.index;

--- a/lib/web_ui/test/engine/semantics/text_field_test.dart
+++ b/lib/web_ui/test/engine/semantics/text_field_test.dart
@@ -102,26 +102,15 @@ void testMain() {
     //                make sure it tests the right things:
     //                https://github.com/flutter/flutter/issues/147200
     final SemanticsObject node = owner().debugSemanticsTree![0]!;
-    final TextField textFieldRole = node.primaryRole! as TextField;
-    final DomHTMLInputElement inputElement = textFieldRole.activeEditableElement as DomHTMLInputElement;
-    expect(inputElement.tagName.toLowerCase(), 'input');
-    expect(inputElement.value, '');
-    expect(inputElement.disabled, isFalse);
-  });
-
-  test('renders a disabled text field', () {
-    createTextFieldSemantics(isEnabled: false, value: 'hello');
-    expectSemanticsTree(owner(), '''<sem><input /></sem>''');
-    final SemanticsObject node = owner().debugSemanticsTree![0]!;
-    final TextField textFieldRole = node.primaryRole! as TextField;
-    final DomHTMLInputElement inputElement = textFieldRole.activeEditableElement as DomHTMLInputElement;
-    expect(inputElement.tagName.toLowerCase(), 'input');
-    expect(inputElement.disabled, isTrue);
+    expect(
+      (node.element as DomHTMLInputElement).value,
+      isNull,
+    );
   });
 
     // TODO(yjbanov): this test will need to be adjusted for Safari when we add
     //                Safari testing.
-    test('sends a SemanticsAction.focus action when browser requests focus', () async {
+    test('sends a didGainAccessibilityFocus/didLoseAccessibilityFocus action when browser requests focus/blur', () async {
       final SemanticsActionLogger logger = SemanticsActionLogger();
       createTextFieldSemantics(value: 'hello');
 
@@ -134,11 +123,13 @@ void testMain() {
 
       expect(owner().semanticsHost.ownerDocument?.activeElement, textField);
       expect(await logger.idLog.first, 0);
-      expect(await logger.actionLog.first, ui.SemanticsAction.focus);
+      expect(await logger.actionLog.first, ui.SemanticsAction.didGainAccessibilityFocus);
 
       textField.blur();
 
       expect(owner().semanticsHost.ownerDocument?.activeElement, isNot(textField));
+      expect(await logger.idLog.first, 0);
+      expect(await logger.actionLog.first, ui.SemanticsAction.didLoseAccessibilityFocus);
     }, // TODO(yjbanov): https://github.com/flutter/flutter/issues/46638
        // TODO(yjbanov): https://github.com/flutter/flutter/issues/50590
     skip: ui_web.browser.browserEngine != ui_web.BrowserEngine.blink);
@@ -436,7 +427,6 @@ void testMain() {
         children: <SemanticsNodeUpdate>[
           builder.updateNode(
             id: 1,
-            isEnabled: true,
             isTextField: true,
             value: 'Hello',
             isFocused: focusFieldId == 1,
@@ -444,7 +434,6 @@ void testMain() {
           ),
           builder.updateNode(
             id: 2,
-            isEnabled: true,
             isTextField: true,
             value: 'World',
             isFocused: focusFieldId == 2,
@@ -895,7 +884,6 @@ void testMain() {
 SemanticsObject createTextFieldSemantics({
   required String value,
   String label = '',
-  bool isEnabled = true,
   bool isFocused = false,
   bool isMultiline = false,
   ui.Rect rect = const ui.Rect.fromLTRB(0, 0, 100, 50),
@@ -905,7 +893,6 @@ SemanticsObject createTextFieldSemantics({
   final SemanticsTester tester = SemanticsTester(owner());
   tester.updateNode(
     id: 0,
-    isEnabled: isEnabled,
     label: label,
     value: value,
     isTextField: true,
@@ -986,7 +973,6 @@ Map<int, SemanticsObject> createTwoFieldSemanticsForIos(SemanticsTester builder,
     children: <SemanticsNodeUpdate>[
       builder.updateNode(
         id: 1,
-        isEnabled: true,
         isTextField: true,
         value: 'Hello',
         label: 'Hello',
@@ -995,7 +981,6 @@ Map<int, SemanticsObject> createTwoFieldSemanticsForIos(SemanticsTester builder,
       ),
       builder.updateNode(
         id: 2,
-        isEnabled: true,
         isTextField: true,
         value: 'World',
         label: 'World',
@@ -1016,7 +1001,6 @@ Map<int, SemanticsObject> createTwoFieldSemanticsForIos(SemanticsTester builder,
     children: <SemanticsNodeUpdate>[
       builder.updateNode(
         id: 1,
-        isEnabled: true,
         isTextField: true,
         value: 'Hello',
         label: 'Hello',
@@ -1025,7 +1009,6 @@ Map<int, SemanticsObject> createTwoFieldSemanticsForIos(SemanticsTester builder,
       ),
       builder.updateNode(
         id: 2,
-        isEnabled: true,
         isTextField: true,
         value: 'World',
         label: 'World',


### PR DESCRIPTION
…#53134)"

This reverts commit a22270bc8419cb12d2560482476af3d61cc7978d.

Reverting because the engine PR landed prematurely. It needs to wait for a framework change, otherwise, things will break.