### PR TITLE
Remove otherwise unused third_party/web_dependencies.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -792,16 +792,6 @@ deps = {
      'dep_type': 'cipd',
    },
 
-  'src/third_party/web_dependencies': {
-     'packages': [
-       {
-         'package': 'flutter/web/canvaskit_bundle',
-         'version': Var('canvaskit_cipd_instance')
-       }
-     ],
-     'dep_type': 'cipd',
-   },
-
   'src/third_party/java/openjdk': {
      'packages': [
        {

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: 44921bea6071222d521ad8c486a1bd58
+Signature: 8fcfb02b766e80ce50611b894f3fe047
 

--- a/tools/licenses/lib/paths.dart
+++ b/tools/licenses/lib/paths.dart
@@ -223,7 +223,6 @@ final Set<String> skippedPaths = <String>{
   r'third_party/android_tools', // excluded on advice
   r'third_party/java', // only used for Android builds
   r'third_party/libxml', // dependency of the testing system that we don't actually use
-  r'third_party/web_dependencies/canvaskit', // redundant; covered by Skia dependencies
   r'tools', // not distributed in binary
 };
 


### PR DESCRIPTION
There are no usages other than the reference in the LICENSE checker.