### PR TITLE
Add `PlatformDispatcher.focusedViewId` and  `FlutterView.hasFocus`.

### DIFF
--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -185,6 +185,15 @@ class PlatformDispatcher {
   /// otherwise.
   FlutterView? view({required int id}) => _views[id];
 
+  /// The ID of the currently focused [FlutterView].
+  ///
+  /// Returns -1 if no view is focused.
+  ///
+  /// See also:
+  /// * [FlutterView.hasFocus] to ask a specific view if it is focused.
+  int get focusedViewId => _focusedViewId;
+  int _focusedViewId = -1;
+
   /// The [FlutterView] provided by the engine if the platform is unable to
   /// create windows, or, for backwards compatibility.
   ///
@@ -347,7 +356,13 @@ class PlatformDispatcher {
   // ignore: unused_field, field will be used when platforms other than web use these focus APIs.
   Zone _onViewFocusChangeZone = Zone.root;
   set onViewFocusChange(ViewFocusChangeCallback? callback) {
-    _onViewFocusChange = callback;
+    _onViewFocusChange = (ViewFocusEvent event) {
+      _focusedViewId = switch (event.state) {
+        ViewFocusState.focused => event.viewId,
+        ViewFocusState.unfocused => -1,
+      };
+      callback?.call(event);
+    };
     _onViewFocusChangeZone = Zone.current;
   }
 

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -106,6 +106,10 @@ class FlutterView {
     return platformDispatcher._displays[_viewConfiguration.displayId]!;
   }
 
+  /// Returns true if this view currently is the focused view in the
+  /// [PlatformDispatcher].
+  bool get hasFocus => platformDispatcher.focusedViewId == viewId;
+
   /// The number of device pixels for each logical pixel for the screen this
   /// view is displayed on.
   ///
@@ -144,7 +148,7 @@ class FlutterView {
   ///
   /// The view can take on any [Size] that fulfills these constraints. These
   /// constraints are typically used by an UI framework as the input for its
-  /// layout algorithm to determine an approrpiate size for the view. To size
+  /// layout algorithm to determine an appropriate size for the view. To size
   /// the view, the selected size must be provided to the [render] method and it
   /// must satisfy the constraints.
   ///

--- a/lib/web_ui/lib/platform_dispatcher.dart
+++ b/lib/web_ui/lib/platform_dispatcher.dart
@@ -36,6 +36,8 @@ abstract class PlatformDispatcher {
 
   FlutterView? view({required int id});
 
+  int get focusedViewId;
+
   FlutterView? get implicitView;
 
   VoidCallback? get onMetricsChanged;

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -167,6 +167,10 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   @override
   EngineFlutterView? view({required int id}) => viewManager[id];
 
+  @override
+  int get focusedViewId => _focusedViewId;
+  int _focusedViewId = -1;
+
   /// The [FlutterView] provided by the engine if the platform is unable to
   /// create windows, or, for backwards compatibility.
   ///
@@ -240,7 +244,13 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   Zone? _onViewFocusChangeZone;
   @override
   set onViewFocusChange(ui.ViewFocusChangeCallback? callback) {
-    _onViewFocusChange = callback;
+    _onViewFocusChange = (ui.ViewFocusEvent event) {
+      _focusedViewId = switch (event.state) {
+        ui.ViewFocusState.focused => event.viewId,
+        ui.ViewFocusState.unfocused => -1,
+      };
+      callback?.call(event);
+    };
     _onViewFocusChangeZone = Zone.current;
   }
 

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -259,6 +259,8 @@ base class EngineFlutterView implements ui.FlutterView {
   @override
   EngineFlutterDisplay get display => EngineFlutterDisplay.instance;
 
+  bool get hasFocus => platformDispatcher.focusedViewId == viewId;
+
   @override
   double get devicePixelRatio => display.devicePixelRatio;
 

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -259,6 +259,7 @@ base class EngineFlutterView implements ui.FlutterView {
   @override
   EngineFlutterDisplay get display => EngineFlutterDisplay.instance;
 
+  @override
   bool get hasFocus => platformDispatcher.focusedViewId == viewId;
 
   @override

--- a/lib/web_ui/lib/window.dart
+++ b/lib/web_ui/lib/window.dart
@@ -24,6 +24,7 @@ abstract class FlutterView {
   GestureSettings get gestureSettings;
   List<DisplayFeature> get displayFeatures;
   Display get display;
+  bool get hasFocus;
   void render(Scene scene, {Size? size});
   void updateSemantics(SemanticsUpdate update) => platformDispatcher.updateSemantics(update);
 }

--- a/lib/web_ui/test/engine/platform_dispatcher/platform_dispatcher_test.dart
+++ b/lib/web_ui/test/engine/platform_dispatcher/platform_dispatcher_test.dart
@@ -377,14 +377,16 @@ void testMain() {
     test('invokeOnViewFocusChange calls onViewFocusChange', () {
       final List<ui.ViewFocusEvent> dispatchedViewFocusEvents = <ui.ViewFocusEvent>[];
       const ui.ViewFocusEvent viewFocusEvent = ui.ViewFocusEvent(
-        viewId: 0,
+        viewId: 12,
         state: ui.ViewFocusState.focused,
         direction: ui.ViewFocusDirection.undefined,
       );
 
+      expect(dispatcher.focusedViewId, equals(-1));
       dispatcher.onViewFocusChange = dispatchedViewFocusEvents.add;
       dispatcher.invokeOnViewFocusChange(viewFocusEvent);
 
+      expect(dispatcher.focusedViewId, equals(12));
       expect(dispatchedViewFocusEvents, hasLength(1));
       expect(dispatchedViewFocusEvents.single, viewFocusEvent);
     });

--- a/lib/web_ui/test/engine/platform_dispatcher/view_focus_binding_test.dart
+++ b/lib/web_ui/test/engine/platform_dispatcher/view_focus_binding_test.dart
@@ -93,10 +93,12 @@ void testMain() {
     test('fires a focus event - a view was focused', () async {
       final EngineFlutterView view = createAndRegisterView(dispatcher);
 
+      expect(view.hasFocus, isFalse);
       view.dom.rootElement.focus();
 
       expect(dispatchedViewFocusEvents, hasLength(1));
 
+      expect(view.hasFocus, isTrue);
       expect(dispatchedViewFocusEvents[0].viewId, view.viewId);
       expect(dispatchedViewFocusEvents[0].state, ui.ViewFocusState.focused);
       expect(dispatchedViewFocusEvents[0].direction, ui.ViewFocusDirection.forward);
@@ -105,8 +107,11 @@ void testMain() {
     test('fires a focus event - a view was unfocused', () async {
       final EngineFlutterView view = createAndRegisterView(dispatcher);
 
+      expect(view.hasFocus, isFalse);
       view.dom.rootElement.focus();
+      expect(view.hasFocus, isTrue);
       view.dom.rootElement.blur();
+      expect(view.hasFocus, isFalse);
 
       expect(dispatchedViewFocusEvents, hasLength(2));
 

--- a/lib/web_ui/test/engine/scene_view_test.dart
+++ b/lib/web_ui/test/engine/scene_view_test.dart
@@ -61,6 +61,9 @@ class StubFlutterView implements ui.FlutterView {
   ui.Display get display => throw UnimplementedError();
 
   @override
+  bool get hasFocus => throw UnimplementedError();
+
+  @override
   List<ui.DisplayFeature> get displayFeatures => throw UnimplementedError();
 
   @override


### PR DESCRIPTION
## Description

This adds `PlatformDispatcher.focusedViewId` and  `FlutterView.hasFocus` so that a FlutterView can be asked if it is the currently focused Flutter view.  This is so that we can reduce the calls to the engine when focus changes in the Framework by asking if the view associated with a widget is already focused or not.

## Related Issues
 - https://github.com/flutter/flutter/issues/151251

## Tests
 - Added tests for `web_ui` platform dispatcher