### PR TITLE
Prepend third_party/pyyaml to python sys.path

### DIFF
--- a/tools/fuchsia/dart/gen_dart_package_config.py
+++ b/tools/fuchsia/dart/gen_dart_package_config.py
@@ -15,7 +15,7 @@ import re
 import sys
 
 THIS_DIR = os.path.abspath(os.path.dirname(__file__))
-sys.path += [os.path.join(THIS_DIR, '..', '..', '..', 'third_party', 'pyyaml', 'lib')]
+sys.path.insert(0, os.path.join(THIS_DIR, '..', '..', '..', 'third_party', 'pyyaml', 'lib'))
 import yaml
 
 DEFAULT_LANGUAGE_VERSION = '2.8'

--- a/tools/pub_get_offline.py
+++ b/tools/pub_get_offline.py
@@ -15,7 +15,7 @@ import subprocess
 import sys
 
 THIS_DIR = os.path.abspath(os.path.dirname(__file__))
-sys.path += [os.path.join(THIS_DIR, '..', 'third_party', 'pyyaml', 'lib')]
+sys.path.insert(0, os.path.join(THIS_DIR, '..', 'third_party', 'pyyaml', 'lib'))
 import yaml  # pylint: disable=import-error, wrong-import-position
 
 SRC_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))


### PR DESCRIPTION
Previously we were appending Flutter's fork of third_party/pyyaml to the Python sys.path. In the case where a bot image or local install already has pyyaml installed elsewhere on the path, ours will fail to be picked up. Instead prepend to the path.

Issue spotted by jsimmons@.

Related: https://github.com/flutter/engine/pull/54001


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
