### PR TITLE
Add a `FlutterEngineRule` (JUnit `TestRule`) and use it in `FlutterRendererTest`

### DIFF
--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterEngineRule.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterEngineRule.java
@@ -1,0 +1,86 @@
+
+package io.flutter.embedding.engine.renderer;
+
+import android.content.Context;
+import android.content.Intent;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.embedding.engine.FlutterEngineCache;
+import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.embedding.engine.loader.FlutterLoader;
+
+/**
+ * Prepares and returns a {@link FlutterEngine} and {@link Intent} primed with an engine for tests.
+ */
+public final class FlutterEngineRule extends TestWatcher {
+    private final static Context ctx = ApplicationProvider.getApplicationContext();
+    private final static String cachedEngineId = "flutter_engine_rule_cached_engine";
+    private FlutterJNI flutterJNI;
+    private FlutterEngine flutterEngine;
+    private boolean jniIsAttached = true;
+
+    @Override
+    protected void starting(Description description) {
+        // Setup mock JNI.
+        flutterJNI = mock(FlutterJNI.class);
+        when(flutterJNI.isAttached()).thenAnswer(i -> jniIsAttached);
+
+        // We will not try to load plugins in these tests.
+        FlutterLoader mockFlutterLoader = mock(FlutterLoader.class);
+        when(mockFlutterLoader.automaticallyRegisterPlugins()).thenReturn(false);
+
+        // Create an engine.
+        flutterEngine = new FlutterEngine(ctx, mockFlutterLoader, flutterJNI);
+
+        // Place it in the engine cache.
+        FlutterEngineCache.getInstance().put(cachedEngineId, flutterEngine);
+    }
+
+    @Override
+    protected void finished(Description description) {
+        FlutterEngineCache.getInstance().clear();
+    }
+
+    /**
+     * Returns a Mockito-mocked version of {@link FlutterJNI}.
+     *
+     * @return an instance that is already considered attached.
+     */
+    FlutterJNI getFlutterJNI() {
+        return this.flutterJNI;
+    }
+
+    /**
+     * Returns a pre-configured engine.
+     *
+     * @return flutter engine using the mock provided by {{@link #getFlutterJNI()}}.
+     */
+    FlutterEngine getFlutterEngine() {
+        return this.flutterEngine;
+    }
+
+    /**
+     * Sets what {@link  FlutterJNI#isAttached()} returns. If not invoked, defaults to true.
+     * @param isAttached whether to consider JNI attached.
+     */
+    void setJniIsAttached(boolean isAttached) {
+        this.jniIsAttached = isAttached;
+    }
+
+    /**
+     * Creates an intent with {@link FlutterEngine} instance already provided.
+     * @return intent, i.e. to use with {@link androidx.test.ext.junit.rules.ActivityScenarioRule}.
+     */
+    Intent makeIntent() {
+        return FlutterActivity.withCachedEngine(cachedEngineId).build(ctx);
+    }
+}

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterEngineRule.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterEngineRule.java
@@ -18,8 +18,8 @@ import org.junit.runner.Description;
  * Prepares and returns a {@link FlutterEngine} and {@link Intent} primed with an engine for tests.
  */
 public final class FlutterEngineRule extends TestWatcher {
-  private static final Context ctx = ApplicationProvider.getApplicationContext();
   private static final String cachedEngineId = "flutter_engine_rule_cached_engine";
+  private Context ctx;
   private FlutterJNI flutterJNI;
   private FlutterEngine flutterEngine;
   private boolean jniIsAttached = true;
@@ -35,6 +35,7 @@ public final class FlutterEngineRule extends TestWatcher {
     when(mockFlutterLoader.automaticallyRegisterPlugins()).thenReturn(false);
 
     // Create an engine.
+    ctx = = ApplicationProvider.getApplicationContext();
     flutterEngine = new FlutterEngine(ctx, mockFlutterLoader, flutterJNI);
 
     // Place it in the engine cache.

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterEngineRule.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterEngineRule.java
@@ -19,7 +19,7 @@ import org.junit.runner.Description;
  */
 public final class FlutterEngineRule extends TestWatcher {
   private static final String cachedEngineId = "flutter_engine_rule_cached_engine";
-  private Context ctx;
+  private final Context ctx = ApplicationProvider.getApplicationContext();
   private FlutterJNI flutterJNI;
   private FlutterEngine flutterEngine;
   private boolean jniIsAttached = true;
@@ -35,7 +35,6 @@ public final class FlutterEngineRule extends TestWatcher {
     when(mockFlutterLoader.automaticallyRegisterPlugins()).thenReturn(false);
 
     // Create an engine.
-    ctx = ApplicationProvider.getApplicationContext();
     flutterEngine = new FlutterEngine(ctx, mockFlutterLoader, flutterJNI);
 
     // Place it in the engine cache.

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterEngineRule.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterEngineRule.java
@@ -35,7 +35,7 @@ public final class FlutterEngineRule extends TestWatcher {
     when(mockFlutterLoader.automaticallyRegisterPlugins()).thenReturn(false);
 
     // Create an engine.
-    ctx = = ApplicationProvider.getApplicationContext();
+    ctx = ApplicationProvider.getApplicationContext();
     flutterEngine = new FlutterEngine(ctx, mockFlutterLoader, flutterJNI);
 
     // Place it in the engine cache.

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterEngineRule.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterEngineRule.java
@@ -1,86 +1,84 @@
-
 package io.flutter.embedding.engine.renderer;
-
-import android.content.Context;
-import android.content.Intent;
-
-import androidx.test.core.app.ApplicationProvider;
-
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import android.content.Context;
+import android.content.Intent;
+import androidx.test.core.app.ApplicationProvider;
 import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterEngineCache;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.loader.FlutterLoader;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 
 /**
  * Prepares and returns a {@link FlutterEngine} and {@link Intent} primed with an engine for tests.
  */
 public final class FlutterEngineRule extends TestWatcher {
-    private final static Context ctx = ApplicationProvider.getApplicationContext();
-    private final static String cachedEngineId = "flutter_engine_rule_cached_engine";
-    private FlutterJNI flutterJNI;
-    private FlutterEngine flutterEngine;
-    private boolean jniIsAttached = true;
+  private static final Context ctx = ApplicationProvider.getApplicationContext();
+  private static final String cachedEngineId = "flutter_engine_rule_cached_engine";
+  private FlutterJNI flutterJNI;
+  private FlutterEngine flutterEngine;
+  private boolean jniIsAttached = true;
 
-    @Override
-    protected void starting(Description description) {
-        // Setup mock JNI.
-        flutterJNI = mock(FlutterJNI.class);
-        when(flutterJNI.isAttached()).thenAnswer(i -> jniIsAttached);
+  @Override
+  protected void starting(Description description) {
+    // Setup mock JNI.
+    flutterJNI = mock(FlutterJNI.class);
+    when(flutterJNI.isAttached()).thenAnswer(i -> jniIsAttached);
 
-        // We will not try to load plugins in these tests.
-        FlutterLoader mockFlutterLoader = mock(FlutterLoader.class);
-        when(mockFlutterLoader.automaticallyRegisterPlugins()).thenReturn(false);
+    // We will not try to load plugins in these tests.
+    FlutterLoader mockFlutterLoader = mock(FlutterLoader.class);
+    when(mockFlutterLoader.automaticallyRegisterPlugins()).thenReturn(false);
 
-        // Create an engine.
-        flutterEngine = new FlutterEngine(ctx, mockFlutterLoader, flutterJNI);
+    // Create an engine.
+    flutterEngine = new FlutterEngine(ctx, mockFlutterLoader, flutterJNI);
 
-        // Place it in the engine cache.
-        FlutterEngineCache.getInstance().put(cachedEngineId, flutterEngine);
-    }
+    // Place it in the engine cache.
+    FlutterEngineCache.getInstance().put(cachedEngineId, flutterEngine);
+  }
 
-    @Override
-    protected void finished(Description description) {
-        FlutterEngineCache.getInstance().clear();
-    }
+  @Override
+  protected void finished(Description description) {
+    FlutterEngineCache.getInstance().clear();
+  }
 
-    /**
-     * Returns a Mockito-mocked version of {@link FlutterJNI}.
-     *
-     * @return an instance that is already considered attached.
-     */
-    FlutterJNI getFlutterJNI() {
-        return this.flutterJNI;
-    }
+  /**
+   * Returns a Mockito-mocked version of {@link FlutterJNI}.
+   *
+   * @return an instance that is already considered attached.
+   */
+  FlutterJNI getFlutterJNI() {
+    return this.flutterJNI;
+  }
 
-    /**
-     * Returns a pre-configured engine.
-     *
-     * @return flutter engine using the mock provided by {{@link #getFlutterJNI()}}.
-     */
-    FlutterEngine getFlutterEngine() {
-        return this.flutterEngine;
-    }
+  /**
+   * Returns a pre-configured engine.
+   *
+   * @return flutter engine using the mock provided by {{@link #getFlutterJNI()}}.
+   */
+  FlutterEngine getFlutterEngine() {
+    return this.flutterEngine;
+  }
 
-    /**
-     * Sets what {@link  FlutterJNI#isAttached()} returns. If not invoked, defaults to true.
-     * @param isAttached whether to consider JNI attached.
-     */
-    void setJniIsAttached(boolean isAttached) {
-        this.jniIsAttached = isAttached;
-    }
+  /**
+   * Sets what {@link FlutterJNI#isAttached()} returns. If not invoked, defaults to true.
+   *
+   * @param isAttached whether to consider JNI attached.
+   */
+  void setJniIsAttached(boolean isAttached) {
+    this.jniIsAttached = isAttached;
+  }
 
-    /**
-     * Creates an intent with {@link FlutterEngine} instance already provided.
-     * @return intent, i.e. to use with {@link androidx.test.ext.junit.rules.ActivityScenarioRule}.
-     */
-    Intent makeIntent() {
-        return FlutterActivity.withCachedEngine(cachedEngineId).build(ctx);
-    }
+  /**
+   * Creates an intent with {@link FlutterEngine} instance already provided.
+   *
+   * @return intent, i.e. to use with {@link androidx.test.ext.junit.rules.ActivityScenarioRule}.
+   */
+  Intent makeIntent() {
+    return FlutterActivity.withCachedEngine(cachedEngineId).build(ctx);
+  }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -268,8 +268,14 @@ public class FlutterRendererTest {
 
   @Test
   public void itConvertsDisplayFeatureArrayToPrimitiveArrays() {
+    // Intentionally do not use 'engineRule' in this test, because we are testing a very narrow
+    // API (the side-effects of 'setViewportMetrics'). Under normal construction, the engine will
+    // invoke 'setViewportMetrics' a number of times automatically, making testing the side-effects
+    // of the method call more difficult than needed.
+    FlutterJNI fakeFlutterJNI = mock(FlutterJNI.class);
+    FlutterRenderer flutterRenderer = new FlutterRenderer(fakeFlutterJNI);
+
     // Setup the test.
-    FlutterRenderer flutterRenderer = engineRule.getFlutterEngine().getRenderer();
     FlutterRenderer.ViewportMetrics metrics = new FlutterRenderer.ViewportMetrics();
     metrics.width = 1000;
     metrics.height = 1000;
@@ -284,7 +290,6 @@ public class FlutterRendererTest {
             new Rect(50, 60, 70, 80), FlutterRenderer.DisplayFeatureType.CUTOUT));
 
     // Execute the behavior under test.
-    clearInvocations(fakeFlutterJNI);
     flutterRenderer.setViewportMetrics(metrics);
 
     // Verify behavior under test.

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -9,7 +9,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.graphics.Canvas;
@@ -24,11 +23,9 @@ import android.graphics.SurfaceTexture;
 import android.media.Image;
 import android.os.Looper;
 import android.view.Surface;
-
 import androidx.lifecycle.Lifecycle;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-
 import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.view.TextureRegistry;
@@ -48,7 +45,8 @@ public class FlutterRendererTest {
   public final FlutterEngineRule engineRule = new FlutterEngineRule();
 
   @Rule(order = 2)
-  public final ActivityScenarioRule<FlutterActivity> scenarioRule = new ActivityScenarioRule<>(engineRule.makeIntent());
+  public final ActivityScenarioRule<FlutterActivity> scenarioRule =
+      new ActivityScenarioRule<>(engineRule.makeIntent());
 
   private FlutterJNI fakeFlutterJNI;
 
@@ -247,19 +245,19 @@ public class FlutterRendererTest {
     verify(fakeFlutterJNI, times(0)).unregisterTexture(eq(id));
   }
 
-  /** @noinspection FinalizeCalledExplicitly*/
+  /** @noinspection FinalizeCalledExplicitly */
   void runFinalization(FlutterRenderer.SurfaceTextureRegistryEntry entry) {
     CountDownLatch latch = new CountDownLatch(1);
     Thread fakeFinalizer =
         new Thread(
-                () -> {
-                  try {
-                    entry.finalize();
-                    latch.countDown();
-                  } catch (Throwable e) {
-                    // do nothing
-                  }
-                });
+            () -> {
+              try {
+                entry.finalize();
+                latch.countDown();
+              } catch (Throwable e) {
+                // do nothing
+              }
+            });
     fakeFinalizer.start();
     try {
       latch.await();
@@ -336,8 +334,7 @@ public class FlutterRendererTest {
     FlutterRenderer flutterRenderer = engineRule.getFlutterEngine().getRenderer();
 
     AtomicInteger invocationCount = new AtomicInteger(0);
-    final TextureRegistry.OnFrameConsumedListener listener =
-            invocationCount::incrementAndGet;
+    final TextureRegistry.OnFrameConsumedListener listener = invocationCount::incrementAndGet;
 
     FlutterRenderer.SurfaceTextureRegistryEntry entry =
         (FlutterRenderer.SurfaceTextureRegistryEntry) flutterRenderer.createSurfaceTexture();
@@ -384,7 +381,7 @@ public class FlutterRendererTest {
 
     AtomicInteger invocationCount = new AtomicInteger(0);
     final TextureRegistry.OnTrimMemoryListener listener =
-            level -> invocationCount.incrementAndGet();
+        level -> invocationCount.incrementAndGet();
 
     FlutterRenderer.SurfaceTextureRegistryEntry entry =
         (FlutterRenderer.SurfaceTextureRegistryEntry) flutterRenderer.createSurfaceTexture();
@@ -455,7 +452,8 @@ public class FlutterRendererTest {
   public void ImageReaderSurfaceProducerProducesImageOfCorrectSize() {
     FlutterRenderer flutterRenderer = engineRule.getFlutterEngine().getRenderer();
     TextureRegistry.SurfaceProducer producer = flutterRenderer.createSurfaceProducer();
-    FlutterRenderer.ImageReaderSurfaceProducer texture = (FlutterRenderer.ImageReaderSurfaceProducer) producer;
+    FlutterRenderer.ImageReaderSurfaceProducer texture =
+        (FlutterRenderer.ImageReaderSurfaceProducer) producer;
     texture.disableFenceForTest();
 
     // Returns a null image when one hasn't been produced.
@@ -510,7 +508,8 @@ public class FlutterRendererTest {
   public void ImageReaderSurfaceProducerDoesNotDropFramesWhenResizeInFlight() {
     FlutterRenderer flutterRenderer = engineRule.getFlutterEngine().getRenderer();
     TextureRegistry.SurfaceProducer producer = flutterRenderer.createSurfaceProducer();
-    FlutterRenderer.ImageReaderSurfaceProducer texture = (FlutterRenderer.ImageReaderSurfaceProducer) producer;
+    FlutterRenderer.ImageReaderSurfaceProducer texture =
+        (FlutterRenderer.ImageReaderSurfaceProducer) producer;
     texture.disableFenceForTest();
 
     // Returns a null image when one hasn't been produced.
@@ -540,7 +539,8 @@ public class FlutterRendererTest {
   public void ImageReaderSurfaceProducerImageReadersAndImagesCount() {
     FlutterRenderer flutterRenderer = engineRule.getFlutterEngine().getRenderer();
     TextureRegistry.SurfaceProducer producer = flutterRenderer.createSurfaceProducer();
-    FlutterRenderer.ImageReaderSurfaceProducer texture = (FlutterRenderer.ImageReaderSurfaceProducer) producer;
+    FlutterRenderer.ImageReaderSurfaceProducer texture =
+        (FlutterRenderer.ImageReaderSurfaceProducer) producer;
     texture.disableFenceForTest();
 
     // Returns a null image when one hasn't been produced.
@@ -622,7 +622,8 @@ public class FlutterRendererTest {
   public void ImageReaderSurfaceProducerTrimMemoryCallback() {
     FlutterRenderer flutterRenderer = engineRule.getFlutterEngine().getRenderer();
     TextureRegistry.SurfaceProducer producer = flutterRenderer.createSurfaceProducer();
-    FlutterRenderer.ImageReaderSurfaceProducer texture = (FlutterRenderer.ImageReaderSurfaceProducer) producer;
+    FlutterRenderer.ImageReaderSurfaceProducer texture =
+        (FlutterRenderer.ImageReaderSurfaceProducer) producer;
 
     texture.disableFenceForTest();
 

--- a/shell/platform/android/test_runner/src/main/AndroidManifest.xml
+++ b/shell/platform/android/test_runner/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 
   <application>
 
+    <activity android:name="io.flutter.embedding.android.FlutterActivity" />
+
     <activity android:name="io.flutter.embedding.android.FlutterFragmentActivity" />
 
     <activity android:name="io.flutter.embedding.android.FlutterFragmentActivityTest$FlutterFragmentActivityWithProvidedEngine" />


### PR DESCRIPTION
In https://github.com/flutter/engine/pull/53280, I'm adding lifecycle-aware methods to `SurfaceProducer`.

That means, in order to test that it WAI, we'll need to be running in a simulated activity, and be able to switch scenario states (i.e. to `RESUMED`). This was mentioned as well in https://github.com/flutter/flutter/issues/133151 as being something we want to do.

This PR adds a `FlutterEngineRule`, which allows the creation of a "real" `FlutterEngine` and an `Intent` that can power `AndroidScenarioRule<FlutterActivity>`. I felt bad doing all of this work for a single `@Test`, so I also refactored the rest of the file and cleaned things up a bit.

That said, I'm happy to revert or make changes if we liked how things were setup before.