### PR TITLE
[DisplayList] cull clip operations that can be trivially and safely ignored

### DIFF
--- a/display_list/dl_builder.h
+++ b/display_list/dl_builder.h
@@ -566,6 +566,7 @@ class DisplayListBuilder final : public virtual DlCanvas,
     // For constructor (root layer) initialization
     explicit SaveInfo(const DlRect& cull_rect)
         : is_save_layer(true),
+          has_valid_clip(false),
           global_state(cull_rect),
           layer_state(cull_rect),
           layer_info(new LayerInfo(nullptr, 0u)) {}
@@ -576,6 +577,7 @@ class DisplayListBuilder final : public virtual DlCanvas,
     explicit SaveInfo(const SaveInfo* parent_info)
         : is_save_layer(false),
           has_deferred_save_op(true),
+          has_valid_clip(parent_info->has_valid_clip),
           global_state(parent_info->global_state),
           layer_state(parent_info->layer_state),
           layer_info(parent_info->layer_info) {}
@@ -585,6 +587,7 @@ class DisplayListBuilder final : public virtual DlCanvas,
                       const std::shared_ptr<const DlImageFilter>& filter,
                       int rtree_rect_index)
         : is_save_layer(true),
+          has_valid_clip(false),
           global_state(parent_info->global_state),
           layer_state(kMaxCullRect),
           layer_info(new LayerInfo(filter, rtree_rect_index)) {}
@@ -593,6 +596,7 @@ class DisplayListBuilder final : public virtual DlCanvas,
 
     bool has_deferred_save_op = false;
     bool is_nop = false;
+    bool has_valid_clip;
 
     // The depth when the save call is recorded, used to compute the total
     // depth of its content when the associated restore is called.

--- a/display_list/testing/dl_test_snippets.cc
+++ b/display_list/testing/dl_test_snippets.cc
@@ -287,19 +287,22 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
               r.drawRect({10, 10, 20, 20});
               r.restore();
             }},
+           // For saveLayer calls with bounds, we need at least one unclipped
+           // draw command so that the bounds are not reduced in size to the
+           // clip dimensions on the re-dispatch.
            {5, 120, 3,
             [](DlOpReceiver& r) {
               r.saveLayer(&kTestBounds, SaveLayerOptions::kNoAttributes);
+              r.drawRect(kTestBounds);
               r.clipRect({0, 0, 25, 25}, DlCanvas::ClipOp::kIntersect, true);
-              r.drawRect({5, 5, 15, 15});
               r.drawRect({10, 10, 20, 20});
               r.restore();
             }},
            {5, 120, 3,
             [](DlOpReceiver& r) {
               r.saveLayer(&kTestBounds, SaveLayerOptions::kWithAttributes);
+              r.drawRect(kTestBounds);
               r.clipRect({0, 0, 25, 25}, DlCanvas::ClipOp::kIntersect, true);
-              r.drawRect({5, 5, 15, 15});
               r.drawRect({10, 10, 20, 20});
               r.restore();
             }},
@@ -325,8 +328,8 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
             [](DlOpReceiver& r) {
               r.saveLayer(&kTestBounds, SaveLayerOptions::kNoAttributes,
                           &kTestCFImageFilter1);
+              r.drawRect(kTestBounds);
               r.clipRect({0, 0, 25, 25}, DlCanvas::ClipOp::kIntersect, true);
-              r.drawRect({5, 5, 15, 15});
               r.drawRect({10, 10, 20, 20});
               r.restore();
             }},
@@ -334,8 +337,8 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
             [](DlOpReceiver& r) {
               r.saveLayer(&kTestBounds, SaveLayerOptions::kWithAttributes,
                           &kTestCFImageFilter1);
+              r.drawRect(kTestBounds);
               r.clipRect({0, 0, 25, 25}, DlCanvas::ClipOp::kIntersect, true);
-              r.drawRect({5, 5, 15, 15});
               r.drawRect({10, 10, 20, 20});
               r.restore();
             }},

--- a/display_list/utils/dl_matrix_clip_tracker.cc
+++ b/display_list/utils/dl_matrix_clip_tracker.cc
@@ -69,23 +69,40 @@ bool DisplayListMatrixClipState::mapAndClipRect(const SkRect& src,
 void DisplayListMatrixClipState::clipRect(const DlRect& rect,
                                           ClipOp op,
                                           bool is_aa) {
-  adjustCullRect(rect, op, is_aa);
+  if (rect.IsFinite()) {
+    adjustCullRect(rect, op, is_aa);
+  }
 }
 
 void DisplayListMatrixClipState::clipRRect(const SkRRect& rrect,
                                            ClipOp op,
                                            bool is_aa) {
-  SkRect bounds = rrect.getBounds();
+  DlRect bounds = ToDlRect(rrect.getBounds());
+  if (rrect.isRect()) {
+    return clipRect(bounds, op, is_aa);
+  }
   switch (op) {
     case ClipOp::kIntersect:
+      adjustCullRect(bounds, op, is_aa);
       break;
-    case ClipOp::kDifference:
-      if (!rrect.isRect()) {
+    case ClipOp::kDifference: {
+      if (rrect_covers_cull(rrect)) {
+        cull_rect_ = DlRect();
         return;
       }
+      auto upper_left = rrect.radii(SkRRect::kUpperLeft_Corner);
+      auto upper_right = rrect.radii(SkRRect::kUpperRight_Corner);
+      auto lower_left = rrect.radii(SkRRect::kLowerLeft_Corner);
+      auto lower_right = rrect.radii(SkRRect::kLowerRight_Corner);
+      DlRect safe = bounds.Expand(-std::max(upper_left.fX, lower_left.fX), 0,
+                                  -std::max(upper_right.fX, lower_right.fX), 0);
+      adjustCullRect(safe, op, is_aa);
+      safe = bounds.Expand(0, -std::max(upper_left.fY, upper_right.fY),  //
+                           0, -std::max(lower_left.fY, lower_right.fY));
+      adjustCullRect(safe, op, is_aa);
       break;
+    }
   }
-  adjustCullRect(ToDlRect(bounds), op, is_aa);
 }
 
 void DisplayListMatrixClipState::clipPath(const SkPath& path,
@@ -104,18 +121,17 @@ void DisplayListMatrixClipState::clipPath(const SkPath& path,
     }
   }
 
-  SkRect bounds;
+  DlRect bounds = ToDlRect(path.getBounds());
+  if (path.isRect(nullptr)) {
+    return clipRect(bounds, op, is_aa);
+  }
   switch (op) {
     case ClipOp::kIntersect:
-      bounds = path.getBounds();
+      adjustCullRect(bounds, op, is_aa);
       break;
     case ClipOp::kDifference:
-      if (!path.isRect(&bounds)) {
-        return;
-      }
       break;
   }
-  adjustCullRect(ToDlRect(bounds), op, is_aa);
 }
 
 bool DisplayListMatrixClipState::content_culled(
@@ -214,6 +230,107 @@ SkRect DisplayListMatrixClipState::local_cull_rect() const {
   // We eliminated perspective above so we can use the cheaper non-clipping
   // bounds transform method.
   return ToSkRect(cull_rect_.TransformBounds(inverse));
+}
+
+bool DisplayListMatrixClipState::rect_covers_cull(const DlRect& content) const {
+  if (content.IsEmpty()) {
+    return false;
+  }
+  if (cull_rect_.IsEmpty()) {
+    return true;
+  }
+  DlPoint corners[4];
+  if (!getLocalCullCorners(corners)) {
+    return false;
+  }
+  for (auto corner : corners) {
+    if (!content.ContainsInclusive(corner)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool DisplayListMatrixClipState::oval_covers_cull(const DlRect& bounds) const {
+  if (bounds.IsEmpty()) {
+    return false;
+  }
+  if (cull_rect_.IsEmpty()) {
+    return true;
+  }
+  DlPoint corners[4];
+  if (!getLocalCullCorners(corners)) {
+    return false;
+  }
+  DlPoint center = bounds.GetCenter();
+  DlSize scale = 2.0 / bounds.GetSize();
+  for (auto corner : corners) {
+    if (!bounds.Contains(corner)) {
+      return false;
+    }
+    if (((corner - center) * scale).GetLengthSquared() >= 1.0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool DisplayListMatrixClipState::rrect_covers_cull(
+    const SkRRect& content) const {
+  if (content.isEmpty()) {
+    return false;
+  }
+  if (cull_rect_.IsEmpty()) {
+    return true;
+  }
+  if (content.isRect()) {
+    return rect_covers_cull(content.getBounds());
+  }
+  if (content.isOval()) {
+    return oval_covers_cull(content.getBounds());
+  }
+  if (!content.isSimple()) {
+    return false;
+  }
+  DlPoint corners[4];
+  if (!getLocalCullCorners(corners)) {
+    return false;
+  }
+  auto outer = content.getBounds();
+  DlScalar x_center = outer.centerX();
+  DlScalar y_center = outer.centerY();
+  auto radii = content.getSimpleRadii();
+  DlScalar inner_x = outer.width() * 0.5f - radii.fX;
+  DlScalar inner_y = outer.height() * 0.5f - radii.fY;
+  DlScalar scale_x = 1.0 / radii.fX;
+  DlScalar scale_y = 1.0 / radii.fY;
+  for (auto corner : corners) {
+    if (!outer.contains(corner.x, corner.y)) {
+      return false;
+    }
+    DlScalar x_rel = std::abs(corner.x - x_center) - inner_x;
+    DlScalar y_rel = std::abs(corner.y - y_center) - inner_y;
+    if (x_rel > 0.0f && y_rel > 0.0f) {
+      x_rel *= scale_x;
+      y_rel *= scale_y;
+      if (x_rel * x_rel + y_rel * y_rel >= 1.0f) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+bool DisplayListMatrixClipState::getLocalCullCorners(DlPoint corners[4]) const {
+  if (!is_matrix_invertable()) {
+    return false;
+  }
+  DlMatrix inverse = matrix_.Invert();
+  corners[0] = inverse * cull_rect_.GetLeftTop();
+  corners[1] = inverse * cull_rect_.GetRightTop();
+  corners[2] = inverse * cull_rect_.GetRightBottom();
+  corners[3] = inverse * cull_rect_.GetLeftBottom();
+  return true;
 }
 
 }  // namespace flutter

--- a/display_list/utils/dl_matrix_clip_tracker.h
+++ b/display_list/utils/dl_matrix_clip_tracker.h
@@ -63,6 +63,16 @@ class DisplayListMatrixClipState {
   SkRect local_cull_rect() const;
   SkRect device_cull_rect() const { return ToSkRect(cull_rect_); }
 
+  bool rect_covers_cull(const DlRect& content) const;
+  bool rect_covers_cull(const SkRect& content) const {
+    return rect_covers_cull(ToDlRect(content));
+  }
+  bool oval_covers_cull(const DlRect& content_bounds) const;
+  bool oval_covers_cull(const SkRect& content_bounds) const {
+    return oval_covers_cull(ToDlRect(content_bounds));
+  }
+  bool rrect_covers_cull(const SkRRect& content) const;
+
   bool content_culled(const DlRect& content_bounds) const;
   bool content_culled(const SkRect& content_bounds) const {
     return content_culled(ToDlRect(content_bounds));
@@ -146,6 +156,7 @@ class DisplayListMatrixClipState {
   DlRect cull_rect_;
   DlMatrix matrix_;
 
+  bool getLocalCullCorners(DlPoint corners[4]) const;
   void adjustCullRect(const DlRect& clip, ClipOp op, bool is_aa);
 };
 

--- a/flow/layers/backdrop_filter_layer_unittests.cc
+++ b/flow/layers/backdrop_filter_layer_unittests.cc
@@ -394,7 +394,7 @@ TEST_F(BackdropFilterLayerTest, OpacityInheritance) {
 
   clip->Paint(display_list_paint_context());
 
-  DisplayListBuilder expected_builder(clip_rect);
+  DisplayListBuilder expected_builder;
   /* ClipRectLayer::Paint */ {
     expected_builder.Save();
     {

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -226,6 +226,25 @@ struct TRect {
            p.y < bottom_;
   }
 
+  /// @brief  Returns true iff the provided point |p| is inside the
+  ///         closed-range interior of this rectangle.
+  ///
+  ///         Unlike the regular |Contains(TPoint)| method, this method
+  ///         considers all points along the boundary of the rectangle
+  ///         to be contained within the rectangle - useful for testing
+  ///         if vertices that define a filled shape would carry the
+  ///         interior of that shape outside the bounds of the rectangle.
+  ///         Since both geometries are defining half-open spaces, their
+  ///         defining geometry needs to consider their boundaries to
+  ///         be equivalent with respect to interior and exterior.
+  [[nodiscard]] constexpr bool ContainsInclusive(const TPoint<Type>& p) const {
+    return !this->IsEmpty() &&  //
+           p.x >= left_ &&      //
+           p.y >= top_ &&       //
+           p.x <= right_ &&     //
+           p.y <= bottom_;
+  }
+
   /// @brief  Returns true iff this rectangle is not empty and it also
   ///         contains every point considered inside the provided
   ///         rectangle |o| (as determined by |Contains(TPoint)|).

--- a/impeller/geometry/rect_unittests.cc
+++ b/impeller/geometry/rect_unittests.cc
@@ -2259,6 +2259,175 @@ TEST(RectTest, IRectContainsIPoint) {
   }
 }
 
+TEST(RectTest, RectContainsInclusivePoint) {
+  auto check_nans = [](const Rect& rect, const Point& point,
+                       const std::string& label) {
+    ASSERT_TRUE(rect.IsFinite()) << label;
+    ASSERT_TRUE(point.IsFinite()) << label;
+
+    for (int i = 1; i < 16; i++) {
+      EXPECT_FALSE(swap_nan(rect, i).ContainsInclusive(point))
+          << label << ", index = " << i;
+      for (int j = 1; j < 4; j++) {
+        EXPECT_FALSE(swap_nan(rect, i).ContainsInclusive(swap_nan(point, j)))
+            << label << ", indices = " << i << ", " << j;
+      }
+    }
+  };
+
+  auto check_empty_flips = [](const Rect& rect, const Point& point,
+                              const std::string& label) {
+    ASSERT_FALSE(rect.IsEmpty());
+
+    EXPECT_FALSE(flip_lr(rect).ContainsInclusive(point)) << label;
+    EXPECT_FALSE(flip_tb(rect).ContainsInclusive(point)) << label;
+    EXPECT_FALSE(flip_lrtb(rect).ContainsInclusive(point)) << label;
+  };
+
+  auto test_inside = [&check_nans, &check_empty_flips](const Rect& rect,
+                                                       const Point& point) {
+    ASSERT_FALSE(rect.IsEmpty()) << rect;
+
+    std::stringstream stream;
+    stream << rect << " contains " << point;
+    auto label = stream.str();
+
+    EXPECT_TRUE(rect.ContainsInclusive(point)) << label;
+    check_empty_flips(rect, point, label);
+    check_nans(rect, point, label);
+  };
+
+  auto test_outside = [&check_nans, &check_empty_flips](const Rect& rect,
+                                                        const Point& point) {
+    ASSERT_FALSE(rect.IsEmpty()) << rect;
+
+    std::stringstream stream;
+    stream << rect << " contains " << point;
+    auto label = stream.str();
+
+    EXPECT_FALSE(rect.ContainsInclusive(point)) << label;
+    check_empty_flips(rect, point, label);
+    check_nans(rect, point, label);
+  };
+
+  {
+    // Origin is inclusive
+    auto r = Rect::MakeXYWH(100, 100, 100, 100);
+    auto p = Point(100, 100);
+
+    test_inside(r, p);
+  }
+  {
+    // Size is inclusive
+    auto r = Rect::MakeXYWH(100, 100, 100, 100);
+    auto p = Point(200, 200);
+
+    test_inside(r, p);
+  }
+  {
+    // Size + epsilon is exclusive
+    auto r = Rect::MakeXYWH(100, 100, 100, 100);
+    auto p = Point(200 + kEhCloseEnough, 200 + kEhCloseEnough);
+
+    test_outside(r, p);
+  }
+  {
+    auto r = Rect::MakeXYWH(100, 100, 100, 100);
+    auto p = Point(99, 99);
+
+    test_outside(r, p);
+  }
+  {
+    auto r = Rect::MakeXYWH(100, 100, 100, 100);
+    auto p = Point(199, 199);
+
+    test_inside(r, p);
+  }
+
+  {
+    auto r = Rect::MakeMaximum();
+    auto p = Point(199, 199);
+
+    test_inside(r, p);
+  }
+}
+
+TEST(RectTest, IRectContainsInclusiveIPoint) {
+  auto check_empty_flips = [](const IRect& rect, const IPoint& point,
+                              const std::string& label) {
+    ASSERT_FALSE(rect.IsEmpty());
+
+    EXPECT_FALSE(flip_lr(rect).ContainsInclusive(point)) << label;
+    EXPECT_FALSE(flip_tb(rect).ContainsInclusive(point)) << label;
+    EXPECT_FALSE(flip_lrtb(rect).ContainsInclusive(point)) << label;
+  };
+
+  auto test_inside = [&check_empty_flips](const IRect& rect,
+                                          const IPoint& point) {
+    ASSERT_FALSE(rect.IsEmpty()) << rect;
+
+    std::stringstream stream;
+    stream << rect << " contains " << point;
+    auto label = stream.str();
+
+    EXPECT_TRUE(rect.ContainsInclusive(point)) << label;
+    check_empty_flips(rect, point, label);
+  };
+
+  auto test_outside = [&check_empty_flips](const IRect& rect,
+                                           const IPoint& point) {
+    ASSERT_FALSE(rect.IsEmpty()) << rect;
+
+    std::stringstream stream;
+    stream << rect << " contains " << point;
+    auto label = stream.str();
+
+    EXPECT_FALSE(rect.ContainsInclusive(point)) << label;
+    check_empty_flips(rect, point, label);
+  };
+
+  {
+    // Origin is inclusive
+    auto r = IRect::MakeXYWH(100, 100, 100, 100);
+    auto p = IPoint(100, 100);
+
+    test_inside(r, p);
+  }
+  {
+    // Size is inclusive
+    auto r = IRect::MakeXYWH(100, 100, 100, 100);
+    auto p = IPoint(200, 200);
+
+    test_inside(r, p);
+  }
+  {
+    // Size + "epsilon" is exclusive
+    auto r = IRect::MakeXYWH(100, 100, 100, 100);
+    auto p = IPoint(201, 201);
+
+    test_outside(r, p);
+  }
+  {
+    auto r = IRect::MakeXYWH(100, 100, 100, 100);
+    auto p = IPoint(99, 99);
+
+    test_outside(r, p);
+  }
+  {
+    auto r = IRect::MakeXYWH(100, 100, 100, 100);
+    auto p = IPoint(199, 199);
+
+    test_inside(r, p);
+  }
+
+  {
+    auto r = IRect::MakeMaximum();
+    auto p = IPoint(199, 199);
+
+    test_inside(r, p);
+  }
+}
+
 TEST(RectTest, RectContainsRect) {
   auto check_nans = [](const Rect& a, const Rect& b, const std::string& label) {
     ASSERT_TRUE(a.IsFinite()) << label;


### PR DESCRIPTION
This mechanism pulls some clip-reduction logic from Impeller Entities up into DisplayListBuilder to simplify the work that Impeller has to do and also amortize the work if the DisplayList is reused from frame to frame. Since the DisplayList does not have access to information such as surface sizes, there will still be cases that Impeller can catch that must be conservatively included by the recording process in the Builder, so this mechanism does not replace the same code in Impeller, it merely catches some cases earlier, while recording widget output, to avoid the same work on every frame down in Impeller.

In this first pass only the most conservative and straightforward cases are handled - a clip on a layer which has a previous clip that the new clip fully contains (and which was not already restored).

This limited approach is already enough to eliminate a couple of clip operations in the layout of many of the pages in the `new_gallery` benchmarks.