### PR TITLE
[Impeller] blur - cropped the downsample pass for backdrop filters

### DIFF
--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -164,7 +164,7 @@ Rect MakeReferenceUVs(const Rect& reference, const Rect& rect) {
   return result.Scale(1.0f / Vector2(reference.GetSize()));
 }
 
-Quad CalculateBlurUVs(
+Quad CalculateSnapshotUVs(
     const Snapshot& input_snapshot,
     const std::optional<Rect>& source_expanded_coverage_hint) {
   std::optional<Rect> input_snapshot_coverage = input_snapshot.GetCoverage();
@@ -279,7 +279,7 @@ DownsamplePassArgs CalculateDownsamplePassArgs(
   Vector2 effective_scalar = Vector2(subpass_size) / source_size;
   FML_DCHECK(effective_scalar == downsample_scalar);
 
-  Quad uvs = CalculateBlurUVs(input_snapshot, aligned_coverage_hint);
+  Quad uvs = CalculateSnapshotUVs(input_snapshot, aligned_coverage_hint);
   return {
       .subpass_size = subpass_size,
       .uvs = uvs,

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -14,8 +14,6 @@
 #include "impeller/renderer/render_pass.h"
 #include "impeller/renderer/vertex_buffer_builder.h"
 
-#pragma GCC diagnostic ignored "-Wunused-function"
-
 namespace impeller {
 
 using GaussianBlurVertexShader = GaussianBlurPipeline::VertexShader;

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -258,11 +258,14 @@ DownsamplePassArgs CalculateDownsamplePassArgs(
   //     .Contains(coverage_hint.value()))
 
   if (input_snapshot.transform.IsIdentity() &&
-      source_expanded_coverage_hint.has_value()) {
+      source_expanded_coverage_hint.has_value() &&
+      input_snapshot.GetCoverage()->Contains(
+          source_expanded_coverage_hint.value())) {
     // If the snapshot's transform is the identity transform and we have
-    // coverage hint, that means the coverage hint was ignored so we will trim
-    // out the area we are interested in the down-sample pass. This usually
-    // means we have a backdrop image filter.
+    // coverage hint that fits inside of the snapshots coverage that means the
+    // coverage hint was ignored so we will trim out the area we are interested
+    // in the down-sample pass. This usually means we have a backdrop image
+    // filter.
     //
     // The region we cut out will be aligned with the down-sample divisor to
     // avoid pixel alignment problems that create shimmering.

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -257,10 +257,11 @@ DownsamplePassArgs CalculateDownsamplePassArgs(
   //   !input_snapshot->GetCoverage()->Expand(-local_padding)
   //     .Contains(coverage_hint.value()))
 
+  std::optional<Rect> snapshot_coverage = input_snapshot.GetCoverage();
   if (input_snapshot.transform.IsIdentity() &&
       source_expanded_coverage_hint.has_value() &&
-      input_snapshot.GetCoverage()->Contains(
-          source_expanded_coverage_hint.value())) {
+      snapshot_coverage.has_value() &&
+      snapshot_coverage->Contains(source_expanded_coverage_hint.value())) {
     // If the snapshot's transform is the identity transform and we have
     // coverage hint that fits inside of the snapshots coverage that means the
     // coverage hint was ignored so we will trim out the area we are interested

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -261,8 +261,8 @@ DownsamplePassArgs CalculateDownsamplePassArgs(
       source_expanded_coverage_hint.has_value()) {
     // If the snapshot's transform is the identity transform and we have
     // coverage hint, that means the coverage hint was ignored so we will trim
-    // out the area we are interested in the downsample pass. This usually means
-    // we have a backdrop image filter.
+    // out the area we are interested in the down-sample pass. This usually
+    // means we have a backdrop image filter.
     //
     // The region we cut out will be aligned with the down-sample divisor to
     // avoid pixel alignment problems that create shimmering.


### PR DESCRIPTION
This should be no functional change, just makes the case of clipped backdrop filters take up less memory.

fixes: https://github.com/flutter/flutter/issues/150713

test coverage:
- the framework's "backdrop filter" test
- GaussianBlurAnimatedBackdrop

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
