### PR TITLE
[web] Fixes drag scrolling in embedded mode.

### DIFF
--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -431,6 +431,9 @@ extension DomEventExtension on DomEvent {
   external JSString get _type;
   String get type => _type.toDart;
 
+  external JSBoolean? get _cancelable;
+  bool get cancelable => _cancelable?.toDart ?? true;
+
   external JSVoid preventDefault();
   external JSVoid stopPropagation();
 
@@ -720,6 +723,8 @@ extension DomElementExtension on DomElement {
       removeChild(firstChild!);
     }
   }
+
+  external void setPointerCapture(num? pointerId);
 }
 
 @JS()

--- a/lib/web_ui/lib/src/engine/pointer_binding.dart
+++ b/lib/web_ui/lib/src/engine/pointer_binding.dart
@@ -432,8 +432,10 @@ class PointerSupportDetector {
   String toString() => 'pointers:$hasPointerEvents';
 }
 
-class _Listener {
-  _Listener._({
+/// Encapsulates a DomEvent registration so it can be easily unregistered later.
+@visibleForTesting
+class Listener {
+  Listener._({
     required this.event,
     required this.target,
     required this.handler,
@@ -448,7 +450,7 @@ class _Listener {
   /// associated with this event. If `passive` is false, the browser will wait
   /// for the handler to finish execution before performing the respective
   /// action.
-  factory _Listener.register({
+  factory Listener.register({
     required String event,
     required DomEventTarget target,
     required DartDomEventListener handler,
@@ -465,7 +467,7 @@ class _Listener {
       target.addEventListenerWithOptions(event, jsHandler, eventOptions);
     }
 
-    final _Listener listener = _Listener._(
+    final Listener listener = Listener._(
       event: event,
       target: target,
       handler: jsHandler,
@@ -496,7 +498,7 @@ abstract class _BaseAdapter {
   PointerDataConverter get _pointerDataConverter => _owner._pointerDataConverter;
   KeyboardConverter? get _keyboardConverter => _owner._keyboardConverter;
 
-  final List<_Listener> _listeners = <_Listener>[];
+  final List<Listener> _listeners = <Listener>[];
   DomWheelEvent? _lastWheelEvent;
   bool _lastWheelEventWasTrackpad = false;
   bool _lastWheelEventAllowedDefault = false;
@@ -510,7 +512,7 @@ abstract class _BaseAdapter {
 
   /// Cleans up all event listeners attached by this adapter.
   void dispose() {
-    for (final _Listener listener in _listeners) {
+    for (final Listener listener in _listeners) {
       listener.unregister();
     }
     _listeners.clear();
@@ -546,7 +548,7 @@ abstract class _BaseAdapter {
         handler(event);
       }
     }
-    _listeners.add(_Listener.register(
+    _listeners.add(Listener.register(
       event: eventName,
       target: target,
       handler: loggedHandler,
@@ -719,7 +721,7 @@ mixin _WheelEventListenerMixin on _BaseAdapter {
   }
 
   void _addWheelEventListener(DartDomEventListener handler) {
-    _listeners.add(_Listener.register(
+    _listeners.add(Listener.register(
       event: 'wheel',
       target: _viewTarget,
       handler: handler,
@@ -967,13 +969,18 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
   @override
   void setup() {
     // Prevents the browser auto-canceling pointer events.
-    _addPointerEventListener(_viewTarget, 'touchstart', (DomEvent event) {
-      // This is one of the ways I've seen this done. PixiJS does a similar thing.
-      // ThreeJS seems to subscribe move/leave in the pointerdown handler instead?
-      if (event.cancelable) {
-        event.preventDefault();
-      }
-    }, checkModifiers: false);
+    // Register into `_listener` directly so the event isn't forwarded to semantics.
+    _listeners.add(Listener.register(
+      event: 'touchstart',
+      target: _viewTarget,
+      handler: (DomEvent event) {
+        // This is one of the ways I've seen this done. PixiJS does a similar thing.
+        // ThreeJS seems to subscribe move/leave in the pointerdown handler instead?
+        if (event.cancelable) {
+          event.preventDefault();
+        }
+      },
+    ));
 
     _addPointerEventListener(_viewTarget, 'pointerdown', (DomPointerEvent event) {
       final int device = _getPointerId(event);


### PR DESCRIPTION
When Flutter web runs embedded in a page, scrolling by dragging is interrupted very early by the browser.

It turns out that our `pointer` events receive a `pointercancel` + `pointerleave` by the browser because they happen in an area (the flutter glasspane) that is not really scrollable. [See documentation](https://developer.mozilla.org/en-US/docs/Web/API/Element/pointercancel_event).

  > [!NOTE]
  > After the pointercancel event is fired, the browser will also send [pointerout](https://developer.mozilla.org/en-US/docs/Web/API/Element/pointerout_event) followed by [pointerleave](https://developer.mozilla.org/en-US/docs/Web/API/Element/pointerleave_event).

(Firefox is a good browser to test this, because the browser will cancel our events **only if there's scrollable areas around the embedded flutter app**.)

There's several solutions, but one of them (used by PixiJS as well) is to cancel the `touchstart` event that fires with the `pointerdown` event.

(This PR also removes an unnecessary call to `addEventListener` in the `Listener` helper class, and adds some testing to it).

## Testing

* Added a happy case test for the fix (preventDefault on 'touchstart' events)
* Deployed demo app here: https://dit-multiview-scroll.web.app

## Issues

* Fixes https://github.com/flutter/flutter/issues/138985
* Fixes https://github.com/flutter/flutter/issues/146732
* Related to https://github.com/flutter/flutter/issues/139263

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
