### PR TITLE
Delete impeller tests on beta branch

### DIFF
--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -241,19 +241,6 @@
                     "sdk_version": "15a240d"
                 }
             },
-            "tests": [
-                {
-                    "language": "python3",
-                    "name": "Impeller-golden, dart and engine tests for host_release",
-                    "script": "flutter/testing/run_tests.py",
-                    "parameters": [
-                        "--variant",
-                        "ci/host_release",
-                        "--type",
-                        "dart,dart-host,engine"
-                    ]
-                }
-            ],
             "timeout": 90
         },
         {

--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -241,6 +241,19 @@
                     "sdk_version": "15a240d"
                 }
             },
+            "tests": [
+                {
+                    "language": "python3",
+                    "name": "Impeller-golden, dart and engine tests for host_release",
+                    "script": "flutter/testing/run_tests.py",
+                    "parameters": [
+                        "--variant",
+                        "ci/host_release",
+                        "--type",
+                        "dart,dart-host,engine"
+                    ]
+                }
+            ],
             "timeout": 90
         },
         {
@@ -458,19 +471,6 @@
                     "sdk_version": "15a240d"
                 }
             },
-            "tests": [
-                {
-                    "language": "python3",
-                    "name": "Impeller-golden for host_release",
-                    "script": "flutter/testing/run_tests.py",
-                    "parameters": [
-                        "--variant",
-                        "ci/mac_release_arm64",
-                        "--type",
-                        "impeller-golden"
-                    ]
-                }
-            ],
             "timeout": 90
         }
     ],


### PR DESCRIPTION
Delete Impeller tests on beta branch due to the following failure:

`The GOLDCTL environment variable is not set. This is required for Skia Gold tests.`
