### PR TITLE
Update uses of GrVkBackendContext and other deprecated type names

### DIFF
--- a/flutter_vma/flutter_skia_vma.h
+++ b/flutter_vma/flutter_skia_vma.h
@@ -9,8 +9,8 @@
 
 #include "flutter/fml/memory/ref_ptr.h"
 #include "flutter/vulkan/procs/vulkan_proc_table.h"
-#include "third_party/skia/include/gpu/vk/VulkanTypes.h"
 #include "third_party/skia/include/gpu/vk/VulkanMemoryAllocator.h"
+#include "third_party/skia/include/gpu/vk/VulkanTypes.h"
 
 namespace flutter {
 

--- a/flutter_vma/flutter_skia_vma.h
+++ b/flutter_vma/flutter_skia_vma.h
@@ -9,7 +9,8 @@
 
 #include "flutter/fml/memory/ref_ptr.h"
 #include "flutter/vulkan/procs/vulkan_proc_table.h"
-#include "third_party/skia/include/gpu/vk/GrVkBackendContext.h"
+#include "third_party/skia/include/gpu/vk/VulkanTypes.h"
+#include "third_party/skia/include/gpu/vk/VulkanMemoryAllocator.h"
 
 namespace flutter {
 

--- a/shell/common/shell_test_platform_view_vulkan.cc
+++ b/shell/common/shell_test_platform_view_vulkan.cc
@@ -128,7 +128,7 @@ ShellTestPlatformViewVulkan::OffScreenSurface::OffScreenSurface(
 }
 
 bool ShellTestPlatformViewVulkan::OffScreenSurface::CreateSkiaGrContext() {
-  GrVkBackendContext backend_context;
+  skgpu::VulkanBackendContext backend_context;
   skgpu::VulkanExtensions no_extensions;
   // For now, Skia crashes if fDeviceFeatures is set but fVkExtensions is not.
   backend_context.fVkExtensions = &no_extensions;
@@ -161,7 +161,7 @@ bool ShellTestPlatformViewVulkan::OffScreenSurface::CreateSkiaGrContext() {
 }
 
 bool ShellTestPlatformViewVulkan::OffScreenSurface::CreateSkiaBackendContext(
-    GrVkBackendContext* context,
+    skgpu::VulkanBackendContext* context,
     VkPhysicalDeviceFeatures* features) {
   FML_CHECK(context);
   FML_CHECK(features);

--- a/shell/common/shell_test_platform_view_vulkan.h
+++ b/shell/common/shell_test_platform_view_vulkan.h
@@ -11,8 +11,8 @@
 #include "flutter/vulkan/vulkan_application.h"
 #include "flutter/vulkan/vulkan_device.h"
 #include "flutter/vulkan/vulkan_skia_proc_table.h"
-#include "third_party/skia/include/gpu/vk/VulkanTypes.h"
 #include "third_party/skia/include/gpu/vk/VulkanMemoryAllocator.h"
+#include "third_party/skia/include/gpu/vk/VulkanTypes.h"
 
 namespace flutter {
 namespace testing {

--- a/shell/common/shell_test_platform_view_vulkan.h
+++ b/shell/common/shell_test_platform_view_vulkan.h
@@ -11,6 +11,8 @@
 #include "flutter/vulkan/vulkan_application.h"
 #include "flutter/vulkan/vulkan_device.h"
 #include "flutter/vulkan/vulkan_skia_proc_table.h"
+#include "third_party/skia/include/gpu/vk/VulkanTypes.h"
+#include "third_party/skia/include/gpu/vk/VulkanMemoryAllocator.h"
 
 namespace flutter {
 namespace testing {
@@ -60,7 +62,7 @@ class ShellTestPlatformViewVulkan : public ShellTestPlatformView {
     sk_sp<GrDirectContext> context_;
 
     bool CreateSkiaGrContext();
-    bool CreateSkiaBackendContext(GrVkBackendContext*,
+    bool CreateSkiaBackendContext(skgpu::VulkanBackendContext*,
                                   VkPhysicalDeviceFeatures*);
 
     FML_DISALLOW_COPY_AND_ASSIGN(OffScreenSurface);

--- a/shell/platform/embedder/embedder_surface_vulkan.cc
+++ b/shell/platform/embedder/embedder_surface_vulkan.cc
@@ -12,7 +12,7 @@
 #include "flutter/shell/gpu/gpu_surface_vulkan_delegate.h"
 #include "flutter/vulkan/vulkan_skia_proc_table.h"
 #include "include/gpu/GrDirectContext.h"
-#include "include/gpu/vk/GrVkBackendContext.h"
+#include "include/gpu/vk/VulkanBackendContext.h"
 #include "include/gpu/vk/VulkanExtensions.h"
 #include "third_party/skia/include/gpu/ganesh/vk/GrVkDirectContext.h"
 
@@ -143,7 +143,7 @@ sk_sp<GrDirectContext> EmbedderSurfaceVulkan::CreateGrContext(
 
   skgpu::VulkanExtensions extensions;
 
-  GrVkBackendContext backend_context = {};
+  skgpu::VulkanBackendContext backend_context = {};
   backend_context.fInstance = instance;
   backend_context.fPhysicalDevice = device_.GetPhysicalDeviceHandle();
   backend_context.fDevice = device_.GetHandle();

--- a/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
@@ -21,8 +21,8 @@
 #include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
 #include "third_party/skia/include/gpu/ganesh/vk/GrVkBackendSurface.h"
 #include "third_party/skia/include/gpu/ganesh/vk/GrVkDirectContext.h"
-#include "third_party/skia/include/gpu/vk/VulkanBackendContext.h"
 #include "third_party/skia/include/gpu/vk/GrVkTypes.h"
+#include "third_party/skia/include/gpu/vk/VulkanBackendContext.h"
 #include "third_party/skia/include/gpu/vk/VulkanExtensions.h"
 
 namespace flutter_runner {

--- a/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
@@ -21,7 +21,7 @@
 #include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
 #include "third_party/skia/include/gpu/ganesh/vk/GrVkBackendSurface.h"
 #include "third_party/skia/include/gpu/ganesh/vk/GrVkDirectContext.h"
-#include "third_party/skia/include/gpu/vk/GrVkBackendContext.h"
+#include "third_party/skia/include/gpu/vk/VulkanBackendContext.h"
 #include "third_party/skia/include/gpu/vk/GrVkTypes.h"
 #include "third_party/skia/include/gpu/vk/VulkanExtensions.h"
 
@@ -125,7 +125,7 @@ bool VulkanSurfaceProducer::Initialize() {
       logical_device_->GetPhysicalDeviceHandle(), logical_device_->GetHandle(),
       vk_, true);
 
-  GrVkBackendContext backend_context;
+  skgpu::VulkanBackendContext backend_context;
   backend_context.fInstance = application_->GetInstance();
   backend_context.fPhysicalDevice = logical_device_->GetPhysicalDeviceHandle();
   backend_context.fDevice = logical_device_->GetHandle();

--- a/testing/test_vulkan_context.cc
+++ b/testing/test_vulkan_context.cc
@@ -18,8 +18,8 @@
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/skia/include/gpu/ganesh/vk/GrVkDirectContext.h"
-#include "third_party/skia/include/gpu/vk/VulkanExtensions.h"
 #include "third_party/skia/include/gpu/vk/VulkanBackendContext.h"
+#include "third_party/skia/include/gpu/vk/VulkanExtensions.h"
 #include "vulkan/vulkan_core.h"
 
 namespace flutter {

--- a/testing/test_vulkan_context.cc
+++ b/testing/test_vulkan_context.cc
@@ -19,6 +19,7 @@
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/skia/include/gpu/ganesh/vk/GrVkDirectContext.h"
 #include "third_party/skia/include/gpu/vk/VulkanExtensions.h"
+#include "third_party/skia/include/gpu/vk/VulkanBackendContext.h"
 #include "vulkan/vulkan_core.h"
 
 namespace flutter {
@@ -90,7 +91,7 @@ TestVulkanContext::TestVulkanContext() {
 
   skgpu::VulkanExtensions extensions;
 
-  GrVkBackendContext backend_context = {};
+  skgpu::VulkanBackendContext backend_context = {};
   backend_context.fInstance = application_->GetInstance();
   backend_context.fPhysicalDevice = device_->GetPhysicalDeviceHandle();
   backend_context.fDevice = device_->GetHandle();

--- a/vulkan/vulkan_device.cc
+++ b/vulkan/vulkan_device.cc
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "flutter/vulkan/procs/vulkan_proc_table.h"
-#include "third_party/skia/include/gpu/vk/GrVkBackendContext.h"
 #include "vulkan_surface.h"
 #include "vulkan_utilities.h"
 

--- a/vulkan/vulkan_native_surface_android.cc
+++ b/vulkan/vulkan_native_surface_android.cc
@@ -6,8 +6,6 @@
 
 #include <android/native_window.h>
 
-#include "third_party/skia/include/gpu/vk/GrVkBackendContext.h"
-
 namespace vulkan {
 
 VulkanNativeSurfaceAndroid::VulkanNativeSurfaceAndroid(

--- a/vulkan/vulkan_skia_proc_table.cc
+++ b/vulkan/vulkan_skia_proc_table.cc
@@ -6,7 +6,8 @@
 
 namespace vulkan {
 
-skgpu::VulkanGetProc CreateSkiaGetProc(const fml::RefPtr<vulkan::VulkanProcTable>& vk) {
+skgpu::VulkanGetProc CreateSkiaGetProc(
+    const fml::RefPtr<vulkan::VulkanProcTable>& vk) {
   if (!vk || !vk->IsValid()) {
     return nullptr;
   }

--- a/vulkan/vulkan_skia_proc_table.cc
+++ b/vulkan/vulkan_skia_proc_table.cc
@@ -6,7 +6,7 @@
 
 namespace vulkan {
 
-GrVkGetProc CreateSkiaGetProc(const fml::RefPtr<vulkan::VulkanProcTable>& vk) {
+skgpu::VulkanGetProc CreateSkiaGetProc(const fml::RefPtr<vulkan::VulkanProcTable>& vk) {
   if (!vk || !vk->IsValid()) {
     return nullptr;
   }

--- a/vulkan/vulkan_skia_proc_table.h
+++ b/vulkan/vulkan_skia_proc_table.h
@@ -7,11 +7,11 @@
 
 #include "flutter/vulkan/procs/vulkan_proc_table.h"
 
-#include "third_party/skia/include/gpu/vk/GrVkBackendContext.h"
+#include "third_party/skia/include/gpu/vk/VulkanTypes.h"
 
 namespace vulkan {
 
-GrVkGetProc CreateSkiaGetProc(const fml::RefPtr<vulkan::VulkanProcTable>& vk);
+skgpu::VulkanGetProc CreateSkiaGetProc(const fml::RefPtr<vulkan::VulkanProcTable>& vk);
 
 }  // namespace vulkan
 

--- a/vulkan/vulkan_skia_proc_table.h
+++ b/vulkan/vulkan_skia_proc_table.h
@@ -11,7 +11,8 @@
 
 namespace vulkan {
 
-skgpu::VulkanGetProc CreateSkiaGetProc(const fml::RefPtr<vulkan::VulkanProcTable>& vk);
+skgpu::VulkanGetProc CreateSkiaGetProc(
+    const fml::RefPtr<vulkan::VulkanProcTable>& vk);
 
 }  // namespace vulkan
 

--- a/vulkan/vulkan_window.cc
+++ b/vulkan/vulkan_window.cc
@@ -122,7 +122,7 @@ GrDirectContext* VulkanWindow::GetSkiaGrContext() {
 
 bool VulkanWindow::CreateSkiaGrContext() {
 #ifdef SK_VULKAN
-  GrVkBackendContext backend_context;
+  skgpu::VulkanBackendContext backend_context;
   VkPhysicalDeviceFeatures features;
   skgpu::VulkanExtensions extensions;
 
@@ -151,7 +151,7 @@ bool VulkanWindow::CreateSkiaGrContext() {
 }
 
 bool VulkanWindow::CreateSkiaBackendContext(
-    GrVkBackendContext* context,
+    skgpu::VulkanBackendContext* context,
     VkPhysicalDeviceFeatures* features,
     skgpu::VulkanExtensions* extensions) {
 #ifdef SK_VULKAN

--- a/vulkan/vulkan_window.h
+++ b/vulkan/vulkan_window.h
@@ -17,7 +17,7 @@
 #include "third_party/skia/include/core/SkSize.h"
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
-#include "third_party/skia/include/gpu/vk/GrVkBackendContext.h"
+#include "third_party/skia/include/gpu/vk/VulkanBackendContext.h"
 
 namespace vulkan {
 
@@ -68,7 +68,7 @@ class VulkanWindow {
 
   bool CreateSkiaGrContext();
 
-  bool CreateSkiaBackendContext(GrVkBackendContext*,
+  bool CreateSkiaBackendContext(skgpu::VulkanBackendContext*,
                                 VkPhysicalDeviceFeatures*,
                                 skgpu::VulkanExtensions*);
 


### PR DESCRIPTION
As of [this CL](https://skia-review.googlesource.com/c/skia/+/859125), `GrVkBackendContext` is an alias for `skgpu::VulkanBackendContext`, so this updates Flutter to use the GPU-backend agnostic version. See [https://issues.skia.org/issues/309785258].

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
