### PR TITLE
Hack to prevent Safari from being backgrounded during unit tests.

### DIFF
--- a/ci/builders/linux_web_engine.json
+++ b/ci/builders/linux_web_engine.json
@@ -1131,7 +1131,7 @@
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "cpu=arm64"
       ],
       "gclient_variables": {
@@ -1164,7 +1164,7 @@
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "cpu=arm64"
       ],
       "gclient_variables": {
@@ -1197,7 +1197,7 @@
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "cpu=arm64"
       ],
       "gclient_variables": {
@@ -1230,7 +1230,7 @@
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "cpu=arm64"
       ],
       "gclient_variables": {
@@ -1263,7 +1263,7 @@
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "cpu=arm64"
       ],
       "gclient_variables": {
@@ -1296,7 +1296,7 @@
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac-13",
+        "os=Mac-13|Mac-14",
         "cpu=arm64"
       ],
       "gclient_variables": {

--- a/lib/web_ui/dev/generate_builder_json.dart
+++ b/lib/web_ui/dev/generate_builder_json.dart
@@ -113,7 +113,7 @@ Iterable<dynamic> _getAllTestSteps(List<TestSuite> suites) {
       suite.runConfig.browser == BrowserName.chrome ||
       suite.runConfig.browser == BrowserName.firefox
     ),
-    ..._getTestStepsForPlatform(suites, 'Mac', specificOS: 'Mac-13', cpu: 'arm64', (TestSuite suite) =>
+    ..._getTestStepsForPlatform(suites, 'Mac', specificOS: 'Mac-13|Mac-14', cpu: 'arm64', (TestSuite suite) =>
       suite.runConfig.browser == BrowserName.safari
     ),
     ..._getTestStepsForPlatform(suites, 'Windows', (TestSuite suite) =>


### PR DESCRIPTION
Safari actually pauses execution of our unit tests if the window becomes occluded or non-visible. As such, I am inserting this egregious hack which just makes the Safari window frontmost every 2 seconds so that the unit tests don't get stalled out.

This should fix https://github.com/flutter/flutter/issues/150023