### PR TITLE
Avoid using a private GTest macro to skip tests.

### DIFF
--- a/impeller/aiks/aiks_blur_unittests.cc
+++ b/impeller/aiks/aiks_blur_unittests.cc
@@ -502,14 +502,14 @@ TEST_P(AiksTest, GaussianBlurAtPeripheryHorizontal) {
 
 TEST_P(AiksTest, GaussianBlurWithoutDecalSupport) {
   if (GetParam() != PlaygroundBackend::kMetal) {
-    GTEST_SKIP_(
-        "This backend doesn't yet support setting device capabilities.");
+    GTEST_SKIP()
+        << "This backend doesn't yet support setting device capabilities.";
   }
   if (!WillRenderSomething()) {
     // Sometimes these tests are run without playgrounds enabled which is
     // pointless for this test since we are asserting that
     // `SupportsDecalSamplerAddressMode` is called.
-    GTEST_SKIP_("This test requires playgrounds.");
+    GTEST_SKIP() << "This test requires playgrounds.";
   }
 
   std::shared_ptr<const Capabilities> old_capabilities =

--- a/impeller/compiler/compiler_unittests.cc
+++ b/impeller/compiler/compiler_unittests.cc
@@ -55,7 +55,8 @@ TEST_P(CompilerTest, CanCompileHLSLWithMultipleStages) {
 
 TEST_P(CompilerTest, CanCompileComputeShader) {
   if (!TargetPlatformIsMetal(GetParam())) {
-    GTEST_SKIP_("Only enabled on Metal backends till ES 3.2 support is added.");
+    GTEST_SKIP()
+        << "Only enabled on Metal backends till ES 3.2 support is added.";
   }
   ASSERT_TRUE(CanCompileAndReflect("sample.comp"));
   ASSERT_TRUE(CanCompileAndReflect("sample.comp", SourceType::kComputeShader));

--- a/impeller/entity/contents/tiled_texture_contents_unittests.cc
+++ b/impeller/entity/contents/tiled_texture_contents_unittests.cc
@@ -56,8 +56,8 @@ TEST_P(EntityTest, TiledTextureContentsRendersWithCorrectPipeline) {
 #if !defined(FML_OS_MACOSX)
 TEST_P(EntityTest, TiledTextureContentsRendersWithCorrectPipelineExternalOES) {
   if (GetParam() != PlaygroundBackend::kOpenGLES) {
-    GTEST_SKIP_(
-        "External OES textures are only valid for the OpenGLES backend.");
+    GTEST_SKIP()
+        << "External OES textures are only valid for the OpenGLES backend.";
   }
 
   TextureDescriptor texture_desc;

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -1916,7 +1916,8 @@ static std::vector<std::shared_ptr<Texture>> CreateTestYUVTextures(
 TEST_P(EntityTest, YUVToRGBFilter) {
   if (GetParam() == PlaygroundBackend::kOpenGLES) {
     // TODO(114588) : Support YUV to RGB filter on OpenGLES backend.
-    GTEST_SKIP_("YUV to RGB filter is not supported on OpenGLES backend yet.");
+    GTEST_SKIP()
+        << "YUV to RGB filter is not supported on OpenGLES backend yet.";
   }
 
   auto callback = [&](ContentContext& context, RenderPass& pass) -> bool {

--- a/impeller/golden_tests/golden_playground_test_mac.cc
+++ b/impeller/golden_tests/golden_playground_test_mac.cc
@@ -210,15 +210,15 @@ void GoldenPlaygroundTest::SetUp() {
   switch (GetParam()) {
     case PlaygroundBackend::kMetal:
       if (!DoesSupportWideGamutTests()) {
-        GTEST_SKIP_(
-            "This metal device doesn't support wide gamut golden tests.");
+        GTEST_SKIP()
+            << "This metal device doesn't support wide gamut golden tests.";
       }
       pimpl_->screenshotter =
           std::make_unique<testing::MetalScreenshotter>(enable_wide_gamut);
       break;
     case PlaygroundBackend::kVulkan: {
       if (enable_wide_gamut) {
-        GTEST_SKIP_("Vulkan doesn't support wide gamut golden tests.");
+        GTEST_SKIP() << "Vulkan doesn't support wide gamut golden tests.";
       }
       const std::unique_ptr<PlaygroundImpl>& playground =
           GetSharedVulkanPlayground(/*enable_validations=*/true);
@@ -228,7 +228,7 @@ void GoldenPlaygroundTest::SetUp() {
     }
     case PlaygroundBackend::kOpenGLES: {
       if (enable_wide_gamut) {
-        GTEST_SKIP_("OpenGLES doesn't support wide gamut golden tests.");
+        GTEST_SKIP() << "OpenGLES doesn't support wide gamut golden tests.";
       }
       FML_CHECK(::glfwInit() == GLFW_TRUE);
       PlaygroundSwitches playground_switches;
@@ -243,9 +243,9 @@ void GoldenPlaygroundTest::SetUp() {
 
   if (std::find(kSkipTests.begin(), kSkipTests.end(), test_name) !=
       kSkipTests.end()) {
-    GTEST_SKIP_(
-        "GoldenPlaygroundTest doesn't support interactive playground tests "
-        "yet.");
+    GTEST_SKIP()
+        << "GoldenPlaygroundTest doesn't support interactive playground tests "
+           "yet.";
   }
 
   testing::GoldenDigest::Instance()->AddDimension(

--- a/impeller/golden_tests/golden_playground_test_stub.cc
+++ b/impeller/golden_tests/golden_playground_test_stub.cc
@@ -20,7 +20,7 @@ void GoldenPlaygroundTest::SetTypographerContext(
 void GoldenPlaygroundTest::TearDown() {}
 
 void GoldenPlaygroundTest::SetUp() {
-  GTEST_SKIP_("GoldenPlaygroundTest doesn't support this backend type.");
+  GTEST_SKIP() << "GoldenPlaygroundTest doesn't support this backend type.";
 }
 
 PlaygroundBackend GoldenPlaygroundTest::GetBackend() const {

--- a/impeller/playground/compute_playground_test.cc
+++ b/impeller/playground/compute_playground_test.cc
@@ -16,12 +16,12 @@ ComputePlaygroundTest::~ComputePlaygroundTest() = default;
 
 void ComputePlaygroundTest::SetUp() {
   if (!Playground::SupportsBackend(GetParam())) {
-    GTEST_SKIP_("Playground doesn't support this backend type.");
+    GTEST_SKIP() << "Playground doesn't support this backend type.";
     return;
   }
 
   if (!Playground::ShouldOpenNewPlaygrounds()) {
-    GTEST_SKIP_("Skipping due to user action.");
+    GTEST_SKIP() << "Skipping due to user action.";
     return;
   }
 

--- a/impeller/playground/playground_test.cc
+++ b/impeller/playground/playground_test.cc
@@ -27,12 +27,12 @@ bool DoesSupportWideGamutTests() {
 
 void PlaygroundTest::SetUp() {
   if (!Playground::SupportsBackend(GetParam())) {
-    GTEST_SKIP_("Playground doesn't support this backend type.");
+    GTEST_SKIP() << "Playground doesn't support this backend type.";
     return;
   }
 
   if (!Playground::ShouldOpenNewPlaygrounds()) {
-    GTEST_SKIP_("Skipping due to user action.");
+    GTEST_SKIP() << "Skipping due to user action.";
     return;
   }
 
@@ -46,7 +46,7 @@ void PlaygroundTest::SetUp() {
 
   if (switches.enable_wide_gamut && (GetParam() != PlaygroundBackend::kMetal ||
                                      !DoesSupportWideGamutTests())) {
-    GTEST_SKIP_("This backend doesn't yet support wide gamut.");
+    GTEST_SKIP() << "This backend doesn't yet support wide gamut.";
     return;
   }
 

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -440,7 +440,7 @@ TEST_P(RendererTest, CanRenderToTexture) {
 
 TEST_P(RendererTest, CanRenderInstanced) {
   if (GetParam() == PlaygroundBackend::kOpenGLES) {
-    GTEST_SKIP_("Instancing is not supported on OpenGL.");
+    GTEST_SKIP() << "Instancing is not supported on OpenGL.";
   }
   using VS = InstancedDrawVertexShader;
   using FS = InstancedDrawFragmentShader;
@@ -1403,8 +1403,8 @@ TEST_P(RendererTest, CanSepiaToneWithSubpasses) {
   ASSERT_TRUE(context);
 
   if (!context->GetCapabilities()->SupportsFramebufferFetch()) {
-    GTEST_SKIP_(
-        "This test uses framebuffer fetch and the backend doesn't support it.");
+    GTEST_SKIP() << "This test uses framebuffer fetch and the backend doesn't "
+                    "support it.";
     return;
   }
 
@@ -1494,8 +1494,8 @@ TEST_P(RendererTest, CanSepiaToneThenSwizzleWithSubpasses) {
   ASSERT_TRUE(context);
 
   if (!context->GetCapabilities()->SupportsFramebufferFetch()) {
-    GTEST_SKIP_(
-        "This test uses framebuffer fetch and the backend doesn't support it.");
+    GTEST_SKIP() << "This test uses framebuffer fetch and the backend doesn't "
+                    "support it.";
     return;
   }
 

--- a/impeller/scene/scene_unittests.cc
+++ b/impeller/scene/scene_unittests.cc
@@ -112,7 +112,7 @@ TEST_P(SceneTest, FlutterLogo) {
 
 TEST_P(SceneTest, TwoTriangles) {
   if (GetBackend() == PlaygroundBackend::kVulkan) {
-    GTEST_SKIP_("Temporarily disabled.");
+    GTEST_SKIP() << "Temporarily disabled.";
   }
   auto allocator = GetContext()->GetResourceAllocator();
 


### PR DESCRIPTION
I admit to using this private macro initially without realizing that the documented way to do this is to use the stream the other macro returns. The non-private variant is actually more powerful since it allows for easier customization of the reason for the skip.

No change in functionality. Just removes the use of the private macros.
