### PR TITLE
[et] Plumb -j to ninja

### DIFF
--- a/tools/engine_tool/lib/src/build_utils.dart
+++ b/tools/engine_tool/lib/src/build_utils.dart
@@ -126,6 +126,7 @@ Future<int> runBuild(
   required bool enableRbe,
   List<String> extraGnArgs = const <String>[],
   List<Label> targets = const <Label>[],
+  int concurrency = 0,
 }) async {
   final List<String> gnArgs = <String>[
     if (!enableRbe) '--no-rbe',
@@ -139,6 +140,7 @@ Future<int> runBuild(
     abi: environment.abi,
     engineSrcDir: environment.engine.srcDir,
     build: build,
+    concurrency: concurrency,
     extraGnArgs: gnArgs,
     runTests: false,
     extraNinjaArgs: <String>[

--- a/tools/engine_tool/lib/src/commands/command.dart
+++ b/tools/engine_tool/lib/src/commands/command.dart
@@ -53,3 +53,13 @@ void addConfigOption(
     },
   );
 }
+
+/// Adds the -j option to the parser.
+void addConcurrencyOption(ArgParser parser) {
+  parser.addOption(
+    concurrencyFlag,
+    abbr: 'j',
+    defaultsTo: '0',
+    help: 'Specify the concurrency level to use for the ninja build.',
+  );
+}

--- a/tools/engine_tool/lib/src/commands/flags.dart
+++ b/tools/engine_tool/lib/src/commands/flags.dart
@@ -13,6 +13,7 @@
 // Keep this list alphabetized.
 const String allFlag = 'all';
 const String builderFlag = 'builder';
+const String concurrencyFlag = 'concurrency';
 const String configFlag = 'config';
 const String dryRunFlag = 'dry-run';
 const String ltoFlag = 'lto';

--- a/tools/engine_tool/lib/src/commands/test_command.dart
+++ b/tools/engine_tool/lib/src/commands/test_command.dart
@@ -31,6 +31,7 @@ final class TestCommand extends CommandBase {
       argParser,
       builds,
     );
+    addConcurrencyOption(argParser);
     argParser.addFlag(
       rbeFlag,
       defaultsTo: environment.hasRbeConfigInTree(),
@@ -65,6 +66,13 @@ et test //flutter/fml:fml_benchmarks  # Run a single test target in `//flutter/f
         builds.where((Build build) => build.name == demangledName).firstOrNull;
     if (build == null) {
       environment.logger.error('Could not find config $configName');
+      return 1;
+    }
+
+    final String dashJ = argResults![concurrencyFlag] as String;
+    final int? concurrency = int.tryParse(dashJ);
+    if (concurrency == null || concurrency < 0) {
+      environment.logger.error('-j must specify a positive integer.');
       return 1;
     }
 
@@ -104,6 +112,7 @@ et test //flutter/fml:fml_benchmarks  # Run a single test target in `//flutter/f
     final int buildExitCode = await runBuild(
       environment,
       build,
+      concurrency: concurrency,
       targets: testTargets.map((BuildTarget target) => target.label).toList(),
       enableRbe: useRbe,
     );

--- a/tools/engine_tool/test/build_command_test.dart
+++ b/tools/engine_tool/test/build_command_test.dart
@@ -177,6 +177,33 @@ void main() {
     }
   });
 
+  test('build command plumbs -j to ninja', () async {
+    final TestEnvironment testEnv = TestEnvironment.withTestEngine(
+      withRbe: true,
+      cannedProcesses: cannedProcesses,
+    );
+    try {
+      final ToolCommandRunner runner = ToolCommandRunner(
+        environment: testEnv.environment,
+        configs: configs,
+      );
+      final int result = await runner.run(<String>[
+        'build',
+        '--config',
+        'ci/android_debug_rbe_arm64',
+        '-j',
+        '500',
+      ]);
+      expect(result, equals(0));
+      expect(testEnv.processHistory[0].command[0],
+          contains(path.join('tools', 'gn')));
+      expect(testEnv.processHistory[0].command[2], equals('--rbe'));
+      expect(testEnv.processHistory[2].command.contains('500'), isTrue);
+    } finally {
+      testEnv.cleanup();
+    }
+  });
+
   test('build command fails when rbe is enabled but not supported', () async {
     final TestEnvironment testEnv = TestEnvironment.withTestEngine(
       cannedProcesses: cannedProcesses,

--- a/tools/engine_tool/test/run_command_test.dart
+++ b/tools/engine_tool/test/run_command_test.dart
@@ -64,7 +64,9 @@ void main() {
         platform: FakePlatform(
             operatingSystem: Platform.linux,
             resolvedExecutable: io.Platform.resolvedExecutable,
-            pathSeparator: '/'),
+            pathSeparator: '/',
+            numberOfProcessors: 32,
+        ),
         processRunner: ProcessRunner(
           processManager: FakeProcessManager(onStart: (List<String> command) {
             runHistory.add(command);

--- a/tools/engine_tool/test/utils.dart
+++ b/tools/engine_tool/test/utils.dart
@@ -67,7 +67,9 @@ class TestEnvironment {
       platform: FakePlatform(
           operatingSystem: _operatingSystemForAbi(abi),
           resolvedExecutable: io.Platform.resolvedExecutable,
-          pathSeparator: _pathSeparatorForAbi(abi)),
+          pathSeparator: _pathSeparatorForAbi(abi),
+          numberOfProcessors: 32,
+      ),
       processRunner: ProcessRunner(
           processManager: FakeProcessManager(onStart: (List<String> command) {
         final FakeProcess processResult =

--- a/tools/pkg/engine_build_configs/test/build_config_runner_test.dart
+++ b/tools/pkg/engine_build_configs/test/build_config_runner_test.dart
@@ -36,7 +36,10 @@ void main() {
   test('BuildTaskRunner runs the right commands', () async {
     final BuildTask generator = buildConfig.builds[0].generators[0];
     final BuildTaskRunner taskRunner = BuildTaskRunner(
-      platform: FakePlatform(operatingSystem: Platform.linux),
+      platform: FakePlatform(
+        operatingSystem: Platform.linux,
+        numberOfProcessors: 32,
+      ),
       processRunner: ProcessRunner(
         // dryRun should not try to spawn any processes.
         processManager: _fakeProcessManager(),
@@ -63,7 +66,10 @@ void main() {
   test('BuildTestRunner runs the right commands', () async {
     final BuildTest test = buildConfig.builds[0].tests[0];
     final BuildTestRunner testRunner = BuildTestRunner(
-      platform: FakePlatform(operatingSystem: Platform.linux),
+      platform: FakePlatform(
+        operatingSystem: Platform.linux,
+        numberOfProcessors: 32,
+      ),
       processRunner: ProcessRunner(
         // dryRun should not try to spawn any processes.
         processManager: _fakeProcessManager(),
@@ -92,7 +98,10 @@ void main() {
   test('GlobalBuildRunner runs the right commands', () async {
     final Build targetBuild = buildConfig.builds[0];
     final BuildRunner buildRunner = BuildRunner(
-      platform: FakePlatform(operatingSystem: Platform.linux),
+      platform: FakePlatform(
+        operatingSystem: Platform.linux,
+        numberOfProcessors: 32,
+      ),
       processRunner: ProcessRunner(
         // dryRun should not try to spawn any processes.
         processManager: _fakeProcessManager(),
@@ -155,7 +164,10 @@ void main() {
   test('GlobalBuildRunner extra args are propagated correctly', () async {
     final Build targetBuild = buildConfig.builds[0];
     final BuildRunner buildRunner = BuildRunner(
-      platform: FakePlatform(operatingSystem: Platform.linux),
+      platform: FakePlatform(
+        operatingSystem: Platform.linux,
+        numberOfProcessors: 32,
+      ),
       processRunner: ProcessRunner(
         // dryRun should not try to spawn any processes.
         processManager: _fakeProcessManager(),
@@ -195,7 +207,10 @@ void main() {
   test('GlobalBuildRunner passes large -j for an rbe build', () async {
     final Build targetBuild = buildConfig.builds[0];
     final BuildRunner buildRunner = BuildRunner(
-      platform: FakePlatform(operatingSystem: Platform.linux),
+      platform: FakePlatform(
+        operatingSystem: Platform.linux,
+        numberOfProcessors: 32,
+      ),
       processRunner: ProcessRunner(
         processManager: _fakeProcessManager(),
       ),
@@ -223,7 +238,7 @@ void main() {
     expect(events[4] is RunnerStart, isTrue);
     expect(events[4].name, equals('$buildName: ninja'));
     expect(events[4].command.contains('-j'), isTrue);
-    expect(events[4].command.contains('200'), isTrue);
+    expect(events[4].command.contains('1000'), isTrue);
     expect(events[5] is RunnerResult, isTrue);
     expect(events[5].name, equals('$buildName: ninja'));
 
@@ -234,10 +249,81 @@ void main() {
     expect((events[7] as RunnerResult).okMessage, equals('OK'));
   });
 
+  test('GlobalBuildRunner passes the specified -j when explicitly provided in an RBE build', () async {
+    final Build targetBuild = buildConfig.builds[0];
+    final BuildRunner buildRunner = BuildRunner(
+      platform: FakePlatform(
+        operatingSystem: Platform.linux,
+        numberOfProcessors: 32,
+      ),
+      processRunner: ProcessRunner(
+        processManager: _fakeProcessManager(),
+      ),
+      abi: ffi.Abi.linuxX64,
+      engineSrcDir: engine.srcDir,
+      build: targetBuild,
+      concurrency: 500,
+      extraGnArgs: <String>['--rbe'],
+      dryRun: true,
+    );
+    final List<RunnerEvent> events = <RunnerEvent>[];
+    void handler(RunnerEvent event) => events.add(event);
+    final bool runResult = await buildRunner.run(handler);
+
+    final String buildName = targetBuild.name;
+
+    expect(runResult, isTrue);
+
+    // Check that the events for the Ninja command are correct.
+    expect(events[4] is RunnerStart, isTrue);
+    expect(events[4].name, equals('$buildName: ninja'));
+    expect(events[4].command.contains('-j'), isTrue);
+    expect(events[4].command.contains('500'), isTrue);
+    expect(events[5] is RunnerResult, isTrue);
+    expect(events[5].name, equals('$buildName: ninja'));
+  });
+
+  test('GlobalBuildRunner passes the specified -j when explicitly provided in a non-RBE build', () async {
+    final Build targetBuild = buildConfig.builds[0];
+    final BuildRunner buildRunner = BuildRunner(
+      platform: FakePlatform(
+        operatingSystem: Platform.linux,
+        numberOfProcessors: 32,
+      ),
+      processRunner: ProcessRunner(
+        processManager: _fakeProcessManager(),
+      ),
+      abi: ffi.Abi.linuxX64,
+      engineSrcDir: engine.srcDir,
+      build: targetBuild,
+      concurrency: 500,
+      extraGnArgs: <String>['--no-rbe'],
+      dryRun: true,
+    );
+    final List<RunnerEvent> events = <RunnerEvent>[];
+    void handler(RunnerEvent event) => events.add(event);
+    final bool runResult = await buildRunner.run(handler);
+
+    final String buildName = targetBuild.name;
+
+    expect(runResult, isTrue);
+
+    // Check that the events for the Ninja command are correct.
+    expect(events[2] is RunnerStart, isTrue);
+    expect(events[2].name, equals('$buildName: ninja'));
+    expect(events[2].command.contains('-j'), isTrue);
+    expect(events[2].command.contains('500'), isTrue);
+    expect(events[3] is RunnerResult, isTrue);
+    expect(events[3].name, equals('$buildName: ninja'));
+  });
+
   test('GlobalBuildRunner skips GN when runGn is false', () async {
     final Build targetBuild = buildConfig.builds[0];
     final BuildRunner buildRunner = BuildRunner(
-      platform: FakePlatform(operatingSystem: Platform.linux),
+      platform: FakePlatform(
+        operatingSystem: Platform.linux,
+        numberOfProcessors: 32,
+      ),
       processRunner: ProcessRunner(
         // dryRun should not try to spawn any processes.
         processManager: _fakeProcessManager(),
@@ -273,7 +359,10 @@ void main() {
   test('GlobalBuildRunner skips Ninja when runNinja is false', () async {
     final Build targetBuild = buildConfig.builds[0];
     final BuildRunner buildRunner = BuildRunner(
-      platform: FakePlatform(operatingSystem: Platform.linux),
+      platform: FakePlatform(
+        operatingSystem: Platform.linux,
+        numberOfProcessors: 32,
+      ),
       processRunner: ProcessRunner(
         // dryRun should not try to spawn any processes.
         processManager: _fakeProcessManager(),
@@ -316,7 +405,10 @@ void main() {
       () async {
     final Build targetBuild = buildConfig.builds[0];
     final BuildRunner buildRunner = BuildRunner(
-      platform: FakePlatform(operatingSystem: Platform.linux),
+      platform: FakePlatform(
+        operatingSystem: Platform.linux,
+        numberOfProcessors: 32,
+      ),
       processRunner: ProcessRunner(
         // dryRun should not try to spawn any processes.
         processManager: _fakeProcessManager(),
@@ -361,7 +453,10 @@ void main() {
   test('GlobalBuildRunner skips tests when runTests is false', () async {
     final Build targetBuild = buildConfig.builds[0];
     final BuildRunner buildRunner = BuildRunner(
-      platform: FakePlatform(operatingSystem: Platform.linux),
+      platform: FakePlatform(
+        operatingSystem: Platform.linux,
+        numberOfProcessors: 32,
+      ),
       processRunner: ProcessRunner(
         // dryRun should not try to spawn any processes.
         processManager: _fakeProcessManager(),
@@ -393,7 +488,10 @@ void main() {
   test('GlobalBuildRunner extraGnArgs overrides build config args', () async {
     final Build targetBuild = buildConfig.builds[0];
     final BuildRunner buildRunner = BuildRunner(
-      platform: FakePlatform(operatingSystem: Platform.linux),
+      platform: FakePlatform(
+        operatingSystem: Platform.linux,
+        numberOfProcessors: 32,
+      ),
       processRunner: ProcessRunner(
         processManager: _fakeProcessManager(),
       ),
@@ -426,7 +524,10 @@ void main() {
   test('GlobalBuildRunner canRun returns false on OS mismatch', () async {
     final Build targetBuild = buildConfig.builds[0];
     final BuildRunner buildRunner = BuildRunner(
-      platform: FakePlatform(operatingSystem: Platform.macOS),
+      platform: FakePlatform(
+        operatingSystem: Platform.macOS,
+        numberOfProcessors: 32,
+      ),
       processRunner: ProcessRunner(
         // dryRun should not try to spawn any processes.
         processManager: _fakeProcessManager(),
@@ -447,7 +548,10 @@ void main() {
   test('GlobalBuildRunner fails when gn fails', () async {
     final Build targetBuild = buildConfig.builds[0];
     final BuildRunner buildRunner = BuildRunner(
-      platform: FakePlatform(operatingSystem: Platform.linux),
+      platform: FakePlatform(
+        operatingSystem: Platform.linux,
+        numberOfProcessors: 32,
+      ),
       processRunner: ProcessRunner(
         processManager: _fakeProcessManager(
           gnResult: io.ProcessResult(1, 1, '', ''),
@@ -474,7 +578,10 @@ void main() {
   test('GlobalBuildRunner fails when ninja fails', () async {
     final Build targetBuild = buildConfig.builds[0];
     final BuildRunner buildRunner = BuildRunner(
-      platform: FakePlatform(operatingSystem: Platform.linux),
+      platform: FakePlatform(
+        operatingSystem: Platform.linux,
+        numberOfProcessors: 32,
+      ),
       processRunner: ProcessRunner(
         processManager: _fakeProcessManager(
           ninjaResult: io.ProcessResult(1, 1, '', ''),
@@ -501,7 +608,10 @@ void main() {
   test('GlobalBuildRunner fails an RBE build when bootstrap fails', () async {
     final Build targetBuild = buildConfig.builds[0];
     final BuildRunner buildRunner = BuildRunner(
-      platform: FakePlatform(operatingSystem: Platform.linux),
+      platform: FakePlatform(
+        operatingSystem: Platform.linux,
+        numberOfProcessors: 32,
+      ),
       processRunner: ProcessRunner(
         processManager: _fakeProcessManager(
           bootstrapResult: io.ProcessResult(1, 1, '', ''),
@@ -531,7 +641,10 @@ void main() {
       () async {
     final Build targetBuild = buildConfig.builds[0];
     final BuildRunner buildRunner = BuildRunner(
-      platform: FakePlatform(operatingSystem: Platform.linux),
+      platform: FakePlatform(
+        operatingSystem: Platform.linux,
+        numberOfProcessors: 32,
+      ),
       processRunner: ProcessRunner(
         processManager: _fakeProcessManager(
           canRun: (Object? exe, {String? workingDirectory}) {
@@ -560,7 +673,10 @@ void main() {
       () async {
     final Build targetBuild = buildConfig.builds[0];
     final BuildRunner buildRunner = BuildRunner(
-      platform: FakePlatform(operatingSystem: Platform.linux),
+      platform: FakePlatform(
+        operatingSystem: Platform.linux,
+        numberOfProcessors: 32,
+      ),
       processRunner: ProcessRunner(
         processManager: _fakeProcessManager(),
       ),
@@ -608,7 +724,10 @@ void main() {
       );
       final Build targetBuild = buildConfig.builds[0];
       final BuildRunner buildRunner = BuildRunner(
-        platform: FakePlatform(operatingSystem: Platform.linux),
+        platform: FakePlatform(
+          operatingSystem: Platform.linux,
+          numberOfProcessors: 32,
+        ),
         processRunner: ProcessRunner(
           // dryRun should not try to spawn any processes.
           processManager: _fakeProcessManager(),


### PR DESCRIPTION
Also computes a better `-j` when RBE is enabled.

Fixes https://github.com/flutter/flutter/issues/147667