### PR TITLE
[WIP] expose Semantics.identifier as Windows UIA AutomationId

### DIFF
--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -598,6 +598,9 @@ AccessibilityBridge::FromFlutterSemanticsNode(
   result.scroll_extent_min = flutter_node.scroll_extent_min;
   result.elevation = flutter_node.elevation;
   result.thickness = flutter_node.thickness;
+  if (flutter_node.identifier) {
+    result.identifier = std::string(flutter_node.identifier);
+  }
   if (flutter_node.label) {
     result.label = std::string(flutter_node.label);
   }

--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -291,6 +291,7 @@ void AccessibilityBridge::ConvertFlutterUpdate(const SemanticsNode& node,
   SetIntAttributesFromFlutterUpdate(node_data, node);
   SetIntListAttributesFromFlutterUpdate(node_data, node);
   SetStringListAttributesFromFlutterUpdate(node_data, node);
+  SetIdentifierFromFlutterUpdate(node_data, node);
   SetNameFromFlutterUpdate(node_data, node);
   SetValueFromFlutterUpdate(node_data, node);
   SetTooltipFromFlutterUpdate(node_data, node);
@@ -528,6 +529,13 @@ void AccessibilityBridge::SetStringListAttributesFromFlutterUpdate(
         ax::mojom::StringListAttribute::kCustomActionDescriptions,
         custom_action_description);
   }
+}
+
+void AccessibilityBridge::SetIdentifierFromFlutterUpdate(
+    ui::AXNodeData& node_data,
+    const SemanticsNode& node) {
+  node_data.AddStringAttribute(ax::mojom::StringAttribute::kAuthorUniqueId,
+                               node.identifier);
 }
 
 void AccessibilityBridge::SetNameFromFlutterUpdate(ui::AXNodeData& node_data,

--- a/shell/platform/common/accessibility_bridge.h
+++ b/shell/platform/common/accessibility_bridge.h
@@ -172,6 +172,7 @@ class AccessibilityBridge
     double scroll_extent_min;
     double elevation;
     double thickness;
+    std::string identifier;
     std::string label;
     std::string hint;
     std::string value;

--- a/shell/platform/common/accessibility_bridge.h
+++ b/shell/platform/common/accessibility_bridge.h
@@ -228,6 +228,8 @@ class AccessibilityBridge
                                              const SemanticsNode& node);
   void SetStringListAttributesFromFlutterUpdate(ui::AXNodeData& node_data,
                                                 const SemanticsNode& node);
+  void SetIdentifierFromFlutterUpdate(ui::AXNodeData& node_data,
+                                      const SemanticsNode& node);
   void SetNameFromFlutterUpdate(ui::AXNodeData& node_data,
                                 const SemanticsNode& node);
   void SetValueFromFlutterUpdate(ui::AXNodeData& node_data,

--- a/shell/platform/common/flutter_platform_node_delegate_unittests.cc
+++ b/shell/platform/common/flutter_platform_node_delegate_unittests.cc
@@ -46,6 +46,7 @@ TEST(FlutterPlatformNodeDelegateTest, canPerfomActions) {
   root.actions = static_cast<FlutterSemanticsAction>(0);
   root.text_selection_base = -1;
   root.text_selection_extent = -1;
+  root.identifier = "";
   root.label = "root";
   root.hint = "";
   root.value = "";
@@ -91,6 +92,7 @@ TEST(FlutterPlatformNodeDelegateTest, canGetAXNode) {
   root.actions = static_cast<FlutterSemanticsAction>(0);
   root.text_selection_base = -1;
   root.text_selection_extent = -1;
+  root.identifier = "";
   root.label = "root";
   root.hint = "";
   root.value = "";
@@ -112,6 +114,7 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateBoundsCorrectly) {
       std::make_shared<TestAccessibilityBridge>();
   FlutterSemanticsNode2 root;
   root.id = 0;
+  root.identifier = "";
   root.label = "root";
   root.hint = "";
   root.value = "";
@@ -128,6 +131,7 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateBoundsCorrectly) {
 
   FlutterSemanticsNode2 child1;
   child1.id = 1;
+  child1.identifier = "";
   child1.label = "child 1";
   child1.hint = "";
   child1.value = "";
@@ -158,6 +162,7 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateOffScreenBoundsCorrectly) {
       std::make_shared<TestAccessibilityBridge>();
   FlutterSemanticsNode2 root;
   root.id = 0;
+  root.identifier = "";
   root.label = "root";
   root.hint = "";
   root.value = "";
@@ -174,6 +179,7 @@ TEST(FlutterPlatformNodeDelegateTest, canCalculateOffScreenBoundsCorrectly) {
 
   FlutterSemanticsNode2 child1;
   child1.id = 1;
+  child1.identifier = "";
   child1.label = "child 1";
   child1.hint = "";
   child1.value = "";
@@ -204,6 +210,7 @@ TEST(FlutterPlatformNodeDelegateTest, canUseOwnerBridge) {
       std::make_shared<TestAccessibilityBridge>();
   FlutterSemanticsNode2 root;
   root.id = 0;
+  root.identifier = "";
   root.label = "root";
   root.hint = "";
   root.value = "";
@@ -220,6 +227,7 @@ TEST(FlutterPlatformNodeDelegateTest, canUseOwnerBridge) {
 
   FlutterSemanticsNode2 child1;
   child1.id = 1;
+  child1.identifier = "";
   child1.label = "child 1";
   child1.hint = "";
   child1.value = "";
@@ -236,7 +244,7 @@ TEST(FlutterPlatformNodeDelegateTest, canUseOwnerBridge) {
   auto child1_node = bridge->GetFlutterPlatformNodeDelegateFromID(1).lock();
   auto owner_bridge = child1_node->GetOwnerBridge().lock();
 
-  bool result;
+  bool result = false;
   gfx::RectF bounds = owner_bridge->RelativeToGlobalBounds(
       child1_node->GetAXNode(), result, true);
   EXPECT_EQ(bounds.x(), 0);
@@ -251,6 +259,7 @@ TEST(FlutterPlatformNodeDelegateTest, selfIsLowestPlatformAncestor) {
       std::make_shared<TestAccessibilityBridge>();
   FlutterSemanticsNode2 root;
   root.id = 0;
+  root.identifier = "";
   root.label = "root";
   root.hint = "";
   root.value = "";
@@ -273,6 +282,7 @@ TEST(FlutterPlatformNodeDelegateTest, canGetFromNodeID) {
       std::make_shared<TestAccessibilityBridge>();
   FlutterSemanticsNode2 root;
   root.id = 0;
+  root.identifier = "";
   root.label = "root";
   root.hint = "";
   root.value = "";
@@ -287,6 +297,7 @@ TEST(FlutterPlatformNodeDelegateTest, canGetFromNodeID) {
 
   FlutterSemanticsNode2 child1;
   child1.id = 1;
+  child1.identifier = "";
   child1.label = "child 1";
   child1.hint = "";
   child1.value = "";

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacTest.mm
@@ -104,6 +104,7 @@ TEST_F(AccessibilityBridgeMacWindowTest, SendsAccessibilityCreateNotificationFlu
   root.actions = static_cast<FlutterSemanticsAction>(0);
   root.text_selection_base = -1;
   root.text_selection_extent = -1;
+  root.identifier = "";
   root.label = "root";
   root.hint = "";
   root.value = "";
@@ -163,6 +164,7 @@ TEST_F(AccessibilityBridgeMacWindowTest, NonZeroRootNodeId) {
   node1.actions = static_cast<FlutterSemanticsAction>(0);
   node1.text_selection_base = -1;
   node1.text_selection_extent = -1;
+  node1.identifier = "";
   node1.label = "node1";
   node1.hint = "";
   node1.value = "";
@@ -180,6 +182,7 @@ TEST_F(AccessibilityBridgeMacWindowTest, NonZeroRootNodeId) {
   node2.actions = static_cast<FlutterSemanticsAction>(0);
   node2.text_selection_base = -1;
   node2.text_selection_extent = -1;
+  node2.identifier = "";
   node2.label = "node2";
   node2.hint = "";
   node2.value = "";
@@ -225,6 +228,7 @@ TEST_F(AccessibilityBridgeMacTest, DoesNotSendAccessibilityCreateNotificationWhe
   root.actions = static_cast<FlutterSemanticsAction>(0);
   root.text_selection_base = -1;
   root.text_selection_extent = -1;
+  root.identifier = "";
   root.label = "root";
   root.hint = "";
   root.value = "";
@@ -271,6 +275,7 @@ TEST_F(AccessibilityBridgeMacTest, DoesNotSendAccessibilityCreateNotificationWhe
   root.actions = static_cast<FlutterSemanticsAction>(0);
   root.text_selection_base = -1;
   root.text_selection_extent = -1;
+  root.identifier = "";
   root.label = "root";
   root.hint = "";
   root.value = "";

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
@@ -42,6 +42,7 @@ TEST(FlutterPlatformNodeDelegateMac, Basics) {
   root.actions = static_cast<FlutterSemanticsAction>(0);
   root.text_selection_base = -1;
   root.text_selection_extent = -1;
+  root.identifier = "";
   root.label = "accessibility";
   root.hint = "";
   root.value = "";
@@ -79,6 +80,7 @@ TEST(FlutterPlatformNodeDelegateMac, SelectableTextHasCorrectSemantics) {
   root.actions = static_cast<FlutterSemanticsAction>(0);
   root.text_selection_base = 1;
   root.text_selection_extent = 3;
+  root.identifier = "";
   root.label = "";
   root.hint = "";
   // Selectable text store its text in value
@@ -121,6 +123,7 @@ TEST(FlutterPlatformNodeDelegateMac, SelectableTextWithoutSelectionReturnZeroRan
   root.actions = static_cast<FlutterSemanticsAction>(0);
   root.text_selection_base = -1;
   root.text_selection_extent = -1;
+  root.identifier = "";
   root.label = "";
   root.hint = "";
   // Selectable text store its text in value
@@ -162,6 +165,7 @@ TEST(FlutterPlatformNodeDelegateMac, CanPerformAction) {
   // Initialize ax node data.
   FlutterSemanticsNode2 root;
   root.id = 0;
+  root.identifier = "";
   root.label = "root";
   root.hint = "";
   root.value = "";
@@ -176,6 +180,7 @@ TEST(FlutterPlatformNodeDelegateMac, CanPerformAction) {
 
   FlutterSemanticsNode2 child1;
   child1.id = 1;
+  child1.identifier = "";
   child1.label = "child 1";
   child1.hint = "";
   child1.value = "";
@@ -239,6 +244,7 @@ TEST(FlutterPlatformNodeDelegateMac, TextFieldUsesFlutterTextField) {
   root.id = 0;
   root.flags = static_cast<FlutterSemanticsFlag>(0);
   root.actions = static_cast<FlutterSemanticsAction>(0);
+  root.identifier = "";
   root.label = "root";
   root.hint = "";
   root.value = "";
@@ -260,6 +266,7 @@ TEST(FlutterPlatformNodeDelegateMac, TextFieldUsesFlutterTextField) {
   child1.id = 1;
   child1.flags = FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField;
   child1.actions = static_cast<FlutterSemanticsAction>(0);
+  child1.identifier = "";
   child1.label = "";
   child1.hint = "";
   child1.value = "textfield";
@@ -315,6 +322,7 @@ TEST(FlutterPlatformNodeDelegateMac, ChangingFlagsUpdatesNativeViewAccessible) {
   root.id = 0;
   root.flags = static_cast<FlutterSemanticsFlag>(0);
   root.actions = static_cast<FlutterSemanticsAction>(0);
+  root.identifier = "";
   root.label = "root";
   root.hint = "";
   root.value = "";
@@ -336,6 +344,7 @@ TEST(FlutterPlatformNodeDelegateMac, ChangingFlagsUpdatesNativeViewAccessible) {
   child1.id = 1;
   child1.flags = static_cast<FlutterSemanticsFlag>(0);
   child1.actions = static_cast<FlutterSemanticsAction>(0);
+  child1.identifier = "";
   child1.label = "";
   child1.hint = "";
   child1.value = "textfield";

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -1423,6 +1423,8 @@ typedef struct {
   double elevation;
   /// Describes how much space the semantics node takes up along the z-axis.
   double thickness;
+  /// A technical identifier for the node.
+  const char* identifier;
   /// A textual description of the node.
   const char* label;
   /// A brief description of the result of performing an action on the node.

--- a/shell/platform/embedder/embedder_semantics_update.cc
+++ b/shell/platform/embedder/embedder_semantics_update.cc
@@ -153,6 +153,7 @@ void EmbedderSemanticsUpdate2::AddNode(const SemanticsNode& node) {
       node.scrollExtentMin,
       node.elevation,
       node.thickness,
+      node.identifier.c_str(),
       node.label.c_str(),
       node.hint.c_str(),
       node.value.c_str(),

--- a/shell/platform/windows/flutter_platform_node_delegate_windows.cc
+++ b/shell/platform/windows/flutter_platform_node_delegate_windows.cc
@@ -7,6 +7,7 @@
 #include "flutter/shell/platform/windows/flutter_platform_node_delegate_windows.h"
 
 #include "flutter/fml/logging.h"
+#include "flutter/fml/platform/win/wstring_conversion.h"
 #include "flutter/shell/platform/windows/accessibility_bridge_windows.h"
 #include "flutter/shell/platform/windows/flutter_windows_view.h"
 #include "flutter/third_party/accessibility/ax/ax_clipping_behavior.h"
@@ -76,6 +77,13 @@ gfx::NativeViewAccessible FlutterPlatformNodeDelegateWindows::HitTestSync(
 
   // If no children contain the point, but this node does, return this node.
   return ax_platform_node_->GetNativeViewAccessible();
+}
+
+// |ui::AXPlatformNodeDelegate|
+std::u16string FlutterPlatformNodeDelegateWindows::GetAuthorUniqueId() const {
+  return fml::WideStringToUtf16(
+      fml::Utf8ToWideString(GetData().GetStringAttribute(
+          ax::mojom::StringAttribute::kAuthorUniqueId)));
 }
 
 // |FlutterPlatformNodeDelegate|

--- a/shell/platform/windows/flutter_platform_node_delegate_windows.h
+++ b/shell/platform/windows/flutter_platform_node_delegate_windows.h
@@ -34,6 +34,9 @@ class FlutterPlatformNodeDelegateWindows : public FlutterPlatformNodeDelegate {
       int screen_physical_pixel_x,
       int screen_physical_pixel_y) const override;
 
+  // |ui::AXPlatformNodeDelegate|
+  std::u16string GetAuthorUniqueId() const override;
+
   // |FlutterPlatformNodeDelegate|
   gfx::Rect GetBoundsRect(
       const ui::AXCoordinateSystem coordinate_system,

--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -811,7 +811,6 @@ LRESULT FlutterWindow::OnGetObject(UINT const message,
   if (root_view) {
     CreateAxFragmentRoot();
     if (is_uia_request) {
-#ifdef FLUTTER_ENGINE_USE_UIA
       // Retrieve UIA object for the root view.
       Microsoft::WRL::ComPtr<IRawElementProviderSimple> root;
       if (SUCCEEDED(
@@ -824,7 +823,6 @@ LRESULT FlutterWindow::OnGetObject(UINT const message,
       } else {
         FML_LOG(ERROR) << "Failed to query AX fragment root.";
       }
-#endif  // FLUTTER_ENGINE_USE_UIA
     } else if (is_msaa_request) {
       // Create the accessibility root if it does not already exist.
       // Return the IAccessible for the root view.

--- a/shell/platform/windows/window_unittests.cc
+++ b/shell/platform/windows/window_unittests.cc
@@ -366,9 +366,7 @@ TEST(MockWindow, DISABLED_GetObjectUia) {
   bool uia_called = false;
   ON_CALL(window, OnGetObject)
       .WillByDefault(Invoke([&uia_called](UINT msg, WPARAM wpar, LPARAM lpar) {
-#ifdef FLUTTER_ENGINE_USE_UIA
         uia_called = true;
-#endif  // FLUTTER_ENGINE_USE_UIA
         return static_cast<LRESULT>(0);
       }));
   EXPECT_CALL(window, OnGetObject).Times(1);

--- a/third_party/accessibility/ax/ax_enum_util.cc
+++ b/third_party/accessibility/ax/ax_enum_util.cc
@@ -1413,6 +1413,8 @@ const char* ToString(ax::mojom::StringAttribute string_attribute) {
       return "accessKey";
     case ax::mojom::StringAttribute::kAriaInvalidValue:
       return "ariaInvalidValue";
+    case ax::mojom::StringAttribute::kAuthorUniqueId:
+      return "authorUniqueId";
     case ax::mojom::StringAttribute::kAutoComplete:
       return "autoComplete";
     case ax::mojom::StringAttribute::kChildTreeId:
@@ -1473,6 +1475,8 @@ ax::mojom::StringAttribute ParseStringAttribute(const char* string_attribute) {
     return ax::mojom::StringAttribute::kAccessKey;
   if (0 == strcmp(string_attribute, "ariaInvalidValue"))
     return ax::mojom::StringAttribute::kAriaInvalidValue;
+  if (0 == strcmp(string_attribute, "authorUniqueId"))
+    return ax::mojom::StringAttribute::kAuthorUniqueId;
   if (0 == strcmp(string_attribute, "autoComplete"))
     return ax::mojom::StringAttribute::kAutoComplete;
   if (0 == strcmp(string_attribute, "childTreeId"))

--- a/third_party/accessibility/ax/ax_enums.h
+++ b/third_party/accessibility/ax/ax_enums.h
@@ -523,6 +523,7 @@ enum class StringAttribute {
   kAccessKey,
   // Only used when invalid_state == invalid_state_other.
   kAriaInvalidValue,
+  kAuthorUniqueId,
   kAutoComplete,
   kChildTreeId,
   kClassName,

--- a/third_party/accessibility/ax/ax_node_data.cc
+++ b/third_party/accessibility/ax/ax_node_data.cc
@@ -1444,6 +1444,9 @@ std::string AXNodeData::ToString() const {
       case ax::mojom::StringAttribute::kAriaInvalidValue:
         result += " aria_invalid_value=" + value;
         break;
+      case ax::mojom::StringAttribute::kAuthorUniqueId:
+        result += " author_unique_id=" + value;
+        break;
       case ax::mojom::StringAttribute::kAutoComplete:
         result += " autocomplete=" + value;
         break;


### PR DESCRIPTION
Expose Semantics.identifier as Windows AutomationId to ease application automation.

see https://github.com/flutter/flutter/issues/148763

replaces https://github.com/flutter/engine/pull/53476

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

I don't know how/where I can add tests for this feature.

CLA signing requires my employer to find/define who will sign.

2 tests fail to pass on Windows, both before and after my modifications:
- engine\src\out\host_debug_unopt\flutter_windows_unittests.exe KeyboardTest.DeadKeyTwiceThenLetter
- engine\src\out\host_debug_unopt\flutter_windows_unittests.exe KeyboardTest.DeadKeyWithoutDeadMaskThatCombines