### PR TITLE
[Impeller] Respect the respect_ctm flag for mask blurred text & absorb entity scale when rendering the 2-pass blur input.

### DIFF
--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -909,8 +909,8 @@ void Canvas::DrawTextFrame(const std::shared_ptr<TextFrame>& text_frame,
   //              needs to be reworked in order to interact correctly with
   //              mask filters.
   //              https://github.com/flutter/flutter/issues/133297
-  entity.SetContents(
-      paint.WithFilters(paint.WithMaskBlur(std::move(text_contents), true)));
+  entity.SetContents(paint.WithFilters(paint.WithMaskBlur(
+      std::move(text_contents), true, GetCurrentTransform())));
 
   AddRenderEntityToCurrentPass(std::move(entity));
 }

--- a/impeller/aiks/experimental_canvas.cc
+++ b/impeller/aiks/experimental_canvas.cc
@@ -408,8 +408,8 @@ void ExperimentalCanvas::DrawTextFrame(
   //              needs to be reworked in order to interact correctly with
   //              mask filters.
   //              https://github.com/flutter/flutter/issues/133297
-  entity.SetContents(
-      paint.WithFilters(paint.WithMaskBlur(std::move(text_contents), true)));
+  entity.SetContents(paint.WithFilters(paint.WithMaskBlur(
+      std::move(text_contents), true, GetCurrentTransform())));
 
   AddRenderEntityToCurrentPass(std::move(entity), false);
 }

--- a/impeller/aiks/paint.h
+++ b/impeller/aiks/paint.h
@@ -48,6 +48,9 @@ struct Paint {
   struct MaskBlurDescriptor {
     FilterContents::BlurStyle style;
     Sigma sigma;
+    /// Text mask blurs need to not apply the CTM to the blur kernel.
+    /// See: https://github.com/flutter/flutter/issues/115112
+    bool respect_ctm = true;
 
     std::shared_ptr<FilterContents> CreateMaskBlur(
         std::shared_ptr<ColorSourceContents> color_source_contents,
@@ -58,7 +61,8 @@ struct Paint {
 
     std::shared_ptr<FilterContents> CreateMaskBlur(
         const FilterInput::Ref& input,
-        bool is_solid_color) const;
+        bool is_solid_color,
+        const Matrix& ctm) const;
   };
 
   Color color = Color::Black();
@@ -105,7 +109,8 @@ struct Paint {
   bool HasColorFilter() const;
 
   std::shared_ptr<Contents> WithMaskBlur(std::shared_ptr<Contents> input,
-                                         bool is_solid_color) const;
+                                         bool is_solid_color,
+                                         const Matrix& ctm) const;
 
   std::shared_ptr<FilterContents> WithImageFilter(
       const FilterInput::Variant& input,

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -511,6 +511,7 @@ void DlDispatcherBase::setMaskFilter(const flutter::DlMaskFilter* filter) {
       paint_.mask_blur_descriptor = {
           .style = ToBlurStyle(blur->style()),
           .sigma = Sigma(blur->sigma()),
+          .respect_ctm = blur->respectCTM(),
       };
       break;
     }

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -379,6 +379,14 @@ std::optional<Rect> GaussianBlurFilterContents::GetFilterCoverage(
   return expanded_source_coverage.TransformBounds(entity.GetTransform());
 }
 
+namespace {
+Vector2 ExtractScale(const Matrix& matrix) {
+  Vector2 entity_scale_x = matrix * Vector2(1.0, 0.0);
+  Vector2 entity_scale_y = matrix * Vector2(0.0, 1.0);
+  return Vector2(entity_scale_x.GetLength(), entity_scale_y.GetLength());
+}
+}  // namespace
+
 std::optional<Entity> GaussianBlurFilterContents::RenderFilter(
     const FilterInput::Vector& inputs,
     const ContentContext& renderer,
@@ -390,7 +398,14 @@ std::optional<Entity> GaussianBlurFilterContents::RenderFilter(
     return std::nullopt;
   }
 
+  const Vector2 source_space_scalar =
+      ExtractScale(entity.GetTransform().Basis());
+
   Vector2 scaled_sigma = (effect_transform.Basis() *
+                          // Uncomment the following line to break the text
+                          // shadows, but fix GaussianVsRRectBlur tests.
+                          Matrix::MakeScale({source_space_scalar.x,
+                                             source_space_scalar.y, 1}) *  //
                           Vector2(ScaleSigma(sigma_x_), ScaleSigma(sigma_y_)))
                              .Abs();
   scaled_sigma.x = std::min(scaled_sigma.x, kMaxSigma);
@@ -417,11 +432,13 @@ std::optional<Entity> GaussianBlurFilterContents::RenderFilter(
   }
 
   Entity snapshot_entity = entity.Clone();
-  snapshot_entity.SetTransform(Matrix());
+  snapshot_entity.SetTransform(
+      Matrix::MakeScale({source_space_scalar.x, source_space_scalar.y, 1}));
   std::optional<Rect> source_expanded_coverage_hint;
   if (expanded_coverage_hint.has_value()) {
-    source_expanded_coverage_hint =
-        expanded_coverage_hint->TransformBounds(entity.GetTransform().Invert());
+    source_expanded_coverage_hint = expanded_coverage_hint->TransformBounds(
+        Matrix::MakeScale({source_space_scalar.x, source_space_scalar.y, 1}) *
+        entity.GetTransform().Invert());
   }
 
   std::optional<Snapshot> input_snapshot =
@@ -436,7 +453,10 @@ std::optional<Entity> GaussianBlurFilterContents::RenderFilter(
     Entity result =
         Entity::FromSnapshot(input_snapshot.value(),
                              entity.GetBlendMode());  // No blur to render.
-    result.SetTransform(entity.GetTransform() * input_snapshot->transform);
+    result.SetTransform(entity.GetTransform() *
+                        Matrix::MakeScale({1.f / source_space_scalar.x,
+                                           1.f / source_space_scalar.y, 1}) *
+                        input_snapshot->transform);
     return result;
   }
 
@@ -562,12 +582,16 @@ std::optional<Entity> GaussianBlurFilterContents::RenderFilter(
       MinMagFilter::kLinear, SamplerAddressMode::kClampToEdge);
 
   Entity blur_output_entity = Entity::FromSnapshot(
-      Snapshot{.texture = pass3_out.value().GetRenderTargetTexture(),
-               .transform = entity.GetTransform() * input_snapshot->transform *
-                            padding_snapshot_adjustment *
-                            Matrix::MakeScale(1 / effective_scalar),
-               .sampler_descriptor = sampler_desc,
-               .opacity = input_snapshot->opacity},
+      Snapshot{
+          .texture = pass3_out.value().GetRenderTargetTexture(),
+          .transform = entity.GetTransform() *  //
+                       Matrix::MakeScale({1.f / source_space_scalar.x,
+                                          1.f / source_space_scalar.y, 1}) *  //
+                       input_snapshot->transform *                            //
+                       padding_snapshot_adjustment *                          //
+                       Matrix::MakeScale(1 / effective_scalar),
+          .sampler_descriptor = sampler_desc,
+          .opacity = input_snapshot->opacity},
       entity.GetBlendMode());
 
   return ApplyBlurStyle(mask_blur_style_, entity, inputs[0],

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents_unittests.cc
@@ -401,7 +401,7 @@ TEST_P(GaussianBlurFilterContentsTest,
     if (result_coverage.has_value() && contents_coverage.has_value()) {
       EXPECT_TRUE(RectNear(result_coverage.value(), contents_coverage.value()));
       EXPECT_TRUE(RectNear(contents_coverage.value(),
-                           Rect::MakeXYWH(98.f, 78.f, 204.0f, 204.f)));
+                           Rect::MakeXYWH(94.f, 74.f, 212.0f, 212.f)));
     }
   }
 }
@@ -438,7 +438,7 @@ TEST_P(GaussianBlurFilterContentsTest, TextureContentsWithEffectTransform) {
     if (result_coverage.has_value() && contents_coverage.has_value()) {
       EXPECT_TRUE(RectNear(result_coverage.value(), contents_coverage.value()));
       EXPECT_TRUE(RectNear(contents_coverage.value(),
-                           Rect::MakeXYWH(49.f, 39.f, 102.f, 102.f)));
+                           Rect::MakeXYWH(94.f, 74.f, 212.f, 212.f)));
     }
   }
 }


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/142014
Resolves https://github.com/flutter/flutter/issues/150114

This is a combination of:
1. @gaaclarke's [2-pass blur fix](https://github.com/flutter/flutter/issues/150114#issuecomment-2164001044), and
2. a fix for text mask blurs by supporting the "respect_ctm" flag given by `DlMaskBlurFilter` (thanks to @jonahwilliams for recalling this bug).

Let's see those goldens.

### Skia
<img width="262" alt="Screenshot 2024-06-12 at 8 36 41 PM" src="https://github.com/flutter/engine/assets/919017/dae9549b-35e4-4d91-81d0-4b8f414904ce">

### Impeller
<img width="262" alt="Screenshot 2024-06-12 at 8 24 41 PM" src="https://github.com/flutter/engine/assets/919017/6c4e53f3-c3f8-499b-bbe8-545cc456751a">

### Play/DlGoldenTest.GaussianVsRRectBlur/Metal
<img width="553" alt="image" src="https://github.com/flutter/engine/assets/919017/a7afc4a1-5711-46d3-9c16-6f05e373f49c">

