### PR TITLE
Gracefully fail when `gn desc` returns no targets.

### DIFF
--- a/tools/engine_tool/lib/src/commands/query_command.dart
+++ b/tools/engine_tool/lib/src/commands/query_command.dart
@@ -221,7 +221,8 @@ et query targets //flutter/fml/...  # List all targets under `//flutter/fml`
     }
 
     if (allTargets.isEmpty) {
-      environment.logger.fatal('Query unexpectedly returned an empty list');
+      environment.logger.error('No targets found, nothing to query.');
+      return 1;
     }
 
     for (final BuildTarget target in allTargets) {

--- a/tools/engine_tool/lib/src/commands/test_command.dart
+++ b/tools/engine_tool/lib/src/commands/test_command.dart
@@ -86,6 +86,11 @@ et test //flutter/fml:fml_benchmarks  # Run a single test target in `//flutter/f
       buildTargets.addAll(found);
     }
 
+    if (buildTargets.isEmpty) {
+      environment.logger.error('No targets found, nothing to test.');
+      return 1;
+    }
+
     // Make sure there is at least one test target.
     final List<ExecutableBuildTarget> testTargets = buildTargets
         .whereType<ExecutableBuildTarget>()

--- a/tools/engine_tool/lib/src/gn.dart
+++ b/tools/engine_tool/lib/src/gn.dart
@@ -55,6 +55,26 @@ interface class Gn {
       failOk: true,
     );
     if (process.exitCode != 0) {
+      // If the error was in the format:
+      // "The input testing/scenario_app:scenario_app matches no targets, configs or files."
+      //
+      // Then report a nicer error, versus a fatal error.
+      final stdout = process.stdout;
+      if (stdout.contains('matches no targets, configs or files')) {
+        final gnPattern = pattern.toGnPattern();
+        if (!gnPattern.startsWith('//flutter')) {
+          _environment.logger.warning(
+            'No targets matched the pattern `$gnPattern`.'
+            'Did you mean `//flutter/$gnPattern`?',
+          );
+        } else {
+          _environment.logger.warning(
+            'No targets matched the pattern `${pattern.toGnPattern()}`',
+          );
+        }
+        return <BuildTarget>[];
+      }
+
       _environment.logger.fatal(
         'Failed to run `${command.join(' ')}` (exit code ${process.exitCode})'
         '\n\n'

--- a/tools/engine_tool/test/fixtures.dart
+++ b/tools/engine_tool/test/fixtures.dart
@@ -319,3 +319,7 @@ String gnDescOutput() => '''
    }
 }
 ''';
+
+String gnDescOutputEmpty({required String gnPattern}) => '''
+The input $gnPattern matches no targets, configs or files.
+''';


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/151990.

This is just a nice QOL change, since the `//` format we're using is not "native" to GN or Ninja.