### PR TITLE
Upgrade third_party/pyyaml to 03c67afd452cdff45b41bfe65e19a2fb5b80a0e8

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -666,7 +666,7 @@ deps = {
    Var('flutter_git') + '/third_party/sqlite' + '@' + '0f61bd2023ba94423b4e4c8cfb1a23de1fe6a21c',
 
   'src/flutter/third_party/pyyaml':
-   Var('flutter_git') + '/third_party/pyyaml.git' + '@' + '25e97546488eee166b1abb229a27856cecd8b7ac',
+   Var('flutter_git') + '/third_party/pyyaml.git' + '@' + '03c67afd452cdff45b41bfe65e19a2fb5b80a0e8',
 
    'src/flutter/third_party/swiftshader':
    Var('swiftshader_git') + '/SwiftShader.git' + '@' + '2fa7e9b99ae4e70ea5ae2cc9c8d3afb43391384f',

--- a/tools/fuchsia/dart/gen_dart_package_config.py
+++ b/tools/fuchsia/dart/gen_dart_package_config.py
@@ -15,7 +15,7 @@ import re
 import sys
 
 THIS_DIR = os.path.abspath(os.path.dirname(__file__))
-sys.path += [os.path.join(THIS_DIR, '..', '..', '..', 'third_party', 'pyyaml', 'lib3')]
+sys.path += [os.path.join(THIS_DIR, '..', '..', '..', 'third_party', 'pyyaml', 'lib')]
 import yaml
 
 DEFAULT_LANGUAGE_VERSION = '2.8'

--- a/tools/pub_get_offline.py
+++ b/tools/pub_get_offline.py
@@ -15,7 +15,7 @@ import subprocess
 import sys
 
 THIS_DIR = os.path.abspath(os.path.dirname(__file__))
-sys.path += [os.path.join(THIS_DIR, '..', 'third_party', 'pyyaml', 'lib3')]
+sys.path += [os.path.join(THIS_DIR, '..', 'third_party', 'pyyaml', 'lib')]
 import yaml  # pylint: disable=import-error, wrong-import-position
 
 SRC_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))


### PR DESCRIPTION
We were using a very old version of this library that broke with Python3.12. This updates to a Python 3.12 compatible SHA.

The specific breakage at the former commit was that `collections.Hashable` was deprecated and moved to `collections.abc.Hashable` in Python 3.7. It was removed in Python 3.8. For anyone on newer versions of Python3, such as Python 3.9.6 which ships with macOS 15 Sequoia, this is broken.

The error on versions of Python newer than 3.8 is:
```
________ running 'python3 src/flutter/tools/pub_get_offline.py' in '/Users/chris/Developer/flutter/engine'
Traceback (most recent call last):
  File "/Users/chris/Developer/flutter/engine/src/flutter/tools/pub_get_offline.py", line 167, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/chris/Developer/flutter/engine/src/flutter/tools/pub_get_offline.py", line 157, in main
    if not package_uses_workspace_resolution(package):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chris/Developer/flutter/engine/src/flutter/tools/pub_get_offline.py", line 76, in package_uses_workspace_resolution
    return yaml.safe_load(pubspec_file).get('resolution') == 'workspace'
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chris/Developer/flutter/engine/src/flutter/tools/../third_party/pyyaml/lib3/yaml/__init__.py", line 75, in load
    return loader.get_single_data()
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chris/Developer/flutter/engine/src/flutter/tools/../third_party/pyyaml/lib3/yaml/constructor.py", line 37, in get_single_data
    return self.construct_document(node)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chris/Developer/flutter/engine/src/flutter/tools/../third_party/pyyaml/lib3/yaml/constructor.py", line 46, in construct_document
    for dummy in generator:
  File "/Users/chris/Developer/flutter/engine/src/flutter/tools/../third_party/pyyaml/lib3/yaml/constructor.py", line 398, in construct_yaml_map
    value = self.construct_mapping(node)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chris/Developer/flutter/engine/src/flutter/tools/../third_party/pyyaml/lib3/yaml/constructor.py", line 204, in construct_mapping
    return super().construct_mapping(node, deep=deep)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chris/Developer/flutter/engine/src/flutter/tools/../third_party/pyyaml/lib3/yaml/constructor.py", line 126, in construct_mapping
    if not isinstance(key, collections.Hashable):
                           ^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'collections' has no attribute 'Hashable'
Error: Command 'python3 src/flutter/tools/pub_get_offline.py' returned non-zero exit status 1 in /Users/chris/Developer/flutter/engine
```


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
