### PR TITLE
Run safari-dart2js-html tests on macOS 13

### DIFF
--- a/ci/builders/linux_web_engine.json
+++ b/ci/builders/linux_web_engine.json
@@ -1131,7 +1131,7 @@
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac-13|Mac-14",
+        "os=Mac-13",
         "cpu=arm64"
       ],
       "gclient_variables": {
@@ -1164,7 +1164,7 @@
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac-13|Mac-14",
+        "os=Mac-13",
         "cpu=arm64"
       ],
       "gclient_variables": {
@@ -1197,7 +1197,7 @@
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac-13|Mac-14",
+        "os=Mac-13",
         "cpu=arm64"
       ],
       "gclient_variables": {
@@ -1230,7 +1230,7 @@
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac-13|Mac-14",
+        "os=Mac-13",
         "cpu=arm64"
       ],
       "gclient_variables": {
@@ -1263,7 +1263,7 @@
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac-13|Mac-14",
+        "os=Mac-13",
         "cpu=arm64"
       ],
       "gclient_variables": {
@@ -1296,7 +1296,7 @@
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac-13|Mac-14",
+        "os=Mac-13",
         "cpu=arm64"
       ],
       "gclient_variables": {

--- a/lib/web_ui/dev/generate_builder_json.dart
+++ b/lib/web_ui/dev/generate_builder_json.dart
@@ -113,7 +113,7 @@ Iterable<dynamic> _getAllTestSteps(List<TestSuite> suites) {
       suite.runConfig.browser == BrowserName.chrome ||
       suite.runConfig.browser == BrowserName.firefox
     ),
-    ..._getTestStepsForPlatform(suites, 'Mac', specificOS: 'Mac-13|Mac-14', cpu: 'arm64', (TestSuite suite) =>
+    ..._getTestStepsForPlatform(suites, 'Mac', specificOS: 'Mac-13', cpu: 'arm64', (TestSuite suite) =>
       suite.runConfig.browser == BrowserName.safari
     ),
     ..._getTestStepsForPlatform(suites, 'Windows', (TestSuite suite) =>


### PR DESCRIPTION
https://github.com/flutter/engine/pull/53402 didn't work. Run these Safari tests on macOS 13 only until it can be fixed for macOS 14.
