### PR TITLE
[Impeller] detect max cull rect on bounds.

### DIFF
--- a/impeller/display_list/aiks_dl_unittests.cc
+++ b/impeller/display_list/aiks_dl_unittests.cc
@@ -35,7 +35,7 @@ SkRect GetCullRect(ISize window_size) {
 }  // namespace
 
 TEST_P(AiksTest, CollapsedDrawPaintInSubpass) {
-  DisplayListBuilder builder(GetCullRect(GetWindowSize()));
+  DisplayListBuilder builder;
 
   DlPaint paint;
   paint.setColor(DlColor::kYellow());
@@ -55,7 +55,7 @@ TEST_P(AiksTest, CollapsedDrawPaintInSubpass) {
 
 TEST_P(AiksTest, CollapsedDrawPaintInSubpassBackdropFilter) {
   // Bug: https://github.com/flutter/flutter/issues/131576
-  DisplayListBuilder builder(GetCullRect(GetWindowSize()));
+  DisplayListBuilder builder;
 
   DlPaint paint;
   paint.setColor(DlColor::kYellow());

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -612,6 +612,9 @@ void DlDispatcherBase::save(uint32_t total_content_depth) {
   GetCanvas().Save(total_content_depth);
 }
 
+static constexpr SkRect kMaxCullRect =
+    SkRect::MakeLTRB(-1E9F, -1E9F, 1E9F, 1E9F);
+
 // |flutter::DlOpReceiver|
 void DlDispatcherBase::saveLayer(const SkRect& bounds,
                                  const flutter::SaveLayerOptions& options,
@@ -622,8 +625,15 @@ void DlDispatcherBase::saveLayer(const SkRect& bounds,
   auto promise = options.content_is_clipped()
                      ? ContentBoundsPromise::kMayClipContents
                      : ContentBoundsPromise::kContainsContents;
-  GetCanvas().SaveLayer(paint, skia_conversions::ToRect(bounds),
-                        ToImageFilter(backdrop), promise, total_content_depth,
+  std::optional<Rect> impeller_bounds;
+  if (bounds == kMaxCullRect) {
+    impeller_bounds = std::nullopt;
+  } else {
+    impeller_bounds = skia_conversions::ToRect(bounds);
+  }
+
+  GetCanvas().SaveLayer(paint, impeller_bounds, ToImageFilter(backdrop),
+                        promise, total_content_depth,
                         options.can_distribute_opacity());
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/151785

if the bounds given to impeller SaveLayer is kMaxCullRect, treat this as unbounded.