### PR TITLE
Fix AccessibilityFeatures.disableAnimations flag on Android 12+

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -126,6 +126,12 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
   // Font weight adjustment for bold text. FontWeight.Bold - FontWeight.Normal = w700 - w400 = 300.
   private static final int BOLD_TEXT_WEIGHT_ADJUSTMENT = 300;
 
+  // Default transition animation scale (animations enabled)
+  private static final float DEFAULT_TRANSITION_ANIMATION_SCALE = 1.0f;
+
+  // Transition animation scale when animations are disabled
+  private static final float DISABLED_TRANSITION_ANIMATION_SCALE = 0.0f;
+
   /// Value is derived from ACTION_TYPE_MASK in AccessibilityNodeInfo.java
   private static int FIRST_RESOURCE_ID = 267386881;
 
@@ -399,11 +405,13 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
             return;
           }
           // Retrieve the current value of TRANSITION_ANIMATION_SCALE from the OS.
-          String value =
-              Settings.Global.getString(
-                  contentResolver, Settings.Global.TRANSITION_ANIMATION_SCALE);
+          float value =
+              Settings.Global.getFloat(
+                  contentResolver,
+                  Settings.Global.TRANSITION_ANIMATION_SCALE,
+                  DEFAULT_TRANSITION_ANIMATION_SCALE);
 
-          boolean shouldAnimationsBeDisabled = value != null && value.equals("0");
+          boolean shouldAnimationsBeDisabled = value == DISABLED_TRANSITION_ANIMATION_SCALE;
           if (shouldAnimationsBeDisabled) {
             accessibilityFeatureFlags |= AccessibilityFeature.DISABLE_ANIMATIONS.value;
           } else {

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -568,7 +568,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     if (shouldBold) {
       accessibilityFeatureFlags |= AccessibilityFeature.BOLD_TEXT.value;
     } else {
-      accessibilityFeatureFlags &= AccessibilityFeature.BOLD_TEXT.value;
+      accessibilityFeatureFlags &= ~AccessibilityFeature.BOLD_TEXT.value;
     }
     sendLatestAccessibilityFlagsToFlutter();
   }


### PR DESCRIPTION
This PR fixes the problem where Flutter would not respect the "remove animation" accessibility setting on Android 12+.

Please see this issue for details: https://github.com/flutter/flutter/issues/130976

As [mentioned](https://github.com/flutter/flutter/issues/130976#issuecomment-1931388665) by [horsemankukka](https://github.com/horsemankukka), the problem has to do with reading `Settings.Global.TRANSITION_ANIMATION_SCALE` as a string instead of a float. Flutter would compare it to the string "0" to determine if animations should be disabled. Presumably, this worked because the settings app did indeed use the string "0" or "1" for this setting. But as of Android 12 it's instead written using float representation ("0.0" or "1.0"), at least on Samsung devices. [The documentation](https://developer.android.com/reference/android/provider/Settings.Global#TRANSITION_ANIMATION_SCALE) also states that this setting should be read as a float, which is what this PR does.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
