### PR TITLE
[Impeller] Validation errors in tests cause GTest failures.

### DIFF
--- a/impeller/base/validation.cc
+++ b/impeller/base/validation.cc
@@ -19,7 +19,7 @@ void ImpellerValidationErrorsSetFatal(bool fatal) {
 }
 
 void ImpellerValidationErrorsSetCallback(ValidationFailureCallback callback) {
-  sValidationFailureCallback = callback;
+  sValidationFailureCallback = std::move(callback);
 }
 
 ScopedValidationDisable::ScopedValidationDisable() {

--- a/impeller/base/validation.cc
+++ b/impeller/base/validation.cc
@@ -12,9 +12,14 @@ namespace impeller {
 
 static std::atomic_int32_t sValidationLogsDisabledCount = 0;
 static std::atomic_int32_t sValidationLogsAreFatal = 0;
+static ValidationFailureCallback sValidationFailureCallback;
 
 void ImpellerValidationErrorsSetFatal(bool fatal) {
   sValidationLogsAreFatal = fatal;
+}
+
+void ImpellerValidationErrorsSetCallback(ValidationFailureCallback callback) {
+  sValidationFailureCallback = callback;
 }
 
 ScopedValidationDisable::ScopedValidationDisable() {
@@ -47,6 +52,10 @@ std::ostream& ValidationLog::GetStream() {
 }
 
 void ImpellerValidationBreak(const char* message, const char* file, int line) {
+  if (sValidationFailureCallback &&
+      sValidationFailureCallback(message, file, line)) {
+    return;
+  }
   const auto severity =
       ImpellerValidationErrorsAreFatal() ? fml::LOG_FATAL : fml::LOG_ERROR;
   auto fml_log = fml::LogMessage{severity, file, line, nullptr};

--- a/impeller/base/validation.h
+++ b/impeller/base/validation.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_IMPELLER_BASE_VALIDATION_H_
 #define FLUTTER_IMPELLER_BASE_VALIDATION_H_
 
+#include <functional>
 #include <sstream>
 
 namespace impeller {
@@ -36,6 +37,21 @@ void ImpellerValidationBreak(const char* message, const char* file, int line);
 void ImpellerValidationErrorsSetFatal(bool fatal);
 
 bool ImpellerValidationErrorsAreFatal();
+
+using ValidationFailureCallback =
+    std::function<bool(const char* message, const char* file, int line)>;
+
+//------------------------------------------------------------------------------
+/// @brief      Sets a callback that callers (usually tests) can set to
+///             intercept validation failures.
+///
+///             Returning true from the callback indicates that Impeller can
+///             continue and avoid any default behavior on tripping validation
+///             (which could include process termination).
+///
+/// @param[in]  callback  The callback
+///
+void ImpellerValidationErrorsSetCallback(ValidationFailureCallback callback);
 
 struct ScopedValidationDisable {
   ScopedValidationDisable();


### PR DESCRIPTION
Earlier, this used to take down the entire process. Now, the entire set of failures will be listed instead.