### PR TITLE
Clean up create_macos_gen_snapshots.py options

### DIFF
--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -557,10 +557,10 @@
                 "parameters": [
                     "--dst",
                     "out/debug/snapshot",
-                    "--arm64-out-dir",
-                    "out/ci/mac_debug_arm64",
-                    "--x64-out-dir",
-                    "out/ci/host_debug",
+                    "--arm64-path",
+                    "out/ci/mac_debug_arm64/clang_x64/gen_snapshot",
+                    "--x64-path",
+                    "out/ci/host_debug/gen_snapshot",
                     "--zip"
                 ],
                 "script": "flutter/sky/tools/create_macos_gen_snapshots.py"
@@ -570,10 +570,10 @@
                 "parameters": [
                     "--dst",
                     "out/profile/snapshot",
-                    "--arm64-out-dir",
-                    "out/ci/mac_profile_arm64",
-                    "--x64-out-dir",
-                    "out/ci/host_profile",
+                    "--arm64-path",
+                    "out/ci/mac_profile_arm64/clang_x64/gen_snapshot",
+                    "--x64-path",
+                    "out/ci/host_profile/gen_snapshot",
                     "--zip"
                 ],
                 "script": "flutter/sky/tools/create_macos_gen_snapshots.py"
@@ -583,10 +583,10 @@
                 "parameters": [
                     "--dst",
                     "out/release/snapshot",
-                    "--arm64-out-dir",
-                    "out/ci/mac_release_arm64",
-                    "--x64-out-dir",
-                    "out/ci/host_release",
+                    "--arm64-path",
+                    "out/ci/mac_release_arm64/clang_x64/gen_snapshot",
+                    "--x64-path",
+                    "out/ci/host_release/gen_snapshot",
                     "--zip"
                 ],
                 "script": "flutter/sky/tools/create_macos_gen_snapshots.py"

--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -519,8 +519,8 @@
                 "parameters": [
                     "--dst",
                     "out/release",
-                    "--arm64-out-dir",
-                    "out/ci/ios_release"
+                    "--arm64-path",
+                    "out/ci/ios_release/clang_x64/gen_snapshot"
                 ],
                 "script": "flutter/sky/tools/create_macos_gen_snapshots.py",
                 "language": "python3"

--- a/sky/tools/create_macos_gen_snapshots.py
+++ b/sky/tools/create_macos_gen_snapshots.py
@@ -18,9 +18,8 @@ def main():
   )
 
   parser.add_argument('--dst', type=str, required=True)
-  parser.add_argument('--clang-dir', type=str, default='clang_x64')
-  parser.add_argument('--x64-out-dir', type=str)
-  parser.add_argument('--arm64-out-dir', type=str)
+  parser.add_argument('--x64-path', type=str)
+  parser.add_argument('--arm64-path', type=str)
   parser.add_argument('--zip', action='store_true', default=False)
 
   args = parser.parse_args()
@@ -31,21 +30,17 @@ def main():
   if not os.path.exists(dst):
     os.makedirs(dst)
 
-  if args.x64_out_dir:
-    x64_out_dir = (
-        args.x64_out_dir
-        if os.path.isabs(args.x64_out_dir) else os.path.join(buildroot_dir, args.x64_out_dir)
-    )
-    generate_gen_snapshot(x64_out_dir, os.path.join(dst, 'gen_snapshot_x64'))
+  if args.x64_path:
+    x64_path = args.x64_path
+    if not os.path.isabs(args.x64_path):
+      x64_path = os.path.join(buildroot_dir, args.x64_path)
+    generate_gen_snapshot(x64_path, os.path.join(dst, 'gen_snapshot_x64'))
 
-  if args.arm64_out_dir:
-    arm64_out_dir = (
-        args.arm64_out_dir
-        if os.path.isabs(args.arm64_out_dir) else os.path.join(buildroot_dir, args.arm64_out_dir)
-    )
-    generate_gen_snapshot(
-        os.path.join(arm64_out_dir, args.clang_dir), os.path.join(dst, 'gen_snapshot_arm64')
-    )
+  if args.arm64_path:
+    arm64_path = args.arm64_path
+    if not os.path.isabs(args.arm64_path):
+      arm64_path = os.path.join(buildroot_dir, args.arm64_path)
+    generate_gen_snapshot(arm64_path, os.path.join(dst, 'gen_snapshot_arm64'))
 
   if args.zip:
     zip_archive(dst)
@@ -69,13 +64,12 @@ def zip_archive(dst):
   ], cwd=dst)
 
 
-def generate_gen_snapshot(directory, destination):
-  gen_snapshot_dir = os.path.join(directory, 'gen_snapshot')
-  if not os.path.isfile(gen_snapshot_dir):
-    print('Cannot find gen_snapshot at %s' % gen_snapshot_dir)
+def generate_gen_snapshot(gen_snapshot_path, destination):
+  if not os.path.isfile(gen_snapshot_path):
+    print('Cannot find gen_snapshot at %s' % gen_snapshot_path)
     sys.exit(1)
 
-  subprocess.check_call(['xcrun', 'bitcode_strip', '-r', gen_snapshot_dir, '-o', destination])
+  subprocess.check_call(['xcrun', 'bitcode_strip', '-r', gen_snapshot_path, '-o', destination])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This patch updates `create_macos_gen_snapshots.py` to take the path to the input `gen_snapshot` binaries rather than just the path to the buildroot, and hardcoding the binary names and buildroot-relative paths internally.

This has a couple advantages:
* Those grepping the source for gen_snapshot to see where it's bundled will immediately find it in the recipe JSON as a parameter to this script.
* In future (the next patch I send out) we can pass different input paths that point to gen_snapshot binaries that are universal binaries. The current binaries are single-architecture x64 host binaries.

This is a refactoring with no semantic change, therefore no tests have changed.

Background
----------

`create_macos_gen_snapshot.py` is used to:
* Generate a named copy of gen_snapshot for the specified target architecture: e.g. gen_snapshot_arm64, gen_snapshot_x64
* Strip bitcode, if present. Today, bitcode is no longer enabled by default.
* Create a zip archive containing the (two) gen_snapshot binaries and bundle with an entitlements.txt file.

Issue: https://github.com/flutter/flutter/issues/151848

This is refactoring to support:
Issue: https://github.com/flutter/flutter/issues/101138
Issue: https://github.com/flutter/flutter/issues/69157

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I've dealt with this script more than any one person should ever have to deal with such a thing in one lifetime.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
