### PR TITLE
[macOS] Eliminate archive_gen_snapshot target

### DIFF
--- a/build/archives/BUILD.gn
+++ b/build/archives/BUILD.gn
@@ -272,23 +272,7 @@ if (host_os == "win") {
   }
 }
 
-# Archives Flutter Mac Artifacts
 if (is_mac) {
-  zip_bundle("archive_gen_snapshot") {
-    deps = [ "//flutter/lib/snapshot:create_macos_gen_snapshots" ]
-    suffix = "-$flutter_runtime_mode"
-    if (flutter_runtime_mode == "debug") {
-      suffix = ""
-    }
-    output = "$full_platform_name$suffix/gen_snapshot.zip"
-    files = [
-      {
-        source = "${root_out_dir}/gen_snapshot_${target_cpu}"
-        destination = "gen_snapshot_${target_cpu}"
-      },
-    ]
-  }
-
   group("flutter_embedder_framework") {
     deps = [
       "//flutter/shell/platform/embedder:flutter_embedder_framework_archive",

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -42,11 +42,11 @@
             "ninja": {
                 "config": "ci/host_debug",
                 "targets": [
-                    "flutter/build/archives:archive_gen_snapshot",
                     "flutter/build/archives:artifacts",
                     "flutter/build/archives:dart_sdk_archive",
                     "flutter/build/archives:flutter_embedder_framework",
                     "flutter/build/dart:copy_dart_sdk",
+                    "flutter/lib/snapshot:create_macos_gen_snapshots",
                     "flutter/shell/platform/darwin/macos:zip_macos_flutter_framework",
                     "flutter/tools/font_subset",
                     "flutter:unittests"
@@ -127,8 +127,8 @@
                 "config": "ci/host_profile",
                 "targets": [
                     "flutter/build/dart:copy_dart_sdk",
-                    "flutter/build/archives:archive_gen_snapshot",
                     "flutter/build/archives:artifacts",
+                    "flutter/lib/snapshot:create_macos_gen_snapshots",
                     "flutter/shell/platform/darwin/macos:zip_macos_flutter_framework",
                     "flutter:unittests"
                 ]
@@ -214,9 +214,9 @@
             "ninja": {
                 "config": "ci/host_release",
                 "targets": [
-                    "flutter/build/archives:archive_gen_snapshot",
                     "flutter/build/archives:artifacts",
                     "flutter/build/dart:copy_dart_sdk",
+                    "flutter/lib/snapshot:create_macos_gen_snapshots",
                     "flutter/shell/platform/darwin/macos:zip_macos_flutter_framework",
                     "flutter/tools/font_subset",
                     "flutter:unittests"
@@ -298,10 +298,10 @@
                 "config": "ci/mac_debug_arm64",
                 "targets": [
                     "flutter/tools/font_subset",
-                    "flutter/build/archives:archive_gen_snapshot",
                     "flutter/build/archives:artifacts",
                     "flutter/build/archives:dart_sdk_archive",
                     "flutter/build/archives:flutter_embedder_framework",
+                    "flutter/lib/snapshot:create_macos_gen_snapshots",
                     "flutter/shell/platform/darwin/macos:zip_macos_flutter_framework"
                 ]
             },
@@ -442,10 +442,10 @@
                 "config": "ci/mac_release_arm64",
                 "targets": [
                     "flutter:unittests",
-                    "flutter/build/archives:archive_gen_snapshot",
                     "flutter/build/archives:artifacts",
                     "flutter/build/dart:copy_dart_sdk",
                     "flutter/impeller/golden_tests:impeller_golden_tests",
+                    "flutter/lib/snapshot:create_macos_gen_snapshots",
                     "flutter/shell/platform/darwin/macos:zip_macos_flutter_framework",
                     "flutter/tools/font_subset"
                 ]


### PR DESCRIPTION
This target produced an unused zipfile named `gen_snapshot.zip` containing the `gen_snapshot_${target_arch}` binary for the current build's target architecture.

The macOS recipe JSON produces the real `gen_snapshot.zip` that gets uploaded to the cloud bucket and pulled down by the tool. See: https://github.com/flutter/engine/blob/e5215e6854bc61cf8d5bae48715d73293bc1f91c/ci/builders/mac_host_engine.json#L555-L592

The recipe did, however, rely on the `archive_gen_snapshot` rule to ensure that the underlying `gen_snapshot` targets were actually built. See, for example:
https://github.com/flutter/engine/blob/e5215e6854bc61cf8d5bae48715d73293bc1f91c/ci/builders/mac_host_engine.json#L45

A few benefits:
* Eliminates an unnecessary zip operation.
* Eliminates confusion from grepping for gen_snapshot.zip and finding the wrong location in the source.
* Grepping for create_macos_gen_snapshots will turn up the usage in the JSON build file.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I was thoroughly confused by the fact that my changes to the contents of gen_snapshot.zip weren't showing up in the cloud bucket or tool.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
