### PR TITLE
[macOS] Archive universal gen_snapshot binaries

### DIFF
--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -558,9 +558,9 @@
                     "--dst",
                     "out/debug/snapshot",
                     "--arm64-path",
-                    "out/ci/mac_debug_arm64/clang_x64/gen_snapshot",
+                    "out/ci/mac_debug_arm64/gen_snapshot_arm64",
                     "--x64-path",
-                    "out/ci/host_debug/gen_snapshot",
+                    "out/ci/host_debug/gen_snapshot_x64",
                     "--zip"
                 ],
                 "script": "flutter/sky/tools/create_macos_gen_snapshots.py"
@@ -571,9 +571,9 @@
                     "--dst",
                     "out/profile/snapshot",
                     "--arm64-path",
-                    "out/ci/mac_profile_arm64/clang_x64/gen_snapshot",
+                    "out/ci/mac_profile_arm64/gen_snapshot_arm64",
                     "--x64-path",
-                    "out/ci/host_profile/gen_snapshot",
+                    "out/ci/host_profile/gen_snapshot_x64",
                     "--zip"
                 ],
                 "script": "flutter/sky/tools/create_macos_gen_snapshots.py"
@@ -584,9 +584,9 @@
                     "--dst",
                     "out/release/snapshot",
                     "--arm64-path",
-                    "out/ci/mac_release_arm64/clang_x64/gen_snapshot",
+                    "out/ci/mac_release_arm64/gen_snapshot_arm64",
                     "--x64-path",
-                    "out/ci/host_release/gen_snapshot",
+                    "out/ci/host_release/gen_snapshot_x64",
                     "--zip"
                 ],
                 "script": "flutter/sky/tools/create_macos_gen_snapshots.py"

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -368,6 +368,7 @@
                 "config": "ci/mac_profile_arm64",
                 "targets": [
                     "flutter/build/archives:artifacts",
+                    "flutter/lib/snapshot:create_macos_gen_snapshots",
                     "flutter/shell/platform/darwin/macos:zip_macos_flutter_framework"
                 ]
             },


### PR DESCRIPTION
In #53524, we started producing universal `gen_snapshot_arm64` and `gen_snapshot_x64` binaries. This migrates away from bundling `gen_snapshot` binaries with x64-only host architecture to universal binaries that bundle both x64 and arm64 host architectures.

Also adds a dependency on `flutter/lib/snapshot:create_macos_gen_snapshots` to the profile build, where it was previously missing. Presumably, `gen_snapshot` was being built as a side-effect of one of the other targets.

Issue: https://github.com/flutter/flutter/issues/101138
Issue: https://github.com/flutter/flutter/issues/69157

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I have looked into the abyss of our archive generation tooling, and have developed deep sense of dread.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
