### PR TITLE
Revert "[web] switch from .didGain/LoseAccessibilityFocus to .focus"

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -220,9 +220,6 @@ class SemanticsAction {
   /// must immediately become editable, opening a virtual keyboard, if needed.
   /// Buttons must respond to tap/click events from the keyboard.
   ///
-  /// Widget reaction to this action must be idempotent. It is possible to
-  /// receive this action more than once, or when the widget is already focused.
-  ///
   /// Focus behavior is specific to the platform and to the assistive technology
   /// used. Typically on desktop operating systems, such as Windows, macOS, and
   /// Linux, moving accessibility focus will also move the input focus. On

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -2753,30 +2753,6 @@ DomCompositionEvent createDomCompositionEvent(String type,
   }
 }
 
-/// This is a pseudo-type for DOM elements that have the boolean `disabled`
-/// property.
-///
-/// This type cannot be part of the actual type hierarchy because each DOM type
-/// defines its `disabled` property ad hoc, without inheriting it from a common
-/// type, e.g. [DomHTMLInputElement] and [DomHTMLTextAreaElement].
-///
-/// To use, simply cast any element known to have the `disabled` property to
-/// this type using `as DomElementWithDisabledProperty`, then read and write
-/// this property as normal.
-@JS()
-@staticInterop
-class DomElementWithDisabledProperty extends DomHTMLElement {}
-
-extension DomElementWithDisabledPropertyExtension on DomElementWithDisabledProperty {
-  @JS('disabled')
-  external JSBoolean? get _disabled;
-  bool? get disabled => _disabled?.toDart;
-
-  @JS('disabled')
-  external set _disabled(JSBoolean? value);
-  set disabled(bool? value) => _disabled = value?.toJS;
-}
-
 @JS()
 @staticInterop
 class DomHTMLInputElement extends DomHTMLElement {}

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -2218,6 +2218,8 @@ class EngineSemantics {
       'mousemove',
       'mouseleave',
       'mouseup',
+      'keyup',
+      'keydown',
     ];
 
     if (pointerEventTypes.contains(event.type)) {

--- a/lib/web_ui/test/engine/semantics/semantics_tester.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_tester.dart
@@ -75,7 +75,6 @@ class SemanticsTester {
     bool? hasPaste,
     bool? hasDidGainAccessibilityFocus,
     bool? hasDidLoseAccessibilityFocus,
-    bool? hasFocus,
     bool? hasCustomAction,
     bool? hasDismiss,
     bool? hasMoveCursorForwardByWord,
@@ -242,9 +241,6 @@ class SemanticsTester {
     }
     if (hasDidLoseAccessibilityFocus ?? false) {
       actions |= ui.SemanticsAction.didLoseAccessibilityFocus.index;
-    }
-    if (hasFocus ?? false) {
-      actions |= ui.SemanticsAction.focus.index;
     }
     if (hasCustomAction ?? false) {
       actions |= ui.SemanticsAction.customAction.index;

--- a/lib/web_ui/test/engine/semantics/text_field_test.dart
+++ b/lib/web_ui/test/engine/semantics/text_field_test.dart
@@ -2,7 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
+@TestOn('chrome || safari || firefox')
+library;
+
 import 'dart:typed_data';
 
 import 'package:test/bootstrap/browser.dart';
@@ -14,8 +16,7 @@ import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 import '../../common/test_initialization.dart';
 import 'semantics_tester.dart';
 
-final InputConfiguration singlelineConfig =
-    InputConfiguration(viewId: kImplicitViewId);
+final InputConfiguration singlelineConfig = InputConfiguration(viewId: kImplicitViewId);
 
 final InputConfiguration multilineConfig = InputConfiguration(
   viewId: kImplicitViewId,
@@ -24,8 +25,7 @@ final InputConfiguration multilineConfig = InputConfiguration(
 );
 
 EngineSemantics semantics() => EngineSemantics.instance;
-EngineSemanticsOwner owner() =>
-    EnginePlatformDispatcher.instance.implicitView!.semantics;
+EngineSemanticsOwner owner() => EnginePlatformDispatcher.instance.implicitView!.semantics;
 
 const MethodCodec codec = JSONMethodCodec();
 
@@ -89,66 +89,53 @@ void testMain() {
       semantics().semanticsEnabled = false;
     });
 
-    test('renders a text field', () {
-      createTextFieldSemantics(value: 'hello');
+  test('renders a text field', () {
+    createTextFieldSemantics(value: 'hello');
 
-      expectSemanticsTree(owner(), '''
-  <sem>
-    <input />
-  </sem>''');
+    expectSemanticsTree(owner(), '''
+<sem>
+  <input />
+</sem>''');
 
-      // TODO(yjbanov): this used to attempt to test that value="hello" but the
-      //                test was a false positive. We should revise this test and
-      //                make sure it tests the right things:
-      //                https://github.com/flutter/flutter/issues/147200
-      final SemanticsObject node = owner().debugSemanticsTree![0]!;
-      final TextField textFieldRole = node.primaryRole! as TextField;
-      final DomHTMLInputElement inputElement =
-          textFieldRole.editableElement as DomHTMLInputElement;
-      expect(inputElement.tagName.toLowerCase(), 'input');
-      expect(inputElement.value, '');
-      expect(inputElement.disabled, isFalse);
-    });
+    // TODO(yjbanov): this used to attempt to test that value="hello" but the
+    //                test was a false positive. We should revise this test and
+    //                make sure it tests the right things:
+    //                https://github.com/flutter/flutter/issues/147200
+    final SemanticsObject node = owner().debugSemanticsTree![0]!;
+    expect(
+      (node.element as DomHTMLInputElement).value,
+      isNull,
+    );
+  });
 
-    test('renders a disabled text field', () {
-      createTextFieldSemantics(isEnabled: false, value: 'hello');
-      expectSemanticsTree(owner(), '''<sem><input /></sem>''');
-      final SemanticsObject node = owner().debugSemanticsTree![0]!;
-      final TextField textFieldRole = node.primaryRole! as TextField;
-      final DomHTMLInputElement inputElement =
-          textFieldRole.editableElement as DomHTMLInputElement;
-      expect(inputElement.tagName.toLowerCase(), 'input');
-      expect(inputElement.disabled, isTrue);
-    });
-
-    test('sends a SemanticsAction.focus action when browser requests focus',
-        () async {
+    // TODO(yjbanov): this test will need to be adjusted for Safari when we add
+    //                Safari testing.
+    test('sends a didGainAccessibilityFocus/didLoseAccessibilityFocus action when browser requests focus/blur', () async {
       final SemanticsActionLogger logger = SemanticsActionLogger();
       createTextFieldSemantics(value: 'hello');
 
-      final DomElement textField = owner()
-          .semanticsHost
+      final DomElement textField = owner().semanticsHost
           .querySelector('input[data-semantics-role="text-field"]')!;
 
-      expect(
-          owner().semanticsHost.ownerDocument?.activeElement, isNot(textField));
+      expect(owner().semanticsHost.ownerDocument?.activeElement, isNot(textField));
 
       textField.focus();
 
       expect(owner().semanticsHost.ownerDocument?.activeElement, textField);
       expect(await logger.idLog.first, 0);
-      expect(await logger.actionLog.first, ui.SemanticsAction.focus);
+      expect(await logger.actionLog.first, ui.SemanticsAction.didGainAccessibilityFocus);
 
       textField.blur();
 
-      expect(
-          owner().semanticsHost.ownerDocument?.activeElement, isNot(textField));
-      // TODO(yjbanov): https://github.com/flutter/flutter/issues/46638
-    }, skip: ui_web.browser.browserEngine == ui_web.BrowserEngine.firefox);
+      expect(owner().semanticsHost.ownerDocument?.activeElement, isNot(textField));
+      expect(await logger.idLog.first, 0);
+      expect(await logger.actionLog.first, ui.SemanticsAction.didLoseAccessibilityFocus);
+    }, // TODO(yjbanov): https://github.com/flutter/flutter/issues/46638
+       // TODO(yjbanov): https://github.com/flutter/flutter/issues/50590
+    skip: ui_web.browser.browserEngine != ui_web.BrowserEngine.blink);
 
-    test('Syncs semantic state from framework', () async {
-      expect(
-          owner().semanticsHost.ownerDocument?.activeElement, domDocument.body);
+    test('Syncs semantic state from framework', () {
+      expect(owner().semanticsHost.ownerDocument?.activeElement, domDocument.body);
 
       int changeCount = 0;
       int actionCount = 0;
@@ -171,12 +158,11 @@ void testMain() {
       );
 
       final TextField textField = textFieldSemantics.primaryRole! as TextField;
-      expect(owner().semanticsHost.ownerDocument?.activeElement,
-          strategy.domElement);
+      expect(owner().semanticsHost.ownerDocument?.activeElement, strategy.domElement);
       expect(textField.editableElement, strategy.domElement);
-      expect(textField.editableElement.getAttribute('aria-label'), 'greeting');
-      expect(textField.editableElement.style.width, '10px');
-      expect(textField.editableElement.style.height, '15px');
+      expect(textField.activeEditableElement.getAttribute('aria-label'), 'greeting');
+      expect(textField.activeEditableElement.style.width, '10px');
+      expect(textField.activeEditableElement.style.height, '15px');
 
       // Update
       createTextFieldSemantics(
@@ -185,36 +171,13 @@ void testMain() {
         rect: const ui.Rect.fromLTWH(0, 0, 12, 17),
       );
 
-      // The web engine used to explicitly blur() elements when the framework
-      // sent an node update with isFocused == false. This is no longer done, as
-      // blurring an element without focusing on another element confuses screen
-      // readers. However, if another element gains focus (e.g. because the
-      // framework focuses on a different widget), then the current element will
-      // be blurred automatically, without needing to call DomElement.blur().
-      expect(
-        owner().semanticsHost.ownerDocument?.activeElement,
-        strategy.domElement,
-      );
-      expect(textField.editableElement.getAttribute('aria-label'), 'farewell');
-      expect(textField.editableElement.style.width, '12px');
-      expect(textField.editableElement.style.height, '17px');
+      expect(owner().semanticsHost.ownerDocument?.activeElement, domDocument.body);
+      expect(strategy.domElement, null);
+      expect(textField.activeEditableElement.getAttribute('aria-label'), 'farewell');
+      expect(textField.activeEditableElement.style.width, '12px');
+      expect(textField.activeEditableElement.style.height, '17px');
 
       strategy.disable();
-      expect(strategy.domElement, null);
-
-      // Transitively disabling the strategy calls
-      // DefaultTextEditingStrategy.scheduleFocusFlutterView, which uses a timer
-      // before shifting focus. So initially the editable DOM element should be
-      // in place, and is cleared after the timer fires.
-      expect(
-        owner().semanticsHost.ownerDocument?.activeElement,
-        textField.editableElement,
-      );
-      await Future<void>.delayed(Duration.zero);
-      expect(
-        owner().semanticsHost.ownerDocument?.activeElement,
-        EnginePlatformDispatcher.instance.implicitView!.dom.rootElement,
-      );
 
       // There was no user interaction with the <input> element,
       // so we should expect no engine-to-framework feedback.
@@ -240,7 +203,7 @@ void testMain() {
 
       final TextField textField = textFieldSemantics.primaryRole! as TextField;
       final DomHTMLInputElement editableElement =
-          textField.editableElement as DomHTMLInputElement;
+          textField.activeEditableElement as DomHTMLInputElement;
 
       expect(editableElement, strategy.domElement);
       expect(editableElement.value, '');
@@ -253,8 +216,7 @@ void testMain() {
     test(
         'Updates editing state when receiving framework messages from the text input channel',
         () {
-      expect(
-          owner().semanticsHost.ownerDocument?.activeElement, domDocument.body);
+      expect(owner().semanticsHost.ownerDocument?.activeElement, domDocument.body);
 
       strategy.enable(
         singlelineConfig,
@@ -271,7 +233,7 @@ void testMain() {
 
       final TextField textField = textFieldSemantics.primaryRole! as TextField;
       final DomHTMLInputElement editableElement =
-          textField.editableElement as DomHTMLInputElement;
+          textField.activeEditableElement as DomHTMLInputElement;
 
       // No updates expected on semantic updates
       expect(editableElement, strategy.domElement);
@@ -286,8 +248,7 @@ void testMain() {
         'selectionBase': 2,
         'selectionExtent': 3,
       });
-      sendFrameworkMessage(
-          codec.encodeMethodCall(setEditingState), testTextEditing);
+      sendFrameworkMessage(codec.encodeMethodCall(setEditingState), testTextEditing);
 
       // Editing state should now be updated
       expect(editableElement.value, 'updated');
@@ -298,8 +259,7 @@ void testMain() {
     });
 
     test('Gives up focus after DOM blur', () {
-      expect(
-          owner().semanticsHost.ownerDocument?.activeElement, domDocument.body);
+      expect(owner().semanticsHost.ownerDocument?.activeElement, domDocument.body);
 
       strategy.enable(
         singlelineConfig,
@@ -313,18 +273,15 @@ void testMain() {
 
       final TextField textField = textFieldSemantics.primaryRole! as TextField;
       expect(textField.editableElement, strategy.domElement);
-      expect(owner().semanticsHost.ownerDocument?.activeElement,
-          strategy.domElement);
+      expect(owner().semanticsHost.ownerDocument?.activeElement, strategy.domElement);
 
       // The input should not refocus after blur.
-      textField.editableElement.blur();
-      expect(
-          owner().semanticsHost.ownerDocument?.activeElement, domDocument.body);
+      textField.activeEditableElement.blur();
+      expect(owner().semanticsHost.ownerDocument?.activeElement, domDocument.body);
       strategy.disable();
     });
 
-    test('Does not dispose and recreate dom elements in persistent mode',
-        () async {
+    test('Does not dispose and recreate dom elements in persistent mode', () {
       strategy.enable(
         singlelineConfig,
         onChange: (_, __) {},
@@ -340,8 +297,7 @@ void testMain() {
         isFocused: true,
       );
       expect(strategy.domElement, isNotNull);
-      expect(owner().semanticsHost.ownerDocument?.activeElement,
-          strategy.domElement);
+      expect(owner().semanticsHost.ownerDocument?.activeElement, strategy.domElement);
 
       strategy.disable();
       expect(strategy.domElement, isNull);
@@ -351,11 +307,7 @@ void testMain() {
       expect(owner().semanticsHost.contains(textField.editableElement), isTrue);
       // Editing element is not enabled.
       expect(strategy.isEnabled, isFalse);
-      await Future<void>.delayed(Duration.zero);
-      expect(
-        owner().semanticsHost.ownerDocument?.activeElement,
-        EnginePlatformDispatcher.instance.implicitView!.dom.rootElement,
-      );
+      expect(owner().semanticsHost.ownerDocument?.activeElement, domDocument.body);
     });
 
     test('Refocuses when setting editing state', () {
@@ -370,13 +322,11 @@ void testMain() {
         isFocused: true,
       );
       expect(strategy.domElement, isNotNull);
-      expect(owner().semanticsHost.ownerDocument?.activeElement,
-          strategy.domElement);
+      expect(owner().semanticsHost.ownerDocument?.activeElement, strategy.domElement);
 
       // Blur the element without telling the framework.
       strategy.activeDomElement.blur();
-      expect(
-          owner().semanticsHost.ownerDocument?.activeElement, domDocument.body);
+      expect(owner().semanticsHost.ownerDocument?.activeElement, domDocument.body);
 
       // The input will have focus after editing state is set and semantics updated.
       strategy.setEditingState(EditingState(text: 'foo'));
@@ -394,8 +344,7 @@ void testMain() {
         value: 'hello',
         isFocused: true,
       );
-      expect(owner().semanticsHost.ownerDocument?.activeElement,
-          strategy.domElement);
+      expect(owner().semanticsHost.ownerDocument?.activeElement, strategy.domElement);
 
       strategy.disable();
     });
@@ -415,8 +364,7 @@ void testMain() {
       final DomHTMLTextAreaElement textArea =
           strategy.domElement! as DomHTMLTextAreaElement;
 
-      expect(owner().semanticsHost.ownerDocument?.activeElement,
-          strategy.domElement);
+      expect(owner().semanticsHost.ownerDocument?.activeElement, strategy.domElement);
 
       strategy.enable(
         singlelineConfig,
@@ -425,8 +373,7 @@ void testMain() {
       );
 
       textArea.blur();
-      expect(
-          owner().semanticsHost.ownerDocument?.activeElement, domDocument.body);
+      expect(owner().semanticsHost.ownerDocument?.activeElement, domDocument.body);
 
       strategy.disable();
       // It doesn't remove the textarea from the DOM.
@@ -480,7 +427,6 @@ void testMain() {
         children: <SemanticsNodeUpdate>[
           builder.updateNode(
             id: 1,
-            isEnabled: true,
             isTextField: true,
             value: 'Hello',
             isFocused: focusFieldId == 1,
@@ -488,7 +434,6 @@ void testMain() {
           ),
           builder.updateNode(
             id: 2,
-            isEnabled: true,
             isTextField: true,
             value: 'World',
             isFocused: focusFieldId == 2,
@@ -499,9 +444,7 @@ void testMain() {
       return builder.apply();
     }
 
-    test(
-        'Changes focus from one text field to another through a semantics update',
-        () {
+    test('Changes focus from one text field to another through a semantics update', () {
       strategy.enable(
         singlelineConfig,
         onChange: (_, __) {},
@@ -525,13 +468,422 @@ void testMain() {
         expect(strategy.domElement, tester.getTextField(2).editableElement);
       }
     });
-  });
+  }, skip: isIosSafari);
+
+  group('$SemanticsTextEditingStrategy in iOS', () {
+    late HybridTextEditing testTextEditing;
+    late SemanticsTextEditingStrategy strategy;
+
+    setUp(() {
+      testTextEditing = HybridTextEditing();
+      SemanticsTextEditingStrategy.ensureInitialized(testTextEditing);
+      strategy = SemanticsTextEditingStrategy.instance;
+      testTextEditing.debugTextEditingStrategyOverride = strategy;
+      testTextEditing.configuration = singlelineConfig;
+      ui_web.browser.debugBrowserEngineOverride = ui_web.BrowserEngine.webkit;
+      ui_web.browser.debugOperatingSystemOverride = ui_web.OperatingSystem.iOs;
+      semantics()
+        ..debugOverrideTimestampFunction(() => _testTime)
+        ..semanticsEnabled = true;
+    });
+
+    tearDown(() {
+      ui_web.browser.debugBrowserEngineOverride = null;
+      ui_web.browser.debugOperatingSystemOverride = null;
+      semantics().semanticsEnabled = false;
+    });
+
+    test('does not render a text field', () {
+      expect(owner().semanticsHost.querySelector('flt-semantics[role="textbox"]'), isNull);
+      createTextFieldSemanticsForIos(value: 'hello');
+      expect(owner().semanticsHost.querySelector('flt-semantics[role="textbox"]'), isNotNull);
+    });
+
+    test('tap detection works', () async {
+      final SemanticsActionLogger logger = SemanticsActionLogger();
+      createTextFieldSemanticsForIos(value: 'hello');
+
+      final DomElement textField = owner().semanticsHost
+          .querySelector('flt-semantics[role="textbox"]')!;
+
+      simulateTap(textField);
+      expect(await logger.idLog.first, 0);
+      expect(await logger.actionLog.first, ui.SemanticsAction.tap);
+    });
+
+    test('Syncs semantic state from framework', () {
+      expect(owner().semanticsHost.ownerDocument?.activeElement, domDocument.body);
+
+      int changeCount = 0;
+      int actionCount = 0;
+      strategy.enable(
+        singlelineConfig,
+        onChange: (_, __) {
+          changeCount++;
+        },
+        onAction: (_) {
+          actionCount++;
+        },
+      );
+
+      // Create
+      final SemanticsObject textFieldSemantics = createTextFieldSemanticsForIos(
+        value: 'hello',
+        label: 'greeting',
+        isFocused: true,
+        rect: const ui.Rect.fromLTWH(0, 0, 10, 15),
+      );
+
+      final TextField textField = textFieldSemantics.primaryRole! as TextField;
+      expect(owner().semanticsHost.ownerDocument?.activeElement, strategy.domElement);
+      expect(textField.editableElement, strategy.domElement);
+      expect(textField.activeEditableElement.getAttribute('aria-label'), 'greeting');
+      expect(textField.activeEditableElement.style.width, '10px');
+      expect(textField.activeEditableElement.style.height, '15px');
+
+      // Update
+      createTextFieldSemanticsForIos(
+        value: 'bye',
+        label: 'farewell',
+        rect: const ui.Rect.fromLTWH(0, 0, 12, 17),
+      );
+      final DomElement textBox =
+          owner().semanticsHost.querySelector('flt-semantics[role="textbox"]')!;
+
+      expect(strategy.domElement, null);
+      expect(owner().semanticsHost.ownerDocument?.activeElement, textBox);
+      expect(textBox.getAttribute('aria-label'), 'farewell');
+
+      strategy.disable();
+
+      // There was no user interaction with the <input> element,
+      // so we should expect no engine-to-framework feedback.
+      expect(changeCount, 0);
+      expect(actionCount, 0);
+    });
+
+    test(
+        'Does not overwrite text value and selection editing state on semantic updates',
+        () {
+      strategy.enable(
+        singlelineConfig,
+        onChange: (_, __) {},
+        onAction: (_) {},
+      );
+
+      final SemanticsObject textFieldSemantics = createTextFieldSemanticsForIos(
+          value: 'hello',
+          textSelectionBase: 1,
+          textSelectionExtent: 3,
+          isFocused: true,
+          rect: const ui.Rect.fromLTWH(0, 0, 10, 15));
+
+      final TextField textField = textFieldSemantics.primaryRole! as TextField;
+      final DomHTMLInputElement editableElement =
+          textField.activeEditableElement as DomHTMLInputElement;
+
+      expect(editableElement, strategy.domElement);
+      expect(editableElement.value, '');
+      expect(editableElement.selectionStart, 0);
+      expect(editableElement.selectionEnd, 0);
+
+      strategy.disable();
+    });
+
+    test(
+        'Updates editing state when receiving framework messages from the text input channel',
+        () {
+      expect(owner().semanticsHost.ownerDocument?.activeElement, domDocument.body);
+
+      strategy.enable(
+        singlelineConfig,
+        onChange: (_, __) {},
+        onAction: (_) {},
+      );
+
+      final SemanticsObject textFieldSemantics = createTextFieldSemanticsForIos(
+          value: 'hello',
+          textSelectionBase: 1,
+          textSelectionExtent: 3,
+          isFocused: true,
+          rect: const ui.Rect.fromLTWH(0, 0, 10, 15));
+
+      final TextField textField = textFieldSemantics.primaryRole! as TextField;
+      final DomHTMLInputElement editableElement =
+          textField.activeEditableElement as DomHTMLInputElement;
+
+      // No updates expected on semantic updates
+      expect(editableElement, strategy.domElement);
+      expect(editableElement.value, '');
+      expect(editableElement.selectionStart, 0);
+      expect(editableElement.selectionEnd, 0);
+
+      // Update from framework
+      const MethodCall setEditingState =
+          MethodCall('TextInput.setEditingState', <String, dynamic>{
+        'text': 'updated',
+        'selectionBase': 2,
+        'selectionExtent': 3,
+      });
+      sendFrameworkMessage(codec.encodeMethodCall(setEditingState), testTextEditing);
+
+      // Editing state should now be updated
+      // expect(editableElement.value, 'updated');
+      expect(editableElement.selectionStart, 2);
+      expect(editableElement.selectionEnd, 3);
+
+      strategy.disable();
+    });
+
+    test('Gives up focus after DOM blur', () {
+      expect(owner().semanticsHost.ownerDocument?.activeElement, domDocument.body);
+
+      strategy.enable(
+        singlelineConfig,
+        onChange: (_, __) {},
+        onAction: (_) {},
+      );
+      final SemanticsObject textFieldSemantics = createTextFieldSemanticsForIos(
+        value: 'hello',
+        isFocused: true,
+      );
+
+      final TextField textField = textFieldSemantics.primaryRole! as TextField;
+      expect(textField.editableElement, strategy.domElement);
+      expect(owner().semanticsHost.ownerDocument?.activeElement, strategy.domElement);
+
+      // The input should not refocus after blur.
+      textField.activeEditableElement.blur();
+      final DomElement textBox =
+          owner().semanticsHost.querySelector('flt-semantics[role="textbox"]')!;
+      expect(owner().semanticsHost.ownerDocument?.activeElement, textBox);
+
+      strategy.disable();
+    });
+
+    test('Disposes and recreates dom elements in persistent mode', () {
+      strategy.enable(
+        singlelineConfig,
+        onChange: (_, __) {},
+        onAction: (_) {},
+      );
+
+      // It doesn't create a new DOM element.
+      expect(strategy.domElement, isNull);
+
+      // During the semantics update the DOM element is created and is focused on.
+      final SemanticsObject textFieldSemantics = createTextFieldSemanticsForIos(
+        value: 'hello',
+        isFocused: true,
+      );
+      expect(strategy.domElement, isNotNull);
+      expect(owner().semanticsHost.ownerDocument?.activeElement, strategy.domElement);
+
+      strategy.disable();
+      expect(strategy.domElement, isNull);
+
+      // It removes the DOM element.
+      final TextField textField = textFieldSemantics.primaryRole! as TextField;
+      expect(owner().semanticsHost.contains(textField.editableElement), isFalse);
+      // Editing element is not enabled.
+      expect(strategy.isEnabled, isFalse);
+      // Focus is on the semantic object
+      final DomElement textBox =
+          owner().semanticsHost.querySelector('flt-semantics[role="textbox"]')!;
+      expect(owner().semanticsHost.ownerDocument?.activeElement, textBox);
+    });
+
+    test('Refocuses when setting editing state', () {
+      strategy.enable(
+        singlelineConfig,
+        onChange: (_, __) {},
+        onAction: (_) {},
+      );
+
+      createTextFieldSemanticsForIos(
+        value: 'hello',
+        isFocused: true,
+      );
+      expect(strategy.domElement, isNotNull);
+      expect(owner().semanticsHost.ownerDocument?.activeElement, strategy.domElement);
+
+      // Blur the element without telling the framework.
+      strategy.activeDomElement.blur();
+      final DomElement textBox =
+          owner().semanticsHost.querySelector('flt-semantics[role="textbox"]')!;
+      expect(owner().semanticsHost.ownerDocument?.activeElement, textBox);
+
+      // The input will have focus after editing state is set and semantics updated.
+      strategy.setEditingState(EditingState(text: 'foo'));
+
+      // NOTE: at this point some browsers, e.g. some versions of Safari will
+      //       have set the focus on the editing element as a result of setting
+      //       the test selection range. Other browsers require an explicit call
+      //       to `element.focus()` for the element to acquire focus. So far,
+      //       this discrepancy hasn't caused issues, so we're not checking for
+      //       any particular focus state between setEditingState and
+      //       createTextFieldSemantics. However, this is something for us to
+      //       keep in mind in case this causes issues in the future.
+
+      createTextFieldSemanticsForIos(
+        value: 'hello',
+        isFocused: true,
+      );
+      expect(owner().semanticsHost.ownerDocument?.activeElement, strategy.domElement);
+
+      strategy.disable();
+    });
+
+    test('Works in multi-line mode', () {
+      strategy.enable(
+        multilineConfig,
+        onChange: (_, __) {},
+        onAction: (_) {},
+      );
+      createTextFieldSemanticsForIos(
+        value: 'hello',
+        isFocused: true,
+        isMultiline: true,
+      );
+
+      final DomHTMLTextAreaElement textArea =
+          strategy.domElement! as DomHTMLTextAreaElement;
+      expect(owner().semanticsHost.ownerDocument?.activeElement, strategy.domElement);
+
+      strategy.enable(
+        singlelineConfig,
+        onChange: (_, __) {},
+        onAction: (_) {},
+      );
+
+      expect(owner().semanticsHost.contains(textArea), isTrue);
+
+      textArea.blur();
+      final DomElement textBox =
+          owner().semanticsHost.querySelector('flt-semantics[role="textbox"]')!;
+
+      expect(owner().semanticsHost.ownerDocument?.activeElement, textBox);
+
+      strategy.disable();
+      // It removes the textarea from the DOM.
+      expect(owner().semanticsHost.contains(textArea), isFalse);
+      // Editing element is not enabled.
+      expect(strategy.isEnabled, isFalse);
+    });
+
+    test('Does not position or size its DOM element', () {
+      strategy.enable(
+        singlelineConfig,
+        onChange: (_, __) {},
+        onAction: (_) {},
+      );
+
+      // Send width and height that are different from semantics values on
+      // purpose.
+      final Matrix4 transform = Matrix4.translationValues(14, 15, 0);
+      final EditableTextGeometry geometry = EditableTextGeometry(
+        height: 12,
+        width: 13,
+        globalTransform: transform.storage,
+      );
+      const ui.Rect semanticsRect = ui.Rect.fromLTRB(0, 0, 100, 50);
+
+      testTextEditing.acceptCommand(
+        TextInputSetEditableSizeAndTransform(geometry: geometry),
+        () {},
+      );
+
+      createTextFieldSemanticsForIos(
+        value: 'hello',
+        isFocused: true,
+      );
+
+      // Checks that the placement attributes come from semantics and not from
+      // EditableTextGeometry.
+      void checkPlacementIsSetBySemantics() {
+        expect(strategy.activeDomElement.style.transform,
+            isNot(equals(transform.toString())));
+        expect(strategy.activeDomElement.style.width, '${semanticsRect.width}px');
+        expect(strategy.activeDomElement.style.height, '${semanticsRect.height}px');
+      }
+
+      checkPlacementIsSetBySemantics();
+      strategy.placeElement();
+      checkPlacementIsSetBySemantics();
+    });
+
+    test('Changes focus from one text field to another through a semantics update', () {
+      strategy.enable(
+        singlelineConfig,
+        onChange: (_, __) {},
+        onAction: (_) {},
+      );
+
+      // Switch between the two fields a few times.
+      for (int i = 0; i < 1; i++) {
+        final SemanticsTester tester = SemanticsTester(owner());
+        createTwoFieldSemanticsForIos(tester, focusFieldId: 1);
+
+        expect(tester.apply().length, 3);
+        expect(owner().semanticsHost.ownerDocument?.activeElement,
+            tester.getTextField(1).editableElement);
+        expect(strategy.domElement, tester.getTextField(1).editableElement);
+
+        createTwoFieldSemanticsForIos(tester, focusFieldId: 2);
+        expect(tester.apply().length, 3);
+        expect(owner().semanticsHost.ownerDocument?.activeElement,
+            tester.getTextField(2).editableElement);
+        expect(strategy.domElement, tester.getTextField(2).editableElement);
+      }
+    });
+
+    test('input transform is correct', () async {
+      strategy.enable(
+        singlelineConfig,
+        onChange: (_, __) {},
+        onAction: (_) {},
+      );
+      createTextFieldSemanticsForIos(
+        value: 'hello',
+        isFocused: true,
+        );
+      expect(strategy.activeDomElement.style.transform, 'translate(${offScreenOffset}px, ${offScreenOffset}px)');
+      // See [_delayBeforePlacement].
+      await Future<void>.delayed(const Duration(milliseconds: 120) , (){});
+      expect(strategy.activeDomElement.style.transform, '');
+    });
+
+    test('disposes the editable element, if there is one', () {
+      strategy.enable(
+        singlelineConfig,
+        onChange: (_, __) {},
+        onAction: (_) {},
+      );
+      SemanticsObject textFieldSemantics = createTextFieldSemanticsForIos(
+        value: 'hello',
+      );
+      TextField textField = textFieldSemantics.primaryRole! as TextField;
+      expect(textField.editableElement, isNull);
+      textField.dispose();
+      expect(textField.editableElement, isNull);
+
+      textFieldSemantics = createTextFieldSemanticsForIos(
+        value: 'hi',
+        isFocused: true,
+      );
+      textField = textFieldSemantics.primaryRole! as TextField;
+
+      expect(textField.editableElement, isNotNull);
+      textField.dispose();
+      expect(textField.editableElement, isNull);
+    });
+  }, skip: !isSafari);
 }
+
 
 SemanticsObject createTextFieldSemantics({
   required String value,
   String label = '',
-  bool isEnabled = true,
   bool isFocused = false,
   bool isMultiline = false,
   ui.Rect rect = const ui.Rect.fromLTRB(0, 0, 100, 50),
@@ -540,24 +892,135 @@ SemanticsObject createTextFieldSemantics({
 }) {
   final SemanticsTester tester = SemanticsTester(owner());
   tester.updateNode(
-      id: 0,
-      isEnabled: isEnabled,
-      label: label,
-      value: value,
-      isTextField: true,
-      isFocused: isFocused,
-      isMultiline: isMultiline,
-      hasTap: true,
-      rect: rect,
-      textDirection: ui.TextDirection.ltr,
-      textSelectionBase: textSelectionBase,
-      textSelectionExtent: textSelectionExtent);
+    id: 0,
+    label: label,
+    value: value,
+    isTextField: true,
+    isFocused: isFocused,
+    isMultiline: isMultiline,
+    hasTap: true,
+    rect: rect,
+    textDirection: ui.TextDirection.ltr,
+    textSelectionBase: textSelectionBase,
+    textSelectionExtent: textSelectionExtent
+  );
   tester.apply();
   return tester.getSemanticsObject(0);
 }
 
+void simulateTap(DomElement element) {
+  element.dispatchEvent(createDomPointerEvent(
+    'pointerdown',
+    <Object?, Object?>{
+      'clientX': 125,
+      'clientY': 248,
+    },
+  ));
+  element.dispatchEvent(createDomPointerEvent(
+    'pointerup',
+    <Object?, Object?>{
+      'clientX': 126,
+      'clientY': 248,
+    },
+  ));
+}
+
+/// An editable DOM element won't be created on iOS unless a tap is detected.
+/// This function mimics the workflow by simulating a tap and sending a second
+/// semantic update.
+SemanticsObject createTextFieldSemanticsForIos({
+  required String value,
+  String label = '',
+  bool isFocused = false,
+  bool isMultiline = false,
+  ui.Rect rect = const ui.Rect.fromLTRB(0, 0, 100, 50),
+  int textSelectionBase = 0,
+  int textSelectionExtent = 0,
+}) {
+  final SemanticsObject textFieldSemantics = createTextFieldSemantics(
+    value: value,
+    isFocused: isFocused,
+    label: label,
+    isMultiline: isMultiline,
+    rect: rect,
+    textSelectionBase: textSelectionBase,
+    textSelectionExtent: textSelectionExtent,
+  );
+
+  if (isFocused) {
+    final TextField textField = textFieldSemantics.primaryRole! as TextField;
+
+    simulateTap(textField.semanticsObject.element);
+
+    return createTextFieldSemantics(
+      value: value,
+      isFocused: isFocused,
+      label: label,
+      isMultiline: isMultiline,
+      rect: rect,
+      textSelectionBase: textSelectionBase,
+      textSelectionExtent: textSelectionExtent,
+    );
+  }
+  return textFieldSemantics;
+}
+
+/// See [createTextFieldSemanticsForIos].
+Map<int, SemanticsObject> createTwoFieldSemanticsForIos(SemanticsTester builder,
+    {int? focusFieldId}) {
+  builder.updateNode(
+    id: 0,
+    children: <SemanticsNodeUpdate>[
+      builder.updateNode(
+        id: 1,
+        isTextField: true,
+        value: 'Hello',
+        label: 'Hello',
+        isFocused: false,
+        rect: const ui.Rect.fromLTWH(0, 0, 10, 10),
+      ),
+      builder.updateNode(
+        id: 2,
+        isTextField: true,
+        value: 'World',
+        label: 'World',
+        isFocused: false,
+        rect: const ui.Rect.fromLTWH(20, 20, 10, 10),
+      ),
+    ],
+  );
+  builder.apply();
+  final String label = focusFieldId == 1 ? 'Hello' : 'World';
+  final DomElement textBox =
+      owner().semanticsHost.querySelector('flt-semantics[aria-label="$label"]')!;
+
+  simulateTap(textBox);
+
+  builder.updateNode(
+    id: 0,
+    children: <SemanticsNodeUpdate>[
+      builder.updateNode(
+        id: 1,
+        isTextField: true,
+        value: 'Hello',
+        label: 'Hello',
+        isFocused: focusFieldId == 1,
+        rect: const ui.Rect.fromLTWH(0, 0, 10, 10),
+      ),
+      builder.updateNode(
+        id: 2,
+        isTextField: true,
+        value: 'World',
+        label: 'World',
+        isFocused: focusFieldId == 2,
+        rect: const ui.Rect.fromLTWH(20, 20, 10, 10),
+      ),
+    ],
+  );
+  return builder.apply();
+}
+
 /// Emulates sending of a message by the framework to the engine.
-void sendFrameworkMessage(
-    ByteData? message, HybridTextEditing testTextEditing) {
+void sendFrameworkMessage(ByteData? message, HybridTextEditing testTextEditing) {
   testTextEditing.channel.handleTextInput(message, (ByteData? data) {});
 }


### PR DESCRIPTION
Reverts flutter/engine#53360

Breaking google3 in b/350131288.

There is a test that does something like the following, to check if a radio button is selected.

```dart
      // Send a bunch of tabs to focus on the correct radio button
      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
      await tester.pump();
      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
      await tester.pump();
      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
      await tester.pump();

      // Toggle the radio button with space
      await tester.sendKeyEvent(LogicalKeyboardKey.space);
      await tester.pump();

      final selectedRadio =
          tester.widget<Radio<bool>>(find.byType(Radio<bool>).at(1));
      expect(selectedRadio.value, isTrue);
```

After this commit, the above test fails. See the linked bug above for more details.