### PR TITLE
Add createImageFromTextureSource method to ui_web

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:js_interop';
 import 'dart:math' as math;
 import 'dart:typed_data';
 
@@ -239,10 +240,10 @@ class CanvasKitRenderer implements Renderer {
   }
 
   @override
-  FutureOr<ui.Image> createImageFromTextureSource(Object object,
+  FutureOr<ui.Image> createImageFromTextureSource(JSAny object,
       {required int width, required int height, required bool transferOwnership}) async {
         if (!transferOwnership) {
-          final DomImageBitmap bitmap = await createImageBitmap(object.toJSAnyShallow, (x:0, y: 0, width: width, height: height));
+          final DomImageBitmap bitmap = await createImageBitmap(object, (x:0, y: 0, width: width, height: height));
           return createImageFromImageBitmap(bitmap);
         }
     final SkImage? skImage = canvasKit.MakeLazyImageFromTextureSourceWithInfo(

--- a/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
@@ -239,8 +239,12 @@ class CanvasKitRenderer implements Renderer {
   }
 
   @override
-  ui.Image createImageFromTextureSource(Object object,
-      {required int width, required int height}) {
+  FutureOr<ui.Image> createImageFromTextureSource(Object object,
+      {required int width, required int height, required bool transferOwnership}) async {
+        if(!transferOwnership) {
+          final DomImageBitmap bitmap = await createImageBitmap(object.toJSAnyShallow, (x:0, y: 0, width: width, height: height));
+          return createImageFromImageBitmap(bitmap);
+        }
     final SkImage? skImage = canvasKit.MakeLazyImageFromTextureSourceWithInfo(
         object,
         SkPartialImageInfo(

--- a/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
@@ -241,7 +241,7 @@ class CanvasKitRenderer implements Renderer {
   @override
   FutureOr<ui.Image> createImageFromTextureSource(Object object,
       {required int width, required int height, required bool transferOwnership}) async {
-        if(!transferOwnership) {
+        if (!transferOwnership) {
           final DomImageBitmap bitmap = await createImageBitmap(object.toJSAnyShallow, (x:0, y: 0, width: width, height: height));
           return createImageFromImageBitmap(bitmap);
         }

--- a/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
@@ -239,16 +239,18 @@ class CanvasKitRenderer implements Renderer {
   }
 
   @override
-  ui.Image createImageFromTextureSource(Object object,  { required int width, required int height }) {
-    final SkImage? skImage = canvasKit.MakeLazyImageFromTextureSourceWithInfo(object, 
-      SkPartialImageInfo(
-        width: width.toDouble(), 
-        height: height.toDouble(), 
-        alphaType: canvasKit.AlphaType.Premul,
-        colorType: canvasKit.ColorType.RGBA_8888,
-        colorSpace: SkColorSpaceSRGB, 
-      ));
-      
+  ui.Image createImageFromTextureSource(Object object,
+      {required int width, required int height}) {
+    final SkImage? skImage = canvasKit.MakeLazyImageFromTextureSourceWithInfo(
+        object,
+        SkPartialImageInfo(
+          width: width.toDouble(),
+          height: height.toDouble(),
+          alphaType: canvasKit.AlphaType.Premul,
+          colorType: canvasKit.ColorType.RGBA_8888,
+          colorSpace: SkColorSpaceSRGB,
+        ));
+
     if (skImage == null) {
       throw Exception('Failed to convert image bitmap to an SkImage.');
     }

--- a/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
@@ -239,6 +239,23 @@ class CanvasKitRenderer implements Renderer {
   }
 
   @override
+  ui.Image createImageFromTextureSource(Object object,  { required int width, required int height }) {
+    final SkImage? skImage = canvasKit.MakeLazyImageFromTextureSourceWithInfo(object, 
+      SkPartialImageInfo(
+        width: width.toDouble(), 
+        height: height.toDouble(), 
+        alphaType: canvasKit.AlphaType.Premul,
+        colorType: canvasKit.ColorType.RGBA_8888,
+        colorSpace: SkColorSpaceSRGB, 
+      ));
+      
+    if (skImage == null) {
+      throw Exception('Failed to convert image bitmap to an SkImage.');
+    }
+    return CkImage(skImage);
+  }
+
+  @override
   void decodeImageFromPixels(Uint8List pixels, int width, int height,
           ui.PixelFormat format, ui.ImageDecoderCallback callback,
           {int? rowBytes,

--- a/lib/web_ui/lib/src/engine/html/renderer.dart
+++ b/lib/web_ui/lib/src/engine/html/renderer.dart
@@ -373,7 +373,7 @@ class HtmlRenderer implements Renderer {
   }
 
   @override
-  ui.Image createImageFromTextureSource(Object object,  { required int width, required int height }) {
+  FutureOr<ui.Image> createImageFromTextureSource(Object object,  { required int width, required int height, required bool transferOwnership }) {
     throw Exception('Not implemented for HTML renderer');
   }
 }

--- a/lib/web_ui/lib/src/engine/html/renderer.dart
+++ b/lib/web_ui/lib/src/engine/html/renderer.dart
@@ -373,7 +373,7 @@ class HtmlRenderer implements Renderer {
   }
 
   @override
-  FutureOr<ui.Image> createImageFromTextureSource(Object object,  { required int width, required int height, required bool transferOwnership }) {
+  FutureOr<ui.Image> createImageFromTextureSource(JSAny object,  { required int width, required int height, required bool transferOwnership }) {
     throw Exception('Not implemented for HTML renderer');
   }
 }

--- a/lib/web_ui/lib/src/engine/html/renderer.dart
+++ b/lib/web_ui/lib/src/engine/html/renderer.dart
@@ -371,4 +371,9 @@ class HtmlRenderer implements Renderer {
     imageElement.src = await canvas.toDataUrl();
     return completer.future;
   }
+
+  @override
+  ui.Image createImageFromTextureSource(Object object,  { required int width, required int height }) {
+    throw Exception('Not implemented for HTML renderer');
+  }
 }

--- a/lib/web_ui/lib/src/engine/renderer.dart
+++ b/lib/web_ui/lib/src/engine/renderer.dart
@@ -7,7 +7,8 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:ui/src/engine.dart';
-import 'package:ui/src/engine/skwasm/skwasm_impl.dart' if (dart.library.html) 'package:ui/src/engine/skwasm/skwasm_stub.dart';
+import 'package:ui/src/engine/skwasm/skwasm_impl.dart'
+    if (dart.library.html) 'package:ui/src/engine/skwasm/skwasm_stub.dart';
 import 'package:ui/ui.dart' as ui;
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
@@ -103,17 +104,18 @@ abstract class Renderer {
     Float32List? matrix4,
   ]);
 
-  ui.ImageFilter createBlurImageFilter({
-    double sigmaX = 0.0,
-    double sigmaY = 0.0,
-    ui.TileMode tileMode = ui.TileMode.clamp});
-  ui.ImageFilter createDilateImageFilter({ double radiusX = 0.0, double radiusY = 0.0});
-  ui.ImageFilter createErodeImageFilter({ double radiusX = 0.0, double radiusY = 0.0});
-  ui.ImageFilter createMatrixImageFilter(
-    Float64List matrix4, {
-    ui.FilterQuality filterQuality = ui.FilterQuality.low
-  });
-  ui.ImageFilter composeImageFilters({required ui.ImageFilter outer, required ui.ImageFilter inner});
+  ui.ImageFilter createBlurImageFilter(
+      {double sigmaX = 0.0,
+      double sigmaY = 0.0,
+      ui.TileMode tileMode = ui.TileMode.clamp});
+  ui.ImageFilter createDilateImageFilter(
+      {double radiusX = 0.0, double radiusY = 0.0});
+  ui.ImageFilter createErodeImageFilter(
+      {double radiusX = 0.0, double radiusY = 0.0});
+  ui.ImageFilter createMatrixImageFilter(Float64List matrix4,
+      {ui.FilterQuality filterQuality = ui.FilterQuality.low});
+  ui.ImageFilter composeImageFilters(
+      {required ui.ImageFilter outer, required ui.ImageFilter inner});
 
   Future<ui.Codec> instantiateImageCodec(
     Uint8List list, {
@@ -129,20 +131,15 @@ abstract class Renderer {
 
   FutureOr<ui.Image> createImageFromImageBitmap(DomImageBitmap imageSource);
 
-  ui.Image createImageFromTextureSource(Object object,  { required int width, required int height });
- 
+  ui.Image createImageFromTextureSource(Object object,
+      {required int width, required int height});
 
-  void decodeImageFromPixels(
-    Uint8List pixels,
-    int width,
-    int height,
-    ui.PixelFormat format,
-    ui.ImageDecoderCallback callback, {
-    int? rowBytes,
-    int? targetWidth,
-    int? targetHeight,
-    bool allowUpscaling = true
-  });
+  void decodeImageFromPixels(Uint8List pixels, int width, int height,
+      ui.PixelFormat format, ui.ImageDecoderCallback callback,
+      {int? rowBytes,
+      int? targetWidth,
+      int? targetHeight,
+      bool allowUpscaling = true});
 
   ui.ImageShader createImageShader(
     ui.Image image,

--- a/lib/web_ui/lib/src/engine/renderer.dart
+++ b/lib/web_ui/lib/src/engine/renderer.dart
@@ -129,6 +129,9 @@ abstract class Renderer {
 
   FutureOr<ui.Image> createImageFromImageBitmap(DomImageBitmap imageSource);
 
+  ui.Image createImageFromTextureSource(Object object,  { required int width, required int height });
+ 
+
   void decodeImageFromPixels(
     Uint8List pixels,
     int width,

--- a/lib/web_ui/lib/src/engine/renderer.dart
+++ b/lib/web_ui/lib/src/engine/renderer.dart
@@ -7,8 +7,7 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:ui/src/engine.dart';
-import 'package:ui/src/engine/skwasm/skwasm_impl.dart'
-    if (dart.library.html) 'package:ui/src/engine/skwasm/skwasm_stub.dart';
+import 'package:ui/src/engine/skwasm/skwasm_impl.dart' if (dart.library.html) 'package:ui/src/engine/skwasm/skwasm_stub.dart';
 import 'package:ui/ui.dart' as ui;
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 

--- a/lib/web_ui/lib/src/engine/renderer.dart
+++ b/lib/web_ui/lib/src/engine/renderer.dart
@@ -130,8 +130,8 @@ abstract class Renderer {
 
   FutureOr<ui.Image> createImageFromImageBitmap(DomImageBitmap imageSource);
 
-  ui.Image createImageFromTextureSource(Object object,
-      {required int width, required int height});
+  FutureOr<ui.Image> createImageFromTextureSource(Object object,
+      {required int width, required int height, required bool transferOwnership });
 
   void decodeImageFromPixels(Uint8List pixels, int width, int height,
       ui.PixelFormat format, ui.ImageDecoderCallback callback,

--- a/lib/web_ui/lib/src/engine/renderer.dart
+++ b/lib/web_ui/lib/src/engine/renderer.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:js_interop';
 import 'dart:math' as math;
 import 'dart:typed_data';
 
@@ -103,18 +104,17 @@ abstract class Renderer {
     Float32List? matrix4,
   ]);
 
-  ui.ImageFilter createBlurImageFilter(
-      {double sigmaX = 0.0,
-      double sigmaY = 0.0,
-      ui.TileMode tileMode = ui.TileMode.clamp});
-  ui.ImageFilter createDilateImageFilter(
-      {double radiusX = 0.0, double radiusY = 0.0});
-  ui.ImageFilter createErodeImageFilter(
-      {double radiusX = 0.0, double radiusY = 0.0});
-  ui.ImageFilter createMatrixImageFilter(Float64List matrix4,
-      {ui.FilterQuality filterQuality = ui.FilterQuality.low});
-  ui.ImageFilter composeImageFilters(
-      {required ui.ImageFilter outer, required ui.ImageFilter inner});
+  ui.ImageFilter createBlurImageFilter({
+    double sigmaX = 0.0,
+    double sigmaY = 0.0,
+    ui.TileMode tileMode = ui.TileMode.clamp});
+  ui.ImageFilter createDilateImageFilter({ double radiusX = 0.0, double radiusY = 0.0});
+  ui.ImageFilter createErodeImageFilter({ double radiusX = 0.0, double radiusY = 0.0});
+  ui.ImageFilter createMatrixImageFilter(
+    Float64List matrix4, {
+    ui.FilterQuality filterQuality = ui.FilterQuality.low
+  });
+  ui.ImageFilter composeImageFilters({required ui.ImageFilter outer, required ui.ImageFilter inner});
 
   Future<ui.Codec> instantiateImageCodec(
     Uint8List list, {
@@ -130,15 +130,20 @@ abstract class Renderer {
 
   FutureOr<ui.Image> createImageFromImageBitmap(DomImageBitmap imageSource);
 
-  FutureOr<ui.Image> createImageFromTextureSource(Object object,
-      {required int width, required int height, required bool transferOwnership });
+  FutureOr<ui.Image> createImageFromTextureSource(JSAny object,
+      {required int width, required int height, required bool transferOwnership});
 
-  void decodeImageFromPixels(Uint8List pixels, int width, int height,
-      ui.PixelFormat format, ui.ImageDecoderCallback callback,
-      {int? rowBytes,
-      int? targetWidth,
-      int? targetHeight,
-      bool allowUpscaling = true});
+  void decodeImageFromPixels(
+    Uint8List pixels,
+    int width,
+    int height,
+    ui.PixelFormat format,
+    ui.ImageDecoderCallback callback, {
+    int? rowBytes,
+    int? targetWidth,
+    int? targetHeight,
+    bool allowUpscaling = true
+  });
 
   ui.ImageShader createImageShader(
     ui.Image image,

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
@@ -472,6 +472,16 @@ class SkwasmRenderer implements Renderer {
       surface.handle,
     ));
   }
+
+  @override
+  ui.Image createImageFromTextureSource(Object textureSource, { required int width, required int height }) {
+    return SkwasmImage(imageCreateFromTextureSource(
+      textureSource as JSObject,
+      width,
+      height,
+      surface.handle,
+    ));
+  }
 }
 
 class SkwasmPictureRenderer implements PictureRenderer {

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
@@ -475,7 +475,7 @@ class SkwasmRenderer implements Renderer {
 
   @override
   FutureOr<ui.Image> createImageFromTextureSource(Object textureSource, { required int width, required int height, required bool transferOwnership }) async {
-    if(!transferOwnership) {
+    if (!transferOwnership) {
       textureSource = await createImageBitmap(textureSource.toJSAnyShallow, (x: 0, y: 0, width: width, height: height));
     }
     return SkwasmImage(imageCreateFromTextureSource(

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
@@ -474,9 +474,9 @@ class SkwasmRenderer implements Renderer {
   }
 
   @override
-  FutureOr<ui.Image> createImageFromTextureSource(Object textureSource, { required int width, required int height, required bool transferOwnership }) async {
+  FutureOr<ui.Image> createImageFromTextureSource(JSAny textureSource, { required int width, required int height, required bool transferOwnership }) async {
     if (!transferOwnership) {
-      textureSource = await createImageBitmap(textureSource.toJSAnyShallow, (x: 0, y: 0, width: width, height: height));
+      textureSource = (await createImageBitmap(textureSource, (x: 0, y: 0, width: width, height: height))).toJSAnyShallow;
     }
     return SkwasmImage(imageCreateFromTextureSource(
       textureSource as JSObject,

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
@@ -474,7 +474,10 @@ class SkwasmRenderer implements Renderer {
   }
 
   @override
-  ui.Image createImageFromTextureSource(Object textureSource, { required int width, required int height }) {
+  FutureOr<ui.Image> createImageFromTextureSource(Object textureSource, { required int width, required int height, required bool transferOwnership }) async {
+    if(!transferOwnership) {
+      textureSource = await createImageBitmap(textureSource.toJSAnyShallow, (x: 0, y: 0, width: width, height: height));
+    }
     return SkwasmImage(imageCreateFromTextureSource(
       textureSource as JSObject,
       width,

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_stub/renderer.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_stub/renderer.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:js_interop';
 import 'dart:math' as math;
 import 'dart:typed_data';
 
@@ -191,7 +192,7 @@ class SkwasmRenderer implements Renderer {
   }
 
   @override
-  ui.Image createImageFromTextureSource(Object object,  { required int width, required int height, required bool transferOwnership }) {
+  ui.Image createImageFromTextureSource(JSAny object,  { required int width, required int height, required bool transferOwnership }) {
     throw Exception('Skwasm not implemented on this platform.');
   }
 }

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_stub/renderer.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_stub/renderer.dart
@@ -191,7 +191,7 @@ class SkwasmRenderer implements Renderer {
   }
 
   @override
-  ui.Image createImageFromTextureSource(Object object,  { required int width, required int height }) {
+  ui.Image createImageFromTextureSource(Object object,  { required int width, required int height, required bool transferOwnership }) {
     throw Exception('Skwasm not implemented on this platform.');
   }
 }

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_stub/renderer.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_stub/renderer.dart
@@ -189,4 +189,9 @@ class SkwasmRenderer implements Renderer {
   ui.Image createImageFromImageBitmap(DomImageBitmap imageSource) {
     throw UnimplementedError('Skwasm not implemented on this platform.');
   }
+
+  @override
+  ui.Image createImageFromTextureSource(Object object,  { required int width, required int height }) {
+    throw Exception('Skwasm not implemented on this platform.');
+  }
 }

--- a/lib/web_ui/lib/ui_web/src/ui_web/images.dart
+++ b/lib/web_ui/lib/ui_web/src/ui_web/images.dart
@@ -45,9 +45,16 @@ FutureOr<ui.Image> createImageFromImageBitmap(JSAny imageSource) {
   );
 }
 
-/// Creates a [ui.Image] from a valid texture source (for example HTMLImageElement | HTMLVideoElement | HTMLCanvasElement).
-ui.Image createImageFromTextureSource(Object object,  { required int width, required int height }) {
+/// Creates a [ui.Image] from a valid texture source (for example 
+/// HTMLImageElement | HTMLVideoElement | HTMLCanvasElement).
+/// 
+/// By default, the ownership of the texture will be not be transferred to the 
+/// renderer, and a copy of the texture source will be made. If this is not 
+/// desired, the ownership of the object can be transferred to the renderer and 
+/// the engine will take ownership of the ImageBitmap object and consume its
+/// contents.
+FutureOr<ui.Image> createImageFromTextureSource(Object object,  { required int width, required int height, bool transferOwnership = false }) {
   return renderer.createImageFromTextureSource(
-    object, width: width, height: height,
+    object, width: width, height: height, transferOwnership: transferOwnership
   );
 }

--- a/lib/web_ui/lib/ui_web/src/ui_web/images.dart
+++ b/lib/web_ui/lib/ui_web/src/ui_web/images.dart
@@ -53,7 +53,7 @@ FutureOr<ui.Image> createImageFromImageBitmap(JSAny imageSource) {
 /// will be made. If this is not desired, the ownership of the object can be
 /// transferred to the renderer and the engine will take ownership of the
 /// texture source and consume its contents.
-FutureOr<ui.Image> createImageFromTextureSource(Object object,  { required int width, required int height, bool transferOwnership = false }) {
+FutureOr<ui.Image> createImageFromTextureSource(JSAny object,  { required int width, required int height, bool transferOwnership = false }) {
   return renderer.createImageFromTextureSource(
     object, width: width, height: height, transferOwnership: transferOwnership
   );

--- a/lib/web_ui/lib/ui_web/src/ui_web/images.dart
+++ b/lib/web_ui/lib/ui_web/src/ui_web/images.dart
@@ -44,3 +44,10 @@ FutureOr<ui.Image> createImageFromImageBitmap(JSAny imageSource) {
     imageSource as DomImageBitmap,
   );
 }
+
+/// Creates a [ui.Image] from a valid texture source (for example HTMLImageElement | HTMLVideoElement | HTMLCanvasElement).
+ui.Image createImageFromTextureSource(Object object,  { required int width, required int height }) {
+  return renderer.createImageFromTextureSource(
+    object, width: width, height: height,
+  );
+}

--- a/lib/web_ui/lib/ui_web/src/ui_web/images.dart
+++ b/lib/web_ui/lib/ui_web/src/ui_web/images.dart
@@ -45,12 +45,12 @@ FutureOr<ui.Image> createImageFromImageBitmap(JSAny imageSource) {
   );
 }
 
-/// Creates a [ui.Image] from a valid texture source (for example 
+/// Creates a [ui.Image] from a valid texture source (for example
 /// HTMLImageElement | HTMLVideoElement | HTMLCanvasElement).
-/// 
-/// By default, the ownership of the texture will be not be transferred to the 
-/// renderer, and a copy of the texture source will be made. If this is not 
-/// desired, the ownership of the object can be transferred to the renderer and 
+///
+/// By default, the ownership of the texture will be not be transferred to the
+/// renderer, and a copy of the texture source will be made. If this is not
+/// desired, the ownership of the object can be transferred to the renderer and
 /// the engine will take ownership of the ImageBitmap object and consume its
 /// contents.
 FutureOr<ui.Image> createImageFromTextureSource(Object object,  { required int width, required int height, bool transferOwnership = false }) {

--- a/lib/web_ui/lib/ui_web/src/ui_web/images.dart
+++ b/lib/web_ui/lib/ui_web/src/ui_web/images.dart
@@ -48,11 +48,11 @@ FutureOr<ui.Image> createImageFromImageBitmap(JSAny imageSource) {
 /// Creates a [ui.Image] from a valid texture source (for example
 /// HTMLImageElement | HTMLVideoElement | HTMLCanvasElement).
 ///
-/// By default, the ownership of the texture will be not be transferred to the
-/// renderer, and a copy of the texture source will be made. If this is not
-/// desired, the ownership of the object can be transferred to the renderer and
-/// the engine will take ownership of the ImageBitmap object and consume its
-/// contents.
+/// By default, [transferOwnership] specifies that the ownership of the texture
+/// will be not be transferred to the renderer, and a copy of the texture source
+/// will be made. If this is not desired, the ownership of the object can be
+/// transferred to the renderer and the engine will take ownership of the
+/// texture source and consume its contents.
 FutureOr<ui.Image> createImageFromTextureSource(Object object,  { required int width, required int height, bool transferOwnership = false }) {
   return renderer.createImageFromTextureSource(
     object, width: width, height: height, transferOwnership: transferOwnership

--- a/lib/web_ui/test/ui/image_golden_test.dart
+++ b/lib/web_ui/test/ui/image_golden_test.dart
@@ -70,7 +70,9 @@ Future<void> testMain() async {
   setUp(() {
     assetScope = fakeAssetManager.pushAssetScope();
     assetScope.setAsset(
-        'glitch_shader', ByteData.sublistView(utf8.encode(kGlitchShaderSksl)));
+      'glitch_shader',
+      ByteData.sublistView(utf8.encode(kGlitchShaderSksl))
+    );
   });
 
   tearDown(() {
@@ -104,19 +106,14 @@ Future<void> testMain() async {
 
         final ui.PictureRecorder recorder = ui.PictureRecorder();
         final ui.Canvas canvas = ui.Canvas(recorder, drawRegion);
-        canvas.drawImage(image, ui.Offset.zero,
-            ui.Paint()..filterQuality = ui.FilterQuality.none);
-        canvas.drawImage(image, const ui.Offset(150, 0),
-            ui.Paint()..filterQuality = ui.FilterQuality.low);
-        canvas.drawImage(image, const ui.Offset(0, 150),
-            ui.Paint()..filterQuality = ui.FilterQuality.medium);
-        canvas.drawImage(image, const ui.Offset(150, 150),
-            ui.Paint()..filterQuality = ui.FilterQuality.high);
+        canvas.drawImage(image, ui.Offset.zero, ui.Paint()..filterQuality = ui.FilterQuality.none);
+        canvas.drawImage(image, const ui.Offset(150, 0), ui.Paint()..filterQuality = ui.FilterQuality.low);
+        canvas.drawImage(image, const ui.Offset(0, 150), ui.Paint()..filterQuality = ui.FilterQuality.medium);
+        canvas.drawImage(image, const ui.Offset(150, 150), ui.Paint()..filterQuality = ui.FilterQuality.high);
 
         await drawPictureUsingCurrentRenderer(recorder.endRecording());
 
-        await matchGoldenFile('${name}_canvas_drawImage.png',
-            region: drawRegion);
+        await matchGoldenFile('${name}_canvas_drawImage.png', region: drawRegion);
       });
 
       test('drawImageRect', () async {
@@ -126,30 +123,33 @@ Future<void> testMain() async {
         final ui.Canvas canvas = ui.Canvas(recorder, drawRegion);
         const ui.Rect srcRect = ui.Rect.fromLTRB(50, 50, 100, 100);
         canvas.drawImageRect(
-            image,
-            srcRect,
-            const ui.Rect.fromLTRB(0, 0, 150, 150),
-            ui.Paint()..filterQuality = ui.FilterQuality.none);
+          image,
+          srcRect,
+          const ui.Rect.fromLTRB(0, 0, 150, 150),
+          ui.Paint()..filterQuality = ui.FilterQuality.none
+        );
         canvas.drawImageRect(
-            image,
-            srcRect,
-            const ui.Rect.fromLTRB(150, 0, 300, 150),
-            ui.Paint()..filterQuality = ui.FilterQuality.low);
+          image,
+          srcRect,
+          const ui.Rect.fromLTRB(150, 0, 300, 150),
+          ui.Paint()..filterQuality = ui.FilterQuality.low
+        );
         canvas.drawImageRect(
-            image,
-            srcRect,
-            const ui.Rect.fromLTRB(0, 150, 150, 300),
-            ui.Paint()..filterQuality = ui.FilterQuality.medium);
+          image,
+          srcRect,
+          const ui.Rect.fromLTRB(0, 150, 150, 300),
+          ui.Paint()..filterQuality = ui.FilterQuality.medium
+        );
         canvas.drawImageRect(
-            image,
-            srcRect,
-            const ui.Rect.fromLTRB(150, 150, 300, 300),
-            ui.Paint()..filterQuality = ui.FilterQuality.high);
+          image,
+          srcRect,
+          const ui.Rect.fromLTRB(150, 150, 300, 300),
+          ui.Paint()..filterQuality = ui.FilterQuality.high
+        );
 
         await drawPictureUsingCurrentRenderer(recorder.endRecording());
 
-        await matchGoldenFile('${name}_canvas_drawImageRect.png',
-            region: drawRegion);
+        await matchGoldenFile('${name}_canvas_drawImageRect.png', region: drawRegion);
       });
 
       test('drawImageNine', () async {
@@ -157,21 +157,23 @@ Future<void> testMain() async {
 
         final ui.PictureRecorder recorder = ui.PictureRecorder();
         final ui.Canvas canvas = ui.Canvas(recorder, drawRegion);
-        canvas.drawImageNine(image, const ui.Rect.fromLTRB(50, 50, 100, 100),
-            drawRegion, ui.Paint());
+        canvas.drawImageNine(
+          image,
+          const ui.Rect.fromLTRB(50, 50, 100, 100),
+          drawRegion,
+          ui.Paint()
+        );
 
         await drawPictureUsingCurrentRenderer(recorder.endRecording());
 
-        await matchGoldenFile('${name}_canvas_drawImageNine.png',
-            region: drawRegion);
+        await matchGoldenFile('${name}_canvas_drawImageNine.png', region: drawRegion);
       });
 
       test('image_shader_cubic_rotated', () async {
         final ui.PictureRecorder recorder = ui.PictureRecorder();
         final ui.Canvas canvas = ui.Canvas(recorder, drawRegion);
         final Float64List matrix = Matrix4.rotationZ(pi / 6).toFloat64();
-        Future<void> drawOvalWithShader(
-            ui.Rect rect, ui.FilterQuality quality) async {
+        Future<void> drawOvalWithShader(ui.Rect rect, ui.FilterQuality quality) async {
           final ui.Image image = await generateImage();
           final ui.ImageShader shader = ui.ImageShader(
             image,
@@ -180,35 +182,32 @@ Future<void> testMain() async {
             matrix,
             filterQuality: quality,
           );
-          canvas.drawOval(rect, ui.Paint()..shader = shader);
+          canvas.drawOval(
+            rect,
+            ui.Paint()..shader = shader
+          );
         }
 
         // Draw image shader with all four qualities.
-        await drawOvalWithShader(
-            const ui.Rect.fromLTRB(0, 0, 150, 100), ui.FilterQuality.none);
-        await drawOvalWithShader(
-            const ui.Rect.fromLTRB(150, 0, 300, 100), ui.FilterQuality.low);
+        await drawOvalWithShader(const ui.Rect.fromLTRB(0, 0, 150, 100), ui.FilterQuality.none);
+        await drawOvalWithShader(const ui.Rect.fromLTRB(150, 0, 300, 100), ui.FilterQuality.low);
 
         // Note that for images that CanvasKit handles lazily (ones created via
         // `createImageFromImageBitmap` or `instantiateImageCodecFromUrl`)
         // there is a CanvasKit bug that this just renders a black oval instead of
         // actually texturing it with the image.
         // See https://g-issues.skia.org/issues/338095525
-        await drawOvalWithShader(
-            const ui.Rect.fromLTRB(0, 100, 150, 200), ui.FilterQuality.medium);
-        await drawOvalWithShader(
-            const ui.Rect.fromLTRB(150, 100, 300, 200), ui.FilterQuality.high);
+        await drawOvalWithShader(const ui.Rect.fromLTRB(0, 100, 150, 200), ui.FilterQuality.medium);
+        await drawOvalWithShader(const ui.Rect.fromLTRB(150, 100, 300, 200), ui.FilterQuality.high);
 
         await drawPictureUsingCurrentRenderer(recorder.endRecording());
-        await matchGoldenFile('${name}_image_shader_cubic_rotated.png',
-            region: drawRegion);
+        await matchGoldenFile('${name}_image_shader_cubic_rotated.png', region: drawRegion);
       });
 
       test('fragment_shader_sampler', () async {
         final ui.Image image = await generateImage();
 
-        final ui.FragmentProgram program =
-            await renderer.createFragmentProgram('glitch_shader');
+        final ui.FragmentProgram program = await renderer.createFragmentProgram('glitch_shader');
         final ui.FragmentShader shader = program.fragmentShader();
 
         // Resolution
@@ -223,13 +222,11 @@ Future<void> testMain() async {
 
         final ui.PictureRecorder recorder = ui.PictureRecorder();
         final ui.Canvas canvas = ui.Canvas(recorder, drawRegion);
-        canvas.drawCircle(
-            const ui.Offset(150, 150), 100, ui.Paint()..shader = shader);
+        canvas.drawCircle(const ui.Offset(150, 150), 100, ui.Paint()..shader = shader);
 
         await drawPictureUsingCurrentRenderer(recorder.endRecording());
 
-        await matchGoldenFile('${name}_fragment_shader_sampler.png',
-            region: drawRegion);
+        await matchGoldenFile('${name}_fragment_shader_sampler.png', region: drawRegion);
       }, skip: isHtml); // HTML doesn't support fragment shaders
 
       test('drawVertices with image shader', () async {
@@ -270,13 +267,11 @@ Future<void> testMain() async {
 
         final ui.PictureRecorder recorder = ui.PictureRecorder();
         final ui.Canvas canvas = ui.Canvas(recorder, drawRegion);
-        canvas.drawVertices(
-            vertices, ui.BlendMode.srcOver, ui.Paint()..shader = shader);
+        canvas.drawVertices(vertices, ui.BlendMode.srcOver, ui.Paint()..shader = shader);
 
         await drawPictureUsingCurrentRenderer(recorder.endRecording());
 
-        await matchGoldenFile('${name}_drawVertices_imageShader.png',
-            region: drawRegion);
+        await matchGoldenFile('${name}_drawVertices_imageShader.png', region: drawRegion);
       }, skip: isHtml); // https://github.com/flutter/flutter/issues/127454;
 
       test('toByteData_rgba', () async {
@@ -290,8 +285,7 @@ Future<void> testMain() async {
       test('toByteData_png', () async {
         final ui.Image image = await generateImage();
 
-        final ByteData? pngData =
-            await image.toByteData(format: ui.ImageByteFormat.png);
+        final ByteData? pngData = await image.toByteData(format: ui.ImageByteFormat.png);
         expect(pngData, isNotNull);
         expect(pngData!.lengthInBytes, isNonZero);
       }, skip: isHtml); // https://github.com/flutter/flutter/issues/126611
@@ -305,10 +299,8 @@ Future<void> testMain() async {
       for (int x = 0; x < 15; x++) {
         final ui.Offset center = ui.Offset(x * 10 + 5, y * 10 + 5);
         final ui.Color color = ui.Color.fromRGBO(
-            (center.dx * 256 / 150).round(),
-            (center.dy * 256 / 150).round(),
-            0,
-            1);
+          (center.dx * 256 / 150).round(),
+          (center.dy * 256 / 150).round(), 0, 1);
         canvas.drawCircle(center, 5, ui.Paint()..color = color);
       }
     }
@@ -316,7 +308,10 @@ Future<void> testMain() async {
   });
 
   Uint8List generatePixelData(
-      int width, int height, ui.Color Function(double, double) generator) {
+    int width,
+    int height,
+    ui.Color Function(double, double) generator
+  ) {
     final Uint8List data = Uint8List(width * height * 4);
     int outputIndex = 0;
     for (int y = 0; y < height; y++) {
@@ -346,8 +341,7 @@ Future<void> testMain() async {
       );
     });
     final Completer<ui.Image> completer = Completer<ui.Image>();
-    ui.decodeImageFromPixels(
-        pixels, 150, 150, ui.PixelFormat.rgba8888, completer.complete);
+    ui.decodeImageFromPixels(pixels, 150, 150, ui.PixelFormat.rgba8888, completer.complete);
     return completer.future;
   });
 
@@ -380,7 +374,8 @@ Future<void> testMain() async {
 
   emitImageTests('codec_uri', () async {
     final ui.Codec codec = await renderer.instantiateImageCodecFromUrl(
-        Uri(path: '/test_images/mandrill_128.png'));
+      Uri(path: '/test_images/mandrill_128.png')
+    );
     expect(codec.frameCount, 1);
 
     final ui.FrameInfo info = await codec.getNextFrame();
@@ -392,14 +387,12 @@ Future<void> testMain() async {
   if (!isFirefox) {
     emitImageTests('svg_image_bitmap', () async {
       final DomBlob svgBlob = createDomBlob(<String>[
-        '''
+  '''
   <svg xmlns="http://www.w3.org/2000/svg" width="150" height="150">
     <path d="M25,75  A50,50 0 1,0 125 75 L75,25 Z" stroke="blue" stroke-width="10" fill="red"></path>
   </svg>
   '''
-      ], <String, String>{
-        'type': 'image/svg+xml'
-      });
+      ], <String, String>{'type': 'image/svg+xml'});
       final String url = domWindow.URL.createObjectURL(svgBlob);
       final DomHTMLImageElement image = createDomHTMLImageElement();
       final Completer<void> completer = Completer<void>();
@@ -416,8 +409,7 @@ Future<void> testMain() async {
 
       expect(bitmap.width.toDartInt, 150);
       expect(bitmap.height.toDartInt, 150);
-      final ui.Image uiImage =
-          await renderer.createImageFromImageBitmap(bitmap);
+      final ui.Image uiImage = await renderer.createImageFromImageBitmap(bitmap);
 
       if (isSkwasm) {
         // Skwasm transfers the bitmap to the web worker, so it should be disposed/consumed.
@@ -453,16 +445,14 @@ Future<void> testMain() async {
       image.src = url;
       await completer.future;
 
-      final ui.Image uiImage = await renderer.createImageFromTextureSource(image,
-          width: 150, height: 150, transferOwnership: false);
+      final ui.Image uiImage =
+          await renderer.createImageFromTextureSource(image.toJSAnyShallow, width: 150, height: 150, transferOwnership: false);
       return uiImage;
-
     });
   }
 
   emitImageTests('codec_list_resized', () async {
-    final ByteBuffer data =
-        await httpFetchByteBuffer('/test_images/mandrill_128.png');
+    final ByteBuffer data = await httpFetchByteBuffer('/test_images/mandrill_128.png');
     final ui.Codec codec = await renderer.instantiateImageCodec(
       data.asUint8List(),
       targetWidth: 150,

--- a/lib/web_ui/test/ui/image_golden_test.dart
+++ b/lib/web_ui/test/ui/image_golden_test.dart
@@ -452,22 +452,11 @@ Future<void> testMain() async {
       image.addEventListener('load', loadListener);
       image.src = url;
       await completer.future;
-
-      if (isSkwasm) {
-        // Send something we can actually transfer to a worker, unfortunately we can't transfer an element.
-        final DomImageBitmap bitmap =
-            await createImageBitmap(image as JSObject);
-        expect(bitmap.width.toDartInt, 150);
-        expect(bitmap.height.toDartInt, 150);
-
-        final ui.Image uiImage = renderer.createImageFromTextureSource(bitmap,
-            width: 150, height: 150);
-        return uiImage;
-      } else {
-        final ui.Image uiImage = renderer.createImageFromTextureSource(image,
-            width: 150, height: 150);
-        return uiImage;
-      }
+      
+      final ui.Image uiImage = await renderer.createImageFromTextureSource(image,
+          width: 150, height: 150, transferOwnership: false);
+      return uiImage;
+      
     });
   }
 

--- a/lib/web_ui/test/ui/image_golden_test.dart
+++ b/lib/web_ui/test/ui/image_golden_test.dart
@@ -13,7 +13,6 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 
 import 'package:ui/ui.dart' as ui;
-import 'package:ui/ui_web/src/ui_web/images.dart';
 import 'package:web_engine_tester/golden_tester.dart';
 
 import '../common/fake_asset_manager.dart';

--- a/lib/web_ui/test/ui/image_golden_test.dart
+++ b/lib/web_ui/test/ui/image_golden_test.dart
@@ -452,11 +452,11 @@ Future<void> testMain() async {
       image.addEventListener('load', loadListener);
       image.src = url;
       await completer.future;
-      
+
       final ui.Image uiImage = await renderer.createImageFromTextureSource(image,
           width: 150, height: 150, transferOwnership: false);
       return uiImage;
-      
+
     });
   }
 

--- a/lib/web_ui/test/ui/image_golden_test.dart
+++ b/lib/web_ui/test/ui/image_golden_test.dart
@@ -71,9 +71,7 @@ Future<void> testMain() async {
   setUp(() {
     assetScope = fakeAssetManager.pushAssetScope();
     assetScope.setAsset(
-      'glitch_shader',
-      ByteData.sublistView(utf8.encode(kGlitchShaderSksl))
-    );
+        'glitch_shader', ByteData.sublistView(utf8.encode(kGlitchShaderSksl)));
   });
 
   tearDown(() {
@@ -107,14 +105,19 @@ Future<void> testMain() async {
 
         final ui.PictureRecorder recorder = ui.PictureRecorder();
         final ui.Canvas canvas = ui.Canvas(recorder, drawRegion);
-        canvas.drawImage(image, ui.Offset.zero, ui.Paint()..filterQuality = ui.FilterQuality.none);
-        canvas.drawImage(image, const ui.Offset(150, 0), ui.Paint()..filterQuality = ui.FilterQuality.low);
-        canvas.drawImage(image, const ui.Offset(0, 150), ui.Paint()..filterQuality = ui.FilterQuality.medium);
-        canvas.drawImage(image, const ui.Offset(150, 150), ui.Paint()..filterQuality = ui.FilterQuality.high);
+        canvas.drawImage(image, ui.Offset.zero,
+            ui.Paint()..filterQuality = ui.FilterQuality.none);
+        canvas.drawImage(image, const ui.Offset(150, 0),
+            ui.Paint()..filterQuality = ui.FilterQuality.low);
+        canvas.drawImage(image, const ui.Offset(0, 150),
+            ui.Paint()..filterQuality = ui.FilterQuality.medium);
+        canvas.drawImage(image, const ui.Offset(150, 150),
+            ui.Paint()..filterQuality = ui.FilterQuality.high);
 
         await drawPictureUsingCurrentRenderer(recorder.endRecording());
 
-        await matchGoldenFile('${name}_canvas_drawImage.png', region: drawRegion);
+        await matchGoldenFile('${name}_canvas_drawImage.png',
+            region: drawRegion);
       });
 
       test('drawImageRect', () async {
@@ -124,33 +127,30 @@ Future<void> testMain() async {
         final ui.Canvas canvas = ui.Canvas(recorder, drawRegion);
         const ui.Rect srcRect = ui.Rect.fromLTRB(50, 50, 100, 100);
         canvas.drawImageRect(
-          image,
-          srcRect,
-          const ui.Rect.fromLTRB(0, 0, 150, 150),
-          ui.Paint()..filterQuality = ui.FilterQuality.none
-        );
+            image,
+            srcRect,
+            const ui.Rect.fromLTRB(0, 0, 150, 150),
+            ui.Paint()..filterQuality = ui.FilterQuality.none);
         canvas.drawImageRect(
-          image,
-          srcRect,
-          const ui.Rect.fromLTRB(150, 0, 300, 150),
-          ui.Paint()..filterQuality = ui.FilterQuality.low
-        );
+            image,
+            srcRect,
+            const ui.Rect.fromLTRB(150, 0, 300, 150),
+            ui.Paint()..filterQuality = ui.FilterQuality.low);
         canvas.drawImageRect(
-          image,
-          srcRect,
-          const ui.Rect.fromLTRB(0, 150, 150, 300),
-          ui.Paint()..filterQuality = ui.FilterQuality.medium
-        );
+            image,
+            srcRect,
+            const ui.Rect.fromLTRB(0, 150, 150, 300),
+            ui.Paint()..filterQuality = ui.FilterQuality.medium);
         canvas.drawImageRect(
-          image,
-          srcRect,
-          const ui.Rect.fromLTRB(150, 150, 300, 300),
-          ui.Paint()..filterQuality = ui.FilterQuality.high
-        );
+            image,
+            srcRect,
+            const ui.Rect.fromLTRB(150, 150, 300, 300),
+            ui.Paint()..filterQuality = ui.FilterQuality.high);
 
         await drawPictureUsingCurrentRenderer(recorder.endRecording());
 
-        await matchGoldenFile('${name}_canvas_drawImageRect.png', region: drawRegion);
+        await matchGoldenFile('${name}_canvas_drawImageRect.png',
+            region: drawRegion);
       });
 
       test('drawImageNine', () async {
@@ -158,23 +158,21 @@ Future<void> testMain() async {
 
         final ui.PictureRecorder recorder = ui.PictureRecorder();
         final ui.Canvas canvas = ui.Canvas(recorder, drawRegion);
-        canvas.drawImageNine(
-          image,
-          const ui.Rect.fromLTRB(50, 50, 100, 100),
-          drawRegion,
-          ui.Paint()
-        );
+        canvas.drawImageNine(image, const ui.Rect.fromLTRB(50, 50, 100, 100),
+            drawRegion, ui.Paint());
 
         await drawPictureUsingCurrentRenderer(recorder.endRecording());
 
-        await matchGoldenFile('${name}_canvas_drawImageNine.png', region: drawRegion);
+        await matchGoldenFile('${name}_canvas_drawImageNine.png',
+            region: drawRegion);
       });
 
       test('image_shader_cubic_rotated', () async {
         final ui.PictureRecorder recorder = ui.PictureRecorder();
         final ui.Canvas canvas = ui.Canvas(recorder, drawRegion);
         final Float64List matrix = Matrix4.rotationZ(pi / 6).toFloat64();
-        Future<void> drawOvalWithShader(ui.Rect rect, ui.FilterQuality quality) async {
+        Future<void> drawOvalWithShader(
+            ui.Rect rect, ui.FilterQuality quality) async {
           final ui.Image image = await generateImage();
           final ui.ImageShader shader = ui.ImageShader(
             image,
@@ -183,32 +181,35 @@ Future<void> testMain() async {
             matrix,
             filterQuality: quality,
           );
-          canvas.drawOval(
-            rect,
-            ui.Paint()..shader = shader
-          );
+          canvas.drawOval(rect, ui.Paint()..shader = shader);
         }
 
         // Draw image shader with all four qualities.
-        await drawOvalWithShader(const ui.Rect.fromLTRB(0, 0, 150, 100), ui.FilterQuality.none);
-        await drawOvalWithShader(const ui.Rect.fromLTRB(150, 0, 300, 100), ui.FilterQuality.low);
+        await drawOvalWithShader(
+            const ui.Rect.fromLTRB(0, 0, 150, 100), ui.FilterQuality.none);
+        await drawOvalWithShader(
+            const ui.Rect.fromLTRB(150, 0, 300, 100), ui.FilterQuality.low);
 
         // Note that for images that CanvasKit handles lazily (ones created via
         // `createImageFromImageBitmap` or `instantiateImageCodecFromUrl`)
         // there is a CanvasKit bug that this just renders a black oval instead of
         // actually texturing it with the image.
         // See https://g-issues.skia.org/issues/338095525
-        await drawOvalWithShader(const ui.Rect.fromLTRB(0, 100, 150, 200), ui.FilterQuality.medium);
-        await drawOvalWithShader(const ui.Rect.fromLTRB(150, 100, 300, 200), ui.FilterQuality.high);
+        await drawOvalWithShader(
+            const ui.Rect.fromLTRB(0, 100, 150, 200), ui.FilterQuality.medium);
+        await drawOvalWithShader(
+            const ui.Rect.fromLTRB(150, 100, 300, 200), ui.FilterQuality.high);
 
         await drawPictureUsingCurrentRenderer(recorder.endRecording());
-        await matchGoldenFile('${name}_image_shader_cubic_rotated.png', region: drawRegion);
+        await matchGoldenFile('${name}_image_shader_cubic_rotated.png',
+            region: drawRegion);
       });
 
       test('fragment_shader_sampler', () async {
         final ui.Image image = await generateImage();
 
-        final ui.FragmentProgram program = await renderer.createFragmentProgram('glitch_shader');
+        final ui.FragmentProgram program =
+            await renderer.createFragmentProgram('glitch_shader');
         final ui.FragmentShader shader = program.fragmentShader();
 
         // Resolution
@@ -223,11 +224,13 @@ Future<void> testMain() async {
 
         final ui.PictureRecorder recorder = ui.PictureRecorder();
         final ui.Canvas canvas = ui.Canvas(recorder, drawRegion);
-        canvas.drawCircle(const ui.Offset(150, 150), 100, ui.Paint()..shader = shader);
+        canvas.drawCircle(
+            const ui.Offset(150, 150), 100, ui.Paint()..shader = shader);
 
         await drawPictureUsingCurrentRenderer(recorder.endRecording());
 
-        await matchGoldenFile('${name}_fragment_shader_sampler.png', region: drawRegion);
+        await matchGoldenFile('${name}_fragment_shader_sampler.png',
+            region: drawRegion);
       }, skip: isHtml); // HTML doesn't support fragment shaders
 
       test('drawVertices with image shader', () async {
@@ -268,11 +271,13 @@ Future<void> testMain() async {
 
         final ui.PictureRecorder recorder = ui.PictureRecorder();
         final ui.Canvas canvas = ui.Canvas(recorder, drawRegion);
-        canvas.drawVertices(vertices, ui.BlendMode.srcOver, ui.Paint()..shader = shader);
+        canvas.drawVertices(
+            vertices, ui.BlendMode.srcOver, ui.Paint()..shader = shader);
 
         await drawPictureUsingCurrentRenderer(recorder.endRecording());
 
-        await matchGoldenFile('${name}_drawVertices_imageShader.png', region: drawRegion);
+        await matchGoldenFile('${name}_drawVertices_imageShader.png',
+            region: drawRegion);
       }, skip: isHtml); // https://github.com/flutter/flutter/issues/127454;
 
       test('toByteData_rgba', () async {
@@ -286,7 +291,8 @@ Future<void> testMain() async {
       test('toByteData_png', () async {
         final ui.Image image = await generateImage();
 
-        final ByteData? pngData = await image.toByteData(format: ui.ImageByteFormat.png);
+        final ByteData? pngData =
+            await image.toByteData(format: ui.ImageByteFormat.png);
         expect(pngData, isNotNull);
         expect(pngData!.lengthInBytes, isNonZero);
       }, skip: isHtml); // https://github.com/flutter/flutter/issues/126611
@@ -300,8 +306,10 @@ Future<void> testMain() async {
       for (int x = 0; x < 15; x++) {
         final ui.Offset center = ui.Offset(x * 10 + 5, y * 10 + 5);
         final ui.Color color = ui.Color.fromRGBO(
-          (center.dx * 256 / 150).round(),
-          (center.dy * 256 / 150).round(), 0, 1);
+            (center.dx * 256 / 150).round(),
+            (center.dy * 256 / 150).round(),
+            0,
+            1);
         canvas.drawCircle(center, 5, ui.Paint()..color = color);
       }
     }
@@ -309,10 +317,7 @@ Future<void> testMain() async {
   });
 
   Uint8List generatePixelData(
-    int width,
-    int height,
-    ui.Color Function(double, double) generator
-  ) {
+      int width, int height, ui.Color Function(double, double) generator) {
     final Uint8List data = Uint8List(width * height * 4);
     int outputIndex = 0;
     for (int y = 0; y < height; y++) {
@@ -342,7 +347,8 @@ Future<void> testMain() async {
       );
     });
     final Completer<ui.Image> completer = Completer<ui.Image>();
-    ui.decodeImageFromPixels(pixels, 150, 150, ui.PixelFormat.rgba8888, completer.complete);
+    ui.decodeImageFromPixels(
+        pixels, 150, 150, ui.PixelFormat.rgba8888, completer.complete);
     return completer.future;
   });
 
@@ -375,8 +381,7 @@ Future<void> testMain() async {
 
   emitImageTests('codec_uri', () async {
     final ui.Codec codec = await renderer.instantiateImageCodecFromUrl(
-      Uri(path: '/test_images/mandrill_128.png')
-    );
+        Uri(path: '/test_images/mandrill_128.png'));
     expect(codec.frameCount, 1);
 
     final ui.FrameInfo info = await codec.getNextFrame();
@@ -388,12 +393,14 @@ Future<void> testMain() async {
   if (!isFirefox) {
     emitImageTests('svg_image_bitmap', () async {
       final DomBlob svgBlob = createDomBlob(<String>[
-  '''
+        '''
   <svg xmlns="http://www.w3.org/2000/svg" width="150" height="150">
     <path d="M25,75  A50,50 0 1,0 125 75 L75,25 Z" stroke="blue" stroke-width="10" fill="red"></path>
   </svg>
   '''
-      ], <String, String>{'type': 'image/svg+xml'});
+      ], <String, String>{
+        'type': 'image/svg+xml'
+      });
       final String url = domWindow.URL.createObjectURL(svgBlob);
       final DomHTMLImageElement image = createDomHTMLImageElement();
       final Completer<void> completer = Completer<void>();
@@ -410,7 +417,8 @@ Future<void> testMain() async {
 
       expect(bitmap.width.toDartInt, 150);
       expect(bitmap.height.toDartInt, 150);
-      final ui.Image uiImage = await renderer.createImageFromImageBitmap(bitmap);
+      final ui.Image uiImage =
+          await renderer.createImageFromImageBitmap(bitmap);
 
       if (isSkwasm) {
         // Skwasm transfers the bitmap to the web worker, so it should be disposed/consumed.
@@ -426,12 +434,14 @@ Future<void> testMain() async {
   if (!isFirefox && !isHtml) {
     emitImageTests('svg_image_bitmap_texture_source', () async {
       final DomBlob svgBlob = createDomBlob(<String>[
-  '''
+        '''
   <svg xmlns="http://www.w3.org/2000/svg" width="150" height="150">
     <path d="M25,75  A50,50 0 1,0 125 75 L75,25 Z" stroke="blue" stroke-width="10" fill="red"></path>
   </svg>
   '''
-      ], <String, String>{'type': 'image/svg+xml'});
+      ], <String, String>{
+        'type': 'image/svg+xml'
+      });
       final String url = domWindow.URL.createObjectURL(svgBlob);
       final DomHTMLImageElement image = createDomHTMLImageElement();
       final Completer<void> completer = Completer<void>();
@@ -444,23 +454,27 @@ Future<void> testMain() async {
       image.src = url;
       await completer.future;
 
-      if(isSkwasm) {
+      if (isSkwasm) {
         // Send something we can actually transfer to a worker, unfortunately we can't transfer an element.
-        final DomImageBitmap bitmap = await createImageBitmap(image as JSObject);
+        final DomImageBitmap bitmap =
+            await createImageBitmap(image as JSObject);
         expect(bitmap.width.toDartInt, 150);
         expect(bitmap.height.toDartInt, 150);
-    
-        final ui.Image uiImage = renderer.createImageFromTextureSource(bitmap, width: 150, height: 150);
+
+        final ui.Image uiImage = renderer.createImageFromTextureSource(bitmap,
+            width: 150, height: 150);
         return uiImage;
       } else {
-        final ui.Image uiImage = renderer.createImageFromTextureSource(image, width: 150, height: 150);
+        final ui.Image uiImage = renderer.createImageFromTextureSource(image,
+            width: 150, height: 150);
         return uiImage;
       }
     });
   }
 
   emitImageTests('codec_list_resized', () async {
-    final ByteBuffer data = await httpFetchByteBuffer('/test_images/mandrill_128.png');
+    final ByteBuffer data =
+        await httpFetchByteBuffer('/test_images/mandrill_128.png');
     final ui.Codec codec = await renderer.instantiateImageCodec(
       data.asUint8List(),
       targetWidth: 150,


### PR DESCRIPTION
Adds createImageFromTextureSource for flutter web, exposed in dart:web_ui.

```dart
final ui.Image uiImage = renderer.createImageFromTextureSource(bitmap,
            width: 150, height: 150, transferOwnership: false);
```

In canvaskit renderer, this will use MakeLazyImageFromTextureSource. In SkWasmRenderer, it will call imageCreateFromTextureSource, which was already implemented in SkWasm for createImageFromImageBitmap to use, but was not exposed in a way that it could be taken advantage of.

By default, createImageFromTextureSource will create a copy of the object it is passed, but transferOwnership: true may be specified to allow transferable objects to be transferred to the renderer, avoiding the copy.

Fixes: https://github.com/flutter/flutter/issues/150479
Fixes: https://github.com/flutter/flutter/issues/144815