### PR TITLE
Change JSArray.length to return int

### DIFF
--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -3763,9 +3763,8 @@ bool get browserSupportsCreateImageBitmap =>
     !isChrome110OrOlder &&
     !debugDisableCreateImageBitmapSupport;
 
-@JS()
-@staticInterop
 extension JSArrayExtension on JSArray<JSAny?> {
   external void push(JSAny value);
-  external JSNumber get length;
+  // TODO(srujzs): Delete this when we add `JSArray.length` in the SDK.
+  external int get length;
 }

--- a/lib/web_ui/test/engine/view_embedder/hot_restart_cache_handler_test.dart
+++ b/lib/web_ui/test/engine/view_embedder/hot_restart_cache_handler_test.dart
@@ -50,8 +50,7 @@ void doTests() {
       HotRestartCacheHandler();
 
       expect(_jsHotRestartStore, isNotNull);
-      // For dart2wasm, we have to check the length this way.
-      expect(_jsHotRestartStore!.length, 0.toJS);
+      expect(_jsHotRestartStore!.length, 0);
     });
   });
 
@@ -94,7 +93,7 @@ void doTests() {
       cache = HotRestartCacheHandler();
 
       // For dart2wasm, we have to check the length this way.
-      expect(_jsHotRestartStore!.length, 0.toJS);
+      expect(_jsHotRestartStore!.length, 0);
       expect(element.isConnected, isFalse); // Removed
       expect(element2.isConnected, isTrue);
     });


### PR DESCRIPTION
This is in preparation for
https://dart-review.googlesource.com/c/sdk/+/373884, which will add length to the extension type itself. This will shadow the extension member, so we should make sure the type signatures match.