### PR TITLE
[Impeller] Cleanly revert requiring backpressure for AHB swapchains.

### DIFF
--- a/impeller/toolkit/android/proc_table.h
+++ b/impeller/toolkit/android/proc_table.h
@@ -60,7 +60,6 @@ namespace impeller::android {
   INVOKE(ASurfaceTransaction_setBuffer, 29)                      \
   INVOKE(ASurfaceTransaction_setColor, 29)                       \
   INVOKE(ASurfaceTransaction_setOnComplete, 29)                  \
-  INVOKE(ASurfaceTransaction_setEnableBackPressure, 31)          \
   INVOKE(ASurfaceTransactionStats_getPreviousReleaseFenceFd, 29) \
   INVOKE(ATrace_isEnabled, 23)                                   \
   INVOKE(eglGetNativeClientBufferANDROID, 0)

--- a/impeller/toolkit/android/surface_control.cc
+++ b/impeller/toolkit/android/surface_control.cc
@@ -5,7 +5,6 @@
 #include "impeller/toolkit/android/surface_control.h"
 
 #include "impeller/base/validation.h"
-#include "impeller/toolkit/android/proc_table.h"
 #include "impeller/toolkit/android/surface_transaction.h"
 
 namespace impeller::android {
@@ -50,8 +49,7 @@ bool SurfaceControl::RemoveFromParent() const {
 
 bool SurfaceControl::IsAvailableOnPlatform() {
   return GetProcTable().IsValid() &&
-         GetProcTable().ASurfaceControl_createFromWindow.IsAvailable() &&
-         GetProcTable().ASurfaceTransaction_setEnableBackPressure.IsAvailable();
+         GetProcTable().ASurfaceControl_createFromWindow.IsAvailable();
 }
 
 }  // namespace impeller::android

--- a/impeller/toolkit/android/surface_transaction.cc
+++ b/impeller/toolkit/android/surface_transaction.cc
@@ -58,10 +58,7 @@ bool SurfaceTransaction::SetContents(const SurfaceControl* control,
     VALIDATION_LOG << "Invalid control or buffer.";
     return false;
   }
-
-  const auto& proc_table = GetProcTable();
-
-  proc_table.ASurfaceTransaction_setBuffer(
+  GetProcTable().ASurfaceTransaction_setBuffer(
       transaction_.get(),                                      //
       control->GetHandle(),                                    //
       buffer->GetHandle(),                                     //


### PR DESCRIPTION
Revert 0c417292c6bdac750ffede38998426fd6e825554

This was a partial revert. See explanation in https://github.com/flutter/engine/pull/54012#issuecomment-2243812137