### PR TITLE
[iOS] Flush layer pool after platform view dispose

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -161,6 +161,10 @@ FlutterPlatformViewLayerPool::RemoveUnusedLayers() {
   return results;
 }
 
+size_t FlutterPlatformViewLayerPool::size() const {
+  return layers_.size();
+}
+
 void FlutterPlatformViewsController::SetFlutterView(UIView* flutter_view) {
   flutter_view_.reset(flutter_view);
 }
@@ -401,6 +405,10 @@ void FlutterPlatformViewsController::PrerollCompositeEmbeddedView(
 
 size_t FlutterPlatformViewsController::EmbeddedViewCount() {
   return composition_order_.size();
+}
+
+size_t FlutterPlatformViewsController::LayerPoolSize() const {
+  return layer_pool_->size();
 }
 
 UIView* FlutterPlatformViewsController::GetPlatformViewByID(int64_t view_id) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -152,11 +152,12 @@ void FlutterPlatformViewLayerPool::RecycleLayers() {
 }
 
 std::vector<std::shared_ptr<FlutterPlatformViewLayer>>
-FlutterPlatformViewLayerPool::GetUnusedLayers() {
+FlutterPlatformViewLayerPool::RemoveUnusedLayers() {
   std::vector<std::shared_ptr<FlutterPlatformViewLayer>> results;
   for (size_t i = available_layer_index_; i < layers_.size(); i++) {
     results.push_back(layers_[i]);
   }
+  layers_.erase(layers_.begin() + available_layer_index_, layers_.end());
   return results;
 }
 
@@ -873,8 +874,7 @@ std::shared_ptr<FlutterPlatformViewLayer> FlutterPlatformViewsController::GetLay
 }
 
 void FlutterPlatformViewsController::RemoveUnusedLayers() {
-  std::vector<std::shared_ptr<FlutterPlatformViewLayer>> layers = layer_pool_->GetUnusedLayers();
-  for (const std::shared_ptr<FlutterPlatformViewLayer>& layer : layers) {
+  for (const auto& layer : layer_pool_->RemoveUnusedLayers()) {
     [layer->overlay_view_wrapper removeFromSuperview];
   }
 
@@ -915,7 +915,6 @@ void FlutterPlatformViewsController::DisposeViews() {
     clip_count_.erase(viewId);
     views_to_recomposite_.erase(viewId);
   }
-
   views_to_dispose_ = std::move(views_to_delay_dispose);
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -176,9 +176,8 @@ class FlutterPlatformViewLayerPool {
                                                      const std::shared_ptr<IOSContext>& ios_context,
                                                      MTLPixelFormat pixel_format);
 
-  // Gets the layers in the pool that aren't currently used.
-  // This method doesn't mark the layers as unused.
-  std::vector<std::shared_ptr<FlutterPlatformViewLayer>> GetUnusedLayers();
+  // Removes unused layers from the pool. Returns the unused layers.
+  std::vector<std::shared_ptr<FlutterPlatformViewLayer>> RemoveUnusedLayers();
 
   // Marks the layers in the pool as available for reuse.
   void RecycleLayers();

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -182,6 +182,9 @@ class FlutterPlatformViewLayerPool {
   // Marks the layers in the pool as available for reuse.
   void RecycleLayers();
 
+  // Returns the count of layers currently in the pool.
+  size_t size() const;
+
  private:
   // The index of the entry in the layers_ vector that determines the beginning of the unused
   // layers. For example, consider the following vector:
@@ -234,6 +237,8 @@ class FlutterPlatformViewsController {
                                     std::unique_ptr<flutter::EmbeddedViewParams> params);
 
   size_t EmbeddedViewCount();
+
+  size_t LayerPoolSize() const;
 
   // Returns the `FlutterPlatformView`'s `view` object associated with the view_id.
   //


### PR DESCRIPTION
`FlutterPlatformViewLayerPool` is a pool of iOS layers used for rendering platform views on iOS. When layers are no longer needed, we currently mark them available for re-use but we never actually flush them and thus recover the memory associated with these layers once we know that the layers are no longer needed.

We now flush the layer pool on `SubmitFrame` if a previously-used layer is no longer used in the current frame. In theory, this could cause a performance regression in the case where an additional layer is needed every second or third frame, but we should keep it simple on the first pass and only complicate things later if warranted.

Fixes: https://github.com/flutter/flutter/issues/152053


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
