### PR TITLE
Give mac_host_engine tests a longer timeout and allow to run on Mac-14

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -363,7 +363,7 @@ targets:
           "sdk_version": "15a240d"
         }
     drone_dimensions:
-      - os=Mac-13
+      - os=Mac-13|Mac-14
 
   - name: Linux mac_clangd
     recipe: engine_v2/engine_v2

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -15,7 +15,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=x86",
                 "mac_model=Macmini8,1"
             ],
@@ -84,7 +84,8 @@
                         "--engine-capture-core-dump"
                     ]
                 }
-            ]
+            ],
+            "timeout": 90
         },
         {
             "archives": [
@@ -100,7 +101,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=x86",
                 "mac_model=Macmini8,1"
             ],
@@ -163,7 +164,8 @@
                         "--engine-capture-core-dump"
                     ]
                 }
-            ]
+            ],
+            "timeout": 90
         },
         {
             "archives": [
@@ -180,7 +182,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=x86",
                 "mac_model=Macmini8,1"
             ],
@@ -251,7 +253,8 @@
                         "dart,dart-host,engine"
                     ]
                 }
-            ]
+            ],
+            "timeout": 90
         },
         {
             "archives": [
@@ -268,7 +271,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-14",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -319,9 +322,11 @@
             },
             "properties": {
                 "$flutter/osx_sdk": {
-                    "sdk_version": "15a240d"
+                    "sdk_version": "15a240d",
+                    "cleanup_cache": true
                 }
-            }
+            },
+            "timeout": 90
         },
         {
             "archives": [
@@ -337,7 +342,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -386,7 +391,8 @@
                 "$flutter/osx_sdk": {
                     "sdk_version": "15a240d"
                 }
-            }
+            },
+            "timeout": 90
         },
         {
             "archives": [
@@ -409,7 +415,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13",
+                "os=Mac-13|Mac-14",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -478,7 +484,8 @@
                         "impeller-golden"
                     ]
                 }
-            ]
+            ],
+            "timeout": 90
         }
     ],
     "generators": {

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -325,7 +325,7 @@
                     "sdk_version": "15a240d"
                 }
             },
-            "timeout": 4
+            "timeout": 90
         },
         {
             "archives": [

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -271,7 +271,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-13|Mac-14",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -322,11 +322,10 @@
             },
             "properties": {
                 "$flutter/osx_sdk": {
-                    "sdk_version": "15a240d",
-                    "cleanup_cache": true
+                    "sdk_version": "15a240d"
                 }
             },
-            "timeout": 90
+            "timeout": 4
         },
         {
             "archives": [


### PR DESCRIPTION
Allow Mac mac_host_engine tests to run for up to 90 minutes (previously assumed 60) and allow the tests to run on Mac-14. This should give the test more time when it needs to do additional tasks like install Xcode.

Timeout was recently added in https://flutter-review.googlesource.com/c/recipes/+/57980.

Timeout tested in https://ci.chromium.org/ui/p/flutter/builders/try/Mac%20Engine%20Drone/941415/infra (timeout set to 4 minutes).

Fixes https://github.com/flutter/flutter/issues/150011.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
