### PR TITLE
Ignore lints that will be triggered by ExternalDartReference changes

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/native_memory.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/native_memory.dart
@@ -22,6 +22,7 @@ import 'package:ui/src/engine.dart';
 /// 6. We call `delete` on SkPaint.
 DomFinalizationRegistry _finalizationRegistry = DomFinalizationRegistry(
   (ExternalDartReference boxedUniq) {
+    // ignore: cast_nullable_to_non_nullable
     final UniqueRef<Object> uniq = boxedUniq.toDartObject as UniqueRef<Object>;
     uniq.collect();
   }.toJS

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/memory.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/memory.dart
@@ -29,6 +29,7 @@ typedef DisposeFunction<T extends NativeType> = void Function(Pointer<T>);
 class SkwasmFinalizationRegistry<T extends NativeType> {
   SkwasmFinalizationRegistry(this.dispose)
     : registry = DomFinalizationRegistry(((ExternalDartReference address) =>
+      // ignore: cast_nullable_to_non_nullable
       dispose(Pointer<T>.fromAddress(address.toDartObject as int))
     ).toJS);
 


### PR DESCRIPTION
https://dart-review.googlesource.com/c/sdk/+/370663 makes ExternalDartReference generic. By doing so, it triggers two cast_nullable_to_non_nullable lints that need to be silenced for it to land. Once the above SDK changes land, this can be refactored to utilize the generic and avoid the manual cast altogether.