### PR TITLE
[Flutter GPU] Add DeviceBuffer.flush & GpuContext.getMinimumUniformByteAlignment.

### DIFF
--- a/lib/gpu/context.cc
+++ b/lib/gpu/context.cc
@@ -9,6 +9,7 @@
 #include "flutter/lib/gpu/formats.h"
 #include "flutter/lib/ui/ui_dart_state.h"
 #include "fml/make_copyable.h"
+#include "impeller/core/platform.h"
 #include "tonic/converter/dart_converter.h"
 
 namespace flutter {
@@ -104,4 +105,9 @@ extern int InternalFlutterGpu_Context_GetDefaultDepthStencilFormat(
       wrapper->GetContext()
           ->GetCapabilities()
           ->GetDefaultDepthStencilFormat()));
+}
+
+extern int InternalFlutterGpu_Context_GetMinimumUniformByteAlignment(
+    flutter::gpu::Context* wrapper) {
+  return impeller::DefaultUniformAlignment();
 }

--- a/lib/gpu/context.h
+++ b/lib/gpu/context.h
@@ -70,6 +70,10 @@ FLUTTER_GPU_EXPORT
 extern int InternalFlutterGpu_Context_GetDefaultDepthStencilFormat(
     flutter::gpu::Context* wrapper);
 
+FLUTTER_GPU_EXPORT
+extern int InternalFlutterGpu_Context_GetMinimumUniformByteAlignment(
+    flutter::gpu::Context* wrapper);
+
 }  // extern "C"
 
 #endif  // FLUTTER_LIB_GPU_CONTEXT_H_

--- a/lib/gpu/device_buffer.cc
+++ b/lib/gpu/device_buffer.cc
@@ -99,3 +99,12 @@ bool InternalFlutterGpu_DeviceBuffer_Overwrite(
   return device_buffer->Overwrite(tonic::DartByteData(source_byte_data),
                                   destination_offset_in_bytes);
 }
+
+bool InternalFlutterGpu_DeviceBuffer_Flush(
+    flutter::gpu::DeviceBuffer* device_buffer,
+    int offset_in_bytes,
+    int size_in_bytes) {
+  device_buffer->GetBuffer()->Flush(
+      impeller::Range(offset_in_bytes, size_in_bytes));
+  return true;
+}

--- a/lib/gpu/device_buffer.h
+++ b/lib/gpu/device_buffer.h
@@ -62,6 +62,12 @@ extern bool InternalFlutterGpu_DeviceBuffer_Overwrite(
     Dart_Handle source_byte_data,
     int destination_offset_in_bytes);
 
+FLUTTER_GPU_EXPORT
+extern bool InternalFlutterGpu_DeviceBuffer_Flush(
+    flutter::gpu::DeviceBuffer* wrapper,
+    int offset_in_bytes,
+    int size_in_bytes);
+
 }  // extern "C"
 
 #endif  // FLUTTER_LIB_GPU_DEVICE_BUFFER_H_

--- a/lib/gpu/lib/src/context.dart
+++ b/lib/gpu/lib/src/context.dart
@@ -40,6 +40,12 @@ base class GpuContext extends NativeFieldWrapperClass1 {
     return PixelFormat.values[_getDefaultDepthStencilFormat()];
   }
 
+  /// The minimum alignment required when referencing uniform blocks stored in a
+  /// `DeviceBuffer`.
+  int get minimumUniformByteAlignment {
+    return _getMinimumUniformByteAlignment();
+  }
+
   /// Allocates a new region of GPU-resident memory.
   ///
   /// The [storageMode] must be either [StorageMode.hostVisible] or
@@ -124,6 +130,10 @@ base class GpuContext extends NativeFieldWrapperClass1 {
   @Native<Int Function(Pointer<Void>)>(
       symbol: 'InternalFlutterGpu_Context_GetDefaultDepthStencilFormat')
   external int _getDefaultDepthStencilFormat();
+
+  @Native<Int Function(Pointer<Void>)>(
+      symbol: 'InternalFlutterGpu_Context_GetMinimumUniformByteAlignment')
+  external int _getMinimumUniformByteAlignment();
 }
 
 /// The default graphics context.

--- a/testing/dart/gpu_test.dart
+++ b/testing/dart/gpu_test.dart
@@ -45,6 +45,11 @@ void main() {
     }
   });
 
+  test('GpuContext.minimumUniformByteAlignment', () async {
+    final int alignment = gpu.gpuContext.minimumUniformByteAlignment;
+    expect(alignment, greaterThanOrEqualTo(16));
+  }, skip: !impellerEnabled);
+
   test('HostBuffer.emplace', () async {
     final gpu.HostBuffer hostBuffer = gpu.gpuContext.createHostBuffer();
 
@@ -74,6 +79,7 @@ void main() {
 
     final bool success = deviceBuffer!
         .overwrite(Int8List.fromList(<int>[0, 1, 2, 3]).buffer.asByteData());
+    deviceBuffer.flush();
     expect(success, true);
   }, skip: !impellerEnabled);
 
@@ -85,6 +91,7 @@ void main() {
     final bool success = deviceBuffer!.overwrite(
         Int8List.fromList(<int>[0, 1, 2, 3]).buffer.asByteData(),
         destinationOffsetInBytes: 1);
+    deviceBuffer.flush();
     expect(success, false);
   }, skip: !impellerEnabled);
 
@@ -98,6 +105,7 @@ void main() {
       deviceBuffer!.overwrite(
           Int8List.fromList(<int>[0, 1, 2, 3]).buffer.asByteData(),
           destinationOffsetInBytes: -1);
+      deviceBuffer.flush();
       fail('Exception not thrown for negative destination offset.');
     } catch (e) {
       expect(


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/150953.

Provide a way to get the required minimum uniform byte alignment when referencing uniform blocks in a device buffer. Allow the user to explicitly flush DeviceBuffers (necessary for devices without shared memory).