### PR TITLE
Relax the event assumptions for keydown events.

### DIFF
--- a/lib/web_ui/lib/src/engine/platform_dispatcher/view_focus_binding.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher/view_focus_binding.dart
@@ -69,8 +69,9 @@ final class ViewFocusBinding {
   });
 
   late final DomEventListener _handleKeyDown = createDomEventListener((DomEvent event) {
-    event as DomKeyboardEvent;
-    if (event.shiftKey ?? false) {
+    // The right event type needs to be checked because Chrome seems to be firing `Event` types
+    // when autofilling is used.
+    if (event is DomKeyboardEvent && (event.shiftKey ?? false)) {
       _viewFocusDirection = ui.ViewFocusDirection.backward;
     }
   });


### PR DESCRIPTION
This PR addresses an issue where autocompleting a text field, even without direct keyboard input, unexpectedly triggers keydown events. To resolve this, the code now relaxes the casting assumptions to accommodate a wider range of event types, not just keyboard events.

By just adding the following script to the console, and filling the text field using autocomplete, you can see that indeed the fired event is not of type `KeyboardEvent` but `Event`. 


```javascript
document.body.addEventListener('keydown', console.log)
```

Fixes https://github.com/flutter/flutter/issues/149968

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
