### PR TITLE
[Impeller] add experimental canvas support to screenshotter.

### DIFF
--- a/impeller/golden_tests/metal_screenshotter.h
+++ b/impeller/golden_tests/metal_screenshotter.h
@@ -25,6 +25,10 @@ class MetalScreenshotter : public Screenshotter {
       const ISize& size = {300, 300},
       bool scale_content = true) override;
 
+  std::unique_ptr<Screenshot> MakeScreenshot(
+      AiksContext& aiks_context,
+      const std::shared_ptr<Texture> texture) override;
+
   PlaygroundImpl& GetPlayground() override { return *playground_; }
 
  private:

--- a/impeller/golden_tests/metal_screenshotter.mm
+++ b/impeller/golden_tests/metal_screenshotter.mm
@@ -31,6 +31,12 @@ std::unique_ptr<Screenshot> MetalScreenshotter::MakeScreenshot(
       aiks_context,
       ISize(size.width * content_scale.x, size.height * content_scale.y));
   std::shared_ptr<Texture> texture = image->GetTexture();
+  return MakeScreenshot(aiks_context, texture);
+}
+
+std::unique_ptr<Screenshot> MetalScreenshotter::MakeScreenshot(
+    AiksContext& aiks_context,
+    const std::shared_ptr<Texture> texture) {
   id<MTLTexture> metal_texture =
       std::static_pointer_cast<TextureMTL>(texture)->GetMTLTexture();
 

--- a/impeller/golden_tests/screenshotter.h
+++ b/impeller/golden_tests/screenshotter.h
@@ -24,6 +24,10 @@ class Screenshotter {
       const ISize& size = {300, 300},
       bool scale_content = true) = 0;
 
+  virtual std::unique_ptr<Screenshot> MakeScreenshot(
+      AiksContext& aiks_context,
+      const std::shared_ptr<Texture> texture) = 0;
+
   virtual PlaygroundImpl& GetPlayground() = 0;
 };
 

--- a/impeller/golden_tests/vulkan_screenshotter.h
+++ b/impeller/golden_tests/vulkan_screenshotter.h
@@ -26,6 +26,10 @@ class VulkanScreenshotter : public Screenshotter {
       const ISize& size = {300, 300},
       bool scale_content = true) override;
 
+  std::unique_ptr<Screenshot> MakeScreenshot(
+      AiksContext& aiks_context,
+      const std::shared_ptr<Texture> texture) override;
+
   PlaygroundImpl& GetPlayground() override { return *playground_; }
 
  private:

--- a/impeller/golden_tests/vulkan_screenshotter.mm
+++ b/impeller/golden_tests/vulkan_screenshotter.mm
@@ -120,5 +120,11 @@ std::unique_ptr<Screenshot> VulkanScreenshotter::MakeScreenshot(
   return ReadTexture(aiks_context.GetContext(), texture);
 }
 
+std::unique_ptr<Screenshot> VulkanScreenshotter::MakeScreenshot(
+    AiksContext& aiks_context,
+    const std::shared_ptr<Texture> texture) {
+  return ReadTexture(aiks_context.GetContext(), texture);
+}
+
 }  // namespace testing
 }  // namespace impeller


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/150993

This change allows testing the experimental canvas dispatcher in the playgrounds, which is important for golden testing. The plan to enable requires demonstrating that the goldens are the same.