### PR TITLE
[Web] Fix extra new line when inputAction is not newline for a multil…

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1513,10 +1513,11 @@ abstract class DefaultTextEditingStrategy with CompositionAwareMixin implements 
       final DomKeyboardEvent event = e as DomKeyboardEvent;
       if (event.keyCode == _kReturnKeyCode) {
         onAction!(inputConfiguration.inputAction);
-        // Prevent the browser from inserting a new line when it's not a multiline input.
-        if (inputConfiguration.inputType is! MultilineInputType) {
-          event.preventDefault();
+        if (inputConfiguration.inputType is MultilineInputType && inputConfiguration.inputAction == 'TextInputAction.newline' ) {
+           return;
         }
+        // Prevent the browser from inserting a new line.
+        event.preventDefault();
       }
     }
   }

--- a/lib/web_ui/test/engine/text_editing_test.dart
+++ b/lib/web_ui/test/engine/text_editing_test.dart
@@ -471,7 +471,35 @@ Future<void> testMain() async {
 
       // Input action is triggered!
       expect(lastInputAction, 'TextInputAction.done');
-      // And default behavior of keyboard event shouldn't have been prevented.
+      // And default behavior of keyboard event should have been prevented.
+      // Only TextInputAction.newline should not prevent default behavior
+      // for a multiline field.
+      expect(event.defaultPrevented, isTrue);
+    });
+
+    test('Does not prevent default behavior when TextInputAction.newline', () {
+      // Regression test for https://github.com/flutter/flutter/issues/145051.
+      final InputConfiguration config = InputConfiguration(
+        viewId: kImplicitViewId,
+        inputAction: 'TextInputAction.newline',
+        inputType: EngineInputType.multilineNone,
+      );
+      editingStrategy!.enable(
+        config,
+        onChange: trackEditingState,
+        onAction: trackInputAction,
+      );
+
+      // No input action so far.
+      expect(lastInputAction, isNull);
+
+      final DomKeyboardEvent event = dispatchKeyboardEvent(
+        editingStrategy!.domElement!,
+        'keydown',
+        keyCode: _kReturnKeyCode,
+      );
+      expect(lastInputAction, 'TextInputAction.newline');
+      // And default behavior of keyboard event should't have been prevented.
       expect(event.defaultPrevented, isFalse);
     });
 
@@ -497,8 +525,10 @@ Future<void> testMain() async {
 
       // Input action is triggered!
       expect(lastInputAction, 'TextInputAction.done');
-      // And default behavior of keyboard event shouldn't have been prevented.
-      expect(event.defaultPrevented, isFalse);
+      // And default behavior of keyboard event should have been prevented.
+      // Only TextInputAction.newline should not prevent default behavior
+      // for a multiline field.
+      expect(event.defaultPrevented, isTrue);
     });
 
     test('Triggers input action and prevent new line key event for single line field', () {
@@ -2520,8 +2550,10 @@ Future<void> testMain() async {
         spy.messages[0].methodArguments,
         <dynamic>[clientId, 'TextInputAction.next'],
       );
-      // And default behavior of keyboard event shouldn't have been prevented.
-      expect(event.defaultPrevented, isFalse);
+      // And default behavior of keyboard event should have been prevented.
+      // Only TextInputAction.newline should not prevent default behavior
+      // for a multiline field.
+      expect(event.defaultPrevented, isTrue);
     });
 
     test('inserts element in the correct view', () async {


### PR DESCRIPTION
## Description

This PR prevents new line key event from being dispatched for a multiline text field when `TextField.textInputAction` is not `TextInputAction.newline`.

Since https://github.com/flutter/engine/pull/33428, web engine does not prevent new line key events.
In https://github.com/flutter/engine/pull/36893, I fixed a similar issue for single line text fields. At that time I was not sure if we want to fix it for multiline text fields. I checked again on non-web platforms (macos, iOS, Android) and the new line is not added if the input action is not `TextInputAction.newline`.

For a **multiline field**, the default text input action is `TextInputAction.newline`.
If the developer sets text input action to another value:
- before this PR, the action is performed and a new line is added.
- after this PR, the action is performed but no new line is added.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/145051

## Tests

Adds 1 tests, updates 3 tests.



