### PR TITLE
[Impeller] temporary fix to scaling adjustment.

### DIFF
--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -254,8 +254,9 @@ bool TextContents::Render(const ContentContext& renderer,
             for (const Point& point : unit_points) {
               Point position;
               if (is_translation_scale) {
-                position = screen_glyph_position +
-                           (basis_transform * point * scaled_bounds.GetSize());
+                position =
+                    screen_glyph_position +
+                    (basis_transform * point * scaled_bounds.GetSize()).Round();
               } else {
                 position = entity_transform * (glyph_position.position +
                                                scaled_bounds.GetLeftTop() +


### PR DESCRIPTION
Due to fp issues we can end up losing a pixel on the edge of glyphs. Though the changes to absorbing the transform have unfortunately regressed txt fidelity again. I'm convinced that the only solution is to full absorb the transform when rendering text.