### PR TITLE
[Impeller] Validation logs indicate where in code the validation error happened.

### DIFF
--- a/impeller/base/validation.h
+++ b/impeller/base/validation.h
@@ -11,13 +11,15 @@ namespace impeller {
 
 class ValidationLog {
  public:
-  ValidationLog();
+  ValidationLog(const char* file, int line);
 
   ~ValidationLog();
 
   std::ostream& GetStream();
 
  private:
+  const char* file_ = nullptr;
+  int line_ = 0;
   std::ostringstream stream_;
 
   ValidationLog(const ValidationLog&) = delete;
@@ -29,7 +31,7 @@ class ValidationLog {
   ValidationLog& operator=(ValidationLog&&) = delete;
 };
 
-void ImpellerValidationBreak(const char* message);
+void ImpellerValidationBreak(const char* message, const char* file, int line);
 
 void ImpellerValidationErrorsSetFatal(bool fatal);
 
@@ -70,6 +72,6 @@ struct ScopedValidationFatal {
 ///   are fatal. The runtime-mode restriction still applies. This usually
 ///   happens in test environments.
 ///
-#define VALIDATION_LOG ::impeller::ValidationLog{}.GetStream()
+#define VALIDATION_LOG ::impeller::ValidationLog{__FILE__, __LINE__}.GetStream()
 
 #endif  // FLUTTER_IMPELLER_BASE_VALIDATION_H_


### PR DESCRIPTION
Earlier, all validation logs originated from validation.cc which was not useful at all since you had to find the string in the source.
