### PR TITLE
[Impeller] cache repeat applications of the rrect blur.

### DIFF
--- a/impeller/aiks/canvas.cc
+++ b/impeller/aiks/canvas.cc
@@ -361,125 +361,136 @@ void Canvas::DrawPaint(const Paint& paint) {
 bool Canvas::AttemptDrawBlurredRRect(const Rect& rect,
                                      Size corner_radii,
                                      const Paint& paint) {
-  if (paint.color_source.GetType() != ColorSource::Type::kColor ||
-      paint.style != Paint::Style::kFill) {
-    return false;
-  }
+  return false;
+  // if (paint.color_source.GetType() != ColorSource::Type::kColor ||
+  //     paint.style != Paint::Style::kFill) {
+  //   return false;
+  // }
 
-  if (!paint.mask_blur_descriptor.has_value()) {
-    return false;
-  }
+  // if (!paint.mask_blur_descriptor.has_value()) {
+  //   return false;
+  // }
 
-  // A blur sigma that is not positive enough should not result in a blur.
-  if (paint.mask_blur_descriptor->sigma.sigma <= kEhCloseEnough) {
-    return false;
-  }
+  // // A blur sigma that is not positive enough should not result in a blur.
+  // if (paint.mask_blur_descriptor->sigma.sigma <= kEhCloseEnough) {
+  //   return false;
+  // }
 
-  // For symmetrically mask blurred solid RRects, absorb the mask blur and use
-  // a faster SDF approximation.
+  // // For symmetrically mask blurred solid RRects, absorb the mask blur and
+  // use
+  // // a faster SDF approximation.
 
-  Color rrect_color =
-      paint.HasColorFilter()
-          // Absorb the color filter, if any.
-          ? paint.GetColorFilter()->GetCPUColorFilterProc()(paint.color)
-          : paint.color;
+  // Color rrect_color =
+  //     paint.HasColorFilter()
+  //         // Absorb the color filter, if any.
+  //         ? paint.GetColorFilter()->GetCPUColorFilterProc()(paint.color)
+  //         : paint.color;
 
-  Paint rrect_paint = {.mask_blur_descriptor = paint.mask_blur_descriptor};
+  // Paint rrect_paint = {.mask_blur_descriptor = paint.mask_blur_descriptor};
 
-  // In some cases, we need to render the mask blur to a separate layer.
-  //
-  //   1. If the blur style is normal, we'll be drawing using one draw call and
-  //      no clips. And so we can just wrap the RRect contents with the
-  //      ImageFilter, which will get applied to the result as per usual.
-  //
-  //   2. If the blur style is solid, we combine the non-blurred RRect with the
-  //      blurred RRect via two separate draw calls, and so we need to defer any
-  //      fancy blending, translucency, or image filtering until after these two
-  //      draws have been combined in a separate layer.
-  //
-  //   3. If the blur style is outer or inner, we apply the blur style via a
-  //      clip. The ImageFilter needs to be applied to the mask blurred result.
-  //      And so if there's an ImageFilter, we need to defer applying it until
-  //      after the clipped RRect blur has been drawn to a separate texture.
-  //      However, since there's only one draw call that produces color, we
-  //      don't need to worry about the blend mode or translucency (unlike with
-  //      BlurStyle::kSolid).
-  //
-  if ((paint.mask_blur_descriptor->style !=
-           FilterContents::BlurStyle::kNormal &&
-       paint.image_filter) ||
-      (paint.mask_blur_descriptor->style == FilterContents::BlurStyle::kSolid &&
-       (!rrect_color.IsOpaque() ||
-        paint.blend_mode != BlendMode::kSourceOver))) {
-    Rect render_bounds = rect;
-    if (paint.mask_blur_descriptor->style !=
-        FilterContents::BlurStyle::kInner) {
-      render_bounds =
-          render_bounds.Expand(paint.mask_blur_descriptor->sigma.sigma * 4.0);
-    }
-    // Defer the alpha, blend mode, and image filter to a separate layer.
-    SaveLayer({.color = Color::White().WithAlpha(rrect_color.alpha),
-               .blend_mode = paint.blend_mode,
-               .image_filter = paint.image_filter},
-              render_bounds, nullptr, ContentBoundsPromise::kContainsContents,
-              1u);
-    rrect_paint.color = rrect_color.WithAlpha(1);
-  } else {
-    rrect_paint.color = rrect_color;
-    rrect_paint.blend_mode = paint.blend_mode;
-    rrect_paint.image_filter = paint.image_filter;
-    Save(1u);
-  }
+  // // In some cases, we need to render the mask blur to a separate layer.
+  // //
+  // //   1. If the blur style is normal, we'll be drawing using one draw call
+  // and
+  // //      no clips. And so we can just wrap the RRect contents with the
+  // //      ImageFilter, which will get applied to the result as per usual.
+  // //
+  // //   2. If the blur style is solid, we combine the non-blurred RRect with
+  // the
+  // //      blurred RRect via two separate draw calls, and so we need to defer
+  // any
+  // //      fancy blending, translucency, or image filtering until after these
+  // two
+  // //      draws have been combined in a separate layer.
+  // //
+  // //   3. If the blur style is outer or inner, we apply the blur style via a
+  // //      clip. The ImageFilter needs to be applied to the mask blurred
+  // result.
+  // //      And so if there's an ImageFilter, we need to defer applying it
+  // until
+  // //      after the clipped RRect blur has been drawn to a separate texture.
+  // //      However, since there's only one draw call that produces color, we
+  // //      don't need to worry about the blend mode or translucency (unlike
+  // with
+  // //      BlurStyle::kSolid).
+  // //
+  // if ((paint.mask_blur_descriptor->style !=
+  //          FilterContents::BlurStyle::kNormal &&
+  //      paint.image_filter) ||
+  //     (paint.mask_blur_descriptor->style == FilterContents::BlurStyle::kSolid
+  //     &&
+  //      (!rrect_color.IsOpaque() ||
+  //       paint.blend_mode != BlendMode::kSourceOver))) {
+  //   Rect render_bounds = rect;
+  //   if (paint.mask_blur_descriptor->style !=
+  //       FilterContents::BlurStyle::kInner) {
+  //     render_bounds =
+  //         render_bounds.Expand(paint.mask_blur_descriptor->sigma.sigma
+  //         * 4.0);
+  //   }
+  //   // Defer the alpha, blend mode, and image filter to a separate layer.
+  //   SaveLayer({.color = Color::White().WithAlpha(rrect_color.alpha),
+  //              .blend_mode = paint.blend_mode,
+  //              .image_filter = paint.image_filter},
+  //             render_bounds, nullptr,
+  //             ContentBoundsPromise::kContainsContents, 1u);
+  //   rrect_paint.color = rrect_color.WithAlpha(1);
+  // } else {
+  //   rrect_paint.color = rrect_color;
+  //   rrect_paint.blend_mode = paint.blend_mode;
+  //   rrect_paint.image_filter = paint.image_filter;
+  //   Save(1u);
+  // }
 
-  auto draw_blurred_rrect = [this, &rect, &corner_radii, &rrect_paint]() {
-    auto contents = std::make_shared<SolidRRectBlurContents>();
+  // auto draw_blurred_rrect = [this, &rect, &corner_radii, &rrect_paint]() {
+  //   auto contents = std::make_shared<SolidRRectBlurContents>();
 
-    contents->SetColor(rrect_paint.color);
-    contents->SetSigma(rrect_paint.mask_blur_descriptor->sigma);
-    contents->SetRRect(rect, corner_radii);
+  //   contents->SetColor(rrect_paint.color);
+  //   contents->SetSigma(rrect_paint.mask_blur_descriptor->sigma);
+  //   contents->SetRRect(rect, corner_radii);
 
-    Entity blurred_rrect_entity;
-    blurred_rrect_entity.SetTransform(GetCurrentTransform());
-    blurred_rrect_entity.SetBlendMode(rrect_paint.blend_mode);
+  //   Entity blurred_rrect_entity;
+  //   blurred_rrect_entity.SetTransform(GetCurrentTransform());
+  //   blurred_rrect_entity.SetBlendMode(rrect_paint.blend_mode);
 
-    rrect_paint.mask_blur_descriptor = std::nullopt;
-    blurred_rrect_entity.SetContents(
-        rrect_paint.WithFilters(std::move(contents)));
-    AddRenderEntityToCurrentPass(std::move(blurred_rrect_entity));
-  };
+  //   rrect_paint.mask_blur_descriptor = std::nullopt;
+  //   blurred_rrect_entity.SetContents(
+  //       rrect_paint.WithFilters(std::move(contents)));
+  //   AddRenderEntityToCurrentPass(std::move(blurred_rrect_entity));
+  // };
 
-  switch (rrect_paint.mask_blur_descriptor->style) {
-    case FilterContents::BlurStyle::kNormal: {
-      draw_blurred_rrect();
-      break;
-    }
-    case FilterContents::BlurStyle::kSolid: {
-      // First, draw the blurred RRect.
-      draw_blurred_rrect();
-      // Then, draw the non-blurred RRect on top.
-      Entity entity;
-      entity.SetTransform(GetCurrentTransform());
-      entity.SetBlendMode(rrect_paint.blend_mode);
-      entity.SetContents(CreateContentsForGeometryWithFilters(
-          rrect_paint, Geometry::MakeRoundRect(rect, corner_radii)));
-      AddRenderEntityToCurrentPass(std::move(entity), true);
-      break;
-    }
-    case FilterContents::BlurStyle::kOuter: {
-      ClipRRect(rect, corner_radii, Entity::ClipOperation::kDifference);
-      draw_blurred_rrect();
-      break;
-    }
-    case FilterContents::BlurStyle::kInner: {
-      ClipRRect(rect, corner_radii, Entity::ClipOperation::kIntersect);
-      draw_blurred_rrect();
-      break;
-    }
-  }
+  // switch (rrect_paint.mask_blur_descriptor->style) {
+  //   case FilterContents::BlurStyle::kNormal: {
+  //     draw_blurred_rrect();
+  //     break;
+  //   }
+  //   case FilterContents::BlurStyle::kSolid: {
+  //     // First, draw the blurred RRect.
+  //     draw_blurred_rrect();
+  //     // Then, draw the non-blurred RRect on top.
+  //     Entity entity;
+  //     entity.SetTransform(GetCurrentTransform());
+  //     entity.SetBlendMode(rrect_paint.blend_mode);
+  //     entity.SetContents(CreateContentsForGeometryWithFilters(
+  //         rrect_paint, Geometry::MakeRoundRect(rect, corner_radii)));
+  //     AddRenderEntityToCurrentPass(std::move(entity), true);
+  //     break;
+  //   }
+  //   case FilterContents::BlurStyle::kOuter: {
+  //     ClipRRect(rect, corner_radii, Entity::ClipOperation::kDifference);
+  //     draw_blurred_rrect();
+  //     break;
+  //   }
+  //   case FilterContents::BlurStyle::kInner: {
+  //     ClipRRect(rect, corner_radii, Entity::ClipOperation::kIntersect);
+  //     draw_blurred_rrect();
+  //     break;
+  //   }
+  // }
 
-  Restore();
+  // Restore();
 
-  return true;
+  // return true;
 }
 
 void Canvas::DrawLine(const Point& p0, const Point& p1, const Paint& paint) {

--- a/impeller/entity/BUILD.gn
+++ b/impeller/entity/BUILD.gn
@@ -201,6 +201,7 @@ impeller_component("entity") {
     "inline_pass_context.h",
     "render_target_cache.cc",
     "render_target_cache.h",
+    "shadow_cache.h",
   ]
 
   public_deps = [

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -15,6 +15,7 @@
 #include "impeller/base/validation.h"
 #include "impeller/core/formats.h"
 #include "impeller/core/host_buffer.h"
+#include "impeller/entity/shadow_cache.h"
 #include "impeller/renderer/capabilities.h"
 #include "impeller/renderer/command_buffer.h"
 #include "impeller/renderer/pipeline.h"
@@ -751,6 +752,8 @@ class ContentContext {
   /// allocate their own device buffers.
   HostBuffer& GetTransientsBuffer() const { return *host_buffer_; }
 
+  std::shared_ptr<ShadowCache> GetShadowCache() const { return shadow_cache_; }
+
  private:
   std::shared_ptr<Context> context_;
   std::shared_ptr<LazyGlyphAtlas> lazy_glyph_atlas_;
@@ -1006,6 +1009,7 @@ class ContentContext {
   std::shared_ptr<RenderTargetAllocator> render_target_cache_;
   std::shared_ptr<HostBuffer> host_buffer_;
   std::shared_ptr<Texture> empty_texture_;
+  std::shared_ptr<ShadowCache> shadow_cache_ = std::make_shared<ShadowCache>();
   bool wireframe_ = false;
 
   ContentContext(const ContentContext&) = delete;

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -357,6 +357,7 @@ bool EntityPass::Render(ContentContext& renderer,
   fml::ScopedCleanupClosure reset_state([&renderer]() {
     renderer.GetLazyGlyphAtlas()->ResetTextFrames();
     renderer.GetRenderTargetCache()->End();
+    renderer.GetShadowCache()->End();
   });
 
   auto root_render_target = render_target;

--- a/impeller/entity/shadow_cache.h
+++ b/impeller/entity/shadow_cache.h
@@ -1,0 +1,79 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_ENTITY_SHADOW_CACHE_H_
+#define FLUTTER_IMPELLER_ENTITY_SHADOW_CACHE_H_
+
+#include "impeller/core/texture.h"
+#include "impeller/renderer/snapshot.h"
+
+namespace impeller {
+
+struct ShadowKey {
+  const Rect rect;
+  const Size corner_radii;
+  const Color rrect_color;
+  const Scalar sigma;
+};
+
+}  // namespace impeller
+
+template <>
+struct std::hash<impeller::ShadowKey> {
+  constexpr std::size_t operator()(const impeller::ShadowKey& sk) const {
+    return fml::HashCombine(sk.rect.GetX(), sk.rect.GetY(), sk.rect.GetWidth(),
+                            sk.rect.GetHeight(), sk.corner_radii.width,
+                            sk.corner_radii.height, sk.rrect_color.ToARGB(),
+                            sk.sigma);
+  }
+};
+
+template <>
+struct std::equal_to<impeller::ShadowKey> {
+  constexpr bool operator()(const impeller::ShadowKey& lhs,
+                            const impeller::ShadowKey& rhs) const {
+    return lhs.rect == rhs.rect && lhs.corner_radii == rhs.corner_radii &&
+           lhs.rrect_color == rhs.rrect_color && lhs.sigma == rhs.sigma;
+  }
+};
+
+namespace impeller {
+
+struct ShadowCacheData {
+  Snapshot input_snapshot;
+  std::shared_ptr<Texture> texture;
+  Matrix transform;
+};
+
+class ShadowCache {
+ public:
+  ShadowCache() {}
+
+  ~ShadowCache() = default;
+
+  void StoreData(const ShadowKey& key,
+                 Snapshot input_snapshot,
+                 std::shared_ptr<Texture> texture,
+                 const Matrix& matrix) {
+    cache_[key] = ShadowCacheData{input_snapshot, texture, matrix};
+  }
+
+  std::optional<ShadowCacheData> GetData(const ShadowKey& key) {
+    auto result = cache_.find(key);
+    if (result == cache_.end()) {
+      return std::nullopt;
+    }
+    return result->second;
+  }
+
+  void End() { cache_.clear(); }
+
+ private:
+  std::unordered_map<ShadowKey, ShadowCacheData> cache_;
+  Matrix matrix_;
+};
+
+}  // namespace impeller
+
+#endif  // FLUTTER_IMPELLER_ENTITY_SHADOW_CACHE_H_


### PR DESCRIPTION
Idea: shadows are frequently repeated across an application, like in https://github.com/flutter/flutter/issues/148496 . We can add an intra-frame cache so that we don't unecessarily re-compute the same blurs over and over again. Additionally, for symmetrical shapes we might be able to blur a fraction of the shape and then mirror.

The current implementation does not correctly implement all of this, but it is sufficient to prove that this is a fast enough approach.

I think we'd need to create a subclass of the gaussian blur filter, and make some adjustments so that properties like color were applied after the fact.