### PR TITLE
[web] Implement `AppLifecycleState.detached` as documented

### DIFF
--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -78,7 +78,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
     _addFontSizeObserver();
     _addLocaleChangedListener();
     registerHotRestartListener(dispose);
-    AppLifecycleState.instance.addListener(_setAppLifecycleState);
+    _appLifecycleState.addListener(_setAppLifecycleState);
     _viewFocusBinding.init();
     domDocument.body?.prepend(accessibilityPlaceholder);
     _onViewDisposedListener = viewManager.onViewDisposed.listen((_) {
@@ -122,7 +122,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
     _disconnectFontSizeObserver();
     _removeLocaleChangedListener();
     HighContrastSupport.instance.removeListener(_updateHighContrast);
-    AppLifecycleState.instance.removeListener(_setAppLifecycleState);
+    _appLifecycleState.removeListener(_setAppLifecycleState);
     _viewFocusBinding.dispose();
     accessibilityPlaceholder.remove();
     _onViewDisposedListener.cancel();
@@ -154,6 +154,9 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   ];
 
   late final FlutterViewManager viewManager = FlutterViewManager(this);
+
+  late final AppLifecycleState _appLifecycleState =
+      AppLifecycleState.create(viewManager);
 
   /// The current list of windows.
   @override

--- a/lib/web_ui/test/engine/platform_dispatcher/app_lifecycle_state_test.dart
+++ b/lib/web_ui/test/engine/platform_dispatcher/app_lifecycle_state_test.dart
@@ -1,0 +1,56 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+import 'package:ui/ui.dart' as ui;
+
+// import '../../common/test_initialization.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  group(AppLifecycleState, () {
+    test('listens to changes in view manager', () {
+      final FlutterViewManager viewManager = FlutterViewManager(EnginePlatformDispatcher.instance);
+      final AppLifecycleState state = AppLifecycleState.create(viewManager);
+
+      ui.AppLifecycleState? currentState;
+      void listener(ui.AppLifecycleState newState) {
+        currentState = newState;
+      }
+
+      state.addListener(listener);
+
+      final view1 = EngineFlutterView(EnginePlatformDispatcher.instance, createDomHTMLDivElement());
+      viewManager.registerView(view1);
+      expect(currentState, ui.AppLifecycleState.resumed);
+      currentState = null;
+
+      final view2 = EngineFlutterView(EnginePlatformDispatcher.instance, createDomHTMLDivElement());
+      viewManager.registerView(view2);
+      // The listener should not be called again. The view manager is still not empty.
+      expect(currentState, isNull);
+
+      viewManager.disposeAndUnregisterView(view1.viewId);
+      // The listener should not be called again. The view manager is still not empty.
+      expect(currentState, isNull);
+
+      viewManager.disposeAndUnregisterView(view2.viewId);
+      expect(currentState, ui.AppLifecycleState.detached);
+      currentState = null;
+
+      final view3 = EngineFlutterView(EnginePlatformDispatcher.instance, createDomHTMLDivElement());
+      viewManager.registerView(view3);
+      // The state should go back to `resumed` after a new view is registered.
+      expect(currentState, ui.AppLifecycleState.resumed);
+
+      viewManager.dispose();
+      state.removeListener(listener);
+    });
+  });
+}


### PR DESCRIPTION
Currently, we are transitioning to the `AppLifecycleState.detached` incorrectly. This is causing the framework to stop pumping frames when the app is still active and visible.

This PR re-implements the transition to `AppLifecycleState.detached` as documented [here](https://api.flutter.dev/flutter/dart-ui/AppLifecycleState.html#detached) (based on whether the app has any views or not).

Fixes https://github.com/flutter/flutter/issues/150636
Fixes https://github.com/flutter/flutter/issues/149417