### PR TITLE
[web] Set touch-action:none in embedded views.

### DIFF
--- a/lib/web_ui/lib/src/engine/pointer_binding.dart
+++ b/lib/web_ui/lib/src/engine/pointer_binding.dart
@@ -968,20 +968,6 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
 
   @override
   void setup() {
-    // Prevents the browser auto-canceling pointer events.
-    // Register into `_listener` directly so the event isn't forwarded to semantics.
-    _listeners.add(Listener.register(
-      event: 'touchstart',
-      target: _viewTarget,
-      handler: (DomEvent event) {
-        // This is one of the ways I've seen this done. PixiJS does a similar thing.
-        // ThreeJS seems to subscribe move/leave in the pointerdown handler instead?
-        if (event.cancelable) {
-          event.preventDefault();
-        }
-      },
-    ));
-
     _addPointerEventListener(_viewTarget, 'pointerdown', (DomPointerEvent event) {
       final int device = _getPointerId(event);
       final List<ui.PointerData> pointerData = <ui.PointerData>[];

--- a/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/custom_element_embedding_strategy.dart
+++ b/lib/web_ui/lib/src/engine/view_embedder/embedding_strategy/custom_element_embedding_strategy.dart
@@ -34,7 +34,10 @@ class CustomElementEmbeddingStrategy implements EmbeddingStrategy {
       ..style.height = '100%'
       ..style.display = 'block'
       ..style.overflow = 'hidden'
-      ..style.position = 'relative';
+      ..style.position = 'relative'
+      // This is needed so the browser lets flutter handle all pointer events
+      // it receives, without canceling them.
+      ..style.touchAction = 'none';
 
     hostElement.appendChild(rootElement);
 

--- a/lib/web_ui/test/engine/pointer_binding_test.dart
+++ b/lib/web_ui/test/engine/pointer_binding_test.dart
@@ -305,15 +305,15 @@ void testMain() {
     },
   );
 
-  test('prevents default on touchstart events', () async {
+  test('allows default on touchstart events', () async {
     final event = createDomEvent('Event', 'touchstart');
 
     rootElement.dispatchEvent(event);
 
     expect(
       event.defaultPrevented,
-      isTrue,
-      reason: 'touchstart events should be prevented so pointer events are not cancelled later.',
+      isFalse,
+      reason: 'touchstart events should NOT be prevented. That breaks semantic taps!',
     );
   });
 

--- a/lib/web_ui/test/engine/view_embedder/embedding_strategy/custom_element_embedding_strategy_test.dart
+++ b/lib/web_ui/test/engine/view_embedder/embedding_strategy/custom_element_embedding_strategy_test.dart
@@ -76,6 +76,8 @@ void doTests() {
           reason: 'Should take 100% of the available height');
       expect(styleAfter.overflow, 'hidden',
           reason: 'Should hide the occasional oversized canvas elements.');
+      expect(styleAfter.touchAction, 'none',
+          reason: 'Should disable browser handling of touch events.');
     });
   });
 }


### PR DESCRIPTION
This PR adds `touch-action:none` to `flutter-view` elements, so the browser lets the flutter engine fully handle all touch gestures.

This fix is more delicate than the first approach, which broke some merged taps when accessibility/semantics are enabled. 

## Issues

* Found while testing: https://github.com/flutter/flutter/issues/130950
* "More correct" fix for: https://github.com/flutter/engine/pull/53647

## Demos

* Flutter scroll: https://dit-multiview-scroll.web.app
* Semantics: https://dit-tests.web.app
* Scrollable platform views: https://dit-multiview-tests.web.app

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
