### PR TITLE
Revert "Reland [DisplayList] Add support for clipOval to leverage Impeller optimization"

### DIFF
--- a/display_list/display_list.h
+++ b/display_list/display_list.h
@@ -98,11 +98,9 @@ namespace flutter {
   V(TransformReset)                 \
                                     \
   V(ClipIntersectRect)              \
-  V(ClipIntersectOval)              \
   V(ClipIntersectRRect)             \
   V(ClipIntersectPath)              \
   V(ClipDifferenceRect)             \
-  V(ClipDifferenceOval)             \
   V(ClipDifferenceRRect)            \
   V(ClipDifferencePath)             \
                                     \

--- a/display_list/dl_builder.cc
+++ b/display_list/dl_builder.cc
@@ -963,50 +963,14 @@ void DisplayListBuilder::ClipRect(const SkRect& rect,
       break;
   }
 }
-void DisplayListBuilder::ClipOval(const SkRect& bounds,
-                                  ClipOp clip_op,
-                                  bool is_aa) {
-  if (!bounds.isFinite()) {
-    return;
-  }
-  if (current_info().is_nop) {
-    return;
-  }
-  if (current_info().has_valid_clip &&
-      clip_op == DlCanvas::ClipOp::kIntersect &&
-      layer_local_state().oval_covers_cull(bounds)) {
-    return;
-  }
-  global_state().clipOval(bounds, clip_op, is_aa);
-  layer_local_state().clipOval(bounds, clip_op, is_aa);
-  if (global_state().is_cull_rect_empty() ||
-      layer_local_state().is_cull_rect_empty()) {
-    current_info().is_nop = true;
-    return;
-  }
-  current_info().has_valid_clip = true;
-  checkForDeferredSave();
-  switch (clip_op) {
-    case ClipOp::kIntersect:
-      Push<ClipIntersectOvalOp>(0, bounds, is_aa);
-      break;
-    case ClipOp::kDifference:
-      Push<ClipDifferenceOvalOp>(0, bounds, is_aa);
-      break;
-  }
-}
 void DisplayListBuilder::ClipRRect(const SkRRect& rrect,
                                    ClipOp clip_op,
                                    bool is_aa) {
-  if (current_info().is_nop) {
-    return;
-  }
   if (rrect.isRect()) {
     clipRect(rrect.rect(), clip_op, is_aa);
     return;
   }
-  if (rrect.isOval()) {
-    clipOval(rrect.rect(), clip_op, is_aa);
+  if (current_info().is_nop) {
     return;
   }
   if (current_info().has_valid_clip &&
@@ -1044,11 +1008,12 @@ void DisplayListBuilder::ClipPath(const SkPath& path,
       this->clipRect(rect, clip_op, is_aa);
       return;
     }
+    SkRRect rrect;
     if (path.isOval(&rect)) {
-      this->clipOval(rect, clip_op, is_aa);
+      rrect.setOval(rect);
+      this->clipRRect(rrect, clip_op, is_aa);
       return;
     }
-    SkRRect rrect;
     if (path.isRRect(&rrect)) {
       this->clipRRect(rrect, clip_op, is_aa);
       return;
@@ -1223,22 +1188,6 @@ void DisplayListBuilder::DrawDRRect(const SkRRect& outer,
   drawDRRect(outer, inner);
 }
 void DisplayListBuilder::drawPath(const SkPath& path) {
-  if (!path.isInverseFillType()) {
-    SkRect rect;
-    if (path.isRect(&rect)) {
-      drawRect(rect);
-      return;
-    }
-    if (path.isOval(&rect)) {
-      drawOval(rect);
-      return;
-    }
-    SkRRect rrect;
-    if (path.isRRect(&rrect)) {
-      drawRRect(rrect);
-      return;
-    }
-  }
   DisplayListAttributeFlags flags = kDrawPathFlags;
   OpResult result = PaintResult(current_, flags);
   if (result != OpResult::kNoEffect) {

--- a/display_list/dl_builder.h
+++ b/display_list/dl_builder.h
@@ -117,10 +117,6 @@ class DisplayListBuilder final : public virtual DlCanvas,
                 ClipOp clip_op = ClipOp::kIntersect,
                 bool is_aa = false) override;
   // |DlCanvas|
-  void ClipOval(const SkRect& bounds,
-                ClipOp clip_op = ClipOp::kIntersect,
-                bool is_aa = false) override;
-  // |DlCanvas|
   void ClipRRect(const SkRRect& rrect,
                  ClipOp clip_op = ClipOp::kIntersect,
                  bool is_aa = false) override;
@@ -402,10 +398,6 @@ class DisplayListBuilder final : public virtual DlCanvas,
   // |DlOpReceiver|
   void clipRect(const SkRect& rect, ClipOp clip_op, bool is_aa) override {
     ClipRect(rect, clip_op, is_aa);
-  }
-  // |DlOpReceiver|
-  void clipOval(const SkRect& bounds, ClipOp clip_op, bool is_aa) override {
-    ClipOval(bounds, clip_op, is_aa);
   }
   // |DlOpReceiver|
   void clipRRect(const SkRRect& rrect, ClipOp clip_op, bool is_aa) override {

--- a/display_list/dl_canvas.h
+++ b/display_list/dl_canvas.h
@@ -105,9 +105,6 @@ class DlCanvas {
   virtual void ClipRect(const SkRect& rect,
                         ClipOp clip_op = ClipOp::kIntersect,
                         bool is_aa = false) = 0;
-  virtual void ClipOval(const SkRect& bounds,
-                        ClipOp clip_op = ClipOp::kIntersect,
-                        bool is_aa = false) = 0;
   virtual void ClipRRect(const SkRRect& rrect,
                          ClipOp clip_op = ClipOp::kIntersect,
                          bool is_aa = false) = 0;

--- a/display_list/dl_op_receiver.h
+++ b/display_list/dl_op_receiver.h
@@ -328,7 +328,6 @@ class DlOpReceiver {
   virtual void transformReset() = 0;
 
   virtual void clipRect(const SkRect& rect, ClipOp clip_op, bool is_aa) = 0;
-  virtual void clipOval(const SkRect& bounds, ClipOp clip_op, bool is_aa) = 0;
   virtual void clipRRect(const SkRRect& rrect, ClipOp clip_op, bool is_aa) = 0;
   virtual void clipPath(const SkPath& path, ClipOp clip_op, bool is_aa) = 0;
 

--- a/display_list/dl_op_records.h
+++ b/display_list/dl_op_records.h
@@ -566,11 +566,11 @@ struct TransformResetOp final : TransformClipOpBase {
 // the header, but the Windows compiler keeps wanting to expand that
 // packing into more bytes than needed (even when they are declared as
 // packed bit fields!)
-#define DEFINE_CLIP_SHAPE_OP(shapename, shapetype, clipop)                     \
-  struct Clip##clipop##shapename##Op final : TransformClipOpBase {             \
-    static constexpr auto kType = DisplayListOpType::kClip##clipop##shapename; \
+#define DEFINE_CLIP_SHAPE_OP(shapetype, clipop)                                \
+  struct Clip##clipop##shapetype##Op final : TransformClipOpBase {             \
+    static constexpr auto kType = DisplayListOpType::kClip##clipop##shapetype; \
                                                                                \
-    Clip##clipop##shapename##Op(Sk##shapetype shape, bool is_aa)               \
+    Clip##clipop##shapetype##Op(Sk##shapetype shape, bool is_aa)               \
         : is_aa(is_aa), shape(shape) {}                                        \
                                                                                \
     const bool is_aa;                                                          \
@@ -578,17 +578,15 @@ struct TransformResetOp final : TransformClipOpBase {
                                                                                \
     void dispatch(DispatchContext& ctx) const {                                \
       if (op_needed(ctx)) {                                                    \
-        ctx.receiver.clip##shapename(shape, DlCanvas::ClipOp::k##clipop,       \
+        ctx.receiver.clip##shapetype(shape, DlCanvas::ClipOp::k##clipop,       \
                                      is_aa);                                   \
       }                                                                        \
     }                                                                          \
   };
-DEFINE_CLIP_SHAPE_OP(Rect, Rect, Intersect)
-DEFINE_CLIP_SHAPE_OP(Oval, Rect, Intersect)
-DEFINE_CLIP_SHAPE_OP(RRect, RRect, Intersect)
-DEFINE_CLIP_SHAPE_OP(Rect, Rect, Difference)
-DEFINE_CLIP_SHAPE_OP(Oval, Rect, Difference)
-DEFINE_CLIP_SHAPE_OP(RRect, RRect, Difference)
+DEFINE_CLIP_SHAPE_OP(Rect, Intersect)
+DEFINE_CLIP_SHAPE_OP(RRect, Intersect)
+DEFINE_CLIP_SHAPE_OP(Rect, Difference)
+DEFINE_CLIP_SHAPE_OP(RRect, Difference)
 #undef DEFINE_CLIP_SHAPE_OP
 
 #define DEFINE_CLIP_PATH_OP(clipop)                                       \

--- a/display_list/skia/dl_sk_canvas.cc
+++ b/display_list/skia/dl_sk_canvas.cc
@@ -153,12 +153,6 @@ void DlSkCanvasAdapter::ClipRect(const SkRect& rect,
   delegate_->clipRect(rect, ToSk(clip_op), is_aa);
 }
 
-void DlSkCanvasAdapter::ClipOval(const SkRect& bounds,
-                                 ClipOp clip_op,
-                                 bool is_aa) {
-  delegate_->clipRRect(SkRRect::MakeOval(bounds), ToSk(clip_op), is_aa);
-}
-
 void DlSkCanvasAdapter::ClipRRect(const SkRRect& rrect,
                                   ClipOp clip_op,
                                   bool is_aa) {

--- a/display_list/skia/dl_sk_canvas.h
+++ b/display_list/skia/dl_sk_canvas.h
@@ -72,7 +72,6 @@ class DlSkCanvasAdapter final : public virtual DlCanvas {
   SkMatrix GetTransform() const override;
 
   void ClipRect(const SkRect& rect, ClipOp clip_op, bool is_aa) override;
-  void ClipOval(const SkRect& bounds, ClipOp clip_op, bool is_aa) override;
   void ClipRRect(const SkRRect& rrect, ClipOp clip_op, bool is_aa) override;
   void ClipPath(const SkPath& path, ClipOp clip_op, bool is_aa) override;
 

--- a/display_list/skia/dl_sk_dispatcher.cc
+++ b/display_list/skia/dl_sk_dispatcher.cc
@@ -122,11 +122,6 @@ void DlSkCanvasDispatcher::clipRect(const SkRect& rect,
                                     bool is_aa) {
   canvas_->clipRect(rect, ToSk(clip_op), is_aa);
 }
-void DlSkCanvasDispatcher::clipOval(const SkRect& bounds,
-                                    ClipOp clip_op,
-                                    bool is_aa) {
-  canvas_->clipRRect(SkRRect::MakeOval(bounds), ToSk(clip_op), is_aa);
-}
 void DlSkCanvasDispatcher::clipRRect(const SkRRect& rrect,
                                      ClipOp clip_op,
                                      bool is_aa) {

--- a/display_list/skia/dl_sk_dispatcher.h
+++ b/display_list/skia/dl_sk_dispatcher.h
@@ -51,7 +51,6 @@ class DlSkCanvasDispatcher : public virtual DlOpReceiver,
   void transformReset() override;
 
   void clipRect(const SkRect& rect, ClipOp clip_op, bool is_aa) override;
-  void clipOval(const SkRect& bounds, ClipOp clip_op, bool is_aa) override;
   void clipRRect(const SkRRect& rrect, ClipOp clip_op, bool is_aa) override;
   void clipPath(const SkPath& path, ClipOp clip_op, bool is_aa) override;
 

--- a/display_list/testing/dl_rendering_unittests.cc
+++ b/display_list/testing/dl_rendering_unittests.cc
@@ -2073,39 +2073,6 @@ class CanvasCompareTester {
                      ctx.canvas->ClipRect(r_clip, ClipOp::kDifference, false);
                    })
                    .with_diff_clip());
-    // Skia lacks clipOval and requires us to make an oval SkRRect
-    SkRRect rr_oval_clip = SkRRect::MakeOval(r_clip);
-    RenderWith(testP, env, intersect_tolerance,
-               CaseParameters(
-                   "Hard ClipOval",
-                   [=](const SkSetupContext& ctx) {
-                     ctx.canvas->clipRRect(rr_oval_clip, SkClipOp::kIntersect,
-                                           false);
-                   },
-                   [=](const DlSetupContext& ctx) {
-                     ctx.canvas->ClipOval(r_clip, ClipOp::kIntersect, false);
-                   }));
-    RenderWith(testP, env, intersect_tolerance,
-               CaseParameters(
-                   "AntiAlias ClipOval",
-                   [=](const SkSetupContext& ctx) {
-                     ctx.canvas->clipRRect(rr_oval_clip, SkClipOp::kIntersect,
-                                           true);
-                   },
-                   [=](const DlSetupContext& ctx) {
-                     ctx.canvas->ClipOval(r_clip, ClipOp::kIntersect, true);
-                   }));
-    RenderWith(testP, env, diff_tolerance,
-               CaseParameters(
-                   "Hard ClipOval Diff",
-                   [=](const SkSetupContext& ctx) {
-                     ctx.canvas->clipRRect(rr_oval_clip, SkClipOp::kDifference,
-                                           false);
-                   },
-                   [=](const DlSetupContext& ctx) {
-                     ctx.canvas->ClipOval(r_clip, ClipOp::kDifference, false);
-                   })
-                   .with_diff_clip());
     // This test RR clip used to use very small radii, but due to
     // optimizations in the HW rrect rasterization, this caused small
     // bulges in the corners of the RRect which were interpreted as
@@ -2883,14 +2850,12 @@ TEST_F(DisplayListRendering, DrawDiagonalLines) {
   SkPoint p2 = SkPoint::Make(kRenderRight, kRenderBottom);
   SkPoint p3 = SkPoint::Make(kRenderLeft, kRenderBottom);
   SkPoint p4 = SkPoint::Make(kRenderRight, kRenderTop);
-  // Adding some edge to edge diagonals that run through the points about
-  // 16 units in from the center of that edge.
   // Adding some edge center to edge center diagonals to better fill
   // out the RRect Clip so bounds checking sees less empty bounds space.
-  SkPoint p5 = SkPoint::Make(kRenderCenterX, kRenderTop + 15);
-  SkPoint p6 = SkPoint::Make(kRenderRight - 15, kRenderCenterY);
-  SkPoint p7 = SkPoint::Make(kRenderCenterX, kRenderBottom - 15);
-  SkPoint p8 = SkPoint::Make(kRenderLeft + 15, kRenderCenterY);
+  SkPoint p5 = SkPoint::Make(kRenderCenterX, kRenderTop);
+  SkPoint p6 = SkPoint::Make(kRenderRight, kRenderCenterY);
+  SkPoint p7 = SkPoint::Make(kRenderLeft, kRenderCenterY);
+  SkPoint p8 = SkPoint::Make(kRenderCenterX, kRenderBottom);
 
   CanvasCompareTester::RenderAll(  //
       TestParameters(
@@ -2915,13 +2880,9 @@ TEST_F(DisplayListRendering, DrawDiagonalLines) {
           .set_draw_line());
 }
 
-TEST_F(DisplayListRendering, DrawHorizontalLines) {
-  SkPoint p1 = SkPoint::Make(kRenderLeft, kRenderTop + 16);
-  SkPoint p2 = SkPoint::Make(kRenderRight, kRenderTop + 16);
-  SkPoint p3 = SkPoint::Make(kRenderLeft, kRenderCenterY);
-  SkPoint p4 = SkPoint::Make(kRenderRight, kRenderCenterY);
-  SkPoint p5 = SkPoint::Make(kRenderLeft, kRenderBottom - 16);
-  SkPoint p6 = SkPoint::Make(kRenderRight, kRenderBottom - 16);
+TEST_F(DisplayListRendering, DrawHorizontalLine) {
+  SkPoint p1 = SkPoint::Make(kRenderLeft, kRenderCenterY);
+  SkPoint p2 = SkPoint::Make(kRenderRight, kRenderCenterY);
 
   CanvasCompareTester::RenderAll(  //
       TestParameters(
@@ -2932,26 +2893,18 @@ TEST_F(DisplayListRendering, DrawHorizontalLines) {
             SkPaint p = ctx.paint;
             p.setStyle(SkPaint::kStroke_Style);
             ctx.canvas->drawLine(p1, p2, p);
-            ctx.canvas->drawLine(p3, p4, p);
-            ctx.canvas->drawLine(p5, p6, p);
           },
           [=](const DlRenderContext& ctx) {  //
             ctx.canvas->DrawLine(p1, p2, ctx.paint);
-            ctx.canvas->DrawLine(p3, p4, ctx.paint);
-            ctx.canvas->DrawLine(p5, p6, ctx.paint);
           },
           kDrawHVLineFlags)
           .set_draw_line()
           .set_horizontal_line());
 }
 
-TEST_F(DisplayListRendering, DrawVerticalLines) {
-  SkPoint p1 = SkPoint::Make(kRenderLeft + 16, kRenderTop);
-  SkPoint p2 = SkPoint::Make(kRenderLeft + 16, kRenderBottom);
-  SkPoint p3 = SkPoint::Make(kRenderCenterX, kRenderTop);
-  SkPoint p4 = SkPoint::Make(kRenderCenterX, kRenderBottom);
-  SkPoint p5 = SkPoint::Make(kRenderRight - 16, kRenderTop);
-  SkPoint p6 = SkPoint::Make(kRenderRight - 16, kRenderBottom);
+TEST_F(DisplayListRendering, DrawVerticalLine) {
+  SkPoint p1 = SkPoint::Make(kRenderCenterX, kRenderTop);
+  SkPoint p2 = SkPoint::Make(kRenderCenterY, kRenderBottom);
 
   CanvasCompareTester::RenderAll(  //
       TestParameters(
@@ -2962,13 +2915,9 @@ TEST_F(DisplayListRendering, DrawVerticalLines) {
             SkPaint p = ctx.paint;
             p.setStyle(SkPaint::kStroke_Style);
             ctx.canvas->drawLine(p1, p2, p);
-            ctx.canvas->drawLine(p3, p4, p);
-            ctx.canvas->drawLine(p5, p6, p);
           },
           [=](const DlRenderContext& ctx) {  //
             ctx.canvas->DrawLine(p1, p2, ctx.paint);
-            ctx.canvas->DrawLine(p3, p4, ctx.paint);
-            ctx.canvas->DrawLine(p5, p6, ctx.paint);
           },
           kDrawHVLineFlags)
           .set_draw_line()
@@ -2980,14 +2929,12 @@ TEST_F(DisplayListRendering, DrawDiagonalDashedLines) {
   SkPoint p2 = SkPoint::Make(kRenderRight, kRenderBottom);
   SkPoint p3 = SkPoint::Make(kRenderLeft, kRenderBottom);
   SkPoint p4 = SkPoint::Make(kRenderRight, kRenderTop);
-  // Adding some edge to edge diagonals that run through the points about
-  // 16 units in from the center of that edge.
   // Adding some edge center to edge center diagonals to better fill
   // out the RRect Clip so bounds checking sees less empty bounds space.
-  SkPoint p5 = SkPoint::Make(kRenderCenterX, kRenderTop + 15);
-  SkPoint p6 = SkPoint::Make(kRenderRight - 15, kRenderCenterY);
-  SkPoint p7 = SkPoint::Make(kRenderCenterX, kRenderBottom - 15);
-  SkPoint p8 = SkPoint::Make(kRenderLeft + 15, kRenderCenterY);
+  SkPoint p5 = SkPoint::Make(kRenderCenterX, kRenderTop);
+  SkPoint p6 = SkPoint::Make(kRenderRight, kRenderCenterY);
+  SkPoint p7 = SkPoint::Make(kRenderLeft, kRenderCenterY);
+  SkPoint p8 = SkPoint::Make(kRenderCenterX, kRenderBottom);
 
   // Full diagonals are 100x100 which are 140 in length
   // Dashing them with 25 on, 5 off means that the last
@@ -3008,7 +2955,7 @@ TEST_F(DisplayListRendering, DrawDiagonalDashedLines) {
             SkPaint p = ctx.paint;
             p.setStyle(SkPaint::kStroke_Style);
             SkScalar intervals[2] = {25.0f, 5.0f};
-            p.setPathEffect(SkDashPathEffect::Make(intervals, 2, 0.0f));
+            p.setPathEffect(SkDashPathEffect::Make(intervals, 2.0f, 0.0f));
             ctx.canvas->drawLine(p1, p2, p);
             ctx.canvas->drawLine(p3, p4, p);
             ctx.canvas->drawLine(p5, p6, p);
@@ -3178,7 +3125,7 @@ TEST_F(DisplayListRendering, DrawPointsAsPoints) {
   const SkScalar x3 = kRenderCenterX + 0.1;
   const SkScalar x4 = (kRenderRight + kRenderCenterX) * 0.5;
   const SkScalar x5 = kRenderRight - 16;
-  const SkScalar x6 = kRenderRight - 1;
+  const SkScalar x6 = kRenderRight;
 
   const SkScalar y0 = kRenderTop;
   const SkScalar y1 = kRenderTop + 16;
@@ -3186,7 +3133,7 @@ TEST_F(DisplayListRendering, DrawPointsAsPoints) {
   const SkScalar y3 = kRenderCenterY + 0.1;
   const SkScalar y4 = (kRenderBottom + kRenderCenterY) * 0.5;
   const SkScalar y5 = kRenderBottom - 16;
-  const SkScalar y6 = kRenderBottom - 1;
+  const SkScalar y6 = kRenderBottom;
 
   // clang-format off
   const SkPoint points[] = {
@@ -3230,7 +3177,7 @@ TEST_F(DisplayListRendering, DrawPointsAsLines) {
   const SkScalar y0 = kRenderTop;
   const SkScalar y1 = kRenderTop + 16;
   const SkScalar y2 = kRenderBottom - 16;
-  const SkScalar y3 = kRenderBottom - 1;
+  const SkScalar y3 = kRenderBottom;
 
   // clang-format off
   const SkPoint points[] = {
@@ -3279,12 +3226,10 @@ TEST_F(DisplayListRendering, DrawPointsAsPolygon) {
       SkPoint::Make(kRenderRight, kRenderBottom),
       SkPoint::Make(kRenderLeft, kRenderBottom),
       SkPoint::Make(kRenderLeft, kRenderTop),
-
-      SkPoint::Make(kRenderCenterX, kRenderTop + 15),
-      SkPoint::Make(kRenderRight - 15, kRenderCenterY),
-      SkPoint::Make(kRenderCenterX, kRenderBottom - 15),
-      SkPoint::Make(kRenderLeft + 15, kRenderCenterY),
-      SkPoint::Make(kRenderCenterX, kRenderTop + 15),
+      SkPoint::Make(kRenderCenterX, kRenderTop),
+      SkPoint::Make(kRenderRight, kRenderCenterY),
+      SkPoint::Make(kRenderCenterX, kRenderBottom),
+      SkPoint::Make(kRenderLeft, kRenderCenterY),
   };
   const int count1 = sizeof(points1) / sizeof(points1[0]);
 
@@ -3785,7 +3730,7 @@ TEST_F(DisplayListRendering, DrawShadow) {
       },
       kRenderCornerRadius, kRenderCornerRadius);
   const DlColor color = DlColor::kDarkGrey();
-  const SkScalar elevation = 7;
+  const SkScalar elevation = 5;
 
   CanvasCompareTester::RenderAll(  //
       TestParameters(
@@ -3811,7 +3756,7 @@ TEST_F(DisplayListRendering, DrawShadowTransparentOccluder) {
       },
       kRenderCornerRadius, kRenderCornerRadius);
   const DlColor color = DlColor::kDarkGrey();
-  const SkScalar elevation = 7;
+  const SkScalar elevation = 5;
 
   CanvasCompareTester::RenderAll(  //
       TestParameters(
@@ -3837,7 +3782,7 @@ TEST_F(DisplayListRendering, DrawShadowDpr) {
       },
       kRenderCornerRadius, kRenderCornerRadius);
   const DlColor color = DlColor::kDarkGrey();
-  const SkScalar elevation = 7;
+  const SkScalar elevation = 5;
 
   CanvasCompareTester::RenderAll(  //
       TestParameters(

--- a/display_list/testing/dl_test_snippets.cc
+++ b/display_list/testing/dl_test_snippets.cc
@@ -424,30 +424,6 @@ std::vector<DisplayListInvocationGroup> CreateAllClipOps() {
               r.clipRect(kTestBounds, DlCanvas::ClipOp::kDifference, false);
             }},
        }},
-      {"ClipOval",
-       {
-           {1, 24, 0,
-            [](DlOpReceiver& r) {
-              r.clipOval(kTestBounds, DlCanvas::ClipOp::kIntersect, true);
-            }},
-           {1, 24, 0,
-            [](DlOpReceiver& r) {
-              r.clipOval(kTestBounds.makeOffset(1, 1),
-                         DlCanvas::ClipOp::kIntersect, true);
-            }},
-           {1, 24, 0,
-            [](DlOpReceiver& r) {
-              r.clipOval(kTestBounds, DlCanvas::ClipOp::kIntersect, false);
-            }},
-           {1, 24, 0,
-            [](DlOpReceiver& r) {
-              r.clipOval(kTestBounds, DlCanvas::ClipOp::kDifference, true);
-            }},
-           {1, 24, 0,
-            [](DlOpReceiver& r) {
-              r.clipOval(kTestBounds, DlCanvas::ClipOp::kDifference, false);
-            }},
-       }},
       {"ClipRRect",
        {
            {1, 64, 0,
@@ -503,15 +479,10 @@ std::vector<DisplayListInvocationGroup> CreateAllClipOps() {
             [](DlOpReceiver& r) {
               r.clipPath(kTestPathRect, DlCanvas::ClipOp::kIntersect, true);
             }},
-           // clipPath(oval) becomes clipOval
-           {1, 24, 0,
-            [](DlOpReceiver& r) {
-              r.clipPath(kTestPathOval, DlCanvas::ClipOp::kIntersect, true);
-            }},
-           // clipPath(rrect) becomes clipRRect
+           // clipPath(oval) becomes clipRRect
            {1, 64, 0,
             [](DlOpReceiver& r) {
-              r.clipPath(kTestPathRRect, DlCanvas::ClipOp::kIntersect, true);
+              r.clipPath(kTestPathOval, DlCanvas::ClipOp::kIntersect, true);
             }},
        }},
   };
@@ -666,11 +637,8 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
            {1, 40, 1, [](DlOpReceiver& r) { r.drawPath(kTestPath1); }},
            {1, 40, 1, [](DlOpReceiver& r) { r.drawPath(kTestPath2); }},
            {1, 40, 1, [](DlOpReceiver& r) { r.drawPath(kTestPath3); }},
-           // oval and rect paths are redirected to drawRect and drawOval
-           {1, 24, 1, [](DlOpReceiver& r) { r.drawPath(kTestPathRect); }},
-           {1, 24, 1, [](DlOpReceiver& r) { r.drawPath(kTestPathOval); }},
-           // rrect path is redirected to drawRRect
-           {1, 56, 1, [](DlOpReceiver& r) { r.drawPath(kTestPathRRect); }},
+           {1, 40, 1, [](DlOpReceiver& r) { r.drawPath(kTestPathRect); }},
+           {1, 40, 1, [](DlOpReceiver& r) { r.drawPath(kTestPathOval); }},
        }},
       {"DrawArc",
        {

--- a/display_list/testing/dl_test_snippets.h
+++ b/display_list/testing/dl_test_snippets.h
@@ -183,7 +183,6 @@ static const SkRRect kTestInnerRRect =
     SkRRect::MakeRectXY(kTestBounds.makeInset(5, 5), 2, 2);
 static const SkPath kTestPathRect = SkPath::Rect(kTestBounds);
 static const SkPath kTestPathOval = SkPath::Oval(kTestBounds);
-static const SkPath kTestPathRRect = SkPath::RRect(kTestRRect);
 static const SkPath kTestPath1 =
     SkPath::Polygon({{0, 0}, {10, 10}, {10, 0}, {0, 10}}, true);
 static const SkPath kTestPath2 =

--- a/display_list/utils/dl_matrix_clip_tracker.cc
+++ b/display_list/utils/dl_matrix_clip_tracker.cc
@@ -74,24 +74,6 @@ void DisplayListMatrixClipState::clipRect(const DlRect& rect,
   }
 }
 
-void DisplayListMatrixClipState::clipOval(const DlRect& bounds,
-                                          ClipOp op,
-                                          bool is_aa) {
-  if (!bounds.IsFinite()) {
-    return;
-  }
-  switch (op) {
-    case DlCanvas::ClipOp::kIntersect:
-      adjustCullRect(bounds, op, is_aa);
-      break;
-    case DlCanvas::ClipOp::kDifference:
-      if (oval_covers_cull(bounds)) {
-        cull_rect_ = DlRect();
-      }
-      break;
-  }
-}
-
 void DisplayListMatrixClipState::clipRRect(const SkRRect& rrect,
                                            ClipOp op,
                                            bool is_aa) {

--- a/display_list/utils/dl_matrix_clip_tracker.h
+++ b/display_list/utils/dl_matrix_clip_tracker.h
@@ -149,10 +149,6 @@ class DisplayListMatrixClipState {
   void clipRect(const SkRect& rect, ClipOp op, bool is_aa) {
     clipRect(ToDlRect(rect), op, is_aa);
   }
-  void clipOval(const DlRect& bounds, ClipOp op, bool is_aa);
-  void clipOval(const SkRect& bounds, ClipOp op, bool is_aa) {
-    clipRect(ToDlRect(bounds), op, is_aa);
-  }
   void clipRRect(const SkRRect& rrect, ClipOp op, bool is_aa);
   void clipPath(const SkPath& path, ClipOp op, bool is_aa);
 

--- a/display_list/utils/dl_receiver_utils.h
+++ b/display_list/utils/dl_receiver_utils.h
@@ -44,9 +44,6 @@ class IgnoreClipDispatchHelper : public virtual DlOpReceiver {
   void clipRect(const SkRect& rect,
                 DlCanvas::ClipOp clip_op,
                 bool is_aa) override {}
-  void clipOval(const SkRect& bounds,
-                DlCanvas::ClipOp clip_op,
-                bool is_aa) override {}
   void clipRRect(const SkRRect& rrect,
                  DlCanvas::ClipOp clip_op,
                  bool is_aa) override {}

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -724,14 +724,6 @@ void DlDispatcherBase::clipRect(const SkRect& rect,
 }
 
 // |flutter::DlOpReceiver|
-void DlDispatcherBase::clipOval(const SkRect& bounds,
-                                ClipOp clip_op,
-                                bool is_aa) {
-  GetCanvas().ClipOval(skia_conversions::ToRect(bounds),
-                       ToClipOperation(clip_op));
-}
-
-// |flutter::DlOpReceiver|
 void DlDispatcherBase::clipRRect(const SkRRect& rrect,
                                  ClipOp sk_op,
                                  bool is_aa) {

--- a/impeller/display_list/dl_dispatcher.h
+++ b/impeller/display_list/dl_dispatcher.h
@@ -124,9 +124,6 @@ class DlDispatcherBase : public flutter::DlOpReceiver {
   void clipRect(const SkRect& rect, ClipOp clip_op, bool is_aa) override;
 
   // |flutter::DlOpReceiver|
-  void clipOval(const SkRect& bounds, ClipOp clip_op, bool is_aa) override;
-
-  // |flutter::DlOpReceiver|
   void clipRRect(const SkRRect& rrect, ClipOp clip_op, bool is_aa) override;
 
   // |flutter::DlOpReceiver|

--- a/testing/display_list_testing.cc
+++ b/testing/display_list_testing.cc
@@ -742,14 +742,6 @@ void DisplayListStreamDispatcher::clipRect(const SkRect& rect, ClipOp clip_op,
            << "isaa: " << is_aa
            << ");" << std::endl;
 }
-void DisplayListStreamDispatcher::clipOval(const SkRect& bounds, ClipOp clip_op,
-                                           bool is_aa) {
-  startl() << "clipOval("
-           << bounds << ", "
-           << clip_op << ", "
-           << "isaa: " << is_aa
-           << ");" << std::endl;
-}
 void DisplayListStreamDispatcher::clipRRect(const SkRRect& rrect,
                          ClipOp clip_op,
                          bool is_aa) {

--- a/testing/display_list_testing.h
+++ b/testing/display_list_testing.h
@@ -118,7 +118,6 @@ class DisplayListStreamDispatcher final : public DlOpReceiver {
   void transformReset() override;
 
   void clipRect(const SkRect& rect, ClipOp clip_op, bool is_aa) override;
-  void clipOval(const SkRect& bounds, ClipOp clip_op, bool is_aa) override;
   void clipRRect(const SkRRect& rrect, ClipOp clip_op, bool is_aa) override;
   void clipPath(const SkPath& path, ClipOp clip_op, bool is_aa) override;
 

--- a/testing/mock_canvas.cc
+++ b/testing/mock_canvas.cc
@@ -214,13 +214,6 @@ void MockCanvas::ClipRect(const SkRect& rect, ClipOp op, bool is_aa) {
   state_stack_.back().clipRect(rect, op, is_aa);
 }
 
-void MockCanvas::ClipOval(const SkRect& bounds, ClipOp op, bool is_aa) {
-  ClipEdgeStyle style = is_aa ? kSoftClipEdgeStyle : kHardClipEdgeStyle;
-  draw_calls_.emplace_back(
-      DrawCall{current_layer_, ClipOvalData{bounds, op, style}});
-  state_stack_.back().clipOval(bounds, op, is_aa);
-}
-
 void MockCanvas::ClipRRect(const SkRRect& rrect, ClipOp op, bool is_aa) {
   ClipEdgeStyle style = is_aa ? kSoftClipEdgeStyle : kHardClipEdgeStyle;
   draw_calls_.emplace_back(
@@ -525,16 +518,6 @@ static std::ostream& operator<<(std::ostream& os,
 std::ostream& operator<<(std::ostream& os,
                          const MockCanvas::ClipRectData& data) {
   return os << data.rect << " " << data.clip_op << " " << data.style;
-}
-
-bool operator==(const MockCanvas::ClipOvalData& a,
-                const MockCanvas::ClipOvalData& b) {
-  return a.bounds == b.bounds && a.clip_op == b.clip_op && a.style == b.style;
-}
-
-std::ostream& operator<<(std::ostream& os,
-                         const MockCanvas::ClipOvalData& data) {
-  return os << data.bounds << " " << data.clip_op << " " << data.style;
 }
 
 bool operator==(const MockCanvas::ClipRRectData& a,

--- a/testing/mock_canvas.h
+++ b/testing/mock_canvas.h
@@ -114,12 +114,6 @@ class MockCanvas final : public DlCanvas {
     ClipEdgeStyle style;
   };
 
-  struct ClipOvalData {
-    SkRect bounds;
-    ClipOp clip_op;
-    ClipEdgeStyle style;
-  };
-
   struct ClipRRectData {
     SkRRect rrect;
     ClipOp clip_op;
@@ -151,7 +145,6 @@ class MockCanvas final : public DlCanvas {
                                     DrawDisplayListData,
                                     DrawShadowData,
                                     ClipRectData,
-                                    ClipOvalData,
                                     ClipRRectData,
                                     ClipPathData,
                                     DrawPaintData>;
@@ -213,7 +206,6 @@ class MockCanvas final : public DlCanvas {
   SkMatrix GetTransform() const override;
 
   void ClipRect(const SkRect& rect, ClipOp clip_op, bool is_aa) override;
-  void ClipOval(const SkRect& bounds, ClipOp clip_op, bool is_aa) override;
   void ClipRRect(const SkRRect& rrect, ClipOp clip_op, bool is_aa) override;
   void ClipPath(const SkPath& path, ClipOp clip_op, bool is_aa) override;
 


### PR DESCRIPTION
Reverts flutter/engine#53642

This change causes 10k golden updates internally and we need to land this out of band (go/lssc). There is also an existing issue with one particular client screenshot test - see b/350129213 for more details.