### PR TITLE
[iOS] Delete gen_snapshot_armv7 support

### DIFF
--- a/sky/tools/create_ios_framework.py
+++ b/sky/tools/create_ios_framework.py
@@ -24,7 +24,6 @@ def main():
 
   parser.add_argument('--dst', type=str, required=True)
   parser.add_argument('--arm64-out-dir', type=str, required=True)
-  parser.add_argument('--armv7-out-dir', type=str, required=False)
   # TODO(gw280): Remove --simulator-out-dir alias when all recipes are updated
   parser.add_argument('--simulator-x64-out-dir', '--simulator-out-dir', type=str, required=True)
   parser.add_argument('--simulator-arm64-out-dir', type=str, required=False)

--- a/sky/tools/create_macos_gen_snapshots.py
+++ b/sky/tools/create_macos_gen_snapshots.py
@@ -21,7 +21,6 @@ def main():
   parser.add_argument('--clang-dir', type=str, default='clang_x64')
   parser.add_argument('--x64-out-dir', type=str)
   parser.add_argument('--arm64-out-dir', type=str)
-  parser.add_argument('--armv7-out-dir', type=str)
   parser.add_argument('--zip', action='store_true', default=False)
 
   args = parser.parse_args()
@@ -48,14 +47,6 @@ def main():
         os.path.join(arm64_out_dir, args.clang_dir), os.path.join(dst, 'gen_snapshot_arm64')
     )
 
-  if args.armv7_out_dir:
-    armv7_out_dir = (
-        args.armv7_out_dir
-        if os.path.isabs(args.armv7_out_dir) else os.path.join(buildroot_dir, args.armv7_out_dir)
-    )
-    generate_gen_snapshot(
-        os.path.join(armv7_out_dir, args.clang_dir), os.path.join(dst, 'gen_snapshot_armv7')
-    )
   if args.zip:
     zip_archive(dst)
 


### PR DESCRIPTION
We dropped support for armv7 iOS devices in:
* Framework: flutter/flutter#97342.
* Buildroot: flutter/buildroot#569
* Engine: https://github.com/flutter/engine/pull/32664
* Recipes:
  * https://flutter-review.googlesource.com/c/recipes/+/29060
  * https://flutter-review.googlesource.com/c/recipes/+/29060 (revert)
  * https://flutter-review.googlesource.com/c/recipes/+/29582 (reland)
* Issue: flutter/flutter#97345

This eliminates the code (and an unused flag) to deal with producing zip archives including components for the armv7 architecture.


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I just resurfaced from an archaeological dig through our repo history, and I didn't like what I found.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
