### PR TITLE
[web] use semantic tags for headings (h1, h2, etc), and fix missing secondary roles

### DIFF
--- a/lib/web_ui/lib/src/engine/semantics/heading.dart
+++ b/lib/web_ui/lib/src/engine/semantics/heading.dart
@@ -25,7 +25,7 @@ class Heading extends PrimaryRoleManager {
   ///
   /// Normally, heading elements are not focusable as they do not receive
   /// keyboard input. However, when a route is pushed (e.g. a dialog pops up),
-  /// the it may be desirable to move the screen reader focus to the heading
+  /// then it may be desirable to move the screen reader focus to the heading
   /// that explains the contents of the route to the user. This method makes the
   /// element artificially focusable and moves the screen reader focus to it.
   ///

--- a/lib/web_ui/lib/src/engine/semantics/heading.dart
+++ b/lib/web_ui/lib/src/engine/semantics/heading.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import '../dom.dart';
+import 'label_and_value.dart';
 import 'semantics.dart';
 
 /// Renders semantics objects as headings with the corresponding
@@ -10,28 +11,36 @@ import 'semantics.dart';
 class Heading extends PrimaryRoleManager {
   Heading(SemanticsObject semanticsObject)
       : super.blank(PrimaryRole.heading, semanticsObject) {
-        addHeadingRole();
-      }
+    addFocusManagement();
+    addLiveRegion();
+    addRouteName();
+    addLabelAndValue(preferredRepresentation: LabelRepresentation.domText);
+  }
 
   @override
-  void update() {
-    super.update();
+  DomElement createElement() => createDomElement('h${semanticsObject.headingLevel}');
 
-    if (!semanticsObject.isHeadingLevelDirty) {
-      return;
+  /// Focuses on this heading element if it turns out to be the default element
+  /// of a route.
+  ///
+  /// Normally, heading elements are not focusable as they do not receive
+  /// keyboard input. However, when a route is pushed (e.g. a dialog pops up),
+  /// the it may be desirable to move the screen reader focus to the heading
+  /// that explains the contents of the route to the user. This method makes the
+  /// element artificially focusable and moves the screen reader focus to it.
+  ///
+  /// That said, if the node is formally focusable, then the focus is
+  /// transferred using [Focusable].
+  @override
+  bool focusAsRouteDefault() {
+    if (semanticsObject.isFocusable) {
+      final focusable = this.focusable;
+      if (focusable != null) {
+        return focusable.focusAsRouteDefault();
+      }
     }
 
-    addHeadingLevel(semanticsObject.headingLevel);
-  }
-
-  @override
-  bool focusAsRouteDefault() => focusable?.focusAsRouteDefault() ?? false;
-
-  void addHeadingRole() {
-    setAriaRole('heading');
-  }
-
-  void addHeadingLevel(int headingLevel) {
-    semanticsObject.element.setAttribute('aria-level', headingLevel);
+    labelAndValue!.focusAsRouteDefault();
+    return true;
   }
 }

--- a/lib/web_ui/lib/src/engine/semantics/heading.dart
+++ b/lib/web_ui/lib/src/engine/semantics/heading.dart
@@ -18,7 +18,25 @@ class Heading extends PrimaryRoleManager {
   }
 
   @override
-  DomElement createElement() => createDomElement('h${semanticsObject.headingLevel}');
+  DomElement createElement() {
+    final element = createDomElement('h${semanticsObject.headingLevel}');
+    element.style
+      // Browser adds default non-zero margins/paddings to <h*> tags, which
+      // affects the size of the element. As the element size is fully defined
+      // by semanticsObject.rect, the extra margins/paddings must be zeroed out.
+      ..margin = '0'
+      ..padding = '0'
+
+      // The 10px size was picked empirically. By default the browser will scale
+      // the font size based on the heading level. Font size should not be
+      // important in semantics since rendering is done via the render tree.
+      // Speculatively locking the font size to something not too big and not
+      // too small, which will hopefully satisfy whoever is consuming the DOM
+      // tree, be it a screen reader or a web crawler. However, if there's a
+      // good reason to do otherwise, feel free to revise this code.
+      ..fontSize = '10px';
+    return element;
+  }
 
   /// Focuses on this heading element if it turns out to be the default element
   /// of a route.

--- a/lib/web_ui/test/common/matchers.dart
+++ b/lib/web_ui/test/common/matchers.dart
@@ -477,8 +477,13 @@ class HtmlPatternMatcher extends Matcher {
     Map<Object?, Object?> matchState,
     bool verbose,
   ) {
+    if (object == null) {
+      mismatchDescription.add('Expected a DOM element, but got null.');
+      return mismatchDescription;
+    }
+
     mismatchDescription.add('The following DOM structure did not match the expected pattern:\n');
-    mismatchDescription.add('${(object! as DomElement).outerHTML!}\n\n');
+    mismatchDescription.add('${(object as DomElement).outerHTML!}\n\n');
     mismatchDescription.add('Specifically:\n');
 
     final List<String> mismatches = matchState['mismatches']! as List<String>;

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -87,6 +87,9 @@ void runSemanticsTests() {
   group('header', () {
     _testHeader();
   });
+  group('heading', () {
+    _testHeading();
+  });
   group('live region', () {
     _testLiveRegion();
   });
@@ -790,7 +793,9 @@ void _testHeader() {
 
     semantics().semanticsEnabled = false;
   });
+}
 
+void _testHeading() {
   test('renders aria-level tag for headings with heading level', () {
     semantics()
       ..debugOverrideTimestampFunction(() => _testTime)
@@ -800,14 +805,13 @@ void _testHeader() {
     updateNode(
       builder,
       headingLevel: 2,
+      label: 'This is a heading',
       transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
     );
 
     owner().updateSemantics(builder.build());
-    expectSemanticsTree(owner(), '''
-<sem aria-level="2" role="heading" style="filter: opacity(0%); color: rgba(0, 0, 0, 0)"></sem>
-''');
+    expectSemanticsTree(owner(), '<h2>This is a heading</h2>');
 
     semantics().semanticsEnabled = false;
   });

--- a/lib/web_ui/test/engine/semantics/semantics_tester.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_tester.dart
@@ -345,7 +345,7 @@ class SemanticsTester {
 /// Verifies the HTML structure of the current semantics tree.
 void expectSemanticsTree(EngineSemanticsOwner owner, String semanticsHtml) {
   expect(
-    owner.semanticsHost.querySelector('flt-semantics'),
+    owner.semanticsHost.children.single,
     hasHtml(semanticsHtml),
   );
 }


### PR DESCRIPTION
Switch to using semantic heading tags (h1, h2, etc).

Fix missing secondary roles: focus, live region, route name, and label.
Improves indexability (https://github.com/flutter/flutter/issues/46789)
