### PR TITLE
Roll web_ui dependencies to enable the next roll of the Dart SDK

### DIFF
--- a/lib/web_ui/pubspec.yaml
+++ b/lib/web_ui/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
     path: ../../third_party/web_test_fonts
 
 dev_dependencies:
-  archive: 3.4.2
+  archive: 3.6.1
   args: any
   async: any
   convert: any

--- a/web_sdk/web_test_utils/pubspec.yaml
+++ b/web_sdk/web_test_utils/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
 
 dependencies:
   collection: 1.17.0
-  crypto: 3.0.1
+  crypto: 3.0.3
   image: 3.0.1
   js: 0.6.4
   meta: ^1.7.0


### PR DESCRIPTION
Dart has removed the UnmodifiableXXXView classes, which were used by older versions of the archive package.

See https://dart.googlesource.com/sdk/+/18994e6e46ec9fb2fac8368c43d448119abd579f