### PR TITLE
[Impeller] absorb the last blur pass into an entity instead of baking it in a render pass

### DIFF
--- a/impeller/aiks/aiks_blur_unittests.cc
+++ b/impeller/aiks/aiks_blur_unittests.cc
@@ -17,6 +17,8 @@
 // blurs.
 ////////////////////////////////////////////////////////////////////////////////
 
+impeller::Scalar foo = 1.0f;
+
 namespace impeller {
 namespace testing {
 
@@ -769,15 +771,25 @@ TEST_P(AiksTest, GaussianBlurAnimatedBackdrop) {
       CreateTextureForFixture("boston.jpg", /*enable_mipmapping=*/true));
   ASSERT_TRUE(boston);
   int64_t count = 0;
-  Scalar sigma = 20.0;
+  Scalar sigma_x = 20.0;
+  Scalar sigma_y = 20.0;
   Scalar freq = 0.1;
   Scalar amp = 50.0;
+  bool is_combined = false;
   auto callback = [&](AiksContext& renderer) -> std::optional<Picture> {
     if (AiksTest::ImGuiBegin("Controls", nullptr,
                              ImGuiWindowFlags_AlwaysAutoResize)) {
-      ImGui::SliderFloat("Sigma", &sigma, 0, 200);
+      ImGui::Checkbox("Combined sigma", &is_combined);
+      if (is_combined) {
+        ImGui::SliderFloat("Sigma", &sigma_x, 0, 200);
+        sigma_y = sigma_x;
+      } else {
+        ImGui::SliderFloat("Sigma X", &sigma_x, 0, 200);
+        ImGui::SliderFloat("Sigma Y", &sigma_y, 0, 200);
+      }
       ImGui::SliderFloat("Frequency", &freq, 0.01, 2.0);
       ImGui::SliderFloat("Amplitude", &amp, 1, 100);
+      ImGui::SliderFloat("foo", &foo, 0, 2);
       ImGui::End();
     }
 
@@ -795,7 +807,7 @@ TEST_P(AiksTest, GaussianBlurAnimatedBackdrop) {
         Rect::MakeLTRB(handle_a.x, handle_a.y, handle_b.x, handle_b.y));
     canvas.ClipRect(Rect::MakeLTRB(100, 100, 900, 700));
     canvas.SaveLayer({.blend_mode = BlendMode::kSource}, std::nullopt,
-                     ImageFilter::MakeBlur(Sigma(sigma), Sigma(sigma),
+                     ImageFilter::MakeBlur(Sigma(sigma_x), Sigma(sigma_y),
                                            FilterContents::BlurStyle::kNormal,
                                            Entity::TileMode::kClamp));
     count += 1;

--- a/impeller/aiks/aiks_blur_unittests.cc
+++ b/impeller/aiks/aiks_blur_unittests.cc
@@ -17,8 +17,6 @@
 // blurs.
 ////////////////////////////////////////////////////////////////////////////////
 
-impeller::Scalar foo = 1.0f;
-
 namespace impeller {
 namespace testing {
 
@@ -789,7 +787,6 @@ TEST_P(AiksTest, GaussianBlurAnimatedBackdrop) {
       }
       ImGui::SliderFloat("Frequency", &freq, 0.01, 2.0);
       ImGui::SliderFloat("Amplitude", &amp, 1, 100);
-      ImGui::SliderFloat("foo", &foo, 0, 2);
       ImGui::End();
     }
 

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -14,8 +14,6 @@
 #include "impeller/renderer/render_pass.h"
 #include "impeller/renderer/vertex_buffer_builder.h"
 
-extern impeller::Scalar foo;
-
 namespace impeller {
 
 using GaussianBlurVertexShader = GaussianBlurPipeline::VertexShader;
@@ -732,11 +730,11 @@ std::optional<Entity> GaussianBlurFilterContents::RenderFilter(
 
   Scalar y_sigma =
       blur_info.scaled_sigma.y * downsample_pass_args.effective_scalar.y;
-  Matrix blur_output_entity_transform =
-      entity.GetTransform() *                                   //
-      Matrix::MakeScale(1.f / blur_info.source_space_scalar) *  //
-      downsample_pass_args.transform *                          //
-      Matrix::MakeScale(1 / downsample_pass_args.effective_scalar);
+  Matrix bar = Matrix::MakeScale(1.f / blur_info.source_space_scalar) *  //
+               downsample_pass_args.transform *                          //
+               Matrix::MakeScale(1 / downsample_pass_args.effective_scalar);
+  Matrix blur_output_entity_transform = entity.GetTransform() *  //
+                                        bar;
   if (y_sigma < kEhCloseEnough) {
     Entity blur_output_entity = Entity::FromSnapshot(
         Snapshot{.texture = pass2_out.value().GetRenderTargetTexture(),
@@ -753,8 +751,7 @@ std::optional<Entity> GaussianBlurFilterContents::RenderFilter(
         pass2_out.value().GetRenderTargetTexture();
     blur_output_entity.SetBlendMode(entity.GetBlendMode());
     blur_output_entity.SetTransform(blur_output_entity_transform);
-    Vector2 inline_pixel_size =
-        effect_transform.Basis().Invert() * pass1_pixel_size;
+    Vector2 inline_pixel_size = 0.5 * pass1_pixel_size;
     blur_output_entity.SetContents(Contents::MakeAnonymous(
         /*render_proc=*/
         [sampler_desc, texture, inline_pixel_size, blur_info,
@@ -768,7 +765,7 @@ std::optional<Entity> GaussianBlurFilterContents::RenderFilter(
           return Render1DBlur(
               renderer, pass, blur_vertices, blur_uvs, sampler_desc, texture,
               BlurParameters{
-                  .blur_uv_offset = Point(inline_pixel_size.x * foo, 0.0),
+                  .blur_uv_offset = Point(inline_pixel_size.x, 0.0),
                   .blur_sigma = blur_info.scaled_sigma.x *
                                 downsample_pass_args.effective_scalar.x,
                   .blur_radius =

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -14,6 +14,8 @@
 #include "impeller/renderer/render_pass.h"
 #include "impeller/renderer/vertex_buffer_builder.h"
 
+extern impeller::Scalar foo;
+
 namespace impeller {
 
 using GaussianBlurVertexShader = GaussianBlurPipeline::VertexShader;
@@ -751,9 +753,11 @@ std::optional<Entity> GaussianBlurFilterContents::RenderFilter(
         pass2_out.value().GetRenderTargetTexture();
     blur_output_entity.SetBlendMode(entity.GetBlendMode());
     blur_output_entity.SetTransform(blur_output_entity_transform);
+    Vector2 inline_pixel_size =
+        effect_transform.Basis().Invert() * pass1_pixel_size;
     blur_output_entity.SetContents(Contents::MakeAnonymous(
         /*render_proc=*/
-        [sampler_desc, texture, pass1_pixel_size, blur_info,
+        [sampler_desc, texture, inline_pixel_size, blur_info,
          downsample_pass_args](const ContentContext& renderer,
                                const Entity& entity, RenderPass& pass) {
           Quad blur_uvs = {Point(0, 0), Point(1, 0), Point(0, 1), Point(1, 1)};
@@ -764,7 +768,7 @@ std::optional<Entity> GaussianBlurFilterContents::RenderFilter(
           return Render1DBlur(
               renderer, pass, blur_vertices, blur_uvs, sampler_desc, texture,
               BlurParameters{
-                  .blur_uv_offset = Point(pass1_pixel_size.x, 0.0),
+                  .blur_uv_offset = Point(inline_pixel_size.x * foo, 0.0),
                   .blur_sigma = blur_info.scaled_sigma.x *
                                 downsample_pass_args.effective_scalar.x,
                   .blur_radius =

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -751,7 +751,8 @@ std::optional<Entity> GaussianBlurFilterContents::RenderFilter(
         pass2_out.value().GetRenderTargetTexture();
     blur_output_entity.SetBlendMode(entity.GetBlendMode());
     blur_output_entity.SetTransform(blur_output_entity_transform);
-    Vector2 inline_pixel_size = 0.5 * pass1_pixel_size;
+    constexpr Vector2 orthographic_size(2.0f, 2.0f);
+    Vector2 inline_pixel_size = pass1_pixel_size / orthographic_size;
     blur_output_entity.SetContents(Contents::MakeAnonymous(
         /*render_proc=*/
         [sampler_desc, texture, inline_pixel_size, blur_info,

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -62,6 +62,8 @@
 // TODO(zanderso): https://github.com/flutter/flutter/issues/127701
 // NOLINTBEGIN(bugprone-unchecked-optional-access)
 
+extern impeller::Scalar foo;
+
 namespace impeller {
 namespace testing {
 
@@ -1130,6 +1132,7 @@ TEST_P(EntityTest, GaussianBlurFilter) {
       ImGui::SliderFloat2("Scale", scale, 0, 3);
       ImGui::SliderFloat2("Skew", skew, -3, 3);
       ImGui::SliderFloat4("Path XYWH", path_rect, -1000, 1000);
+      ImGui::SliderFloat("foo", &foo, 0, 2);
     }
     ImGui::End();
 

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -62,8 +62,6 @@
 // TODO(zanderso): https://github.com/flutter/flutter/issues/127701
 // NOLINTBEGIN(bugprone-unchecked-optional-access)
 
-extern impeller::Scalar foo;
-
 namespace impeller {
 namespace testing {
 
@@ -1132,7 +1130,6 @@ TEST_P(EntityTest, GaussianBlurFilter) {
       ImGui::SliderFloat2("Scale", scale, 0, 3);
       ImGui::SliderFloat2("Skew", skew, -3, 3);
       ImGui::SliderFloat4("Path XYWH", path_rect, -1000, 1000);
-      ImGui::SliderFloat("foo", &foo, 0, 2);
     }
     ImGui::End();
 


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/150720

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
