### PR TITLE
[Impeller] ensure fp rounding errors don't cause us to lose a row of pixels when computing text positions.

### DIFF
--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -231,7 +231,7 @@ bool TextContents::Render(const ContentContext& renderer,
             const Rect& atlas_glyph_bounds =
                 maybe_atlas_glyph_bounds.value().first;
             Rect glyph_bounds = maybe_atlas_glyph_bounds.value().second;
-            Rect scaled_bounds = glyph_bounds.Scale(1.0 / rounded_scale);
+
             // For each glyph, we compute two rectangles. One for the vertex
             // positions and one for the texture coordinates (UVs). The atlas
             // glyph bounds are used to compute UVs in cases where the
@@ -243,20 +243,27 @@ bool TextContents::Render(const ContentContext& renderer,
             Point uv_size =
                 (atlas_glyph_bounds.GetSize() + Point(1, 1)) / atlas_size;
 
+            // Apply the non-scale portions of the basis transform (usually
+            // inversion) to th glyph bounds.
+            Matrix inverse_scale =
+                Matrix::MakeScale(Vector2{1.0f / scale_, 1.0f / scale_});
+            Matrix bounds_scale = basis_transform * inverse_scale;
+
             Point unrounded_glyph_position =
-                basis_transform *
-                (glyph_position.position + scaled_bounds.GetLeftTop());
+                (basis_transform * glyph_position.position) +
+                (bounds_scale * glyph_bounds.GetLeftTop());
 
             Point screen_glyph_position =
                 (screen_offset + unrounded_glyph_position + subpixel_adjustment)
                     .Floor();
 
+            Size scaled_size = glyph_bounds.GetSize();
             for (const Point& point : unit_points) {
               Point position;
               if (is_translation_scale) {
-                position = screen_glyph_position +
-                           (basis_transform * point * scaled_bounds.GetSize());
+                position = screen_glyph_position + (point * scaled_size);
               } else {
+                Rect scaled_bounds = glyph_bounds.Scale(1.0 / rounded_scale);
                 position = entity_transform * (glyph_position.position +
                                                scaled_bounds.GetLeftTop() +
                                                point * scaled_bounds.GetSize());

--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -255,7 +255,8 @@ bool TextContents::Render(const ContentContext& renderer,
               Point position;
               if (is_translation_scale) {
                 position = (screen_glyph_position +
-                           (basis_transform * point * scaled_bounds.GetSize())).Round();
+                            (basis_transform * point * scaled_bounds.GetSize()))
+                               .Round();
               } else {
                 position = entity_transform * (glyph_position.position +
                                                scaled_bounds.GetLeftTop() +

--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -261,7 +261,7 @@ bool TextContents::Render(const ContentContext& renderer,
             for (const Point& point : unit_points) {
               Point position;
               if (is_translation_scale) {
-                position = screen_glyph_position + (point * scaled_size);
+                position = screen_glyph_position + (bounds_scale * point * scaled_size);
               } else {
                 Rect scaled_bounds = glyph_bounds.Scale(1.0 / rounded_scale);
                 position = entity_transform * (glyph_position.position +

--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -231,7 +231,7 @@ bool TextContents::Render(const ContentContext& renderer,
             const Rect& atlas_glyph_bounds =
                 maybe_atlas_glyph_bounds.value().first;
             Rect glyph_bounds = maybe_atlas_glyph_bounds.value().second;
-
+            Rect scaled_bounds = glyph_bounds.Scale(1.0 / rounded_scale);
             // For each glyph, we compute two rectangles. One for the vertex
             // positions and one for the texture coordinates (UVs). The atlas
             // glyph bounds are used to compute UVs in cases where the
@@ -243,27 +243,20 @@ bool TextContents::Render(const ContentContext& renderer,
             Point uv_size =
                 (atlas_glyph_bounds.GetSize() + Point(1, 1)) / atlas_size;
 
-            // Apply the non-scale portions of the basis transform (usually
-            // inversion) to th glyph bounds.
-            Matrix inverse_scale =
-                Matrix::MakeScale(Vector2{1.0f / scale_, 1.0f / scale_});
-            Matrix bounds_scale = basis_transform * inverse_scale;
-
             Point unrounded_glyph_position =
-                (basis_transform * glyph_position.position) +
-                (bounds_scale * glyph_bounds.GetLeftTop());
+                basis_transform *
+                (glyph_position.position + scaled_bounds.GetLeftTop());
 
             Point screen_glyph_position =
                 (screen_offset + unrounded_glyph_position + subpixel_adjustment)
                     .Floor();
 
-            Size scaled_size = glyph_bounds.GetSize();
             for (const Point& point : unit_points) {
               Point position;
               if (is_translation_scale) {
-                position = screen_glyph_position + (bounds_scale * point * scaled_size);
+                position = (screen_glyph_position +
+                           (basis_transform * point * scaled_bounds.GetSize())).Round();
               } else {
-                Rect scaled_bounds = glyph_bounds.Scale(1.0 / rounded_scale);
                 position = entity_transform * (glyph_position.position +
                                                scaled_bounds.GetLeftTop() +
                                                point * scaled_bounds.GetSize());


### PR DESCRIPTION
Dividing then multipliying can lead to position values like 432.99987 which end up losing a pixel.