### PR TITLE
[Impeller] Enable framebuffer fetch tests disabled on OpenGL ES.

### DIFF
--- a/impeller/fixtures/BUILD.gn
+++ b/impeller/fixtures/BUILD.gn
@@ -11,6 +11,10 @@ impeller_shaders("shader_fixtures") {
   # 2.3 adds support for framebuffer fetch in Metal.
   metal_version = "2.3"
 
+  # Specify that framebuffer fetch is required for all backends. Compilation of
+  # shaders will be gated on capability checks.
+  require_framebuffer_fetch = true
+
   # Not analyzing because they are not performance critical, and mipmap uses
   # textureLod, which uses an extension that malioc does not support.
   analyze = false

--- a/impeller/fixtures/BUILD.gn
+++ b/impeller/fixtures/BUILD.gn
@@ -5,8 +5,8 @@
 import("//flutter/impeller/tools/impeller.gni")
 import("//flutter/testing/testing.gni")
 
-impeller_shaders("shader_fixtures") {
-  name = "fixtures"
+impeller_shaders("modern_shader_fixtures") {
+  name = "modern_fixtures"
 
   # 2.3 adds support for framebuffer fetch in Metal.
   metal_version = "2.3"
@@ -15,9 +15,27 @@ impeller_shaders("shader_fixtures") {
   # shaders will be gated on capability checks.
   require_framebuffer_fetch = true
 
+  # These shaders are not performance critical and malioc analysis of shaders
+  # that use framebuffer fetch is unsupported anyway.
+  analyze = false
+
+  shaders = [
+    "sepia.frag",
+    "sepia.vert",
+    "swizzle.frag",
+  ]
+}
+
+impeller_shaders("shader_fixtures") {
+  name = "fixtures"
+
+  # 2.3 adds support for framebuffer fetch in Metal.
+  metal_version = "2.3"
+
   # Not analyzing because they are not performance critical, and mipmap uses
   # textureLod, which uses an extension that malioc does not support.
   analyze = false
+
   shaders = [
     "array.frag",
     "array.vert",
@@ -39,12 +57,9 @@ impeller_shaders("shader_fixtures") {
     "planet.frag",
     "planet.vert",
     "sample.comp",
-    "sepia.frag",
-    "sepia.vert",
     "simple.vert",
     "stage1.comp",
     "stage2.comp",
-    "swizzle.frag",
     "test_texture.frag",
     "test_texture.vert",
     "texture.frag",
@@ -176,6 +191,7 @@ group("fixtures") {
 
   public_deps = [
     ":file_fixtures",
+    ":modern_shader_fixtures",
     ":scene_fixtures",
     ":shader_fixtures",
   ]

--- a/impeller/playground/BUILD.gn
+++ b/impeller/playground/BUILD.gn
@@ -47,6 +47,7 @@ impeller_component("playground") {
   }
 
   public_deps = [
+    "../fixtures:modern_shader_fixtures",
     "../fixtures:shader_fixtures",
     "../renderer",
     "../scene/shaders",

--- a/impeller/playground/backend/gles/playground_impl_gles.cc
+++ b/impeller/playground/backend/gles/playground_impl_gles.cc
@@ -18,6 +18,7 @@
 #include "impeller/entity/gles/framebuffer_blend_shaders_gles.h"
 #include "impeller/entity/gles/modern_shaders_gles.h"
 #include "impeller/fixtures/gles/fixtures_shaders_gles.h"
+#include "impeller/fixtures/gles/modern_fixtures_shaders_gles.h"
 #include "impeller/playground/imgui/gles/imgui_shaders_gles.h"
 #include "impeller/renderer/backend/gles/context_gles.h"
 #include "impeller/renderer/backend/gles/surface_gles.h"
@@ -117,6 +118,9 @@ ShaderLibraryMappingsForPlayground() {
       std::make_shared<fml::NonOwnedMapping>(
           impeller_fixtures_shaders_gles_data,
           impeller_fixtures_shaders_gles_length),
+      std::make_shared<fml::NonOwnedMapping>(
+          impeller_modern_fixtures_shaders_gles_data,
+          impeller_modern_fixtures_shaders_gles_length),
       std::make_shared<fml::NonOwnedMapping>(
           impeller_imgui_shaders_gles_data, impeller_imgui_shaders_gles_length),
       std::make_shared<fml::NonOwnedMapping>(

--- a/impeller/playground/backend/metal/playground_impl_mtl.mm
+++ b/impeller/playground/backend/metal/playground_impl_mtl.mm
@@ -18,6 +18,7 @@
 #include "impeller/entity/mtl/framebuffer_blend_shaders.h"
 #include "impeller/entity/mtl/modern_shaders.h"
 #include "impeller/fixtures/mtl/fixtures_shaders.h"
+#include "impeller/fixtures/mtl/modern_fixtures_shaders.h"
 #include "impeller/playground/imgui/mtl/imgui_shaders.h"
 #include "impeller/renderer/backend/metal/context_mtl.h"
 #include "impeller/renderer/backend/metal/formats_mtl.h"
@@ -43,6 +44,9 @@ ShaderLibraryMappingsForPlayground() {
               impeller_framebuffer_blend_shaders_length),
           std::make_shared<fml::NonOwnedMapping>(
               impeller_fixtures_shaders_data, impeller_fixtures_shaders_length),
+          std::make_shared<fml::NonOwnedMapping>(
+              impeller_modern_fixtures_shaders_data,
+              impeller_modern_fixtures_shaders_length),
           std::make_shared<fml::NonOwnedMapping>(impeller_imgui_shaders_data,
                                                  impeller_imgui_shaders_length),
           std::make_shared<fml::NonOwnedMapping>(impeller_scene_shaders_data,

--- a/impeller/playground/backend/vulkan/playground_impl_vk.cc
+++ b/impeller/playground/backend/vulkan/playground_impl_vk.cc
@@ -16,6 +16,7 @@
 #include "impeller/entity/vk/framebuffer_blend_shaders_vk.h"
 #include "impeller/entity/vk/modern_shaders_vk.h"
 #include "impeller/fixtures/vk/fixtures_shaders_vk.h"
+#include "impeller/fixtures/vk/modern_fixtures_shaders_vk.h"
 #include "impeller/playground/imgui/vk/imgui_shaders_vk.h"
 #include "impeller/renderer/backend/vulkan/context_vk.h"
 #include "impeller/renderer/backend/vulkan/formats_vk.h"
@@ -40,6 +41,9 @@ ShaderLibraryMappingsForPlayground() {
       std::make_shared<fml::NonOwnedMapping>(
           impeller_fixtures_shaders_vk_data,
           impeller_fixtures_shaders_vk_length),
+      std::make_shared<fml::NonOwnedMapping>(
+          impeller_modern_fixtures_shaders_vk_data,
+          impeller_modern_fixtures_shaders_vk_length),
       std::make_shared<fml::NonOwnedMapping>(impeller_imgui_shaders_vk_data,
                                              impeller_imgui_shaders_vk_length),
       std::make_shared<fml::NonOwnedMapping>(impeller_scene_shaders_vk_data,

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -1392,13 +1392,6 @@ std::shared_ptr<Pipeline<PipelineDescriptor>> CreateDefaultPipeline(
 }
 
 TEST_P(RendererTest, CanSepiaToneWithSubpasses) {
-  // The GLES framebuffer fetch implementation currently does not support this.
-  // TODO(chinmaygarde): revisit after the GLES framebuffer fetch capabilities
-  // are clarified.
-  if (GetParam() == PlaygroundBackend::kOpenGLES) {
-    GTEST_SKIP_("Not supported on GLES.");
-  }
-
   // Define shader types
   using TextureVS = TextureVertexShader;
   using TextureFS = TextureFragmentShader;
@@ -1487,13 +1480,6 @@ TEST_P(RendererTest, CanSepiaToneWithSubpasses) {
 }
 
 TEST_P(RendererTest, CanSepiaToneThenSwizzleWithSubpasses) {
-  // The GLES framebuffer fetch implementation currently does not support this.
-  // TODO(chinmaygarde): revisit after the GLES framebuffer fetch capabilities
-  // are clarified.
-  if (GetParam() == PlaygroundBackend::kOpenGLES) {
-    GTEST_SKIP_("Not supported on GLES.");
-  }
-
   // Define shader types
   using TextureVS = TextureVertexShader;
   using TextureFS = TextureFragmentShader;


### PR DESCRIPTION
The texel fetch fallback used in place of framebuffer fetch isn't supported on ES 100. And this test is explicitly about framebuffer fetch.

Fixes https://github.com/flutter/flutter/issues/144181

<img width="1050" alt="Screenshot 2024-07-08 at 3 21 30 PM" src="https://github.com/flutter/engine/assets/44085/b7468a2d-c385-457c-adf4-2ddb2cbae4a2">
