### PR TITLE
Remove incorrect line

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/KeyEmbedderResponder.java
+++ b/shell/platform/android/io/flutter/embedding/android/KeyEmbedderResponder.java
@@ -369,7 +369,6 @@ public class KeyEmbedderResponder implements KeyboardManager.Responder {
     output.physicalKey = physicalKey;
     output.character = character;
     output.synthesized = false;
-    output.deviceType = KeyData.DeviceType.kKeyboard;
 
     sendKeyEvent(output, onKeyEventHandledCallback);
     for (final Runnable postSyncEvent : postSynchronizeEvents) {

--- a/shell/platform/android/test/io/flutter/embedding/android/KeyboardManagerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/KeyboardManagerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import android.view.InputDevice;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
 import androidx.annotation.NonNull;
@@ -88,7 +89,7 @@ public class KeyboardManagerTest {
     /**
      * Construct an empty call record.
      *
-     * <p>Use the static functions to constuct specific types instead.
+     * <p>Use the static functions to construct specific types instead.
      */
     private CallRecord() {}
 
@@ -1920,5 +1921,62 @@ public class KeyboardManagerTest {
     tester.keyboardManager.handleEvent(
         new FakeKeyEvent(ACTION_UP, SCAN_KEY_A, KEYCODE_A, 0, 'a', 0));
     assertEquals(tester.keyboardManager.getKeyboardState(), Map.of());
+  }
+
+  @Test
+  public void deviceTypeFromInputDevice() {
+      final KeyboardTester tester = new KeyboardTester();
+      final ArrayList<CallRecord> calls = new ArrayList<>();
+
+      tester.recordEmbedderCallsTo(calls);
+      tester.respondToTextInputWith(true);
+
+      // Keyboard
+      final KeyEvent keyboardEvent = new FakeKeyEvent(
+              ACTION_DOWN, SCAN_KEY_A, KEYCODE_A, 0, 'a', 0, InputDevice.SOURCE_KEYBOARD);
+      assertEquals(true, tester.keyboardManager.handleEvent(keyboardEvent));
+      verifyEmbedderEvents(calls,
+              new KeyData[] {
+                      buildKeyData(Type.kDown, PHYSICAL_KEY_A, LOGICAL_KEY_A, "a", false,
+                              DeviceType.kKeyboard),
+              });
+      calls.clear();
+
+      // Directional pad
+      final KeyEvent directionalPadEvent = new FakeKeyEvent(
+              ACTION_DOWN, SCAN_ARROW_LEFT, KEYCODE_DPAD_LEFT, 0, '\0', 0, InputDevice.SOURCE_DPAD);
+      assertEquals(true, tester.keyboardManager.handleEvent(directionalPadEvent));
+      verifyEmbedderEvents(calls,
+              new KeyData[] {
+                      buildKeyData(Type.kDown, PHYSICAL_ARROW_LEFT, LOGICAL_ARROW_LEFT, null, false,
+                              DeviceType.kDirectionalPad),
+              });
+      calls.clear();
+
+      // Gamepad
+      final KeyEvent gamepadEvent = new FakeKeyEvent(ACTION_DOWN, SCAN_ARROW_LEFT, KEYCODE_BUTTON_A,
+              0, '\0', 0, InputDevice.SOURCE_GAMEPAD);
+      assertEquals(true, tester.keyboardManager.handleEvent(gamepadEvent));
+      verifyEmbedderEvents(calls,
+              new KeyData[] {
+                      buildKeyData(Type.kUp, PHYSICAL_ARROW_LEFT, LOGICAL_ARROW_LEFT, null, true,
+                              DeviceType.kKeyboard),
+                      buildKeyData(Type.kDown, PHYSICAL_ARROW_LEFT, LOGICAL_GAME_BUTTON_A, null,
+                              false, DeviceType.kGamepad),
+              });
+      calls.clear();
+
+      // HDMI
+      final KeyEvent hdmiEvent = new FakeKeyEvent(
+              ACTION_DOWN, SCAN_ARROW_LEFT, KEYCODE_BUTTON_A, 0, '\0', 0, InputDevice.SOURCE_HDMI);
+      assertEquals(true, tester.keyboardManager.handleEvent(hdmiEvent));
+      verifyEmbedderEvents(calls,
+              new KeyData[] {
+                      buildKeyData(Type.kUp, PHYSICAL_ARROW_LEFT, LOGICAL_GAME_BUTTON_A, null, true,
+                              DeviceType.kKeyboard),
+                      buildKeyData(Type.kDown, PHYSICAL_ARROW_LEFT, LOGICAL_GAME_BUTTON_A, null,
+                              false, DeviceType.kHdmi),
+              });
+      calls.clear();
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/android/KeyboardManagerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/KeyboardManagerTest.java
@@ -1925,58 +1925,85 @@ public class KeyboardManagerTest {
 
   @Test
   public void deviceTypeFromInputDevice() {
-      final KeyboardTester tester = new KeyboardTester();
-      final ArrayList<CallRecord> calls = new ArrayList<>();
+    final KeyboardTester tester = new KeyboardTester();
+    final ArrayList<CallRecord> calls = new ArrayList<>();
 
-      tester.recordEmbedderCallsTo(calls);
-      tester.respondToTextInputWith(true);
+    tester.recordEmbedderCallsTo(calls);
+    tester.respondToTextInputWith(true);
 
-      // Keyboard
-      final KeyEvent keyboardEvent = new FakeKeyEvent(
-              ACTION_DOWN, SCAN_KEY_A, KEYCODE_A, 0, 'a', 0, InputDevice.SOURCE_KEYBOARD);
-      assertEquals(true, tester.keyboardManager.handleEvent(keyboardEvent));
-      verifyEmbedderEvents(calls,
-              new KeyData[] {
-                      buildKeyData(Type.kDown, PHYSICAL_KEY_A, LOGICAL_KEY_A, "a", false,
-                              DeviceType.kKeyboard),
-              });
-      calls.clear();
+    // Keyboard
+    final KeyEvent keyboardEvent =
+        new FakeKeyEvent(
+            ACTION_DOWN, SCAN_KEY_A, KEYCODE_A, 0, 'a', 0, InputDevice.SOURCE_KEYBOARD);
+    assertEquals(true, tester.keyboardManager.handleEvent(keyboardEvent));
+    verifyEmbedderEvents(
+        calls,
+        new KeyData[] {
+          buildKeyData(Type.kDown, PHYSICAL_KEY_A, LOGICAL_KEY_A, "a", false, DeviceType.kKeyboard),
+        });
+    calls.clear();
 
-      // Directional pad
-      final KeyEvent directionalPadEvent = new FakeKeyEvent(
-              ACTION_DOWN, SCAN_ARROW_LEFT, KEYCODE_DPAD_LEFT, 0, '\0', 0, InputDevice.SOURCE_DPAD);
-      assertEquals(true, tester.keyboardManager.handleEvent(directionalPadEvent));
-      verifyEmbedderEvents(calls,
-              new KeyData[] {
-                      buildKeyData(Type.kDown, PHYSICAL_ARROW_LEFT, LOGICAL_ARROW_LEFT, null, false,
-                              DeviceType.kDirectionalPad),
-              });
-      calls.clear();
+    // Directional pad
+    final KeyEvent directionalPadEvent =
+        new FakeKeyEvent(
+            ACTION_DOWN, SCAN_ARROW_LEFT, KEYCODE_DPAD_LEFT, 0, '\0', 0, InputDevice.SOURCE_DPAD);
+    assertEquals(true, tester.keyboardManager.handleEvent(directionalPadEvent));
+    verifyEmbedderEvents(
+        calls,
+        new KeyData[] {
+          buildKeyData(
+              Type.kDown,
+              PHYSICAL_ARROW_LEFT,
+              LOGICAL_ARROW_LEFT,
+              null,
+              false,
+              DeviceType.kDirectionalPad),
+        });
+    calls.clear();
 
-      // Gamepad
-      final KeyEvent gamepadEvent = new FakeKeyEvent(ACTION_DOWN, SCAN_ARROW_LEFT, KEYCODE_BUTTON_A,
-              0, '\0', 0, InputDevice.SOURCE_GAMEPAD);
-      assertEquals(true, tester.keyboardManager.handleEvent(gamepadEvent));
-      verifyEmbedderEvents(calls,
-              new KeyData[] {
-                      buildKeyData(Type.kUp, PHYSICAL_ARROW_LEFT, LOGICAL_ARROW_LEFT, null, true,
-                              DeviceType.kKeyboard),
-                      buildKeyData(Type.kDown, PHYSICAL_ARROW_LEFT, LOGICAL_GAME_BUTTON_A, null,
-                              false, DeviceType.kGamepad),
-              });
-      calls.clear();
+    // Gamepad
+    final KeyEvent gamepadEvent =
+        new FakeKeyEvent(
+            ACTION_DOWN, SCAN_ARROW_LEFT, KEYCODE_BUTTON_A, 0, '\0', 0, InputDevice.SOURCE_GAMEPAD);
+    assertEquals(true, tester.keyboardManager.handleEvent(gamepadEvent));
+    verifyEmbedderEvents(
+        calls,
+        new KeyData[] {
+          buildKeyData(
+              Type.kUp, PHYSICAL_ARROW_LEFT, LOGICAL_ARROW_LEFT, null, true, DeviceType.kKeyboard),
+          buildKeyData(
+              Type.kDown,
+              PHYSICAL_ARROW_LEFT,
+              LOGICAL_GAME_BUTTON_A,
+              null,
+              false,
+              DeviceType.kGamepad),
+        });
+    calls.clear();
 
-      // HDMI
-      final KeyEvent hdmiEvent = new FakeKeyEvent(
-              ACTION_DOWN, SCAN_ARROW_LEFT, KEYCODE_BUTTON_A, 0, '\0', 0, InputDevice.SOURCE_HDMI);
-      assertEquals(true, tester.keyboardManager.handleEvent(hdmiEvent));
-      verifyEmbedderEvents(calls,
-              new KeyData[] {
-                      buildKeyData(Type.kUp, PHYSICAL_ARROW_LEFT, LOGICAL_GAME_BUTTON_A, null, true,
-                              DeviceType.kKeyboard),
-                      buildKeyData(Type.kDown, PHYSICAL_ARROW_LEFT, LOGICAL_GAME_BUTTON_A, null,
-                              false, DeviceType.kHdmi),
-              });
-      calls.clear();
+    // HDMI
+    final KeyEvent hdmiEvent =
+        new FakeKeyEvent(
+            ACTION_DOWN, SCAN_ARROW_LEFT, KEYCODE_BUTTON_A, 0, '\0', 0, InputDevice.SOURCE_HDMI);
+    assertEquals(true, tester.keyboardManager.handleEvent(hdmiEvent));
+    verifyEmbedderEvents(
+        calls,
+        new KeyData[] {
+          buildKeyData(
+              Type.kUp,
+              PHYSICAL_ARROW_LEFT,
+              LOGICAL_GAME_BUTTON_A,
+              null,
+              true,
+              DeviceType.kKeyboard),
+          buildKeyData(
+              Type.kDown,
+              PHYSICAL_ARROW_LEFT,
+              LOGICAL_GAME_BUTTON_A,
+              null,
+              false,
+              DeviceType.kHdmi),
+        });
+    calls.clear();
   }
 }

--- a/shell/platform/android/test/io/flutter/util/FakeKeyEvent.java
+++ b/shell/platform/android/test/io/flutter/util/FakeKeyEvent.java
@@ -20,6 +20,12 @@ public class FakeKeyEvent extends KeyEvent {
     this.character = character;
   }
 
+  public FakeKeyEvent(
+      int action, int scancode, int code, int repeat, char character, int metaState, int source) {
+    super(0, 0, action, code, repeat, metaState, 0, scancode, 0, source);
+    this.character = character;
+  }
+
   private char character = 0;
 
   public final int getUnicodeChar() {


### PR DESCRIPTION
## Description

Removes a line that shadows setting the device type correctly for keyboard events.

## Related Issues
 - Fixes https://github.com/flutter/flutter/issues/151308
