### PR TITLE
Better clipRect culling accuracy under scaling transforms

### DIFF
--- a/display_list/utils/dl_matrix_clip_tracker.cc
+++ b/display_list/utils/dl_matrix_clip_tracker.cc
@@ -239,6 +239,12 @@ bool DisplayListMatrixClipState::rect_covers_cull(const DlRect& content) const {
   if (cull_rect_.IsEmpty()) {
     return true;
   }
+  if (matrix_.IsAligned2D()) {
+    // This transform-to-device calculation is faster and more accurate
+    // for rect-to-rect aligned transformations, but not accurate under
+    // (non-quadrant) rotations and skews.
+    return content.TransformAndClipBounds(matrix_).Contains(cull_rect_);
+  }
   DlPoint corners[4];
   if (!getLocalCullCorners(corners)) {
     return false;


### PR DESCRIPTION
The clipRect culling in DisplayListBuilder can sometimes fail to cull a clip due to round-off error in the math and this case happens to trigger when trying to cull against the initial frame bounds of a Pixel 6a with its uncommon 2.625 DPR as a scaling transform. An optimization in the culling tests for axis-aligned transforms (very common in Flutter) happens to do the right thing for this odd case, likely due to less math to incur round-off errors.