### PR TITLE
[Impeller] Disable OpenGL dithering by default.

### DIFF
--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -241,6 +241,7 @@ struct RenderPassData {
   gl.Disable(GL_STENCIL_TEST);
   gl.Disable(GL_CULL_FACE);
   gl.Disable(GL_BLEND);
+  gl.Disable(GL_DITHER);
   gl.ColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
   gl.DepthMask(GL_TRUE);
   gl.StencilMaskSeparate(GL_FRONT, 0xFFFFFFFF);


### PR DESCRIPTION
My expectation was that all toggles were disabled with OpenGL. But the specification states: "The initial value for each capability with the exception of GL_DITHER is GL_FALSE. The initial value for GL_DITHER is GL_TRUE."

The kind of dithering is implementation dependent and our layered OpenGL implementations choose to do nothing when this is enabled (unless extensions like VK_EXT_legacy_dithering are supported). Since, again, per the spec: "As far as OpenGL layering is concerned, no dithering is technically an acceptable algorithm".

But it does have a cost of older hardware where dithering is supported.

This sets the default to match our other backends and get some performance on hardware that does do dithering.
