### PR TITLE
Make FlWindowStateMonitor

### DIFF
--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -90,6 +90,7 @@ source_set("flutter_linux_sources") {
              "fl_method_channel_private.h",
              "fl_method_codec_private.h",
              "fl_plugin_registrar_private.h",
+             "fl_window_state_monitor.h",
              "key_mapping.h",
            ]
 
@@ -146,6 +147,7 @@ source_set("flutter_linux_sources") {
     "fl_value.cc",
     "fl_view.cc",
     "fl_view_accessible.cc",
+    "fl_window_state_monitor.cc",
     "key_mapping.g.cc",
   ]
 
@@ -227,6 +229,7 @@ executable("flutter_linux_unittests") {
     "fl_value_test.cc",
     "fl_view_accessible_test.cc",
     "fl_view_test.cc",
+    "fl_window_state_monitor_test.cc",
     "key_mapping_test.cc",
     "testing/fl_test.cc",
     "testing/fl_test_gtk_logs.cc",
@@ -243,6 +246,7 @@ executable("flutter_linux_unittests") {
     "testing/mock_text_input_handler.cc",
     "testing/mock_text_input_view_delegate.cc",
     "testing/mock_texture_registrar.cc",
+    "testing/mock_window.cc",
   ]
 
   public_configs = [ "//flutter:config" ]

--- a/shell/platform/linux/fl_engine.cc
+++ b/shell/platform/linux/fl_engine.cc
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include "flutter/common/constants.h"
-#include "flutter/shell/platform/common/app_lifecycle_state.h"
 #include "flutter/shell/platform/common/engine_switches.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/linux/fl_binary_messenger_private.h"
@@ -25,7 +24,6 @@
 #include "flutter/shell/platform/linux/fl_texture_gl_private.h"
 #include "flutter/shell/platform/linux/fl_texture_registrar_private.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_plugin_registry.h"
-#include "flutter/shell/platform/linux/public/flutter_linux/fl_string_codec.h"
 
 // Unique number associated with platform tasks.
 static constexpr size_t kPlatformTaskRunnerIdentifier = 1;
@@ -34,8 +32,6 @@ static constexpr size_t kPlatformTaskRunnerIdentifier = 1;
 // differentiate the actual device (mouse v.s. trackpad)
 static constexpr int32_t kMousePointerDeviceId = 0;
 static constexpr int32_t kPointerPanZoomDeviceId = 1;
-
-static constexpr const char* kFlutterLifecycleChannel = "flutter/lifecycle";
 
 struct _FlEngine {
   GObject parent_instance;
@@ -125,25 +121,6 @@ static void parse_locale(const gchar* locale,
   if (language != nullptr) {
     *language = l;
   }
-}
-
-static void set_app_lifecycle_state(FlEngine* self,
-                                    const flutter::AppLifecycleState state) {
-  FlBinaryMessenger* binary_messenger = fl_engine_get_binary_messenger(self);
-
-  g_autoptr(FlValue) value =
-      fl_value_new_string(flutter::AppLifecycleStateToString(state));
-  g_autoptr(FlStringCodec) codec = fl_string_codec_new();
-  g_autoptr(GBytes) message =
-      fl_message_codec_encode_message(FL_MESSAGE_CODEC(codec), value, nullptr);
-
-  if (message == nullptr) {
-    return;
-  }
-
-  fl_binary_messenger_send_on_channel(binary_messenger,
-                                      kFlutterLifecycleChannel, message,
-                                      nullptr, nullptr, nullptr);
 }
 
 // Passes locale information to the Flutter engine.
@@ -754,18 +731,6 @@ GBytes* fl_engine_send_platform_message_finish(FlEngine* self,
   g_return_val_if_fail(g_task_is_valid(result, self), FALSE);
 
   return static_cast<GBytes*>(g_task_propagate_pointer(G_TASK(result), error));
-}
-
-void fl_engine_send_window_state_event(FlEngine* self,
-                                       gboolean visible,
-                                       gboolean focused) {
-  if (visible && focused) {
-    set_app_lifecycle_state(self, flutter::AppLifecycleState::kResumed);
-  } else if (visible) {
-    set_app_lifecycle_state(self, flutter::AppLifecycleState::kInactive);
-  } else {
-    set_app_lifecycle_state(self, flutter::AppLifecycleState::kHidden);
-  }
 }
 
 void fl_engine_send_window_metrics_event(FlEngine* self,

--- a/shell/platform/linux/fl_engine_private.h
+++ b/shell/platform/linux/fl_engine_private.h
@@ -170,18 +170,6 @@ void fl_engine_send_window_metrics_event(FlEngine* engine,
                                          double pixel_ratio);
 
 /**
- * fl_engine_send_window_state_event:
- * @engine: an #FlEngine.
- * @visible: whether the window is currently visible or not.
- * @focused: whether the window is currently focused or not.
- *
- * Sends a window state event to the engine.
- */
-void fl_engine_send_window_state_event(FlEngine* engine,
-                                       gboolean visible,
-                                       gboolean focused);
-
-/**
  * fl_engine_send_mouse_pointer_event:
  * @engine: an #FlEngine.
  * @phase: mouse phase.

--- a/shell/platform/linux/fl_engine_test.cc
+++ b/shell/platform/linux/fl_engine_test.cc
@@ -5,7 +5,6 @@
 // Included first as it collides with the X11 headers.
 #include "gtest/gtest.h"
 
-#include "flutter/shell/platform/common/app_lifecycle_state.h"
 #include "flutter/shell/platform/embedder/test_utils/proc_table_replacement.h"
 #include "flutter/shell/platform/linux/fl_engine_private.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_engine.h"
@@ -424,42 +423,6 @@ TEST(FlEngineTest, SwitchesEmpty) {
   g_autoptr(GPtrArray) switches = fl_engine_get_switches(engine);
 
   EXPECT_EQ(switches->len, 0U);
-}
-
-TEST(FlEngineTest, SendWindowStateEvent) {
-  g_autoptr(FlEngine) engine = make_mock_engine();
-  FlutterEngineProcTable* embedder_api = fl_engine_get_embedder_api(engine);
-
-  bool called = false;
-  std::string state;
-  embedder_api->SendPlatformMessage = MOCK_ENGINE_PROC(
-      SendPlatformMessage,
-      ([&called, &state](auto engine, const FlutterPlatformMessage* message) {
-        EXPECT_STREQ(message->channel, "flutter/lifecycle");
-        called = true;
-        g_autoptr(FlStringCodec) codec = fl_string_codec_new();
-        g_autoptr(GBytes) data =
-            g_bytes_new(message->message, message->message_size);
-        g_autoptr(GError) error = nullptr;
-        g_autoptr(FlValue) parsed_state = fl_message_codec_decode_message(
-            FL_MESSAGE_CODEC(codec), data, &error);
-
-        state = fl_value_get_string(parsed_state);
-        return kSuccess;
-      }));
-  fl_engine_send_window_state_event(engine, false, false);
-  EXPECT_STREQ(state.c_str(), flutter::AppLifecycleStateToString(
-                                  flutter::AppLifecycleState::kHidden));
-  fl_engine_send_window_state_event(engine, false, true);
-  EXPECT_STREQ(state.c_str(), flutter::AppLifecycleStateToString(
-                                  flutter::AppLifecycleState::kHidden));
-  fl_engine_send_window_state_event(engine, true, false);
-  EXPECT_STREQ(state.c_str(), flutter::AppLifecycleStateToString(
-                                  flutter::AppLifecycleState::kInactive));
-  fl_engine_send_window_state_event(engine, true, true);
-  EXPECT_STREQ(state.c_str(), flutter::AppLifecycleStateToString(
-                                  flutter::AppLifecycleState::kResumed));
-  EXPECT_TRUE(called);
 }
 
 #ifndef FLUTTER_RELEASE

--- a/shell/platform/linux/fl_window_state_monitor.cc
+++ b/shell/platform/linux/fl_window_state_monitor.cc
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gtk/gtk.h>
-
 #include "flutter/shell/platform/linux/fl_window_state_monitor.h"
+
+#include <gtk/gtk.h>
 
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_string_codec.h"
 

--- a/shell/platform/linux/fl_window_state_monitor.cc
+++ b/shell/platform/linux/fl_window_state_monitor.cc
@@ -1,0 +1,119 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtk/gtk.h>
+
+#include "flutter/shell/platform/linux/fl_window_state_monitor.h"
+
+#include "flutter/shell/platform/linux/public/flutter_linux/fl_string_codec.h"
+
+static constexpr const char* kFlutterLifecycleChannel = "flutter/lifecycle";
+
+static constexpr const char* kAppLifecycleStateResumed =
+    "AppLifecycleState.resumed";
+static constexpr const char* kAppLifecycleStateInactive =
+    "AppLifecycleState.inactive";
+static constexpr const char* kAppLifecycleStateHidden =
+    "AppLifecycleState.hidden";
+
+struct _FlWindowStateMonitor {
+  GObject parent_instance;
+
+  // Messenger to communicate with engine.
+  FlBinaryMessenger* messenger;
+
+  // Window being monitored.
+  GtkWindow* window;
+
+  // Current state information.
+  GdkWindowState window_state;
+
+  // Signal connection ID for window-state-changed
+  gulong window_state_event_cb_id;
+};
+
+G_DEFINE_TYPE(FlWindowStateMonitor, fl_window_state_monitor, G_TYPE_OBJECT);
+
+static void send_lifecycle_state(FlWindowStateMonitor* self,
+                                 const gchar* lifecycle_state) {
+  g_autoptr(FlValue) value = fl_value_new_string(lifecycle_state);
+  g_autoptr(FlStringCodec) codec = fl_string_codec_new();
+  g_autoptr(GError) error = nullptr;
+  g_autoptr(GBytes) message =
+      fl_message_codec_encode_message(FL_MESSAGE_CODEC(codec), value, &error);
+  if (message == nullptr) {
+    g_warning("Failed to encoding lifecycle state message: %s", error->message);
+    return;
+  }
+
+  fl_binary_messenger_send_on_channel(self->messenger, kFlutterLifecycleChannel,
+                                      message, nullptr, nullptr, nullptr);
+}
+
+static gboolean is_hidden(GdkWindowState state) {
+  return (state & GDK_WINDOW_STATE_WITHDRAWN) ||
+         (state & GDK_WINDOW_STATE_ICONIFIED);
+}
+
+// Signal handler for GtkWindow::window-state-event
+static gboolean window_state_event_cb(FlWindowStateMonitor* self,
+                                      GdkEvent* event) {
+  GdkWindowState state = event->window_state.new_window_state;
+  GdkWindowState previous_state = self->window_state;
+  self->window_state = state;
+  bool was_visible = !is_hidden(previous_state);
+  bool is_visible = !is_hidden(state);
+  bool was_focused = (previous_state & GDK_WINDOW_STATE_FOCUSED);
+  bool is_focused = (state & GDK_WINDOW_STATE_FOCUSED);
+
+  if (was_visible != is_visible || was_focused != is_focused) {
+    const gchar* lifecycle_state;
+    if (is_visible) {
+      lifecycle_state =
+          is_focused ? kAppLifecycleStateResumed : kAppLifecycleStateInactive;
+    } else {
+      lifecycle_state = kAppLifecycleStateHidden;
+    }
+
+    send_lifecycle_state(self, lifecycle_state);
+  }
+
+  return FALSE;
+}
+
+static void fl_window_state_monitor_dispose(GObject* object) {
+  FlWindowStateMonitor* self = FL_WINDOW_STATE_MONITOR(object);
+
+  g_clear_object(&self->messenger);
+  if (self->window_state_event_cb_id != 0) {
+    g_signal_handler_disconnect(self->window, self->window_state_event_cb_id);
+    self->window_state_event_cb_id = 0;
+  }
+
+  G_OBJECT_CLASS(fl_window_state_monitor_parent_class)->dispose(object);
+}
+
+static void fl_window_state_monitor_class_init(
+    FlWindowStateMonitorClass* klass) {
+  G_OBJECT_CLASS(klass)->dispose = fl_window_state_monitor_dispose;
+}
+
+static void fl_window_state_monitor_init(FlWindowStateMonitor* self) {}
+
+FlWindowStateMonitor* fl_window_state_monitor_new(FlBinaryMessenger* messenger,
+                                                  GtkWindow* window) {
+  FlWindowStateMonitor* self = FL_WINDOW_STATE_MONITOR(
+      g_object_new(fl_window_state_monitor_get_type(), nullptr));
+  self->messenger = FL_BINARY_MESSENGER(g_object_ref(messenger));
+  self->window = window;
+
+  // Listen to window state changes.
+  self->window_state_event_cb_id =
+      g_signal_connect_swapped(self->window, "window-state-event",
+                               G_CALLBACK(window_state_event_cb), self);
+  self->window_state =
+      gdk_window_get_state(gtk_widget_get_window(GTK_WIDGET(self->window)));
+
+  return self;
+}

--- a/shell/platform/linux/fl_window_state_monitor.h
+++ b/shell/platform/linux/fl_window_state_monitor.h
@@ -1,0 +1,41 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_LINUX_FL_WINDOW_STATE_MONITOR_H_
+#define FLUTTER_SHELL_PLATFORM_LINUX_FL_WINDOW_STATE_MONITOR_H_
+
+#include <gtk/gtk.h>
+
+#include "flutter/shell/platform/linux/public/flutter_linux/fl_engine.h"
+
+G_BEGIN_DECLS
+
+G_DECLARE_FINAL_TYPE(FlWindowStateMonitor,
+                     fl_window_state_monitor,
+                     FL,
+                     WINDOW_STATE_MONITOR,
+                     GObject);
+
+/**
+ * FlWindowStateMonitor:
+ *
+ * Monitors a GtkWindow and reports state change events to the Flutter engine.
+ */
+
+/**
+ * fl_window_state_monitor_new:
+ * @messenger: an #FlBinaryMessenger.
+ * @window: a #GtkWindow.
+ *
+ * Creates a new window state manager to monitor @window and report events to
+ * @messenger.
+ *
+ * Returns: a new #FlWindowStateMonitor.
+ */
+FlWindowStateMonitor* fl_window_state_monitor_new(FlBinaryMessenger* messenger,
+                                                  GtkWindow* window);
+
+G_END_DECLS
+
+#endif  // FLUTTER_SHELL_PLATFORM_LINUX_FL_WINDOW_STATE_MONITOR_H_

--- a/shell/platform/linux/fl_window_state_monitor_test.cc
+++ b/shell/platform/linux/fl_window_state_monitor_test.cc
@@ -10,11 +10,12 @@
 
 #include "gtest/gtest.h"
 
-class LifecycleStringMatcher {
+// Matches if a FlValue is a the supplied string.
+class FlValueStringMatcher {
  public:
   using is_gtest_matcher = void;
 
-  explicit LifecycleStringMatcher(::testing::Matcher<std::string> value)
+  explicit FlValueStringMatcher(::testing::Matcher<std::string> value)
       : value_(std::move(value)) {}
 
   bool MatchAndExplain(GBytes* data,
@@ -49,7 +50,7 @@ class LifecycleStringMatcher {
 };
 
 ::testing::Matcher<GBytes*> LifecycleString(const std::string& value) {
-  return LifecycleStringMatcher(::testing::StrEq(value));
+  return FlValueStringMatcher(::testing::StrEq(value));
 }
 
 TEST(FlWindowStateMonitorTest, GainFocus) {

--- a/shell/platform/linux/fl_window_state_monitor_test.cc
+++ b/shell/platform/linux/fl_window_state_monitor_test.cc
@@ -1,0 +1,255 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/linux/fl_window_state_monitor.h"
+#include "flutter/shell/platform/linux/public/flutter_linux/fl_string_codec.h"
+#include "flutter/shell/platform/linux/testing/fl_test.h"
+#include "flutter/shell/platform/linux/testing/mock_binary_messenger.h"
+#include "flutter/shell/platform/linux/testing/mock_window.h"
+
+#include "gtest/gtest.h"
+
+class LifecycleStringMatcher {
+ public:
+  using is_gtest_matcher = void;
+
+  explicit LifecycleStringMatcher(::testing::Matcher<std::string> value)
+      : value_(std::move(value)) {}
+
+  bool MatchAndExplain(GBytes* data,
+                       ::testing::MatchResultListener* result_listener) const {
+    g_autoptr(FlStringCodec) codec = fl_string_codec_new();
+    g_autoptr(GError) error = nullptr;
+    g_autoptr(FlValue) value =
+        fl_message_codec_decode_message(FL_MESSAGE_CODEC(codec), data, &error);
+    if (value == nullptr) {
+      *result_listener << ::testing::PrintToString(error->message);
+      return false;
+    }
+    if (!value_.MatchAndExplain(fl_value_get_string(value), result_listener)) {
+      *result_listener << " where the value doesn't match: \"" << value << "\"";
+      return false;
+    }
+    return true;
+  }
+
+  void DescribeTo(std::ostream* os) const {
+    *os << "value ";
+    value_.DescribeTo(os);
+  }
+
+  void DescribeNegationTo(std::ostream* os) const {
+    *os << "value ";
+    value_.DescribeNegationTo(os);
+  }
+
+ private:
+  ::testing::Matcher<std::string> value_;
+};
+
+::testing::Matcher<GBytes*> LifecycleString(const std::string& value) {
+  return LifecycleStringMatcher(::testing::StrEq(value));
+}
+
+TEST(FlWindowStateMonitorTest, GainFocus) {
+  ::testing::NiceMock<flutter::testing::MockBinaryMessenger> messenger;
+  ::testing::NiceMock<flutter::testing::MockWindow> mock_window;
+
+  gtk_init(0, nullptr);
+
+  EXPECT_CALL(mock_window, gdk_window_get_state)
+      .WillOnce(::testing::Return(static_cast<GdkWindowState>(0)));
+  EXPECT_CALL(messenger, fl_binary_messenger_send_on_channel(
+                             ::testing::Eq<FlBinaryMessenger*>(messenger),
+                             ::testing::StrEq("flutter/lifecycle"),
+                             LifecycleString("AppLifecycleState.resumed"),
+                             ::testing::_, ::testing::_, ::testing::_));
+
+  GtkWindow* window = GTK_WINDOW(gtk_window_new(GTK_WINDOW_TOPLEVEL));
+  gtk_widget_show(GTK_WIDGET(window));
+  g_autoptr(FlWindowStateMonitor) monitor =
+      fl_window_state_monitor_new(messenger, window);
+
+  GdkEvent event = {
+      .window_state = {.new_window_state = GDK_WINDOW_STATE_FOCUSED}};
+  gboolean handled;
+  g_signal_emit_by_name(window, "window-state-event", &event, &handled);
+}
+
+TEST(FlWindowStateMonitorTest, LoseFocus) {
+  ::testing::NiceMock<flutter::testing::MockBinaryMessenger> messenger;
+  ::testing::NiceMock<flutter::testing::MockWindow> mock_window;
+
+  gtk_init(0, nullptr);
+
+  EXPECT_CALL(mock_window, gdk_window_get_state)
+      .WillOnce(::testing::Return(GDK_WINDOW_STATE_FOCUSED));
+  EXPECT_CALL(messenger, fl_binary_messenger_send_on_channel(
+                             ::testing::Eq<FlBinaryMessenger*>(messenger),
+                             ::testing::StrEq("flutter/lifecycle"),
+                             LifecycleString("AppLifecycleState.inactive"),
+                             ::testing::_, ::testing::_, ::testing::_));
+
+  GtkWindow* window = GTK_WINDOW(gtk_window_new(GTK_WINDOW_TOPLEVEL));
+  gtk_widget_show(GTK_WIDGET(window));
+  g_autoptr(FlWindowStateMonitor) monitor =
+      fl_window_state_monitor_new(messenger, window);
+
+  GdkEvent event = {
+      .window_state = {.new_window_state = static_cast<GdkWindowState>(0)}};
+  gboolean handled;
+  g_signal_emit_by_name(window, "window-state-event", &event, &handled);
+}
+
+TEST(FlWindowStateMonitorTest, EnterIconified) {
+  ::testing::NiceMock<flutter::testing::MockBinaryMessenger> messenger;
+  ::testing::NiceMock<flutter::testing::MockWindow> mock_window;
+
+  gtk_init(0, nullptr);
+
+  EXPECT_CALL(mock_window, gdk_window_get_state)
+      .WillOnce(::testing::Return(static_cast<GdkWindowState>(0)));
+  EXPECT_CALL(messenger, fl_binary_messenger_send_on_channel(
+                             ::testing::Eq<FlBinaryMessenger*>(messenger),
+                             ::testing::StrEq("flutter/lifecycle"),
+                             LifecycleString("AppLifecycleState.hidden"),
+                             ::testing::_, ::testing::_, ::testing::_));
+
+  GtkWindow* window = GTK_WINDOW(gtk_window_new(GTK_WINDOW_TOPLEVEL));
+  gtk_widget_show(GTK_WIDGET(window));
+  g_autoptr(FlWindowStateMonitor) monitor =
+      fl_window_state_monitor_new(messenger, window);
+
+  GdkEvent event = {
+      .window_state = {.new_window_state = GDK_WINDOW_STATE_ICONIFIED}};
+  gboolean handled;
+  g_signal_emit_by_name(window, "window-state-event", &event, &handled);
+}
+
+TEST(FlWindowStateMonitorTest, LeaveIconified) {
+  ::testing::NiceMock<flutter::testing::MockBinaryMessenger> messenger;
+  ::testing::NiceMock<flutter::testing::MockWindow> mock_window;
+
+  gtk_init(0, nullptr);
+
+  EXPECT_CALL(mock_window, gdk_window_get_state)
+      .WillOnce(::testing::Return(GDK_WINDOW_STATE_ICONIFIED));
+  EXPECT_CALL(messenger, fl_binary_messenger_send_on_channel(
+                             ::testing::Eq<FlBinaryMessenger*>(messenger),
+                             ::testing::StrEq("flutter/lifecycle"),
+                             LifecycleString("AppLifecycleState.inactive"),
+                             ::testing::_, ::testing::_, ::testing::_));
+
+  GtkWindow* window = GTK_WINDOW(gtk_window_new(GTK_WINDOW_TOPLEVEL));
+  gtk_widget_show(GTK_WIDGET(window));
+  g_autoptr(FlWindowStateMonitor) monitor =
+      fl_window_state_monitor_new(messenger, window);
+
+  GdkEvent event = {
+      .window_state = {.new_window_state = static_cast<GdkWindowState>(0)}};
+  gboolean handled;
+  g_signal_emit_by_name(window, "window-state-event", &event, &handled);
+}
+
+TEST(FlWindowStateMonitorTest, LeaveIconifiedFocused) {
+  ::testing::NiceMock<flutter::testing::MockBinaryMessenger> messenger;
+  ::testing::NiceMock<flutter::testing::MockWindow> mock_window;
+
+  gtk_init(0, nullptr);
+
+  EXPECT_CALL(mock_window, gdk_window_get_state)
+      .WillOnce(::testing::Return(GDK_WINDOW_STATE_ICONIFIED));
+  EXPECT_CALL(messenger, fl_binary_messenger_send_on_channel(
+                             ::testing::Eq<FlBinaryMessenger*>(messenger),
+                             ::testing::StrEq("flutter/lifecycle"),
+                             LifecycleString("AppLifecycleState.resumed"),
+                             ::testing::_, ::testing::_, ::testing::_));
+
+  GtkWindow* window = GTK_WINDOW(gtk_window_new(GTK_WINDOW_TOPLEVEL));
+  gtk_widget_show(GTK_WIDGET(window));
+  g_autoptr(FlWindowStateMonitor) monitor =
+      fl_window_state_monitor_new(messenger, window);
+
+  GdkEvent event = {
+      .window_state = {.new_window_state = static_cast<GdkWindowState>(
+                           GDK_WINDOW_STATE_FOCUSED)}};
+  gboolean handled;
+  g_signal_emit_by_name(window, "window-state-event", &event, &handled);
+}
+
+TEST(FlWindowStateMonitorTest, EnterWithdrawn) {
+  ::testing::NiceMock<flutter::testing::MockBinaryMessenger> messenger;
+  ::testing::NiceMock<flutter::testing::MockWindow> mock_window;
+
+  gtk_init(0, nullptr);
+
+  EXPECT_CALL(mock_window, gdk_window_get_state)
+      .WillOnce(::testing::Return(static_cast<GdkWindowState>(0)));
+  EXPECT_CALL(messenger, fl_binary_messenger_send_on_channel(
+                             ::testing::Eq<FlBinaryMessenger*>(messenger),
+                             ::testing::StrEq("flutter/lifecycle"),
+                             LifecycleString("AppLifecycleState.hidden"),
+                             ::testing::_, ::testing::_, ::testing::_));
+
+  GtkWindow* window = GTK_WINDOW(gtk_window_new(GTK_WINDOW_TOPLEVEL));
+  gtk_widget_show(GTK_WIDGET(window));
+  g_autoptr(FlWindowStateMonitor) monitor =
+      fl_window_state_monitor_new(messenger, window);
+
+  GdkEvent event = {
+      .window_state = {.new_window_state = GDK_WINDOW_STATE_WITHDRAWN}};
+  gboolean handled;
+  g_signal_emit_by_name(window, "window-state-event", &event, &handled);
+}
+
+TEST(FlWindowStateMonitorTest, LeaveWithdrawn) {
+  ::testing::NiceMock<flutter::testing::MockBinaryMessenger> messenger;
+  ::testing::NiceMock<flutter::testing::MockWindow> mock_window;
+
+  gtk_init(0, nullptr);
+
+  EXPECT_CALL(mock_window, gdk_window_get_state)
+      .WillOnce(::testing::Return(GDK_WINDOW_STATE_WITHDRAWN));
+  EXPECT_CALL(messenger, fl_binary_messenger_send_on_channel(
+                             ::testing::Eq<FlBinaryMessenger*>(messenger),
+                             ::testing::StrEq("flutter/lifecycle"),
+                             LifecycleString("AppLifecycleState.inactive"),
+                             ::testing::_, ::testing::_, ::testing::_));
+
+  GtkWindow* window = GTK_WINDOW(gtk_window_new(GTK_WINDOW_TOPLEVEL));
+  gtk_widget_show(GTK_WIDGET(window));
+  g_autoptr(FlWindowStateMonitor) monitor =
+      fl_window_state_monitor_new(messenger, window);
+
+  GdkEvent event = {
+      .window_state = {.new_window_state = static_cast<GdkWindowState>(0)}};
+  gboolean handled;
+  g_signal_emit_by_name(window, "window-state-event", &event, &handled);
+}
+
+TEST(FlWindowStateMonitorTest, LeaveWithdrawnFocused) {
+  ::testing::NiceMock<flutter::testing::MockBinaryMessenger> messenger;
+  ::testing::NiceMock<flutter::testing::MockWindow> mock_window;
+
+  gtk_init(0, nullptr);
+
+  EXPECT_CALL(mock_window, gdk_window_get_state)
+      .WillOnce(::testing::Return(GDK_WINDOW_STATE_WITHDRAWN));
+  EXPECT_CALL(messenger, fl_binary_messenger_send_on_channel(
+                             ::testing::Eq<FlBinaryMessenger*>(messenger),
+                             ::testing::StrEq("flutter/lifecycle"),
+                             LifecycleString("AppLifecycleState.resumed"),
+                             ::testing::_, ::testing::_, ::testing::_));
+
+  GtkWindow* window = GTK_WINDOW(gtk_window_new(GTK_WINDOW_TOPLEVEL));
+  gtk_widget_show(GTK_WIDGET(window));
+  g_autoptr(FlWindowStateMonitor) monitor =
+      fl_window_state_monitor_new(messenger, window);
+
+  GdkEvent event = {
+      .window_state = {.new_window_state = static_cast<GdkWindowState>(
+                           GDK_WINDOW_STATE_FOCUSED)}};
+  gboolean handled;
+  g_signal_emit_by_name(window, "window-state-event", &event, &handled);
+}

--- a/shell/platform/linux/testing/mock_window.cc
+++ b/shell/platform/linux/testing/mock_window.cc
@@ -1,0 +1,18 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/linux/testing/mock_window.h"
+
+using namespace flutter::testing;
+
+static MockWindow* mock = nullptr;
+
+MockWindow::MockWindow() {
+  mock = this;
+}
+
+GdkWindowState gdk_window_get_state(GdkWindow* window) {
+  return mock->gdk_window_get_state(window);
+}

--- a/shell/platform/linux/testing/mock_window.cc
+++ b/shell/platform/linux/testing/mock_window.cc
@@ -1,5 +1,4 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
-
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/shell/platform/linux/testing/mock_window.h
+++ b/shell/platform/linux/testing/mock_window.h
@@ -1,0 +1,25 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_LINUX_TESTING_MOCK_WINDOW_H_
+#define FLUTTER_SHELL_PLATFORM_LINUX_TESTING_MOCK_WINDOW_H_
+
+#include "gmock/gmock.h"
+
+#include <gtk/gtk.h>
+
+namespace flutter {
+namespace testing {
+
+class MockWindow {
+ public:
+  MockWindow();
+
+  MOCK_METHOD(GdkWindowState, gdk_window_get_state, (GdkWindow * window));
+};
+
+}  // namespace testing
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_LINUX_TESTING_MOCK_WINDOW_H_


### PR DESCRIPTION
Split window state monitor out of FlView and FlEngine to make it easier to handle different API when using GTK4. It also allows better tests.