### PR TITLE
Return a null image from ImageExternalTextureGL::CreateEGLImage if an EGL display is not available

### DIFF
--- a/shell/platform/android/image_external_texture_gl.cc
+++ b/shell/platform/android/image_external_texture_gl.cc
@@ -87,7 +87,11 @@ impeller::UniqueEGLImageKHR ImageExternalTextureGL::CreateEGLImage(
   }
 
   EGLDisplay display = eglGetCurrentDisplay();
-  FML_CHECK(display != EGL_NO_DISPLAY);
+  if (display == EGL_NO_DISPLAY) {
+    // This could happen when running in a deferred task that executes after
+    // the thread has lost its EGL state.
+    return impeller::UniqueEGLImageKHR();
+  }
 
   EGLClientBuffer client_buffer =
       impeller::android::GetProcTable().eglGetNativeClientBufferANDROID(


### PR DESCRIPTION
Previously CreateEGLImage had been failing an assertion if an EGL display is not active on the calling thread.  CreateEGLImage should not assert here because it could be called from a deferred task that runs after the raster thread has lost its EGL state.

See https://github.com/flutter/flutter/issues/149396