### PR TITLE
Suggest a few common vscode extensions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ tags
 Thumbs.db
 .idea
 pubspec.lock
-.vscode/
 docs/doxygen/
 xcuserdata
 
@@ -49,7 +48,6 @@ xcuserdata
 .classpath
 .project
 .settings/
-.vscode/
 
 # packages file containing multi-root paths
 .packages.generated

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,17 @@
+{
+  "recommendations": [
+    // Uses github-styled markdown preview, which supports more features than the default markdown preview.
+    "bierner.github-markdown-preview",
+
+    // Flutter and Dart extensions.
+    "Dart-Code.dart-code",
+
+    // Supports C/C++ in the engine.
+    // See https://github.com/flutter/engine/blob/main/docs/contributing/Setting-up-the-Engine-development-environment.md#vscode-with-cc-intellisense-cc
+    "llvm-vs-code-extensions.vscode-clangd",
+
+    // Auto-formats C/C++ code.
+    // https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#cc
+    "xaver.clang-format",
+  ]
+}

--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -17,6 +17,7 @@
 ../../../flutter/.github
 ../../../flutter/.gitignore
 ../../../flutter/.style.yapf
+../../../flutter/.vscode
 ../../../flutter/AUTHORS
 ../../../flutter/CODEOWNERS
 ../../../flutter/CONTRIBUTING.md

--- a/tools/clang_tidy/test/header_filter_regex_test.dart
+++ b/tools/clang_tidy/test/header_filter_regex_test.dart
@@ -38,6 +38,7 @@ void main() {
     const Set<String> intentionallyOmitted = <String>{
       '.git',
       '.github',
+      '.vscode',
       'build_overrides',
       'buildtools',
       'prebuilts',

--- a/tools/clang_tidy/test/header_filter_regex_test.dart
+++ b/tools/clang_tidy/test/header_filter_regex_test.dart
@@ -36,6 +36,7 @@ void main() {
   test('contains every root directory in the regex', () {
     // These are a list of directories that should _not_ be included.
     const Set<String> intentionallyOmitted = <String>{
+      '.dart_tool',
       '.git',
       '.github',
       '.vscode',


### PR DESCRIPTION
For example, without the markdown preview, files in `docs/**/*.md` don't all render.