### PR TITLE
[Impeller] skip mip generation if blur downsample is factor is 0.5 or greater

### DIFF
--- a/impeller/aiks/aiks_blur_unittests.cc
+++ b/impeller/aiks/aiks_blur_unittests.cc
@@ -1081,7 +1081,6 @@ TEST_P(AiksTest, GaussianBlurAllocatesCorrectMipCountRenderTarget) {
 }
 
 TEST_P(AiksTest, GaussianBlurMipMapNestedLayer) {
-  fml::testing::LogCapture log_capture;
   size_t blur_required_mip_count =
       GetParam() == PlaygroundBackend::kOpenGLES ? 1 : 4;
 
@@ -1107,22 +1106,11 @@ TEST_P(AiksTest, GaussianBlurMipMapNestedLayer) {
     max_mip_count = std::max(it->config.mip_count, max_mip_count);
   }
   EXPECT_EQ(max_mip_count, blur_required_mip_count);
-  // The log is FML_DLOG, so only check in debug builds.
-#ifndef NDEBUG
-  if (GetParam() != PlaygroundBackend::kOpenGLES) {
-    EXPECT_EQ(log_capture.str().find(GaussianBlurFilterContents::kNoMipsError),
-              std::string::npos);
-  } else {
-    EXPECT_NE(log_capture.str().find(GaussianBlurFilterContents::kNoMipsError),
-              std::string::npos);
-  }
-#endif
 }
 
 TEST_P(AiksTest, GaussianBlurMipMapImageFilter) {
   size_t blur_required_mip_count =
       GetParam() == PlaygroundBackend::kOpenGLES ? 1 : 4;
-  fml::testing::LogCapture log_capture;
   Canvas canvas;
   canvas.SaveLayer(
       {.image_filter = ImageFilter::MakeBlur(Sigma(30), Sigma(30),
@@ -1142,22 +1130,11 @@ TEST_P(AiksTest, GaussianBlurMipMapImageFilter) {
     max_mip_count = std::max(it->config.mip_count, max_mip_count);
   }
   EXPECT_EQ(max_mip_count, blur_required_mip_count);
-  // The log is FML_DLOG, so only check in debug builds.
-#ifndef NDEBUG
-  if (GetParam() != PlaygroundBackend::kOpenGLES) {
-    EXPECT_EQ(log_capture.str().find(GaussianBlurFilterContents::kNoMipsError),
-              std::string::npos);
-  } else {
-    EXPECT_NE(log_capture.str().find(GaussianBlurFilterContents::kNoMipsError),
-              std::string::npos);
-  }
-#endif
 }
 
 TEST_P(AiksTest, GaussianBlurMipMapSolidColor) {
   size_t blur_required_mip_count =
       GetParam() == PlaygroundBackend::kOpenGLES ? 1 : 4;
-  fml::testing::LogCapture log_capture;
   Canvas canvas;
   canvas.DrawPath(PathBuilder{}
                       .MoveTo({100, 100})
@@ -1183,16 +1160,6 @@ TEST_P(AiksTest, GaussianBlurMipMapSolidColor) {
     max_mip_count = std::max(it->config.mip_count, max_mip_count);
   }
   EXPECT_EQ(max_mip_count, blur_required_mip_count);
-  // The log is FML_DLOG, so only check in debug builds.
-#ifndef NDEBUG
-  if (GetParam() != PlaygroundBackend::kOpenGLES) {
-    EXPECT_EQ(log_capture.str().find(GaussianBlurFilterContents::kNoMipsError),
-              std::string::npos);
-  } else {
-    EXPECT_NE(log_capture.str().find(GaussianBlurFilterContents::kNoMipsError),
-              std::string::npos);
-  }
-#endif
 }
 
 TEST_P(AiksTest, MaskBlurDoesntStretchContents) {

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -239,9 +239,6 @@ DownsamplePassArgs CalculateDownsamplePassArgs(
   Scalar desired_scalar =
       std::min(GaussianBlurFilterContents::CalculateScale(scaled_sigma.x),
                GaussianBlurFilterContents::CalculateScale(scaled_sigma.y));
-  // TODO(jonahwilliams): If desired_scalar is 1.0 and we fully acquired the
-  // gutter from the expanded_coverage_hint, we can skip the downsample pass.
-  // pass.
   Vector2 downsample_scalar(desired_scalar, desired_scalar);
   // TODO(gaaclarke): The padding could be removed if we know it's not needed or
   //   resized to account for the expanded_clip_coverage. There doesn't appear
@@ -538,9 +535,6 @@ Entity ApplyBlurStyle(FilterContents::BlurStyle blur_style,
 }
 }  // namespace
 
-std::string_view GaussianBlurFilterContents::kNoMipsError =
-    "Applying gaussian blur without mipmap.";
-
 GaussianBlurFilterContents::GaussianBlurFilterContents(
     Scalar sigma_x,
     Scalar sigma_y,
@@ -680,8 +674,8 @@ std::optional<Entity> GaussianBlurFilterContents::RenderFilter(
       blur_info.scaled_sigma, blur_info.padding, input_snapshot.value(),
       source_expanded_coverage_hint, inputs[0], snapshot_entity);
 
-  // If the blur is scaled by more than 0.5, generate mipmaps. Otherwise, the
-  // bilinear filtering is sufficient to preserve quality.
+  // If a blur scalar is less than 0.5, generate mipmaps. Otherwise, the
+  // bilinear filtering of the base mip level is sufficient to preserve quality.
   bool generated_mips = false;
   if (downsample_pass_args.effective_scalar.x < 0.5 ||
       downsample_pass_args.effective_scalar.y < 0.5) {

--- a/impeller/entity/inline_pass_context.cc
+++ b/impeller/entity/inline_pass_context.cc
@@ -64,15 +64,6 @@ bool InlinePassContext::EndPass() {
     return false;
   }
 
-  const std::shared_ptr<Texture>& target_texture =
-      GetPassTarget().GetRenderTarget().GetRenderTargetTexture();
-  if (target_texture->GetMipCount() > 1) {
-    fml::Status mip_status = AddMipmapGeneration(
-        command_buffer_, renderer_.GetContext(), target_texture);
-    if (!mip_status.ok()) {
-      return false;
-    }
-  }
   if (!renderer_.GetContext()
            ->GetCommandQueue()
            ->Submit({std::move(command_buffer_)})


### PR DESCRIPTION
THe downsample uses bilinear filtering to read from the input texture. To avoid dropping data, we generate mipmaps. However if the downscale factor is 0.5 or 1.0, then we don't need to read from any of the mip levels besides the base. Skip mip generation in this case, since its very expensive.

Additionally, mip generation is moved into the blur, rather than checking for mips and erroring - we generate mips if needed - removing an error condition.
