### PR TITLE
Update header_filter_regex_test.dart

### DIFF
--- a/tools/clang_tidy/test/header_filter_regex_test.dart
+++ b/tools/clang_tidy/test/header_filter_regex_test.dart
@@ -36,6 +36,7 @@ void main() {
   test('contains every root directory in the regex', () {
     // These are a list of directories that should _not_ be included.
     const Set<String> intentionallyOmitted = <String>{
+      '.dart_tool',
       '.git',
       '.github',
       'build_overrides',


### PR DESCRIPTION
Adds '.dart_tool' to the omitted list.

For https://github.com/flutter/flutter/issues/152121