### PR TITLE
[iOS] adjusments to platform view frame and scrollview initialization.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -1562,13 +1562,9 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(const std::string& name) {
                                                                  toView:mockFlutterView];
   XCTAssertTrue([gMockPlatformView.superview.superview isKindOfClass:ChildClippingView.class]);
   ChildClippingView* childClippingView = (ChildClippingView*)gMockPlatformView.superview.superview;
-  // The childclippingview's frame is set based on flow, but the platform view's frame is set based
-  // on quartz. Although they should be the same, but we should tolerate small floating point
-  // errors.
-  XCTAssertLessThan(fabs(platformViewRectInFlutterView.origin.x - childClippingView.frame.origin.x),
-                    kFloatCompareEpsilon);
-  XCTAssertLessThan(fabs(platformViewRectInFlutterView.origin.y - childClippingView.frame.origin.y),
-                    kFloatCompareEpsilon);
+  // The childclippingview's frame has a zero origin, and the transform positions it instead.
+  XCTAssertEqual(childClippingView.frame.origin.x, 0);
+  XCTAssertEqual(childClippingView.frame.origin.y, 0);
   XCTAssertLessThan(
       fabs(platformViewRectInFlutterView.size.width - childClippingView.frame.size.width),
       kFloatCompareEpsilon);

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1386,12 +1386,15 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   CGRect viewBounds = self.view.bounds;
   CGFloat scale = [self flutterScreenIfViewLoaded].scale;
 
-  // Purposefully place this not visible.
-  _scrollView.get().frame = CGRectMake(0.0, 0.0, viewBounds.size.width, 0.0);
-  _scrollView.get().contentOffset = CGPointMake(kScrollViewContentSize, kScrollViewContentSize);
-
   // First time since creation that the dimensions of its view is known.
   bool firstViewBoundsUpdate = !_viewportMetrics.physical_width;
+
+  // Make the scroll view invisible the first time the view is laid out.
+  if (firstViewBoundsUpdate) {
+    _scrollView.get().frame = CGRectMake(0.0, 0.0, viewBounds.size.width, 0.0);
+    _scrollView.get().contentOffset = CGPointMake(kScrollViewContentSize, kScrollViewContentSize);
+  }
+
   _viewportMetrics.device_pixel_ratio = scale;
   [self setViewportMetricsSize];
   [self setViewportMetricsPaddings];


### PR DESCRIPTION
If the platform view bounds haven't changed, we don't need to update its frame. this is a small but measurable performance improvement on the text views platform view example. This also simplifies the code: rather than changing the frame and then untransforming the origin. We can just let the origin be 0, 0. Seems to work!

![image](https://github.com/flutter/engine/assets/8975114/dd433f08-c51f-42b0-913d-8a8a0ce7e69b)
