### PR TITLE
Change element to wait for in AppExtensionTests testAppExtensionLaunching

### DIFF
--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/AppExtensionTests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/AppExtensionTests.m
@@ -33,13 +33,6 @@
   [button tap];
   BOOL launchedExtensionInFlutter = NO;
 
-  // Wait for first cell of share sheet to appear.
-  XCUIElement* firstCell = self.hostApplication.collectionViews.cells.firstMatch;
-  if (![firstCell waitForExistenceWithTimeout:10]) {
-    NSLog(@"%@", self.hostApplication.debugDescription);
-    XCTFail(@"Failed due to not able to find any cells with %@ seconds", @(10));
-  }
-
   // Custom share extension button (like the one in this test) does not have a
   // unique identity on older versions of iOS. They are all identified as
   // `XCElementSnapshotPrivilegedValuePlaceholder`. On iOS 17, they are
@@ -49,6 +42,15 @@
   NSPredicate* cellPredicate = [NSPredicate
       predicateWithFormat:
           @"label == 'XCElementSnapshotPrivilegedValuePlaceholder' OR label = 'Scenarios'"];
+
+  // Wait for the first cell matching the cellPredicate on the share sheet to appear.
+  XCUIElement* firstCell =
+      [self.hostApplication.collectionViews.cells matchingPredicate:cellPredicate].firstMatch;
+  if (![firstCell waitForExistenceWithTimeout:10]) {
+    NSLog(@"%@", self.hostApplication.debugDescription);
+    XCTFail(@"Failed due to not able to find Scenarios cell within %@ seconds", @(10));
+  }
+
   NSArray<XCUIElement*>* shareSheetCells =
       [self.hostApplication.collectionViews.cells matchingPredicate:cellPredicate]
           .allElementsBoundByIndex;


### PR DESCRIPTION
Instead of waiting for the first cell in the share sheet to appear, wait for the first cell matching the predicate to appear. It seems that on macOS 14 it [occasionally doesn't find any matches](https://github.com/flutter/flutter/issues/150117#issuecomment-2163493564), presumably a race condition - so this will wait up to 10 seconds for the desired elements to appear.

Attempting to fix https://github.com/flutter/flutter/issues/150117. I wasn't able to recreate locally and it only happens flakily in CI so hard to guarantee it will fix.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
