### PR TITLE
[DisplayList] Switch to recording DrawVertices objects by reference

### DIFF
--- a/display_list/benchmarking/dl_benchmarks.cc
+++ b/display_list/benchmarking/dl_benchmarks.cc
@@ -806,7 +806,7 @@ void BM_DrawVertices(benchmark::State& state,
     std::shared_ptr<DlVertices> vertices =
         GetTestVertices(p, radius, 50, mode, vertex_count);
     total_vertex_count += vertex_count;
-    builder.DrawVertices(vertices.get(), DlBlendMode::kSrc, paint);
+    builder.DrawVertices(vertices, DlBlendMode::kSrc, paint);
   }
 
   state.counters["VertexCount"] = total_vertex_count;

--- a/display_list/benchmarking/dl_complexity_gl.cc
+++ b/display_list/benchmarking/dl_complexity_gl.cc
@@ -494,7 +494,7 @@ void DisplayListGLComplexityCalculator::GLHelper::drawPoints(
 }
 
 void DisplayListGLComplexityCalculator::GLHelper::drawVertices(
-    const DlVertices* vertices,
+    const std::shared_ptr<DlVertices>& vertices,
     DlBlendMode mode) {
   // There is currently no way for us to get the VertexMode from the SkVertices
   // object, but for future reference:

--- a/display_list/benchmarking/dl_complexity_gl.h
+++ b/display_list/benchmarking/dl_complexity_gl.h
@@ -57,7 +57,8 @@ class DisplayListGLComplexityCalculator
     void drawPoints(DlCanvas::PointMode mode,
                     uint32_t count,
                     const SkPoint points[]) override;
-    void drawVertices(const DlVertices* vertices, DlBlendMode mode) override;
+    void drawVertices(const std::shared_ptr<DlVertices>& vertices,
+                      DlBlendMode mode) override;
     void drawImage(const sk_sp<DlImage> image,
                    const SkPoint point,
                    DlImageSampling sampling,

--- a/display_list/benchmarking/dl_complexity_metal.cc
+++ b/display_list/benchmarking/dl_complexity_metal.cc
@@ -446,7 +446,7 @@ void DisplayListMetalComplexityCalculator::MetalHelper::drawPoints(
 }
 
 void DisplayListMetalComplexityCalculator::MetalHelper::drawVertices(
-    const DlVertices* vertices,
+    const std::shared_ptr<DlVertices>& vertices,
     DlBlendMode mode) {
   // There is currently no way for us to get the VertexMode from the SkVertices
   // object, but for future reference:

--- a/display_list/benchmarking/dl_complexity_metal.h
+++ b/display_list/benchmarking/dl_complexity_metal.h
@@ -57,7 +57,8 @@ class DisplayListMetalComplexityCalculator
     void drawPoints(DlCanvas::PointMode mode,
                     uint32_t count,
                     const SkPoint points[]) override;
-    void drawVertices(const DlVertices* vertices, DlBlendMode mode) override;
+    void drawVertices(const std::shared_ptr<DlVertices>& vertices,
+                      DlBlendMode mode) override;
     void drawImage(const sk_sp<DlImage> image,
                    const SkPoint point,
                    DlImageSampling sampling,

--- a/display_list/benchmarking/dl_complexity_unittests.cc
+++ b/display_list/benchmarking/dl_complexity_unittests.cc
@@ -295,7 +295,7 @@ TEST(DisplayListComplexity, DrawVertices) {
   auto vertices = DlVertices::Make(DlVertexMode::kTriangles, points.size(),
                                    points.data(), nullptr, nullptr);
   DisplayListBuilder builder;
-  builder.DrawVertices(vertices.get(), DlBlendMode::kSrc, DlPaint());
+  builder.DrawVertices(vertices, DlBlendMode::kSrc, DlPaint());
   auto display_list = builder.Build();
 
   auto calculators = AccumulatorCalculators();

--- a/display_list/display_list.cc
+++ b/display_list/display_list.cc
@@ -234,8 +234,7 @@ void DisplayList::DisposeOps(const uint8_t* ptr, const uint8_t* end) {
 #undef DL_OP_DISPOSE
 
       default:
-        FML_DCHECK(false);
-        return;
+        FML_UNREACHABLE();
     }
   }
 }

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -4702,9 +4702,12 @@ TEST_F(DisplayListTest, RecordLargeVertices) {
   auto colors = std::vector<DlColor>();
   colors.reserve(vertex_count);
   for (size_t i = 0; i < vertex_count; i++) {
-    colors[i] = DlColor(-i);
-    points[i] = ((i & 1) == 0) ? SkPoint::Make(-i, i) : SkPoint::Make(i, i);
+    colors.emplace_back(DlColor(-i));
+    points.emplace_back(((i & 1) == 0) ? SkPoint::Make(-i, i)
+                                       : SkPoint::Make(i, i));
   }
+  ASSERT_EQ(points.size(), vertex_count);
+  ASSERT_EQ(colors.size(), vertex_count);
   auto vertices = DlVertices::Make(DlVertexMode::kTriangleStrip, vertex_count,
                                    points.data(), points.data(), colors.data());
   ASSERT_GT(vertices->size(), 1u << 24);

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -1155,8 +1155,7 @@ TEST_F(DisplayListTest, SingleOpsMightSupportGroupOpacityBlendMode) {
   RUN_TESTS2(
       receiver.drawPoints(PointMode::kPoints, TestPointCount, kTestPoints);
       , false);
-  RUN_TESTS2(receiver.drawVertices(TestVertices1.get(), DlBlendMode::kSrc);
-             , false);
+  RUN_TESTS2(receiver.drawVertices(kTestVertices1, DlBlendMode::kSrc);, false);
   RUN_TESTS(receiver.drawImage(TestImage1, {0, 0}, kLinearSampling, true););
   RUN_TESTS2(receiver.drawImage(TestImage1, {0, 0}, kLinearSampling, false);
              , true);
@@ -3270,7 +3269,7 @@ TEST_F(DisplayListTest, NopOperationsOmittedFromRecords) {
           builder.DrawArc({10, 10, 20, 20}, 45, 90, true, paint);
           SkPoint pts[] = {{10, 10}, {20, 20}};
           builder.DrawPoints(PointMode::kLines, 2, pts, paint);
-          builder.DrawVertices(TestVertices1, DlBlendMode::kSrcOver, paint);
+          builder.DrawVertices(kTestVertices1, DlBlendMode::kSrcOver, paint);
           builder.DrawImage(TestImage1, {10, 10}, DlImageSampling::kLinear,
                             &paint);
           builder.DrawImageRect(TestImage1, SkRect{0.0f, 0.0f, 10.0f, 10.0f},

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -4697,14 +4697,16 @@ TEST_F(DisplayListTest, ClipPathRRectNonCulling) {
 
 TEST_F(DisplayListTest, RecordLargeVertices) {
   constexpr size_t vertex_count = 2000000;
-  SkPoint* points = (SkPoint*)malloc(vertex_count * sizeof(SkPoint));
-  DlColor* colors = (DlColor*)malloc(vertex_count * sizeof(DlColor));
+  auto points = std::vector<SkPoint>();
+  points.reserve(vertex_count);
+  auto colors = std::vector<DlColor>();
+  colors.reserve(vertex_count);
   for (size_t i = 0; i < vertex_count; i++) {
     colors[i] = DlColor(-i);
     points[i] = ((i & 1) == 0) ? SkPoint::Make(-i, i) : SkPoint::Make(i, i);
   }
   auto vertices = DlVertices::Make(DlVertexMode::kTriangleStrip, vertex_count,
-                                   points, points, colors);
+                                   points.data(), points.data(), colors.data());
   ASSERT_GT(vertices->size(), 1u << 24);
   auto backdrop = DlBlurImageFilter::Make(5.0f, 5.0f, DlTileMode::kDecal);
 

--- a/display_list/dl_builder.h
+++ b/display_list/dl_builder.h
@@ -188,10 +188,9 @@ class DisplayListBuilder final : public virtual DlCanvas,
                   const SkPoint pts[],
                   const DlPaint& paint) override;
   // |DlCanvas|
-  void DrawVertices(const DlVertices* vertices,
+  void DrawVertices(const std::shared_ptr<DlVertices>& vertices,
                     DlBlendMode mode,
                     const DlPaint& paint) override;
-  using DlCanvas::DrawVertices;
   // |DlCanvas|
   void DrawImage(const sk_sp<DlImage>& image,
                  const SkPoint point,
@@ -442,7 +441,8 @@ class DisplayListBuilder final : public virtual DlCanvas,
   // |DlOpReceiver|
   void drawPoints(PointMode mode, uint32_t count, const SkPoint pts[]) override;
   // |DlOpReceiver|
-  void drawVertices(const DlVertices* vertices, DlBlendMode mode) override;
+  void drawVertices(const std::shared_ptr<DlVertices>& vertices,
+                    DlBlendMode mode) override;
 
   // |DlOpReceiver|
   void drawImage(const sk_sp<DlImage> image,

--- a/display_list/dl_canvas.h
+++ b/display_list/dl_canvas.h
@@ -157,14 +157,9 @@ class DlCanvas {
                           uint32_t count,
                           const SkPoint pts[],
                           const DlPaint& paint) = 0;
-  virtual void DrawVertices(const DlVertices* vertices,
+  virtual void DrawVertices(const std::shared_ptr<DlVertices>& vertices,
                             DlBlendMode mode,
                             const DlPaint& paint) = 0;
-  void DrawVertices(const std::shared_ptr<const DlVertices>& vertices,
-                    DlBlendMode mode,
-                    const DlPaint& paint) {
-    DrawVertices(vertices.get(), mode, paint);
-  }
   virtual void DrawImage(const sk_sp<DlImage>& image,
                          const SkPoint point,
                          DlImageSampling sampling,

--- a/display_list/dl_op_receiver.h
+++ b/display_list/dl_op_receiver.h
@@ -358,7 +358,8 @@ class DlOpReceiver {
   virtual void drawPoints(PointMode mode,
                           uint32_t count,
                           const SkPoint points[]) = 0;
-  virtual void drawVertices(const DlVertices* vertices, DlBlendMode mode) = 0;
+  virtual void drawVertices(const std::shared_ptr<DlVertices>& vertices,
+                            DlBlendMode mode) = 0;
   virtual void drawImage(const sk_sp<DlImage> image,
                          const SkPoint point,
                          DlImageSampling sampling,

--- a/display_list/dl_op_records.h
+++ b/display_list/dl_op_records.h
@@ -802,24 +802,19 @@ DEFINE_DRAW_POINTS_OP(Lines, kLines);
 DEFINE_DRAW_POINTS_OP(Polygon, kPolygon);
 #undef DEFINE_DRAW_POINTS_OP
 
-// 4 byte header + 4 byte payload packs efficiently into 8 bytes
-// The DlVertices object will be pod-allocated after this structure
-// and can take any number of bytes so the final efficiency will
-// depend on the size of the DlVertices.
-// Note that the DlVertices object ends with an array of 16-bit
-// indices so the alignment can be up to 6 bytes off leading to
-// up to 6 bytes of overhead
+// 4 byte header + 20 byte payload packs efficiently into 24 bytes
 struct DrawVerticesOp final : DrawOpBase {
   static constexpr auto kType = DisplayListOpType::kDrawVertices;
 
-  explicit DrawVerticesOp(DlBlendMode mode) : mode(mode) {}
+  explicit DrawVerticesOp(const std::shared_ptr<DlVertices>& vertices,
+                          DlBlendMode mode)
+      : mode(mode), vertices(vertices) {}
 
   const DlBlendMode mode;
+  const std::shared_ptr<DlVertices> vertices;
 
   void dispatch(DispatchContext& ctx) const {
     if (op_needed(ctx)) {
-      const DlVertices* vertices =
-          reinterpret_cast<const DlVertices*>(this + 1);
       ctx.receiver.drawVertices(vertices, mode);
     }
   }

--- a/display_list/dl_vertices.h
+++ b/display_list/dl_vertices.h
@@ -112,7 +112,7 @@ class DlVertices {
     Builder(DlVertexMode mode, int vertex_count, Flags flags, int index_count);
 
     /// Returns true iff the underlying object was successfully allocated.
-    bool is_valid() { return vertices_ != nullptr; }
+    bool is_valid() const { return vertices_ != nullptr; }
 
     /// @brief Copies the indicated list of points as vertices.
     ///

--- a/display_list/dl_vertices_unittests.cc
+++ b/display_list/dl_vertices_unittests.cc
@@ -12,7 +12,7 @@ namespace flutter {
 namespace testing {
 
 TEST(DisplayListVertices, MakeWithZeroAndNegativeVerticesAndIndices) {
-  std::shared_ptr<const DlVertices> vertices1 = DlVertices::Make(
+  std::shared_ptr<DlVertices> vertices1 = DlVertices::Make(
       DlVertexMode::kTriangles, 0, nullptr, nullptr, nullptr, 0, nullptr);
   EXPECT_NE(vertices1, nullptr);
   EXPECT_EQ(vertices1->vertex_count(), 0);
@@ -22,7 +22,7 @@ TEST(DisplayListVertices, MakeWithZeroAndNegativeVerticesAndIndices) {
   EXPECT_EQ(vertices1->index_count(), 0);
   EXPECT_EQ(vertices1->indices(), nullptr);
 
-  std::shared_ptr<const DlVertices> vertices2 = DlVertices::Make(
+  std::shared_ptr<DlVertices> vertices2 = DlVertices::Make(
       DlVertexMode::kTriangles, -1, nullptr, nullptr, nullptr, -1, nullptr);
   EXPECT_NE(vertices2, nullptr);
   EXPECT_EQ(vertices2->vertex_count(), 0);
@@ -56,7 +56,7 @@ TEST(DisplayListVertices, MakeWithTexAndColorAndIndices) {
       1, 2, 0,
   };
 
-  std::shared_ptr<const DlVertices> vertices = DlVertices::Make(
+  std::shared_ptr<DlVertices> vertices = DlVertices::Make(
       DlVertexMode::kTriangles, 3, coords, texture_coords, colors, 6, indices);
 
   ASSERT_NE(vertices, nullptr);
@@ -96,7 +96,7 @@ TEST(DisplayListVertices, MakeWithTexAndColor) {
       DlColor::kGreen(),
   };
 
-  std::shared_ptr<const DlVertices> vertices = DlVertices::Make(
+  std::shared_ptr<DlVertices> vertices = DlVertices::Make(
       DlVertexMode::kTriangles, 3, coords, texture_coords, colors, 6, nullptr);
 
   ASSERT_NE(vertices, nullptr);
@@ -132,7 +132,7 @@ TEST(DisplayListVertices, MakeWithTexAndIndices) {
       1, 2, 0,
   };
 
-  std::shared_ptr<const DlVertices> vertices = DlVertices::Make(
+  std::shared_ptr<DlVertices> vertices = DlVertices::Make(
       DlVertexMode::kTriangles, 3, coords, texture_coords, nullptr, 6, indices);
 
   ASSERT_NE(vertices, nullptr);
@@ -170,7 +170,7 @@ TEST(DisplayListVertices, MakeWithColorAndIndices) {
       1, 2, 0,
   };
 
-  std::shared_ptr<const DlVertices> vertices = DlVertices::Make(
+  std::shared_ptr<DlVertices> vertices = DlVertices::Make(
       DlVertexMode::kTriangles, 3, coords, nullptr, colors, 6, indices);
 
   ASSERT_NE(vertices, nullptr);
@@ -204,7 +204,7 @@ TEST(DisplayListVertices, MakeWithTex) {
       SkPoint::Make(115, 120),
   };
 
-  std::shared_ptr<const DlVertices> vertices = DlVertices::Make(
+  std::shared_ptr<DlVertices> vertices = DlVertices::Make(
       DlVertexMode::kTriangles, 3, coords, texture_coords, nullptr, 6, nullptr);
 
   ASSERT_NE(vertices, nullptr);
@@ -235,7 +235,7 @@ TEST(DisplayListVertices, MakeWithColor) {
       DlColor::kGreen(),
   };
 
-  std::shared_ptr<const DlVertices> vertices = DlVertices::Make(
+  std::shared_ptr<DlVertices> vertices = DlVertices::Make(
       DlVertexMode::kTriangles, 3, coords, nullptr, colors, 6, nullptr);
 
   ASSERT_NE(vertices, nullptr);
@@ -265,7 +265,7 @@ TEST(DisplayListVertices, MakeWithIndices) {
       1, 2, 0,
   };
 
-  std::shared_ptr<const DlVertices> vertices = DlVertices::Make(
+  std::shared_ptr<DlVertices> vertices = DlVertices::Make(
       DlVertexMode::kTriangles, 3, coords, nullptr, nullptr, 6, indices);
 
   ASSERT_NE(vertices, nullptr);
@@ -293,7 +293,7 @@ TEST(DisplayListVertices, MakeWithNoOptionalData) {
       SkPoint::Make(15, 20),
   };
 
-  std::shared_ptr<const DlVertices> vertices = DlVertices::Make(
+  std::shared_ptr<DlVertices> vertices = DlVertices::Make(
       DlVertexMode::kTriangles, 3, coords, nullptr, nullptr, 6, nullptr);
 
   ASSERT_NE(vertices, nullptr);
@@ -322,7 +322,7 @@ TEST(DisplayListVertices, MakeWithIndicesButZeroIndexCount) {
       1, 2, 0,
   };
 
-  std::shared_ptr<const DlVertices> vertices = DlVertices::Make(
+  std::shared_ptr<DlVertices> vertices = DlVertices::Make(
       DlVertexMode::kTriangles, 3, coords, nullptr, nullptr, 0, indices);
 
   ASSERT_NE(vertices, nullptr);
@@ -351,7 +351,7 @@ TEST(DisplayListVertices, MakeWithIndicesButNegativeIndexCount) {
       1, 2, 0,
   };
 
-  std::shared_ptr<const DlVertices> vertices = DlVertices::Make(
+  std::shared_ptr<DlVertices> vertices = DlVertices::Make(
       DlVertexMode::kTriangles, 3, coords, nullptr, nullptr, -5, indices);
 
   ASSERT_NE(vertices, nullptr);
@@ -464,7 +464,7 @@ TEST(DisplayListVertices, BuildWithTexAndColorAndIndices) {
   builder.store_texture_coordinates(texture_coords);
   builder.store_colors(colors);
   builder.store_indices(indices);
-  std::shared_ptr<const DlVertices> vertices = builder.build();
+  std::shared_ptr<DlVertices> vertices = builder.build();
 
   ASSERT_NE(vertices, nullptr);
   ASSERT_NE(vertices->vertices(), nullptr);
@@ -491,11 +491,11 @@ TEST(DisplayListVertices, BuildWithTexAndColorAndIndices) {
   builder2.store_texture_coordinates(texture_coords);
   builder2.store_colors(colors);
   builder2.store_indices(indices);
-  std::shared_ptr<const DlVertices> vertices2 = builder2.build();
+  std::shared_ptr<DlVertices> vertices2 = builder2.build();
 
   TestEquals(*vertices, *vertices2);
 
-  std::shared_ptr<const DlVertices> vertices3 = DlVertices::Make(
+  std::shared_ptr<DlVertices> vertices3 = DlVertices::Make(
       DlVertexMode::kTriangles, 3, coords, texture_coords, colors, 6, indices);
 
   TestEquals(*vertices, *vertices3);
@@ -523,7 +523,7 @@ TEST(DisplayListVertices, BuildWithTexAndColor) {
   builder.store_vertices(coords);
   builder.store_texture_coordinates(texture_coords);
   builder.store_colors(colors);
-  std::shared_ptr<const DlVertices> vertices = builder.build();
+  std::shared_ptr<DlVertices> vertices = builder.build();
 
   ASSERT_NE(vertices, nullptr);
   ASSERT_NE(vertices->vertices(), nullptr);
@@ -563,7 +563,7 @@ TEST(DisplayListVertices, BuildWithTexAndIndices) {
   builder.store_vertices(coords);
   builder.store_texture_coordinates(texture_coords);
   builder.store_indices(indices);
-  std::shared_ptr<const DlVertices> vertices = builder.build();
+  std::shared_ptr<DlVertices> vertices = builder.build();
 
   ASSERT_NE(vertices, nullptr);
   ASSERT_NE(vertices->vertices(), nullptr);
@@ -605,7 +605,7 @@ TEST(DisplayListVertices, BuildWithColorAndIndices) {
   builder.store_vertices(coords);
   builder.store_colors(colors);
   builder.store_indices(indices);
-  std::shared_ptr<const DlVertices> vertices = builder.build();
+  std::shared_ptr<DlVertices> vertices = builder.build();
 
   ASSERT_NE(vertices, nullptr);
   ASSERT_NE(vertices->vertices(), nullptr);
@@ -642,7 +642,7 @@ TEST(DisplayListVertices, BuildWithTexUsingPoints) {
                   Builder::kHasTextureCoordinates, 0);
   builder.store_vertices(coords);
   builder.store_texture_coordinates(texture_coords);
-  std::shared_ptr<const DlVertices> vertices = builder.build();
+  std::shared_ptr<DlVertices> vertices = builder.build();
 
   ASSERT_NE(vertices, nullptr);
   ASSERT_NE(vertices->vertices(), nullptr);
@@ -676,7 +676,7 @@ TEST(DisplayListVertices, BuildWithTexUsingFloats) {
                   Builder::kHasTextureCoordinates, 0);
   builder.store_vertices(coords);
   builder.store_texture_coordinates(texture_coords);
-  std::shared_ptr<const DlVertices> vertices = builder.build();
+  std::shared_ptr<DlVertices> vertices = builder.build();
 
   ASSERT_NE(vertices, nullptr);
   ASSERT_NE(vertices->vertices(), nullptr);
@@ -723,13 +723,13 @@ TEST(DisplayListVertices, BuildUsingFloatsSameAsPoints) {
                          Builder::kHasTextureCoordinates, 0);
   builder_points.store_vertices(coord_points);
   builder_points.store_texture_coordinates(texture_coord_points);
-  std::shared_ptr<const DlVertices> vertices_points = builder_points.build();
+  std::shared_ptr<DlVertices> vertices_points = builder_points.build();
 
   Builder builder_floats(DlVertexMode::kTriangles, 3,  //
                          Builder::kHasTextureCoordinates, 0);
   builder_floats.store_vertices(coord_floats);
   builder_floats.store_texture_coordinates(texture_coord_floats);
-  std::shared_ptr<const DlVertices> vertices_floats = builder_floats.build();
+  std::shared_ptr<DlVertices> vertices_floats = builder_floats.build();
 
   TestEquals(*vertices_points, *vertices_floats);
 }
@@ -750,7 +750,7 @@ TEST(DisplayListVertices, BuildWithColor) {
                   Builder::kHasColors, 0);
   builder.store_vertices(coords);
   builder.store_colors(colors);
-  std::shared_ptr<const DlVertices> vertices = builder.build();
+  std::shared_ptr<DlVertices> vertices = builder.build();
 
   ASSERT_NE(vertices, nullptr);
   ASSERT_NE(vertices->vertices(), nullptr);
@@ -782,7 +782,7 @@ TEST(DisplayListVertices, BuildWithIndices) {
   Builder builder(DlVertexMode::kTriangles, 3, Builder::kNone, 6);
   builder.store_vertices(coords);
   builder.store_indices(indices);
-  std::shared_ptr<const DlVertices> vertices = builder.build();
+  std::shared_ptr<DlVertices> vertices = builder.build();
 
   ASSERT_NE(vertices, nullptr);
   ASSERT_NE(vertices->vertices(), nullptr);
@@ -811,7 +811,7 @@ TEST(DisplayListVertices, BuildWithNoOptionalData) {
 
   Builder builder(DlVertexMode::kTriangles, 3, Builder::kNone, 0);
   builder.store_vertices(coords);
-  std::shared_ptr<const DlVertices> vertices = builder.build();
+  std::shared_ptr<DlVertices> vertices = builder.build();
 
   ASSERT_NE(vertices, nullptr);
   ASSERT_NE(vertices->vertices(), nullptr);
@@ -837,7 +837,7 @@ TEST(DisplayListVertices, BuildWithNegativeIndexCount) {
 
   Builder builder(DlVertexMode::kTriangles, 3, Builder::kNone, -5);
   builder.store_vertices(coords);
-  std::shared_ptr<const DlVertices> vertices = builder.build();
+  std::shared_ptr<DlVertices> vertices = builder.build();
 
   ASSERT_NE(vertices, nullptr);
   ASSERT_NE(vertices->vertices(), nullptr);
@@ -875,9 +875,9 @@ TEST(DisplayListVertices, TestEquals) {
       1, 2, 0,
   };
 
-  std::shared_ptr<const DlVertices> vertices1 = DlVertices::Make(
+  std::shared_ptr<DlVertices> vertices1 = DlVertices::Make(
       DlVertexMode::kTriangles, 3, coords, texture_coords, colors, 6, indices);
-  std::shared_ptr<const DlVertices> vertices2 = DlVertices::Make(
+  std::shared_ptr<DlVertices> vertices2 = DlVertices::Make(
       DlVertexMode::kTriangles, 3, coords, texture_coords, colors, 6, indices);
   TestEquals(*vertices1, *vertices2);
 }
@@ -930,47 +930,47 @@ TEST(DisplayListVertices, TestNotEquals) {
       2, 3, 1,
   };
 
-  std::shared_ptr<const DlVertices> vertices1 = DlVertices::Make(
+  std::shared_ptr<DlVertices> vertices1 = DlVertices::Make(
       DlVertexMode::kTriangles, 4, coords, texture_coords, colors, 9, indices);
 
   {
-    std::shared_ptr<const DlVertices> vertices2 =
+    std::shared_ptr<DlVertices> vertices2 =
         DlVertices::Make(DlVertexMode::kTriangleFan, 4, coords,  //
                          texture_coords, colors, 9, indices);
     TestNotEquals(*vertices1, *vertices2, "vertex mode differs");
   }
   {
-    std::shared_ptr<const DlVertices> vertices2 =
+    std::shared_ptr<DlVertices> vertices2 =
         DlVertices::Make(DlVertexMode::kTriangles, 3, coords,  //
                          texture_coords, colors, 9, indices);
     TestNotEquals(*vertices1, *vertices2, "vertex count differs");
   }
   {
-    std::shared_ptr<const DlVertices> vertices2 =
+    std::shared_ptr<DlVertices> vertices2 =
         DlVertices::Make(DlVertexMode::kTriangles, 4, wrong_coords,  //
                          texture_coords, colors, 9, indices);
     TestNotEquals(*vertices1, *vertices2, "vertex coordinates differ");
   }
   {
-    std::shared_ptr<const DlVertices> vertices2 =
+    std::shared_ptr<DlVertices> vertices2 =
         DlVertices::Make(DlVertexMode::kTriangles, 4, coords,  //
                          wrong_texture_coords, colors, 9, indices);
     TestNotEquals(*vertices1, *vertices2, "texture coordinates differ");
   }
   {
-    std::shared_ptr<const DlVertices> vertices2 =
+    std::shared_ptr<DlVertices> vertices2 =
         DlVertices::Make(DlVertexMode::kTriangles, 4, coords,  //
                          texture_coords, wrong_colors, 9, indices);
     TestNotEquals(*vertices1, *vertices2, "colors differ");
   }
   {
-    std::shared_ptr<const DlVertices> vertices2 =
+    std::shared_ptr<DlVertices> vertices2 =
         DlVertices::Make(DlVertexMode::kTriangles, 4, coords,  //
                          texture_coords, colors, 6, indices);
     TestNotEquals(*vertices1, *vertices2, "index count differs");
   }
   {
-    std::shared_ptr<const DlVertices> vertices2 =
+    std::shared_ptr<DlVertices> vertices2 =
         DlVertices::Make(DlVertexMode::kTriangles, 4, coords,  //
                          texture_coords, colors, 9, wrong_indices);
     TestNotEquals(*vertices1, *vertices2, "indices differ");

--- a/display_list/skia/dl_sk_canvas.cc
+++ b/display_list/skia/dl_sk_canvas.cc
@@ -254,9 +254,10 @@ void DlSkCanvasAdapter::DrawPoints(PointMode mode,
   delegate_->drawPoints(ToSk(mode), count, pts, ToStrokedSk(paint));
 }
 
-void DlSkCanvasAdapter::DrawVertices(const DlVertices* vertices,
-                                     DlBlendMode mode,
-                                     const DlPaint& paint) {
+void DlSkCanvasAdapter::DrawVertices(
+    const std::shared_ptr<DlVertices>& vertices,
+    DlBlendMode mode,
+    const DlPaint& paint) {
   delegate_->drawVertices(ToSk(vertices), ToSk(mode), ToSk(paint));
 }
 

--- a/display_list/skia/dl_sk_canvas.h
+++ b/display_list/skia/dl_sk_canvas.h
@@ -118,7 +118,7 @@ class DlSkCanvasAdapter final : public virtual DlCanvas {
                   uint32_t count,
                   const SkPoint pts[],
                   const DlPaint& paint) override;
-  void DrawVertices(const DlVertices* vertices,
+  void DrawVertices(const std::shared_ptr<DlVertices>& vertices,
                     DlBlendMode mode,
                     const DlPaint& paint) override;
   void DrawImage(const sk_sp<DlImage>& image,

--- a/display_list/skia/dl_sk_conversions.cc
+++ b/display_list/skia/dl_sk_conversions.cc
@@ -274,7 +274,7 @@ sk_sp<SkMaskFilter> ToSk(const DlMaskFilter* filter) {
   }
 }
 
-sk_sp<SkVertices> ToSk(const DlVertices* vertices) {
+sk_sp<SkVertices> ToSk(const std::shared_ptr<DlVertices>& vertices) {
   const SkColor* sk_colors =
       reinterpret_cast<const SkColor*>(vertices->colors());
   return SkVertices::MakeCopy(ToSk(vertices->mode()), vertices->vertex_count(),

--- a/display_list/skia/dl_sk_conversions.h
+++ b/display_list/skia/dl_sk_conversions.h
@@ -114,14 +114,7 @@ inline sk_sp<SkMaskFilter> ToSk(const DlMaskFilter& filter) {
   return ToSk(&filter);
 }
 
-extern sk_sp<SkVertices> ToSk(const DlVertices* vertices);
-inline sk_sp<SkVertices> ToSk(
-    const std::shared_ptr<const DlVertices>& vertices) {
-  return ToSk(vertices.get());
-}
-inline sk_sp<SkVertices> ToSk(const DlVertices& vertices) {
-  return ToSk(&vertices);
-}
+extern sk_sp<SkVertices> ToSk(const std::shared_ptr<DlVertices>& vertices);
 
 }  // namespace flutter
 

--- a/display_list/skia/dl_sk_conversions_unittests.cc
+++ b/display_list/skia/dl_sk_conversions_unittests.cc
@@ -194,12 +194,12 @@ TEST(DisplayListSkConversions, BlendColorFilterModifiesTransparency) {
 #undef FOR_EACH_BLEND_MODE_ENUM
 
 TEST(DisplayListSkConversions, ConvertWithZeroAndNegativeVerticesAndIndices) {
-  std::shared_ptr<const DlVertices> vertices1 = DlVertices::Make(
+  std::shared_ptr<DlVertices> vertices1 = DlVertices::Make(
       DlVertexMode::kTriangles, 0, nullptr, nullptr, nullptr, 0, nullptr);
   EXPECT_NE(vertices1, nullptr);
   EXPECT_NE(ToSk(vertices1), nullptr);
 
-  std::shared_ptr<const DlVertices> vertices2 = DlVertices::Make(
+  std::shared_ptr<DlVertices> vertices2 = DlVertices::Make(
       DlVertexMode::kTriangles, -1, nullptr, nullptr, nullptr, -1, nullptr);
   EXPECT_NE(vertices2, nullptr);
   EXPECT_NE(ToSk(vertices2), nullptr);

--- a/display_list/skia/dl_sk_dispatcher.cc
+++ b/display_list/skia/dl_sk_dispatcher.cc
@@ -192,8 +192,9 @@ void DlSkCanvasDispatcher::drawPoints(PointMode mode,
                                       const SkPoint pts[]) {
   canvas_->drawPoints(ToSk(mode), count, pts, paint());
 }
-void DlSkCanvasDispatcher::drawVertices(const DlVertices* vertices,
-                                        DlBlendMode mode) {
+void DlSkCanvasDispatcher::drawVertices(
+    const std::shared_ptr<DlVertices>& vertices,
+    DlBlendMode mode) {
   canvas_->drawVertices(ToSk(vertices), ToSk(mode), paint());
 }
 void DlSkCanvasDispatcher::drawImage(const sk_sp<DlImage> image,

--- a/display_list/skia/dl_sk_dispatcher.h
+++ b/display_list/skia/dl_sk_dispatcher.h
@@ -72,7 +72,8 @@ class DlSkCanvasDispatcher : public virtual DlOpReceiver,
                SkScalar sweep,
                bool useCenter) override;
   void drawPoints(PointMode mode, uint32_t count, const SkPoint pts[]) override;
-  void drawVertices(const DlVertices* vertices, DlBlendMode mode) override;
+  void drawVertices(const std::shared_ptr<DlVertices>& vertices,
+                    DlBlendMode mode) override;
   void drawImage(const sk_sp<DlImage> image,
                  const SkPoint point,
                  DlImageSampling sampling,

--- a/display_list/testing/dl_test_snippets.cc
+++ b/display_list/testing/dl_test_snippets.cc
@@ -680,17 +680,17 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
        }},
       {"DrawVertices",
        {
-           {1, 112, 1,
+           {1, 24, 1,
             [](DlOpReceiver& r) {
-              r.drawVertices(TestVertices1.get(), DlBlendMode::kSrcIn);
+              r.drawVertices(kTestVertices1, DlBlendMode::kSrcIn);
             }},
-           {1, 112, 1,
+           {1, 24, 1,
             [](DlOpReceiver& r) {
-              r.drawVertices(TestVertices1.get(), DlBlendMode::kDstIn);
+              r.drawVertices(kTestVertices1, DlBlendMode::kDstIn);
             }},
-           {1, 112, 1,
+           {1, 24, 1,
             [](DlOpReceiver& r) {
-              r.drawVertices(TestVertices2.get(), DlBlendMode::kSrcIn);
+              r.drawVertices(kTestVertices2, DlBlendMode::kSrcIn);
             }},
        }},
       {"DrawImage",

--- a/display_list/testing/dl_test_snippets.h
+++ b/display_list/testing/dl_test_snippets.h
@@ -192,13 +192,13 @@ static const SkPath kTestPath3 =
 static const SkMatrix kTestMatrix1 = SkMatrix::Scale(2, 2);
 static const SkMatrix kTestMatrix2 = SkMatrix::RotateDeg(45);
 
-static std::shared_ptr<const DlVertices> TestVertices1 =
+static const std::shared_ptr<DlVertices> kTestVertices1 =
     DlVertices::Make(DlVertexMode::kTriangles,  //
                      3,
                      kTestPoints,
                      nullptr,
                      kColors);
-static std::shared_ptr<const DlVertices> TestVertices2 =
+static const std::shared_ptr<DlVertices> kTestVertices2 =
     DlVertices::Make(DlVertexMode::kTriangleFan,  //
                      3,
                      kTestPoints,

--- a/display_list/utils/dl_receiver_utils.h
+++ b/display_list/utils/dl_receiver_utils.h
@@ -101,7 +101,8 @@ class IgnoreDrawDispatchHelper : public virtual DlOpReceiver {
   void drawPoints(DlCanvas::PointMode mode,
                   uint32_t count,
                   const SkPoint points[]) override {}
-  void drawVertices(const DlVertices* vertices, DlBlendMode mode) override {}
+  void drawVertices(const std::shared_ptr<DlVertices>& vertices,
+                    DlBlendMode mode) override {}
   void drawImage(const sk_sp<DlImage> image,
                  const SkPoint point,
                  DlImageSampling sampling,

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -957,8 +957,9 @@ void DlDispatcherBase::drawPoints(PointMode mode,
 }
 
 // |flutter::DlOpReceiver|
-void DlDispatcherBase::drawVertices(const flutter::DlVertices* vertices,
-                                    flutter::DlBlendMode dl_mode) {
+void DlDispatcherBase::drawVertices(
+    const std::shared_ptr<flutter::DlVertices>& vertices,
+    flutter::DlBlendMode dl_mode) {
   GetCanvas().DrawVertices(MakeVertices(vertices), ToBlendMode(dl_mode),
                            paint_);
 }

--- a/impeller/display_list/dl_dispatcher.h
+++ b/impeller/display_list/dl_dispatcher.h
@@ -182,7 +182,7 @@ class DlDispatcherBase : public flutter::DlOpReceiver {
                   const SkPoint points[]) override;
 
   // |flutter::DlOpReceiver|
-  void drawVertices(const flutter::DlVertices* vertices,
+  void drawVertices(const std::shared_ptr<flutter::DlVertices>& vertices,
                     flutter::DlBlendMode dl_mode) override;
 
   // |flutter::DlOpReceiver|

--- a/impeller/display_list/dl_vertices_geometry.cc
+++ b/impeller/display_list/dl_vertices_geometry.cc
@@ -29,7 +29,7 @@ static VerticesGeometry::VertexMode ToVertexMode(flutter::DlVertexMode mode) {
 }
 
 std::shared_ptr<impeller::VerticesGeometry> MakeVertices(
-    const flutter::DlVertices* vertices) {
+    const std::shared_ptr<const flutter::DlVertices>& vertices) {
   auto bounds = ToRect(vertices->bounds());
   auto mode = ToVertexMode(vertices->mode());
   std::vector<Point> positions(vertices->vertex_count());

--- a/impeller/display_list/dl_vertices_geometry.h
+++ b/impeller/display_list/dl_vertices_geometry.h
@@ -12,7 +12,7 @@
 namespace impeller {
 
 std::shared_ptr<VerticesGeometry> MakeVertices(
-    const flutter::DlVertices* vertices);
+    const std::shared_ptr<const flutter::DlVertices>& vertices);
 
 }  // namespace impeller
 

--- a/lib/ui/painting/vertices.h
+++ b/lib/ui/painting/vertices.h
@@ -26,7 +26,7 @@ class Vertices : public RefCountedDartWrappable<Vertices> {
                    Dart_Handle colors_handle,
                    Dart_Handle indices_handle);
 
-  const DlVertices* vertices() const { return vertices_.get(); }
+  const std::shared_ptr<DlVertices>& vertices() const { return vertices_; }
 
   void dispose();
 

--- a/shell/common/dl_op_spy.cc
+++ b/shell/common/dl_op_spy.cc
@@ -79,7 +79,8 @@ void DlOpSpy::drawPoints(PointMode mode,
                          const SkPoint points[]) {
   did_draw_ |= will_draw_;
 }
-void DlOpSpy::drawVertices(const DlVertices* vertices, DlBlendMode mode) {
+void DlOpSpy::drawVertices(const std::shared_ptr<DlVertices>& vertices,
+                           DlBlendMode mode) {
   did_draw_ |= will_draw_;
 }
 // In theory, below drawImage methods can produce a transparent screen when a

--- a/shell/common/dl_op_spy.h
+++ b/shell/common/dl_op_spy.h
@@ -63,7 +63,8 @@ class DlOpSpy final : public virtual DlOpReceiver,
   void drawPoints(PointMode mode,
                   uint32_t count,
                   const SkPoint points[]) override;
-  void drawVertices(const DlVertices* vertices, DlBlendMode mode) override;
+  void drawVertices(const std::shared_ptr<DlVertices>& vertices,
+                    DlBlendMode mode) override;
   void drawImage(const sk_sp<DlImage> image,
                  const SkPoint point,
                  DlImageSampling sampling,

--- a/shell/common/dl_op_spy_unittests.cc
+++ b/shell/common/dl_op_spy_unittests.cc
@@ -390,7 +390,7 @@ TEST(DlOpSpy, DrawVertices) {
     };
     auto dl_vertices = DlVertices::Make(DlVertexMode::kTriangles, 3, vertices,
                                         texture_coordinates, colors, 0);
-    builder.DrawVertices(dl_vertices.get(), DlBlendMode::kSrc, paint);
+    builder.DrawVertices(dl_vertices, DlBlendMode::kSrc, paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);
@@ -416,7 +416,7 @@ TEST(DlOpSpy, DrawVertices) {
     };
     auto dl_vertices = DlVertices::Make(DlVertexMode::kTriangles, 3, vertices,
                                         texture_coordinates, colors, 0);
-    builder.DrawVertices(dl_vertices.get(), DlBlendMode::kSrc, paint);
+    builder.DrawVertices(dl_vertices, DlBlendMode::kSrc, paint);
     sk_sp<DisplayList> dl = builder.Build();
     DlOpSpy dl_op_spy;
     dl->Dispatch(dl_op_spy);

--- a/testing/display_list_testing.cc
+++ b/testing/display_list_testing.cc
@@ -823,7 +823,7 @@ void DisplayListStreamDispatcher::drawPoints(PointMode mode,
                           out_array("points", count, points)
            << ");" << std::endl;
 }
-void DisplayListStreamDispatcher::drawVertices(const DlVertices* vertices,
+void DisplayListStreamDispatcher::drawVertices(const std::shared_ptr<DlVertices>& vertices,
                                                DlBlendMode mode) {
   startl() << "drawVertices("
                << "DlVertices("

--- a/testing/display_list_testing.h
+++ b/testing/display_list_testing.h
@@ -141,7 +141,8 @@ class DisplayListStreamDispatcher final : public DlOpReceiver {
   void drawPoints(PointMode mode,
                   uint32_t count,
                   const SkPoint points[]) override;
-  void drawVertices(const DlVertices* vertices, DlBlendMode mode) override;
+  void drawVertices(const std::shared_ptr<DlVertices>& vertices,
+                    DlBlendMode mode) override;
   void drawImage(const sk_sp<DlImage> image,
                  const SkPoint point,
                  DlImageSampling sampling,

--- a/testing/mock_canvas.cc
+++ b/testing/mock_canvas.cc
@@ -312,7 +312,9 @@ void MockCanvas::DrawImageNine(const sk_sp<DlImage>& image,
   FML_DCHECK(false);
 }
 
-void MockCanvas::DrawVertices(const DlVertices*, DlBlendMode, const DlPaint&) {
+void MockCanvas::DrawVertices(const std::shared_ptr<DlVertices>&,
+                              DlBlendMode,
+                              const DlPaint&) {
   FML_DCHECK(false);
 }
 

--- a/testing/mock_canvas.h
+++ b/testing/mock_canvas.h
@@ -242,7 +242,7 @@ class MockCanvas final : public DlCanvas {
                   uint32_t count,
                   const SkPoint pts[],
                   const DlPaint& paint) override;
-  void DrawVertices(const DlVertices* vertices,
+  void DrawVertices(const std::shared_ptr<DlVertices>& vertices,
                     DlBlendMode mode,
                     const DlPaint& paint) override;
 


### PR DESCRIPTION
The Vertices objects are already allocated in a shared object by default so copying them inline into the recording buffer is usually a waste of time rather than reusing the memory allocated for the shared object by recording a reference. Note that the shared DlVertices objects already inline all of their data so we have good data locality as it is without further copying the data into the buffer.

Might help with https://github.com/flutter/flutter/issues/150513