### PR TITLE
[iOS] Eliminate --clang-dir flag

### DIFF
--- a/sky/tools/create_full_ios_framework.py
+++ b/sky/tools/create_full_ios_framework.py
@@ -33,7 +33,6 @@ def main():
   )
 
   parser.add_argument('--dst', type=str, required=True)
-  parser.add_argument('--clang-dir', type=str, default='clang_x64')
   parser.add_argument('--x64-out-dir', type=str)
   parser.add_argument('--arm64-out-dir', type=str, required=True)
   parser.add_argument('--simulator-x64-out-dir', type=str, required=True)
@@ -102,7 +101,7 @@ def main():
       '%s_extension_safe' % simulator_x64_out_dir, '%s_extension_safe' % simulator_arm64_out_dir
   )
 
-  generate_gen_snapshot(args, dst, x64_out_dir, arm64_out_dir)
+  generate_gen_snapshot(dst, x64_out_dir, arm64_out_dir)
   zip_archive(dst)
   return 0
 
@@ -229,13 +228,13 @@ def process_framework(args, dst, framework, framework_binary):
     subprocess.check_call(['strip', '-x', '-S', framework_binary])
 
 
-def generate_gen_snapshot(args, dst, x64_out_dir, arm64_out_dir):
+def generate_gen_snapshot(dst, x64_out_dir, arm64_out_dir):
   if x64_out_dir:
     _generate_gen_snapshot(x64_out_dir, os.path.join(dst, 'gen_snapshot_x64'))
 
   if arm64_out_dir:
     _generate_gen_snapshot(
-        os.path.join(arm64_out_dir, args.clang_dir), os.path.join(dst, 'gen_snapshot_arm64')
+        os.path.join(arm64_out_dir, 'clang_x64'), os.path.join(dst, 'gen_snapshot_arm64')
     )
 
 


### PR DESCRIPTION
This is only ever used for gen_snapshot_arm64 where the value will only ever be 'clang_x64'. If we were to migrate builds to arm64 hosts, the gen_snapshot_x64 target would be broken as the script stands today.

This flag is never passed by recipe infra or outside callers, and can thus be safely inlined. The same refactoring was performed for generating universal gen_snapshots in #53954.

A followup patch will update the location where this gen_snapshot binary is generated (and adds an arm64 host binary build), and the merged universal gen_snapshot_${target_cpu} will be written to the root output directory.

This is minor pre-factoring to simplify the followup patch, which migrates to universal binaries for iOS.

Issue: https://github.com/flutter/flutter/issues/101138
Issue: https://github.com/flutter/flutter/issues/69157

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
