### PR TITLE
[Impeller] enable ahb swapchain on emulators.

### DIFF
--- a/impeller/renderer/backend/vulkan/swapchain/swapchain_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain/swapchain_vk.cc
@@ -55,11 +55,8 @@ std::shared_ptr<SwapchainVK> SwapchainVK::Create(
     return nullptr;
   }
 
-  // TODO(147533): AHB swapchains on emulators are not functional.
-  const auto emulator = ContextVK::Cast(*context).GetDriverInfo()->IsEmulator();
-
   // Try AHB swapchains first.
-  if (!emulator && AHBSwapchainVK::IsAvailableOnPlatform()) {
+  if (AHBSwapchainVK::IsAvailableOnPlatform()) {
     auto ahb_swapchain = std::shared_ptr<AHBSwapchainVK>(new AHBSwapchainVK(
         context,             //
         window.GetHandle(),  //


### PR DESCRIPTION
Fixes  https://github.com/flutter/flutter/issues/147533

This works now that the backpressure issue is fixed. Maybe the wait semaphore didn't work, but the CPU wait on the fence does.