### PR TITLE
[flatland] Handle fence overflow in flatland_connection.cc

### DIFF
--- a/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.cc
+++ b/shell/platform/fuchsia/flutter/tests/fakes/scenic/fake_flatland.cc
@@ -41,7 +41,7 @@ fuchsia::ui::composition::FlatlandHandle FakeFlatland::ConnectFlatland(
 }
 
 void FakeFlatland::Disconnect(fuchsia::ui::composition::FlatlandError error) {
-  flatland_binding_.events().OnError(std::move(error));
+  flatland_binding_.events().OnError(error);
   flatland_binding_.Unbind();
   allocator_binding_
       .Unbind();  // TODO(fxb/85619): Does the real Scenic unbind this when

--- a/shell/platform/fuchsia/flutter/tests/flatland_connection_unittests.cc
+++ b/shell/platform/fuchsia/flutter/tests/flatland_connection_unittests.cc
@@ -8,6 +8,8 @@
 #include <fuchsia/ui/composition/cpp/fidl.h>
 #include <lib/async-testing/test_loop.h>
 #include <lib/async/cpp/task.h>
+#include <zircon/rights.h>
+#include <zircon/types.h>
 
 #include <string>
 #include <vector>
@@ -31,9 +33,8 @@ void AwaitVsyncChecked(FlatlandConnection& flatland_connection,
                        bool& condition_variable,
                        fml::TimeDelta expected_frame_delta) {
   flatland_connection.AwaitVsync(
-      [&condition_variable,
-       expected_frame_delta = std::move(expected_frame_delta)](
-          fml::TimePoint frame_start, fml::TimePoint frame_end) {
+      [&condition_variable, expected_frame_delta](fml::TimePoint frame_start,
+                                                  fml::TimePoint frame_end) {
         EXPECT_EQ(frame_end.ToEpochDelta() - frame_start.ToEpochDelta(),
                   expected_frame_delta);
         condition_variable = true;
@@ -44,8 +45,8 @@ void AwaitVsyncChecked(FlatlandConnection& flatland_connection,
                        bool& condition_variable,
                        fml::TimePoint expected_frame_end) {
   flatland_connection.AwaitVsync(
-      [&condition_variable, expected_frame_end = std::move(expected_frame_end)](
-          fml::TimePoint frame_start, fml::TimePoint frame_end) {
+      [&condition_variable, expected_frame_end](fml::TimePoint frame_start,
+                                                fml::TimePoint frame_end) {
         EXPECT_EQ(frame_end, expected_frame_end);
         condition_variable = true;
       });
@@ -77,6 +78,10 @@ class FlatlandConnectionTest : public ::testing::Test {
   ~FlatlandConnectionTest() override = default;
 
   async::TestLoop& loop() { return loop_; }
+
+  async_dispatcher_t* subloop_dispatcher() {
+    return session_subloop_->dispatcher();
+  }
 
   FakeFlatland& fake_flatland() { return fake_flatland_; }
 
@@ -122,7 +127,7 @@ TEST_F(FlatlandConnectionTest, Initialization) {
   const std::string debug_name = GetCurrentTestName();
   flutter_runner::FlatlandConnection flatland_connection(
       debug_name, TakeFlatlandHandle(), []() { FAIL(); },
-      [](auto...) { FAIL(); });
+      [](auto...) { FAIL(); }, loop().dispatcher());
   EXPECT_EQ(fake_flatland().debug_name(), "");
 
   // Simulate an AwaitVsync that returns immediately.
@@ -145,7 +150,7 @@ TEST_F(FlatlandConnectionTest, FlatlandDisconnect) {
   // completed yet.
   flutter_runner::FlatlandConnection flatland_connection(
       GetCurrentTestName(), TakeFlatlandHandle(), std::move(on_session_error),
-      [](auto...) { FAIL(); });
+      [](auto...) { FAIL(); }, loop().dispatcher());
   EXPECT_FALSE(error_fired);
 
   // Simulate a flatland disconnection, then Pump the loop.  The error callback
@@ -179,7 +184,7 @@ TEST_F(FlatlandConnectionTest, BasicPresent) {
   // completed yet.
   flutter_runner::FlatlandConnection flatland_connection(
       GetCurrentTestName(), TakeFlatlandHandle(), []() { FAIL(); },
-      std::move(on_frame_presented));
+      std::move(on_frame_presented), loop().dispatcher());
   EXPECT_EQ(presents_called, 0u);
   EXPECT_EQ(vsyncs_handled, 0u);
 
@@ -198,7 +203,7 @@ TEST_F(FlatlandConnectionTest, BasicPresent) {
   // release fence should be queued.
   await_vsync_fired = false;
   zx::event first_release_fence;
-  zx::event::create(0, &first_release_fence);
+  zx::event::create(0u, &first_release_fence);
   const zx_handle_t first_release_fence_handle = first_release_fence.get();
   flatland_connection.EnqueueReleaseFence(std::move(first_release_fence));
   flatland_connection.Present();
@@ -252,7 +257,7 @@ TEST_F(FlatlandConnectionTest, AwaitVsyncsBeforeOnNextFrameBegin) {
   // completed yet.
   flutter_runner::FlatlandConnection flatland_connection(
       GetCurrentTestName(), TakeFlatlandHandle(), []() { FAIL(); },
-      [](auto...) {});
+      [](auto...) {}, loop().dispatcher());
   EXPECT_EQ(presents_called, 0u);
 
   // Pump the loop. Nothing is called.
@@ -292,7 +297,7 @@ TEST_F(FlatlandConnectionTest, RunsOutOfFuturePresentationInfos) {
   // completed yet.
   flutter_runner::FlatlandConnection flatland_connection(
       GetCurrentTestName(), TakeFlatlandHandle(), []() { FAIL(); },
-      std::move(on_frame_presented));
+      std::move(on_frame_presented), loop().dispatcher());
   EXPECT_EQ(presents_called, 0u);
   EXPECT_EQ(vsyncs_handled, 0u);
 
@@ -365,7 +370,7 @@ TEST_F(FlatlandConnectionTest, PresentCreditExhaustion) {
   on_frame_presented_event on_frame_presented = [](auto...) {};
   flutter_runner::FlatlandConnection flatland_connection(
       GetCurrentTestName(), TakeFlatlandHandle(), []() { FAIL(); },
-      std::move(on_frame_presented));
+      std::move(on_frame_presented), loop().dispatcher());
   EXPECT_EQ(num_presents_called, 0u);
 
   // Pump the loop. Nothing is called.
@@ -385,9 +390,9 @@ TEST_F(FlatlandConnectionTest, PresentCreditExhaustion) {
                            fml::TimePoint frame_end) {
     async::PostTask(dispatcher, [&flatland_connection]() {
       zx::event acquire_fence;
-      zx::event::create(0, &acquire_fence);
+      zx::event::create(0u, &acquire_fence);
       zx::event release_fence;
-      zx::event::create(0, &release_fence);
+      zx::event::create(0u, &release_fence);
       flatland_connection.EnqueueAcquireFence(std::move(acquire_fence));
       flatland_connection.EnqueueReleaseFence(std::move(release_fence));
       flatland_connection.Present();
@@ -481,6 +486,164 @@ TEST_F(FlatlandConnectionTest, PresentCreditExhaustion) {
   EXPECT_EQ(num_presents_called, 1u);
   EXPECT_EQ(num_acquire_fences, 1u);
   EXPECT_EQ(num_release_fences, num_onfb);
+}
+
+typedef struct {
+  std::shared_ptr<std::vector<zx::event>> fences;
+  std::shared_ptr<std::vector<zx::event>> fences_dup;
+} FencesPair;
+
+// Create two vectors of paired fences.
+FencesPair GetFencesPair(size_t num_fences) {
+  auto fences = std::make_shared<std::vector<zx::event>>();
+  auto fences_dup = std::make_shared<std::vector<zx::event>>();
+  for (size_t i = 0; i < num_fences; i++) {
+    zx::event fence;
+    auto status = zx::event::create(0u, &fence);
+    EXPECT_EQ(status, ZX_OK);
+
+    zx::event fence_dup;
+    status = fence.duplicate(ZX_RIGHT_SAME_RIGHTS, &fence_dup);
+    EXPECT_EQ(status, ZX_OK);
+
+    fences->push_back(std::move(fence));
+    fences_dup->push_back(std::move(fence_dup));
+  }
+  return FencesPair{
+      .fences = fences,
+      .fences_dup = fences_dup,
+  };
+}
+
+void SignalAll(std::vector<zx::event>* fences) {
+  for (auto& fence : *fences) {
+    const auto status = fence.signal(0, ZX_EVENT_SIGNALED);
+    ASSERT_EQ(status, ZX_OK);
+  }
+}
+
+void WaitAll(std::vector<zx::event>* fences) {
+  for (auto& fence : *fences) {
+    zx_signals_t ignored;
+    // Maybe the timeout here should be finite.
+    const auto status =
+        fence.wait_one(ZX_EVENT_SIGNALED, zx::time::infinite(), &ignored);
+    ASSERT_EQ(status, ZX_OK);
+  }
+}
+
+TEST_F(FlatlandConnectionTest, FenceStuffing) {
+  // Set up callbacks which allow sensing of how many presents were handled.
+  size_t num_presents_called = 0u;
+  size_t num_release_fences = 0u;
+  size_t num_acquire_fences = 0u;
+
+  auto reset_test_counters = [&num_presents_called, &num_acquire_fences,
+                              &num_release_fences]() {
+    num_presents_called = 0u;
+    num_release_fences = 0u;
+    num_acquire_fences = 0u;
+  };
+
+  fuchsia::ui::composition::PresentArgs last_present_args;
+  fake_flatland().SetPresentHandler(
+      [&num_presents_called, &num_acquire_fences, &num_release_fences,
+       &last_present_args](fuchsia::ui::composition::PresentArgs present_args) {
+        num_presents_called++;
+        num_acquire_fences = present_args.acquire_fences().size();
+        num_release_fences = present_args.release_fences().size();
+
+        last_present_args = std::move(present_args);
+      });
+
+  // Create the FlatlandConnection but don't pump the loop.  No FIDL calls are
+  // completed yet.
+  on_frame_presented_event on_frame_presented = [](auto...) {};
+  flutter_runner::FlatlandConnection flatland_connection(
+      GetCurrentTestName(), TakeFlatlandHandle(), []() { FAIL(); },
+      std::move(on_frame_presented), subloop_dispatcher());
+  EXPECT_EQ(num_presents_called, 0u);
+
+  // Pump the loop. Nothing is called.
+  loop().RunUntilIdle();
+  EXPECT_EQ(num_presents_called, 0u);
+
+  // Simulate an AwaitVsync that comes before the first Present.
+  flatland_connection.AwaitVsync([](fml::TimePoint, fml::TimePoint) {});
+  loop().RunUntilIdle();
+  EXPECT_EQ(num_presents_called, 0u);
+
+  constexpr size_t kMaxFences = 16;
+
+  // We must signal these.
+  FencesPair acquire = GetFencesPair(kMaxFences + 1);
+  // Flatland will signal these.
+  FencesPair release = GetFencesPair(kMaxFences + 1);
+
+  auto fire_callback = [dispatcher = loop().dispatcher(), &flatland_connection,
+                        rfd = release.fences_dup, afd = acquire.fences_dup](
+                           fml::TimePoint frame_start,
+                           fml::TimePoint frame_end) mutable {
+    async::PostTask(dispatcher, [&flatland_connection, rf = rfd, af = afd]() {
+      for (auto& fence : *rf) {
+        zx::event fence_dup;
+        const auto status = fence.duplicate(ZX_RIGHT_SAME_RIGHTS, &fence_dup);
+        ASSERT_EQ(status, ZX_OK);
+        flatland_connection.EnqueueReleaseFence(std::move(fence_dup));
+      }
+      for (auto& fence : *af) {
+        zx::event fence_dup;
+        const auto status = fence.duplicate(ZX_RIGHT_SAME_RIGHTS, &fence_dup);
+        ASSERT_EQ(status, ZX_OK);
+        flatland_connection.EnqueueAcquireFence(std::move(fence_dup));
+      }
+      flatland_connection.Present();
+    });
+  };
+
+  SignalAll(acquire.fences.get());
+
+  // Call Await Vsync with a callback that triggers Present and consumes the one
+  // and only present credit we start with.
+  reset_test_counters();
+  flatland_connection.AwaitVsync(fire_callback);
+
+  loop().RunUntilIdle();
+
+  EXPECT_EQ(num_presents_called, 1u);
+  EXPECT_EQ(num_acquire_fences, 16u);
+  EXPECT_EQ(num_release_fences, 0u);
+
+  // Move on to next present call. Reset all the expectations and callbacks.
+  reset_test_counters();
+  OnNextFrameBegin(1);
+  // Replenish present credits.
+  loop().RunUntilIdle();
+
+  flatland_connection.AwaitVsync([dispatcher = subloop_dispatcher(),
+                                  &flatland_connection](fml::TimePoint,
+                                                        fml::TimePoint) {
+    async::PostTask(dispatcher,
+                    [&flatland_connection] { flatland_connection.Present(); });
+  });
+  loop().RunUntilIdle();
+
+  // Simulate Flatland signaling all release fences. Note that the set of
+  // release fences here is only the first ~15 of the fences, the rest are
+  // released indirectly via the overflow mechanism.
+  SignalAll(last_present_args.mutable_release_fences());
+
+  loop().RunUntilIdle();
+
+  // At this point all release fences from prior frame should have been released
+  // by Flatland.
+  EXPECT_EQ(num_presents_called, 1u);
+  EXPECT_EQ(num_acquire_fences, 0u);
+  EXPECT_EQ(num_release_fences, 16u);
+
+  // Prove that all release fences have been signaled. If not, this will block
+  // forever.
+  WaitAll(release.fences.get());
 }
 
 }  // namespace flutter_runner::testing

--- a/tools/fuchsia/devshell/run_unit_tests.sh
+++ b/tools/fuchsia/devshell/run_unit_tests.sh
@@ -83,7 +83,13 @@ test_names=()
 for test_package in $test_packages
 do
   engine-info "... publishing ${test_package} ..."
-  ${FUCHSIA_DIR}/.jiri_root/bin/ffx repository publish $FUCHSIA_DIR/$(cat $FUCHSIA_DIR/.fx-build-dir)/amber-files --package-archive "${test_package}"
+  (
+    # ffx can not be called outside of FUCHSIA_DIR.
+    cd ${FUCHSIA_DIR}
+    ${FUCHSIA_DIR}/.jiri_root/bin/ffx repository publish \
+        $FUCHSIA_DIR/$(cat $FUCHSIA_DIR/.fx-build-dir)/amber-files \
+        --package-archive "${test_package}"
+  )
   test_names+=("$(basename ${test_package} | sed -e "s/-0.far//")")
 done
 


### PR DESCRIPTION
flatland_connection.cc used to allow an arbitrary number of acquire and release fences to be scheduled for each frame.

Sadly, Fuchsia has a limitation of (1) the number of total handles that can be sent per a FIDL call, but also (2) the Flatland protocol only supports sending up to 16 fences per each fence type.

Now, normally there should be very few scheduled fences per frame. But if frames get skipped, we could amass many fences which would then crash our attempts to send all of them to the Flatland `Present` endpoint.

This change introduces two fence multiplexer, which allow us to signal more than 16 fences per type, at a performance penalty. We expect to be able *not* to crash the FIDL subsystem using this approach, and may even be able to hobble along for a bit, until the fences issue is hopefully self-resolved.

That said, this issue seems to indicate there are frame scheduling problems elsewhere. But this is a fairly straightforward change to make without affecting the rest of the flatland code or integration, so we opt to do that first.

Issues: [#150136](https://github.com/flutter/engine/pull/53366)

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
