### PR TITLE
Temporarily disable use of glBlitFramebuffer on NVIDIA

### DIFF
--- a/shell/platform/linux/fl_renderer.cc
+++ b/shell/platform/linux/fl_renderer.cc
@@ -60,6 +60,12 @@ typedef struct {
 
 G_DEFINE_TYPE_WITH_PRIVATE(FlRenderer, fl_renderer, G_TYPE_OBJECT)
 
+// Check if running on an NVIDIA driver.
+static gboolean is_nvidia() {
+  const gchar* vendor = reinterpret_cast<const gchar*>(glGetString(GL_VENDOR));
+  return strstr(vendor, "NVIDIA") != nullptr;
+}
+
 // Returns the log for the given OpenGL shader. Must be freed by the caller.
 static gchar* get_shader_log(GLuint shader) {
   GLint log_length;
@@ -408,9 +414,11 @@ void fl_renderer_setup(FlRenderer* self) {
 
   g_return_if_fail(FL_IS_RENDERER(self));
 
+  // Note: NVIDIA is temporarily disabled due to
+  // https://github.com/flutter/flutter/issues/152099
   priv->has_gl_framebuffer_blit =
-      epoxy_gl_version() >= 30 ||
-      epoxy_has_gl_extension("GL_EXT_framebuffer_blit");
+      !is_nvidia() && (epoxy_gl_version() >= 30 ||
+                       epoxy_has_gl_extension("GL_EXT_framebuffer_blit"));
 
   if (!priv->has_gl_framebuffer_blit) {
     setup_shader(self);

--- a/shell/platform/linux/testing/mock_epoxy.cc
+++ b/shell/platform/linux/testing/mock_epoxy.cc
@@ -438,6 +438,10 @@ static void _glGetShaderInfoLog(GLuint shader,
                                 GLsizei* length,
                                 GLchar* infoLog) {}
 
+static const GLubyte* _glGetString(GLenum pname) {
+  return mock->glGetString(pname);
+}
+
 static void _glTexParameterf(GLenum target, GLenum pname, GLfloat param) {}
 
 static void _glTexParameteri(GLenum target, GLenum pname, GLint param) {}
@@ -603,6 +607,7 @@ static void library_init() {
   epoxy_glGetProgramInfoLog = _glGetProgramInfoLog;
   epoxy_glGetShaderiv = _glGetShaderiv;
   epoxy_glGetShaderInfoLog = _glGetShaderInfoLog;
+  epoxy_glGetString = _glGetString;
   epoxy_glLinkProgram = _glLinkProgram;
   epoxy_glShaderSource = _glShaderSource;
   epoxy_glTexParameterf = _glTexParameterf;

--- a/shell/platform/linux/testing/mock_epoxy.h
+++ b/shell/platform/linux/testing/mock_epoxy.h
@@ -32,6 +32,7 @@ class MockEpoxy {
                GLint dstY1,
                GLbitfield mask,
                GLenum filter));
+  MOCK_METHOD(const GLubyte*, glGetString, (GLenum pname));
 };
 
 }  // namespace testing


### PR DESCRIPTION
Workaround for https://github.com/flutter/flutter/issues/152099
