### PR TITLE
[Impeller] try disabling backpressure in AHB swapchain.

### DIFF
--- a/impeller/toolkit/android/surface_transaction.cc
+++ b/impeller/toolkit/android/surface_transaction.cc
@@ -61,9 +61,6 @@ bool SurfaceTransaction::SetContents(const SurfaceControl* control,
 
   const auto& proc_table = GetProcTable();
 
-  proc_table.ASurfaceTransaction_setEnableBackPressure(
-      transaction_.get(), control->GetHandle(), true);
-
   proc_table.ASurfaceTransaction_setBuffer(
       transaction_.get(),                                      //
       control->GetHandle(),                                    //


### PR DESCRIPTION
Enabling the ahb backpressure has increased frame times - probably because this is now WAI and delaying the HB readyness. Lets try disabling it before we back out the AHB swapchain again.


See https://flutter-flutter-perf.skia.org/e/?begin=1721400948&end=1721487348&queries=device_type%3DPixel_7_Pro%26sub_result%3D90th_percentile_frame_rasterizer_time_millis%26sub_result%3D99th_percentile_frame_rasterizer_time_millis%26sub_result%3Daverage_frame_rasterizer_time_millis%26sub_result%3Dworst_frame_rasterizer_time_millis%26test%3Dnew_gallery_impeller__transition_perf&selected=commit%3D41656%26name%3D%252Carch%253Dintel%252Cbranch%253Dmaster%252Cconfig%253Ddefault%252Cdevice_type%253DPixel_7_Pro%252Cdevice_version%253Dnone%252Chost_type%253Dlinux%252Csub_result%253D90th_percentile_frame_rasterizer_time_millis%252Ctest%253Dnew_gallery_impeller__transition_perf%252C

Test: this is all benchmark performance we're testing.
