### PR TITLE
[web] better class names for semantics

### DIFF
--- a/lib/web_ui/lib/src/engine/semantics/checkable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/checkable.dart
@@ -49,11 +49,11 @@ _CheckableKind _checkableKindFromSemanticsFlag(
 /// See also [ui.SemanticsFlag.hasCheckedState], [ui.SemanticsFlag.isChecked],
 /// [ui.SemanticsFlag.isInMutuallyExclusiveGroup], [ui.SemanticsFlag.isToggled],
 /// [ui.SemanticsFlag.hasToggledState]
-class Checkable extends PrimaryRoleManager {
+class Checkable extends SemanticRole {
   Checkable(SemanticsObject semanticsObject)
       : _kind = _checkableKindFromSemanticsFlag(semanticsObject),
         super.withBasics(
-          PrimaryRole.checkable,
+          SemanticRoleId.checkable,
           semanticsObject,
           preferredLabelRepresentation: LabelRepresentation.ariaLabel,
         ) {

--- a/lib/web_ui/lib/src/engine/semantics/checkable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/checkable.dart
@@ -53,7 +53,7 @@ class Checkable extends SemanticRole {
   Checkable(SemanticsObject semanticsObject)
       : _kind = _checkableKindFromSemanticsFlag(semanticsObject),
         super.withBasics(
-          SemanticRoleId.checkable,
+          SemanticRoleKind.checkable,
           semanticsObject,
           preferredLabelRepresentation: LabelRepresentation.ariaLabel,
         ) {

--- a/lib/web_ui/lib/src/engine/semantics/checkable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/checkable.dart
@@ -49,8 +49,8 @@ _CheckableKind _checkableKindFromSemanticsFlag(
 /// See also [ui.SemanticsFlag.hasCheckedState], [ui.SemanticsFlag.isChecked],
 /// [ui.SemanticsFlag.isInMutuallyExclusiveGroup], [ui.SemanticsFlag.isToggled],
 /// [ui.SemanticsFlag.hasToggledState]
-class Checkable extends SemanticRole {
-  Checkable(SemanticsObject semanticsObject)
+class SemanticCheckable extends SemanticRole {
+  SemanticCheckable(SemanticsObject semanticsObject)
       : _kind = _checkableKindFromSemanticsFlag(semanticsObject),
         super.withBasics(
           SemanticRoleKind.checkable,

--- a/lib/web_ui/lib/src/engine/semantics/dialog.dart
+++ b/lib/web_ui/lib/src/engine/semantics/dialog.dart
@@ -6,9 +6,7 @@ import '../dom.dart';
 import '../semantics.dart';
 import '../util.dart';
 
-/// Provides accessibility for dialogs.
-///
-/// See also [Role.dialog].
+/// Provides accessibility for routes, including dialogs and pop-up menus.
 class Dialog extends PrimaryRoleManager {
   Dialog(SemanticsObject semanticsObject) : super.blank(PrimaryRole.dialog, semanticsObject) {
     // The following behaviors can coexist with dialog. Generic `RouteName`
@@ -100,11 +98,15 @@ class Dialog extends PrimaryRoleManager {
 }
 
 /// Supplies a description for the nearest ancestor [Dialog].
+///
+/// This role is assigned to nodes that have `namesRoute` set but not
+/// `scopesRoute`. When both flags are set the node only gets the [Dialog] role.
+///
+/// If the ancestor dialog is missing, this role has no effect. It is up to the
+/// framework, widget, and app authors to make sure a route name is scoped under
+/// a route.
 class RouteName extends SemanticBehavior {
-  RouteName(
-    SemanticsObject semanticsObject,
-    PrimaryRoleManager owner,
-  ) : super(Role.routeName, semanticsObject, owner);
+  RouteName(super.semanticsObject, super.owner);
 
   Dialog? _dialog;
 

--- a/lib/web_ui/lib/src/engine/semantics/dialog.dart
+++ b/lib/web_ui/lib/src/engine/semantics/dialog.dart
@@ -7,8 +7,8 @@ import '../semantics.dart';
 import '../util.dart';
 
 /// Provides accessibility for routes, including dialogs and pop-up menus.
-class Dialog extends PrimaryRoleManager {
-  Dialog(SemanticsObject semanticsObject) : super.blank(PrimaryRole.dialog, semanticsObject) {
+class Dialog extends SemanticRole {
+  Dialog(SemanticsObject semanticsObject) : super.blank(SemanticRoleId.dialog, semanticsObject) {
     // The following behaviors can coexist with dialog. Generic `RouteName`
     // and `LabelAndValue` are not used by this role because when the dialog
     // names its own route an `aria-label` is used instead of `aria-describedby`.
@@ -37,7 +37,7 @@ class Dialog extends PrimaryRoleManager {
 
   void _setDefaultFocus() {
     semanticsObject.visitDepthFirstInTraversalOrder((SemanticsObject node) {
-      final PrimaryRoleManager? roleManager = node.primaryRole;
+      final SemanticRole? roleManager = node.semanticRole;
       if (roleManager == null) {
         return true;
       }
@@ -145,11 +145,11 @@ class RouteName extends SemanticBehavior {
 
   void _lookUpNearestAncestorDialog() {
     SemanticsObject? parent = semanticsObject.parent;
-    while (parent != null && parent.primaryRole?.role != PrimaryRole.dialog) {
+    while (parent != null && parent.semanticRole?.role != SemanticRoleId.dialog) {
       parent = parent.parent;
     }
-    if (parent != null && parent.primaryRole?.role == PrimaryRole.dialog) {
-      _dialog = parent.primaryRole! as Dialog;
+    if (parent != null && parent.semanticRole?.role == SemanticRoleId.dialog) {
+      _dialog = parent.semanticRole! as Dialog;
     }
   }
 }

--- a/lib/web_ui/lib/src/engine/semantics/dialog.dart
+++ b/lib/web_ui/lib/src/engine/semantics/dialog.dart
@@ -7,8 +7,8 @@ import '../semantics.dart';
 import '../util.dart';
 
 /// Provides accessibility for routes, including dialogs and pop-up menus.
-class Dialog extends SemanticRole {
-  Dialog(SemanticsObject semanticsObject) : super.blank(SemanticRoleKind.dialog, semanticsObject) {
+class SemanticDialog extends SemanticRole {
+  SemanticDialog(SemanticsObject semanticsObject) : super.blank(SemanticRoleKind.dialog, semanticsObject) {
     // The following behaviors can coexist with dialog. Generic `RouteName`
     // and `LabelAndValue` are not used by this role because when the dialog
     // names its own route an `aria-label` is used instead of `aria-describedby`.
@@ -97,10 +97,10 @@ class Dialog extends SemanticRole {
   }
 }
 
-/// Supplies a description for the nearest ancestor [Dialog].
+/// Supplies a description for the nearest ancestor [SemanticDialog].
 ///
 /// This role is assigned to nodes that have `namesRoute` set but not
-/// `scopesRoute`. When both flags are set the node only gets the [Dialog] role.
+/// `scopesRoute`. When both flags are set the node only gets the [SemanticDialog] role.
 ///
 /// If the ancestor dialog is missing, this role has no effect. It is up to the
 /// framework, widget, and app authors to make sure a route name is scoped under
@@ -108,7 +108,7 @@ class Dialog extends SemanticRole {
 class RouteName extends SemanticBehavior {
   RouteName(super.semanticsObject, super.owner);
 
-  Dialog? _dialog;
+  SemanticDialog? _dialog;
 
   @override
   void update() {
@@ -126,7 +126,7 @@ class RouteName extends SemanticBehavior {
     }
 
     if (semanticsObject.isLabelDirty) {
-      final Dialog? dialog = _dialog;
+      final SemanticDialog? dialog = _dialog;
       if (dialog != null) {
         // Already attached to a dialog, just update the description.
         dialog.describeBy(this);
@@ -149,7 +149,7 @@ class RouteName extends SemanticBehavior {
       parent = parent.parent;
     }
     if (parent != null && parent.semanticRole?.kind == SemanticRoleKind.dialog) {
-      _dialog = parent.semanticRole! as Dialog;
+      _dialog = parent.semanticRole! as SemanticDialog;
     }
   }
 }

--- a/lib/web_ui/lib/src/engine/semantics/dialog.dart
+++ b/lib/web_ui/lib/src/engine/semantics/dialog.dart
@@ -11,7 +11,7 @@ import '../util.dart';
 /// See also [Role.dialog].
 class Dialog extends PrimaryRoleManager {
   Dialog(SemanticsObject semanticsObject) : super.blank(PrimaryRole.dialog, semanticsObject) {
-    // The following secondary roles can coexist with dialog. Generic `RouteName`
+    // The following behaviors can coexist with dialog. Generic `RouteName`
     // and `LabelAndValue` are not used by this role because when the dialog
     // names its own route an `aria-label` is used instead of `aria-describedby`.
     addFocusManagement();
@@ -100,7 +100,7 @@ class Dialog extends PrimaryRoleManager {
 }
 
 /// Supplies a description for the nearest ancestor [Dialog].
-class RouteName extends RoleManager {
+class RouteName extends SemanticBehavior {
   RouteName(
     SemanticsObject semanticsObject,
     PrimaryRoleManager owner,

--- a/lib/web_ui/lib/src/engine/semantics/dialog.dart
+++ b/lib/web_ui/lib/src/engine/semantics/dialog.dart
@@ -8,7 +8,7 @@ import '../util.dart';
 
 /// Provides accessibility for routes, including dialogs and pop-up menus.
 class Dialog extends SemanticRole {
-  Dialog(SemanticsObject semanticsObject) : super.blank(SemanticRoleId.dialog, semanticsObject) {
+  Dialog(SemanticsObject semanticsObject) : super.blank(SemanticRoleKind.dialog, semanticsObject) {
     // The following behaviors can coexist with dialog. Generic `RouteName`
     // and `LabelAndValue` are not used by this role because when the dialog
     // names its own route an `aria-label` is used instead of `aria-describedby`.
@@ -37,14 +37,14 @@ class Dialog extends SemanticRole {
 
   void _setDefaultFocus() {
     semanticsObject.visitDepthFirstInTraversalOrder((SemanticsObject node) {
-      final SemanticRole? roleManager = node.semanticRole;
-      if (roleManager == null) {
+      final SemanticRole? role = node.semanticRole;
+      if (role == null) {
         return true;
       }
 
       // If the node does not take focus (e.g. focusing on it does not make
       // sense at all). Despair not. Keep looking.
-      final bool didTakeFocus = roleManager.focusAsRouteDefault();
+      final bool didTakeFocus = role.focusAsRouteDefault();
       return !didTakeFocus;
     });
   }
@@ -145,10 +145,10 @@ class RouteName extends SemanticBehavior {
 
   void _lookUpNearestAncestorDialog() {
     SemanticsObject? parent = semanticsObject.parent;
-    while (parent != null && parent.semanticRole?.role != SemanticRoleId.dialog) {
+    while (parent != null && parent.semanticRole?.kind != SemanticRoleKind.dialog) {
       parent = parent.parent;
     }
-    if (parent != null && parent.semanticRole?.role == SemanticRoleId.dialog) {
+    if (parent != null && parent.semanticRole?.kind == SemanticRoleKind.dialog) {
       _dialog = parent.semanticRole! as Dialog;
     }
   }

--- a/lib/web_ui/lib/src/engine/semantics/focusable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/focusable.dart
@@ -12,9 +12,9 @@ import 'semantics.dart';
 /// Supplies generic accessibility focus features to semantics nodes that have
 /// [ui.SemanticsFlag.isFocusable] set.
 ///
-/// Assumes that the element being focused on is [SemanticsObject.element]. Role
-/// managers with special needs can implement custom focus management and
-/// exclude this role manager.
+/// Assumes that the element being focused on is [SemanticsObject.element].
+/// Semantic roles with special needs can implement custom focus management and
+/// exclude this behavior.
 ///
 /// `"tab-index=0"` is used because `<flt-semantics>` is not intrinsically
 /// focusable. Examples of intrinsically focusable elements include:
@@ -43,9 +43,9 @@ class Focusable extends SemanticBehavior {
   /// programmatically, simulating the screen reader choosing a default element
   /// to focus on.
   ///
-  /// Returns `true` if the role manager took the focus. Returns `false` if
-  /// this role manager did not take the focus. The return value can be used to
-  /// decide whether to stop searching for a node that should take focus.
+  /// Returns `true` if the node took the focus. Returns `false` if the node did
+  /// not take the focus. The return value can be used to decide whether to stop
+  /// searching for a node that should take focus.
   bool focusAsRouteDefault() {
     _focusManager._lastEvent = AccessibilityFocusManagerEvent.requestedFocus;
     owner.element.focusWithoutScroll();

--- a/lib/web_ui/lib/src/engine/semantics/focusable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/focusable.dart
@@ -27,7 +27,7 @@ import 'semantics.dart';
 /// See also:
 ///
 ///   * https://developer.mozilla.org/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets
-class Focusable extends RoleManager {
+class Focusable extends SemanticBehavior {
   Focusable(SemanticsObject semanticsObject, PrimaryRoleManager owner)
       : _focusManager = AccessibilityFocusManager(semanticsObject.owner),
         super(Role.focusable, semanticsObject, owner);

--- a/lib/web_ui/lib/src/engine/semantics/focusable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/focusable.dart
@@ -105,10 +105,10 @@ enum AccessibilityFocusManagerEvent {
 ///
 /// Unlike [Focusable], which implements focus features on [SemanticsObject]s
 /// whose [SemanticsObject.element] is directly focusable, this class can help
-/// implementing focus features on custom elements. For example, [Incrementable]
-/// uses a custom `<input>` tag internally while its root-level element is not
-/// focusable. However, it can still use this class to manage the focus of the
-/// internal element.
+/// implementing focus features on custom elements. For example,
+/// [SemanticIncrementable] uses a custom `<input>` tag internally while its
+/// root-level element is not focusable. However, it can still use this class to
+/// manage the focus of the internal element.
 class AccessibilityFocusManager {
   /// Creates a focus manager tied to a specific [EngineSemanticsOwner].
   AccessibilityFocusManager(this._owner);

--- a/lib/web_ui/lib/src/engine/semantics/focusable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/focusable.dart
@@ -28,9 +28,8 @@ import 'semantics.dart';
 ///
 ///   * https://developer.mozilla.org/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets
 class Focusable extends SemanticBehavior {
-  Focusable(SemanticsObject semanticsObject, PrimaryRoleManager owner)
-      : _focusManager = AccessibilityFocusManager(semanticsObject.owner),
-        super(Role.focusable, semanticsObject, owner);
+  Focusable(super.semanticsObject, super.owner)
+      : _focusManager = AccessibilityFocusManager(semanticsObject.owner);
 
   final AccessibilityFocusManager _focusManager;
 

--- a/lib/web_ui/lib/src/engine/semantics/heading.dart
+++ b/lib/web_ui/lib/src/engine/semantics/heading.dart
@@ -8,8 +8,8 @@ import 'semantics.dart';
 
 /// Renders semantics objects as headings with the corresponding
 /// level (h1 ... h6).
-class Heading extends SemanticRole {
-  Heading(SemanticsObject semanticsObject)
+class SemanticHeading extends SemanticRole {
+  SemanticHeading(SemanticsObject semanticsObject)
       : super.blank(SemanticRoleKind.heading, semanticsObject) {
     addFocusManagement();
     addLiveRegion();

--- a/lib/web_ui/lib/src/engine/semantics/heading.dart
+++ b/lib/web_ui/lib/src/engine/semantics/heading.dart
@@ -8,9 +8,9 @@ import 'semantics.dart';
 
 /// Renders semantics objects as headings with the corresponding
 /// level (h1 ... h6).
-class Heading extends PrimaryRoleManager {
+class Heading extends SemanticRole {
   Heading(SemanticsObject semanticsObject)
-      : super.blank(PrimaryRole.heading, semanticsObject) {
+      : super.blank(SemanticRoleId.heading, semanticsObject) {
     addFocusManagement();
     addLiveRegion();
     addRouteName();

--- a/lib/web_ui/lib/src/engine/semantics/heading.dart
+++ b/lib/web_ui/lib/src/engine/semantics/heading.dart
@@ -10,7 +10,7 @@ import 'semantics.dart';
 /// level (h1 ... h6).
 class Heading extends SemanticRole {
   Heading(SemanticsObject semanticsObject)
-      : super.blank(SemanticRoleId.heading, semanticsObject) {
+      : super.blank(SemanticRoleKind.heading, semanticsObject) {
     addFocusManagement();
     addLiveRegion();
     addRouteName();

--- a/lib/web_ui/lib/src/engine/semantics/image.dart
+++ b/lib/web_ui/lib/src/engine/semantics/image.dart
@@ -12,7 +12,7 @@ import 'semantics.dart';
 /// Screen-readers takes advantage of "aria-label" to describe the visual.
 class ImageSemanticRole extends SemanticRole {
   ImageSemanticRole(SemanticsObject semanticsObject)
-      : super.blank(SemanticRoleId.image, semanticsObject) {
+      : super.blank(SemanticRoleKind.image, semanticsObject) {
     // The following behaviors can coexist with images. `LabelAndValue` is
     // not used because this behavior uses special auxiliary elements to
     // supply ARIA labels.

--- a/lib/web_ui/lib/src/engine/semantics/image.dart
+++ b/lib/web_ui/lib/src/engine/semantics/image.dart
@@ -10,11 +10,11 @@ import 'semantics.dart';
 /// Uses aria img role to convey this semantic information to the element.
 ///
 /// Screen-readers takes advantage of "aria-label" to describe the visual.
-class ImageRoleManager extends PrimaryRoleManager {
-  ImageRoleManager(SemanticsObject semanticsObject)
-      : super.blank(PrimaryRole.image, semanticsObject) {
+class ImageSemanticRole extends SemanticRole {
+  ImageSemanticRole(SemanticsObject semanticsObject)
+      : super.blank(SemanticRoleId.image, semanticsObject) {
     // The following behaviors can coexist with images. `LabelAndValue` is
-    // not used because this role manager uses special auxiliary elements to
+    // not used because this behavior uses special auxiliary elements to
     // supply ARIA labels.
     // TODO(yjbanov): reevaluate usage of aux elements, https://github.com/flutter/flutter/issues/129317
     addFocusManagement();

--- a/lib/web_ui/lib/src/engine/semantics/image.dart
+++ b/lib/web_ui/lib/src/engine/semantics/image.dart
@@ -10,8 +10,8 @@ import 'semantics.dart';
 /// Uses aria img role to convey this semantic information to the element.
 ///
 /// Screen-readers takes advantage of "aria-label" to describe the visual.
-class ImageSemanticRole extends SemanticRole {
-  ImageSemanticRole(SemanticsObject semanticsObject)
+class SemanticImage extends SemanticRole {
+  SemanticImage(SemanticsObject semanticsObject)
       : super.blank(SemanticRoleKind.image, semanticsObject) {
     // The following behaviors can coexist with images. `LabelAndValue` is
     // not used because this behavior uses special auxiliary elements to

--- a/lib/web_ui/lib/src/engine/semantics/image.dart
+++ b/lib/web_ui/lib/src/engine/semantics/image.dart
@@ -13,7 +13,7 @@ import 'semantics.dart';
 class ImageRoleManager extends PrimaryRoleManager {
   ImageRoleManager(SemanticsObject semanticsObject)
       : super.blank(PrimaryRole.image, semanticsObject) {
-    // The following secondary roles can coexist with images. `LabelAndValue` is
+    // The following behaviors can coexist with images. `LabelAndValue` is
     // not used because this role manager uses special auxiliary elements to
     // supply ARIA labels.
     // TODO(yjbanov): reevaluate usage of aux elements, https://github.com/flutter/flutter/issues/129317

--- a/lib/web_ui/lib/src/engine/semantics/incrementable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/incrementable.dart
@@ -22,7 +22,7 @@ import 'semantics.dart';
 class Incrementable extends SemanticRole {
   Incrementable(SemanticsObject semanticsObject)
       : _focusManager = AccessibilityFocusManager(semanticsObject.owner),
-        super.blank(SemanticRoleId.incrementable, semanticsObject) {
+        super.blank(SemanticRoleKind.incrementable, semanticsObject) {
     // The following generic roles can coexist with incrementables. Generic focus
     // management is not used by this role because the root DOM element is not
     // the one being focused on, but the internal `<input>` element.

--- a/lib/web_ui/lib/src/engine/semantics/incrementable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/incrementable.dart
@@ -19,8 +19,8 @@ import 'semantics.dart';
 /// The input element is disabled whenever the gesture mode switches to pointer
 /// events. This is to prevent the browser from taking over drag gestures. Drag
 /// gestures must be interpreted by the Flutter framework.
-class Incrementable extends SemanticRole {
-  Incrementable(SemanticsObject semanticsObject)
+class SemanticIncrementable extends SemanticRole {
+  SemanticIncrementable(SemanticsObject semanticsObject)
       : _focusManager = AccessibilityFocusManager(semanticsObject.owner),
         super.blank(SemanticRoleKind.incrementable, semanticsObject) {
     // The following generic roles can coexist with incrementables. Generic focus

--- a/lib/web_ui/lib/src/engine/semantics/incrementable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/incrementable.dart
@@ -19,10 +19,10 @@ import 'semantics.dart';
 /// The input element is disabled whenever the gesture mode switches to pointer
 /// events. This is to prevent the browser from taking over drag gestures. Drag
 /// gestures must be interpreted by the Flutter framework.
-class Incrementable extends PrimaryRoleManager {
+class Incrementable extends SemanticRole {
   Incrementable(SemanticsObject semanticsObject)
       : _focusManager = AccessibilityFocusManager(semanticsObject.owner),
-        super.blank(PrimaryRole.incrementable, semanticsObject) {
+        super.blank(SemanticRoleId.incrementable, semanticsObject) {
     // The following generic roles can coexist with incrementables. Generic focus
     // management is not used by this role because the root DOM element is not
     // the one being focused on, but the internal `<input>` element.

--- a/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
+++ b/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
@@ -438,7 +438,7 @@ final class SizedSpanRepresentation extends LabelRepresentationBehavior {
 /// The value is not always rendered. Some semantics nodes correspond to
 /// interactive controls. In such case the value is reported via that element's
 /// `value` attribute rather than rendering it separately.
-class LabelAndValue extends RoleManager {
+class LabelAndValue extends SemanticBehavior {
   LabelAndValue(SemanticsObject semanticsObject, PrimaryRoleManager owner, { required this.preferredRepresentation })
       : super(Role.labelAndValue, semanticsObject, owner);
 

--- a/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
+++ b/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
@@ -48,7 +48,7 @@ enum LabelRepresentation {
   sizedSpan;
 
   /// Creates the behavior for this label representation.
-  LabelRepresentationBehavior createBehavior(PrimaryRoleManager owner) {
+  LabelRepresentationBehavior createBehavior(SemanticRole owner) {
     return switch (this) {
       ariaLabel => AriaLabelRepresentation._(owner),
       domText => DomTextRepresentation._(owner),
@@ -63,8 +63,8 @@ abstract final class LabelRepresentationBehavior {
 
   final LabelRepresentation kind;
 
-  /// The role manager that this label representation is attached to.
-  final PrimaryRoleManager owner;
+  /// The role that this label representation is attached to.
+  final SemanticRole owner;
 
   /// Convenience getter for the corresponding semantics object.
   SemanticsObject get semanticsObject => owner.semanticsObject;
@@ -109,7 +109,7 @@ abstract final class LabelRepresentationBehavior {
 ///
 ///     <flt-semantics aria-label="Hello, World!"></flt-semantics>
 final class AriaLabelRepresentation extends LabelRepresentationBehavior {
-  AriaLabelRepresentation._(PrimaryRoleManager owner) : super(LabelRepresentation.ariaLabel, owner);
+  AriaLabelRepresentation._(SemanticRole owner) : super(LabelRepresentation.ariaLabel, owner);
 
   String? _previousLabel;
 
@@ -143,7 +143,7 @@ final class AriaLabelRepresentation extends LabelRepresentationBehavior {
 /// no ARIA role set, or the role does not size the element, then the
 /// [SizedSpanRepresentation] representation can be used.
 final class DomTextRepresentation extends LabelRepresentationBehavior {
-  DomTextRepresentation._(PrimaryRoleManager owner) : super(LabelRepresentation.domText, owner);
+  DomTextRepresentation._(SemanticRole owner) : super(LabelRepresentation.domText, owner);
 
   DomText? _domText;
   String? _previousLabel;
@@ -233,7 +233,7 @@ typedef _Measurement = ({
 /// * Use an existing non-text role, e.g. "heading". Sizes correctly, but breaks
 ///   the message (reads "heading").
 final class SizedSpanRepresentation extends LabelRepresentationBehavior {
-  SizedSpanRepresentation._(PrimaryRoleManager owner) : super(LabelRepresentation.sizedSpan, owner) {
+  SizedSpanRepresentation._(SemanticRole owner) : super(LabelRepresentation.sizedSpan, owner) {
     _domText.style
       // `inline-block` is needed for two reasons:
       // - It supports measuring the true size of the text. Pure `block` would
@@ -470,7 +470,7 @@ class LabelAndValue extends SemanticBehavior {
   /// If the node has children always use an `aria-label`. Using extra child
   /// nodes to represent the label will cause layout shifts and confuse the
   /// screen reader. If the are no children, use the representation preferred
-  /// by the primary role manager.
+  /// by the role.
   LabelRepresentationBehavior _getEffectiveRepresentation() {
     final LabelRepresentation effectiveRepresentation = semanticsObject.hasChildren
       ? LabelRepresentation.ariaLabel
@@ -490,7 +490,7 @@ class LabelAndValue extends SemanticBehavior {
   /// combination is present.
   String? _computeLabel() {
     // If the node is incrementable the value is reported to the browser via
-    // the respective role manager. We do not need to also render it again here.
+    // the respective role. We do not need to also render it again here.
     final bool shouldDisplayValue = !semanticsObject.isIncrementable && semanticsObject.hasValue;
 
     return computeDomSemanticsLabel(

--- a/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
+++ b/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
@@ -433,14 +433,13 @@ final class SizedSpanRepresentation extends LabelRepresentationBehavior {
   DomElement get focusTarget => _domText;
 }
 
-/// Renders [SemanticsObject.label] and/or [SemanticsObject.value] to the semantics DOM.
+/// Renders the label for a [SemanticsObject] that can be scanned by screen
+/// readers, web crawlers, and other automated agents.
 ///
-/// The value is not always rendered. Some semantics nodes correspond to
-/// interactive controls. In such case the value is reported via that element's
-/// `value` attribute rather than rendering it separately.
+/// See [computeDomSemanticsLabel] for the exact logic that constructs the label
+/// of a semantic node.
 class LabelAndValue extends SemanticBehavior {
-  LabelAndValue(SemanticsObject semanticsObject, PrimaryRoleManager owner, { required this.preferredRepresentation })
-      : super(Role.labelAndValue, semanticsObject, owner);
+  LabelAndValue(super.semanticsObject, super.owner, { required this.preferredRepresentation });
 
   /// The preferred representation of the label in the DOM.
   ///

--- a/lib/web_ui/lib/src/engine/semantics/link.dart
+++ b/lib/web_ui/lib/src/engine/semantics/link.dart
@@ -6,9 +6,9 @@ import '../dom.dart';
 import '../semantics.dart';
 
 /// Provides accessibility for links.
-class Link extends PrimaryRoleManager {
+class Link extends SemanticRole {
   Link(SemanticsObject semanticsObject) : super.withBasics(
-    PrimaryRole.link,
+    SemanticRoleId.link,
     semanticsObject,
     preferredLabelRepresentation: LabelRepresentation.domText,
   ) {

--- a/lib/web_ui/lib/src/engine/semantics/link.dart
+++ b/lib/web_ui/lib/src/engine/semantics/link.dart
@@ -6,8 +6,8 @@ import '../dom.dart';
 import '../semantics.dart';
 
 /// Provides accessibility for links.
-class Link extends SemanticRole {
-  Link(SemanticsObject semanticsObject) : super.withBasics(
+class SemanticLink extends SemanticRole {
+  SemanticLink(SemanticsObject semanticsObject) : super.withBasics(
     SemanticRoleKind.link,
     semanticsObject,
     preferredLabelRepresentation: LabelRepresentation.domText,

--- a/lib/web_ui/lib/src/engine/semantics/link.dart
+++ b/lib/web_ui/lib/src/engine/semantics/link.dart
@@ -8,7 +8,7 @@ import '../semantics.dart';
 /// Provides accessibility for links.
 class Link extends SemanticRole {
   Link(SemanticsObject semanticsObject) : super.withBasics(
-    SemanticRoleId.link,
+    SemanticRoleKind.link,
     semanticsObject,
     preferredLabelRepresentation: LabelRepresentation.domText,
   ) {

--- a/lib/web_ui/lib/src/engine/semantics/live_region.dart
+++ b/lib/web_ui/lib/src/engine/semantics/live_region.dart
@@ -16,7 +16,7 @@ import 'semantics.dart';
 /// When there is an update to [LiveRegion], assistive technologies read the
 /// label of the element. See [LabelAndValue]. If there is no label provided
 /// no content will be read.
-class LiveRegion extends RoleManager {
+class LiveRegion extends SemanticBehavior {
   LiveRegion(SemanticsObject semanticsObject, PrimaryRoleManager owner)
       : super(Role.liveRegion, semanticsObject, owner);
 

--- a/lib/web_ui/lib/src/engine/semantics/live_region.dart
+++ b/lib/web_ui/lib/src/engine/semantics/live_region.dart
@@ -13,9 +13,9 @@ import 'semantics.dart';
 /// A live region is a region whose changes will be announced by the screen
 /// reader without the user moving focus onto the node.
 ///
-/// Live regions can be a snackbar or a text field error. Once identified
-/// with this role, they will be able to get the assistive technology's
-/// attention right away.
+/// Examples of live regions include snackbars and text field errors. Once
+/// identified with this role, they will be able to get the assistive
+/// technology's attention right away.
 ///
 /// Different assistive technologies treat "aria-live" attribute differently. To
 /// keep the behavior consistent, [AccessibilityAnnouncements.announce] is used.

--- a/lib/web_ui/lib/src/engine/semantics/live_region.dart
+++ b/lib/web_ui/lib/src/engine/semantics/live_region.dart
@@ -10,15 +10,21 @@ import 'semantics.dart';
 
 /// Manages semantics configurations that represent live regions.
 ///
-/// Assistive technologies treat "aria-live" attribute differently. To keep
-/// the behavior consistent, [AccessibilityAnnouncements.announce] is used.
+/// A live region is a region whose changes will be announced by the screen
+/// reader without the user moving focus onto the node.
+///
+/// Live regions can be a snackbar or a text field error. Once identified
+/// with this role, they will be able to get the assistive technology's
+/// attention right away.
+///
+/// Different assistive technologies treat "aria-live" attribute differently. To
+/// keep the behavior consistent, [AccessibilityAnnouncements.announce] is used.
 ///
 /// When there is an update to [LiveRegion], assistive technologies read the
 /// label of the element. See [LabelAndValue]. If there is no label provided
 /// no content will be read.
 class LiveRegion extends SemanticBehavior {
-  LiveRegion(SemanticsObject semanticsObject, PrimaryRoleManager owner)
-      : super(Role.liveRegion, semanticsObject, owner);
+  LiveRegion(super.semanticsObject, super.owner);
 
   String? _lastAnnouncement;
 

--- a/lib/web_ui/lib/src/engine/semantics/platform_view.dart
+++ b/lib/web_ui/lib/src/engine/semantics/platform_view.dart
@@ -20,10 +20,10 @@ import 'semantics.dart';
 /// See also:
 ///   * https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-owns
 ///   * https://bugs.webkit.org/show_bug.cgi?id=223798
-class PlatformViewRoleManager extends PrimaryRoleManager {
-  PlatformViewRoleManager(SemanticsObject semanticsObject)
+class PlatformViewSemanticRole extends SemanticRole {
+  PlatformViewSemanticRole(SemanticsObject semanticsObject)
       : super.withBasics(
-          PrimaryRole.platformView,
+          SemanticRoleId.platformView,
           semanticsObject,
           preferredLabelRepresentation: LabelRepresentation.ariaLabel,
         );

--- a/lib/web_ui/lib/src/engine/semantics/platform_view.dart
+++ b/lib/web_ui/lib/src/engine/semantics/platform_view.dart
@@ -23,7 +23,7 @@ import 'semantics.dart';
 class PlatformViewSemanticRole extends SemanticRole {
   PlatformViewSemanticRole(SemanticsObject semanticsObject)
       : super.withBasics(
-          SemanticRoleId.platformView,
+          SemanticRoleKind.platformView,
           semanticsObject,
           preferredLabelRepresentation: LabelRepresentation.ariaLabel,
         );

--- a/lib/web_ui/lib/src/engine/semantics/platform_view.dart
+++ b/lib/web_ui/lib/src/engine/semantics/platform_view.dart
@@ -20,8 +20,8 @@ import 'semantics.dart';
 /// See also:
 ///   * https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-owns
 ///   * https://bugs.webkit.org/show_bug.cgi?id=223798
-class PlatformViewSemanticRole extends SemanticRole {
-  PlatformViewSemanticRole(SemanticsObject semanticsObject)
+class SemanticPlatformView extends SemanticRole {
+  SemanticPlatformView(SemanticsObject semanticsObject)
       : super.withBasics(
           SemanticRoleKind.platformView,
           semanticsObject,

--- a/lib/web_ui/lib/src/engine/semantics/scrollable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/scrollable.dart
@@ -22,10 +22,10 @@ import 'package:ui/ui.dart' as ui;
 /// contents is less than the size of the viewport the browser snaps
 /// "scrollTop" back to zero. If there is more content than available in the
 /// viewport "scrollTop" may take positive values.
-class Scrollable extends PrimaryRoleManager {
+class Scrollable extends SemanticRole {
   Scrollable(SemanticsObject semanticsObject)
       : super.withBasics(
-          PrimaryRole.scrollable,
+          SemanticRoleId.scrollable,
           semanticsObject,
           preferredLabelRepresentation: LabelRepresentation.ariaLabel,
         ) {

--- a/lib/web_ui/lib/src/engine/semantics/scrollable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/scrollable.dart
@@ -22,8 +22,8 @@ import 'package:ui/ui.dart' as ui;
 /// contents is less than the size of the viewport the browser snaps
 /// "scrollTop" back to zero. If there is more content than available in the
 /// viewport "scrollTop" may take positive values.
-class Scrollable extends SemanticRole {
-  Scrollable(SemanticsObject semanticsObject)
+class SemanticScrollable extends SemanticRole {
+  SemanticScrollable(SemanticsObject semanticsObject)
       : super.withBasics(
           SemanticRoleKind.scrollable,
           semanticsObject,

--- a/lib/web_ui/lib/src/engine/semantics/scrollable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/scrollable.dart
@@ -25,7 +25,7 @@ import 'package:ui/ui.dart' as ui;
 class Scrollable extends SemanticRole {
   Scrollable(SemanticsObject semanticsObject)
       : super.withBasics(
-          SemanticRoleId.scrollable,
+          SemanticRoleKind.scrollable,
           semanticsObject,
           preferredLabelRepresentation: LabelRepresentation.ariaLabel,
         ) {

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -406,40 +406,6 @@ enum PrimaryRole {
   link,
 }
 
-// TODO(yjbanov): kill this?
-/// Identifies one of the [SemanticBehavior]s of a [PrimaryRoleManager].
-enum Role {
-  /// Supplies generic accessibility focus features to semantics nodes that have
-  /// [ui.SemanticsFlag.isFocusable] set.
-  focusable,
-
-  /// Supplies generic tapping/clicking functionality.
-  tappable,
-
-  /// Provides an `aria-label` from `label`, `value`, and/or `tooltip` values.
-  ///
-  /// The two are combined into the same role because they interact with each
-  /// other.
-  labelAndValue,
-
-  /// Contains a region whose changes will be announced to the screen reader
-  /// without having to be in focus.
-  ///
-  /// These regions can be a snackbar or a text field error. Once identified
-  /// with this role, they will be able to get the assistive technology's
-  /// attention right away.
-  liveRegion,
-
-  /// Provides a description for an ancestor dialog.
-  ///
-  /// This role is assigned to nodes that have `namesRoute` set but not
-  /// `scopesRoute`. When both flags are set the node only gets the dialog
-  /// role (see [dialog]).
-  ///
-  /// If the ancestor dialog is missing, this role does nothing useful.
-  routeName,
-}
-
 /// Responsible for setting the `role` ARIA attribute and for attaching zero or
 /// more [SemanticBehavior]s to a [SemanticsObject].
 abstract class PrimaryRoleManager {
@@ -476,12 +442,6 @@ abstract class PrimaryRoleManager {
   /// Semantic behaviors provided by this role, if any.
   List<SemanticBehavior>? get behaviors => _behaviors;
   List<SemanticBehavior>? _behaviors;
-
-  /// Identifiers of semantics behaviors used by this primary role manager.
-  ///
-  /// This is only meant to be used in tests.
-  @visibleForTesting
-  List<Role> get debugSecondaryRoles => _behaviors?.map((behavior) => behavior.role).toList() ?? const <Role>[];
 
   @protected
   DomElement createElement() => domDocument.createElement('flt-semantics');
@@ -592,8 +552,8 @@ abstract class PrimaryRoleManager {
   @protected
   void addSemanticBehavior(SemanticBehavior behavior) {
     assert(
-      _behaviors?.any((existing) => existing.role == behavior.role) != true,
-      'Cannot add semantic behavior ${behavior.role}. This object already has it.',
+      _behaviors?.any((existing) => existing.runtimeType == behavior.runtimeType) != true,
+      'Cannot add semantic behavior ${behavior.runtimeType}. This object already has it.',
     );
     _behaviors ??= <SemanticBehavior>[];
     _behaviors!.add(behavior);
@@ -762,10 +722,7 @@ abstract class SemanticBehavior {
   /// Initializes a behavior for the [semanticsObject].
   ///
   /// A single [SemanticBehavior] object manages exactly one [SemanticsObject].
-  SemanticBehavior(this.role, this.semanticsObject, this.owner);
-
-  /// Role identifier.
-  final Role role;
+  SemanticBehavior(this.semanticsObject, this.owner);
 
   /// The semantics object managed by this role.
   final SemanticsObject semanticsObject;
@@ -1290,13 +1247,9 @@ class SemanticsObject {
       !isButton;
 
   /// Whether this node defines a scope for a route.
-  ///
-  /// See also [Role.dialog].
   bool get scopesRoute => hasFlag(ui.SemanticsFlag.scopesRoute);
 
   /// Whether this node describes a route.
-  ///
-  /// See also [Role.dialog].
   bool get namesRoute => hasFlag(ui.SemanticsFlag.namesRoute);
 
   /// Whether this object carry enabled/disabled state (and if so whether it is

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -711,7 +711,7 @@ final class GenericRole extends SemanticRole {
 /// Provides a piece of functionality to a [SemanticsObject].
 ///
 /// Semantic behaviors can be shared by multiple types of [SemanticRole]s. For
-/// example, [Button] and [Checkable] both use the [Tappable] behavior. If a
+/// example, [SemanticButton] and [SemanticCheckable] both use the [Tappable] behavior. If a
 /// semantic role needs bespoke functionality, it is simpler to implement it
 /// directly in the [SemanticRole] implementation.
 ///
@@ -1663,16 +1663,16 @@ class SemanticsObject {
 
   SemanticRole _createSemanticRole(SemanticRoleKind role) {
     return switch (role) {
-      SemanticRoleKind.textField => TextField(this),
-      SemanticRoleKind.scrollable => Scrollable(this),
-      SemanticRoleKind.incrementable => Incrementable(this),
-      SemanticRoleKind.button => Button(this),
-      SemanticRoleKind.checkable => Checkable(this),
-      SemanticRoleKind.dialog => Dialog(this),
-      SemanticRoleKind.image => ImageSemanticRole(this),
-      SemanticRoleKind.platformView => PlatformViewSemanticRole(this),
-      SemanticRoleKind.link => Link(this),
-      SemanticRoleKind.heading => Heading(this),
+      SemanticRoleKind.textField => SemanticTextField(this),
+      SemanticRoleKind.scrollable => SemanticScrollable(this),
+      SemanticRoleKind.incrementable => SemanticIncrementable(this),
+      SemanticRoleKind.button => SemanticButton(this),
+      SemanticRoleKind.checkable => SemanticCheckable(this),
+      SemanticRoleKind.dialog => SemanticDialog(this),
+      SemanticRoleKind.image => SemanticImage(this),
+      SemanticRoleKind.platformView => SemanticPlatformView(this),
+      SemanticRoleKind.link => SemanticLink(this),
+      SemanticRoleKind.heading => SemanticHeading(this),
       SemanticRoleKind.generic => GenericRole(this),
     };
   }
@@ -1746,7 +1746,7 @@ class SemanticsObject {
 
   /// Role-specific adjustment of the vertical position of the child container.
   ///
-  /// This is used, for example, by the [Scrollable] to compensate for the
+  /// This is used, for example, by the [SemanticScrollable] to compensate for the
   /// `scrollTop` offset in the DOM.
   ///
   /// This field must not be null.
@@ -1755,7 +1755,7 @@ class SemanticsObject {
   /// Role-specific adjustment of the horizontal position of the child
   /// container.
   ///
-  /// This is used, for example, by the [Scrollable] to compensate for the
+  /// This is used, for example, by the [SemanticScrollable] to compensate for the
   /// `scrollLeft` offset in the DOM.
   ///
   /// This field must not be null.
@@ -2586,7 +2586,7 @@ AFTER: $description
 
   /// Declares that a semantics node will explicitly request focus.
   ///
-  /// This prevents others, [Dialog] in particular, from requesting autofocus,
+  /// This prevents others, [SemanticDialog] in particular, from requesting autofocus,
   /// as focus can only be taken by one element. Explicit focus has higher
   /// precedence than autofocus.
   void willRequestFocus() {

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -347,7 +347,7 @@ class SemanticsNodeUpdate {
 ///
 /// Each value corresponds to the most specific role a semantics node plays in
 /// the semantics tree.
-enum SemanticRoleId {
+enum SemanticRoleKind {
   /// Supports incrementing and/or decrementing its value.
   incrementable,
 
@@ -414,7 +414,7 @@ abstract class SemanticRole {
   ///
   /// If `labelRepresentation` is true, configures the [LabelAndValue] role with
   /// [LabelAndValue.labelRepresentation] set to true.
-  SemanticRole.withBasics(this.role, this.semanticsObject, { required LabelRepresentation preferredLabelRepresentation }) {
+  SemanticRole.withBasics(this.kind, this.semanticsObject, { required LabelRepresentation preferredLabelRepresentation }) {
     element = _initElement(createElement(), semanticsObject);
     addFocusManagement();
     addLiveRegion();
@@ -427,14 +427,14 @@ abstract class SemanticRole {
   /// Use this constructor for highly specialized cases where
   /// [SemanticRole.withBasics] does not work, for example when the default focus
   /// management intereferes with the widget's functionality.
-  SemanticRole.blank(this.role, this.semanticsObject) {
+  SemanticRole.blank(this.kind, this.semanticsObject) {
     element = _initElement(createElement(), semanticsObject);
   }
 
   late final DomElement element;
 
-  /// The role identifier.
-  final SemanticRoleId role;
+  /// The kind of the role that this .
+  final SemanticRoleKind kind;
 
   /// The semantics object managed by this role.
   final SemanticsObject semanticsObject;
@@ -628,7 +628,7 @@ abstract class SemanticRole {
 /// A role used when a more specific role couldn't be assigned to the node.
 final class GenericRole extends SemanticRole {
   GenericRole(SemanticsObject semanticsObject) : super.withBasics(
-    SemanticRoleId.generic,
+    SemanticRoleKind.generic,
     semanticsObject,
     // Prefer sized span because if this is a leaf it is frequently a Text widget.
     // But if it turns out to be a container, then LabelAndValue will automatically
@@ -1634,46 +1634,46 @@ class SemanticsObject {
   /// semantics flags and actions.
   SemanticRole? semanticRole;
 
-  SemanticRoleId _getSemanticRoleId() {
+  SemanticRoleKind _getSemanticRoleKind() {
     // The most specific role should take precedence.
     if (isPlatformView) {
-      return SemanticRoleId.platformView;
+      return SemanticRoleKind.platformView;
     } else if (isHeading) {
-      return SemanticRoleId.heading;
+      return SemanticRoleKind.heading;
     } else if (isTextField) {
-      return SemanticRoleId.textField;
+      return SemanticRoleKind.textField;
     } else if (isIncrementable) {
-      return SemanticRoleId.incrementable;
+      return SemanticRoleKind.incrementable;
     } else if (isVisualOnly) {
-      return SemanticRoleId.image;
+      return SemanticRoleKind.image;
     } else if (isCheckable) {
-      return SemanticRoleId.checkable;
+      return SemanticRoleKind.checkable;
     } else if (isButton) {
-      return SemanticRoleId.button;
+      return SemanticRoleKind.button;
     } else if (isScrollContainer) {
-      return SemanticRoleId.scrollable;
+      return SemanticRoleKind.scrollable;
     } else if (scopesRoute) {
-      return SemanticRoleId.dialog;
+      return SemanticRoleKind.dialog;
     } else if (isLink) {
-      return SemanticRoleId.link;
+      return SemanticRoleKind.link;
     } else {
-      return SemanticRoleId.generic;
+      return SemanticRoleKind.generic;
     }
   }
 
-  SemanticRole _createSemanticRole(SemanticRoleId role) {
+  SemanticRole _createSemanticRole(SemanticRoleKind role) {
     return switch (role) {
-      SemanticRoleId.textField => TextField(this),
-      SemanticRoleId.scrollable => Scrollable(this),
-      SemanticRoleId.incrementable => Incrementable(this),
-      SemanticRoleId.button => Button(this),
-      SemanticRoleId.checkable => Checkable(this),
-      SemanticRoleId.dialog => Dialog(this),
-      SemanticRoleId.image => ImageSemanticRole(this),
-      SemanticRoleId.platformView => PlatformViewSemanticRole(this),
-      SemanticRoleId.link => Link(this),
-      SemanticRoleId.heading => Heading(this),
-      SemanticRoleId.generic => GenericRole(this),
+      SemanticRoleKind.textField => TextField(this),
+      SemanticRoleKind.scrollable => Scrollable(this),
+      SemanticRoleKind.incrementable => Incrementable(this),
+      SemanticRoleKind.button => Button(this),
+      SemanticRoleKind.checkable => Checkable(this),
+      SemanticRoleKind.dialog => Dialog(this),
+      SemanticRoleKind.image => ImageSemanticRole(this),
+      SemanticRoleKind.platformView => PlatformViewSemanticRole(this),
+      SemanticRoleKind.link => Link(this),
+      SemanticRoleKind.heading => Heading(this),
+      SemanticRoleKind.generic => GenericRole(this),
     };
   }
 
@@ -1681,11 +1681,11 @@ class SemanticsObject {
   /// update the DOM.
   void _updateRole() {
     SemanticRole? currentSemanticRole = semanticRole;
-    final SemanticRoleId roleId = _getSemanticRoleId();
+    final SemanticRoleKind kind = _getSemanticRoleKind();
     final DomElement? previousElement = semanticRole?.element;
 
     if (currentSemanticRole != null) {
-      if (currentSemanticRole.role == roleId) {
+      if (currentSemanticRole.kind == kind) {
         // Already has a role assigned and the role is the same as before,
         // so simply perform an update.
         currentSemanticRole.update();
@@ -1705,7 +1705,7 @@ class SemanticsObject {
     //  * (Uncommon) the node changed its role, its previous role was disposed
     //    of, and now it needs a new one.
     if (currentSemanticRole == null) {
-      currentSemanticRole = _createSemanticRole(roleId);
+      currentSemanticRole = _createSemanticRole(kind);
       semanticRole = currentSemanticRole;
       currentSemanticRole.initState();
       currentSemanticRole.update();

--- a/lib/web_ui/lib/src/engine/semantics/tappable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/tappable.dart
@@ -37,7 +37,7 @@ class Button extends PrimaryRoleManager {
 /// framework from raw pointer events. When an assistive technology is enabled
 /// the browser may not send us pointer events. In that mode we forward HTML
 /// click as [ui.SemanticsAction.tap].
-class Tappable extends RoleManager {
+class Tappable extends SemanticBehavior {
   Tappable(SemanticsObject semanticsObject, PrimaryRoleManager owner)
       : super(Role.tappable, semanticsObject, owner) {
     _clickListener = createDomEventListener((DomEvent click) {

--- a/lib/web_ui/lib/src/engine/semantics/tappable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/tappable.dart
@@ -6,8 +6,8 @@ import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
 
 /// Sets the "button" ARIA role.
-class Button extends SemanticRole {
-  Button(SemanticsObject semanticsObject) : super.withBasics(
+class SemanticButton extends SemanticRole {
+  SemanticButton(SemanticsObject semanticsObject) : super.withBasics(
     SemanticRoleKind.button,
     semanticsObject,
     preferredLabelRepresentation: LabelRepresentation.domText,

--- a/lib/web_ui/lib/src/engine/semantics/tappable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/tappable.dart
@@ -8,7 +8,7 @@ import 'package:ui/ui.dart' as ui;
 /// Sets the "button" ARIA role.
 class Button extends SemanticRole {
   Button(SemanticsObject semanticsObject) : super.withBasics(
-    SemanticRoleId.button,
+    SemanticRoleKind.button,
     semanticsObject,
     preferredLabelRepresentation: LabelRepresentation.domText,
   ) {

--- a/lib/web_ui/lib/src/engine/semantics/tappable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/tappable.dart
@@ -6,9 +6,9 @@ import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
 
 /// Sets the "button" ARIA role.
-class Button extends PrimaryRoleManager {
+class Button extends SemanticRole {
   Button(SemanticsObject semanticsObject) : super.withBasics(
-    PrimaryRole.button,
+    SemanticRoleId.button,
     semanticsObject,
     preferredLabelRepresentation: LabelRepresentation.domText,
   ) {

--- a/lib/web_ui/lib/src/engine/semantics/tappable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/tappable.dart
@@ -31,15 +31,18 @@ class Button extends PrimaryRoleManager {
   }
 }
 
-/// Listens to HTML "click" gestures detected by the browser.
+/// Implements clicking and tapping behavior for a semantics node.
 ///
-/// This gestures is different from the click and tap gestures detected by the
+/// Listens to HTML DOM "click" events detected by the browser.
+///
+/// A DOM "click" is different from the click and tap gestures detected by the
 /// framework from raw pointer events. When an assistive technology is enabled
 /// the browser may not send us pointer events. In that mode we forward HTML
 /// click as [ui.SemanticsAction.tap].
+///
+/// See also [ClickDebouncer].
 class Tappable extends SemanticBehavior {
-  Tappable(SemanticsObject semanticsObject, PrimaryRoleManager owner)
-      : super(Role.tappable, semanticsObject, owner) {
+  Tappable(super.semanticsObject, super.owner) {
     _clickListener = createDomEventListener((DomEvent click) {
       PointerBinding.clickDebouncer.onClick(
         click,

--- a/lib/web_ui/lib/src/engine/semantics/text_field.dart
+++ b/lib/web_ui/lib/src/engine/semantics/text_field.dart
@@ -42,7 +42,7 @@ class SemanticsTextEditingStrategy extends DefaultTextEditingStrategy {
   /// The text field whose DOM element is currently used for editing.
   ///
   /// If this field is null, no editing takes place.
-  TextField? activeTextField;
+  SemanticTextField? activeTextField;
 
   /// Current input configuration supplied by the "flutter/textinput" channel.
   InputConfiguration? inputConfig;
@@ -66,7 +66,7 @@ class SemanticsTextEditingStrategy extends DefaultTextEditingStrategy {
   ///
   /// This method must be called after [enable] to name sure that [inputConfig],
   /// [onChange], and [onAction] are not null.
-  void activate(TextField textField) {
+  void activate(SemanticTextField textField) {
     assert(
       inputConfig != null && onChange != null && onAction != null,
       '"enable" should be called before "enableFromSemantics" and initialize input configuration',
@@ -91,7 +91,7 @@ class SemanticsTextEditingStrategy extends DefaultTextEditingStrategy {
   ///
   /// Typically at this point the element loses focus (blurs) and stops being
   /// used for editing.
-  void deactivate(TextField textField) {
+  void deactivate(SemanticTextField textField) {
     if (activeTextField == textField) {
       disable();
     }
@@ -167,7 +167,7 @@ class SemanticsTextEditingStrategy extends DefaultTextEditingStrategy {
 
   @override
   void initializeElementPlacement() {
-    // Element placement is done by [TextField].
+    // Element placement is done by [SemanticTextField].
   }
 
   @override
@@ -176,7 +176,7 @@ class SemanticsTextEditingStrategy extends DefaultTextEditingStrategy {
 
   @override
   void updateElementPlacement(EditableTextGeometry textGeometry) {
-    // Element placement is done by [TextField].
+    // Element placement is done by [SemanticTextField].
   }
 
   EditableTextStyle? _queuedStyle;
@@ -208,8 +208,8 @@ class SemanticsTextEditingStrategy extends DefaultTextEditingStrategy {
 /// browser gestures when in pointer mode. In Safari on iOS pointer events are
 /// used to detect text box invocation. This is because Safari issues touch
 /// events even when VoiceOver is enabled.
-class TextField extends SemanticRole {
-  TextField(SemanticsObject semanticsObject) : super.blank(SemanticRoleKind.textField, semanticsObject) {
+class SemanticTextField extends SemanticRole {
+  SemanticTextField(SemanticsObject semanticsObject) : super.blank(SemanticRoleKind.textField, semanticsObject) {
     _initializeEditableElement();
   }
 

--- a/lib/web_ui/lib/src/engine/semantics/text_field.dart
+++ b/lib/web_ui/lib/src/engine/semantics/text_field.dart
@@ -208,8 +208,8 @@ class SemanticsTextEditingStrategy extends DefaultTextEditingStrategy {
 /// browser gestures when in pointer mode. In Safari on iOS pointer events are
 /// used to detect text box invocation. This is because Safari issues touch
 /// events even when VoiceOver is enabled.
-class TextField extends PrimaryRoleManager {
-  TextField(SemanticsObject semanticsObject) : super.blank(PrimaryRole.textField, semanticsObject) {
+class TextField extends SemanticRole {
+  TextField(SemanticsObject semanticsObject) : super.blank(SemanticRoleId.textField, semanticsObject) {
     _initializeEditableElement();
   }
 

--- a/lib/web_ui/lib/src/engine/semantics/text_field.dart
+++ b/lib/web_ui/lib/src/engine/semantics/text_field.dart
@@ -209,7 +209,7 @@ class SemanticsTextEditingStrategy extends DefaultTextEditingStrategy {
 /// used to detect text box invocation. This is because Safari issues touch
 /// events even when VoiceOver is enabled.
 class TextField extends SemanticRole {
-  TextField(SemanticsObject semanticsObject) : super.blank(SemanticRoleId.textField, semanticsObject) {
+  TextField(SemanticsObject semanticsObject) : super.blank(SemanticRoleKind.textField, semanticsObject) {
     _initializeEditableElement();
   }
 

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -1905,7 +1905,7 @@ void _testTextField() {
 
 
     final SemanticsObject node = owner().debugSemanticsTree![0]!;
-    final TextField textFieldRole = node.semanticRole! as TextField;
+    final SemanticTextField textFieldRole = node.semanticRole! as SemanticTextField;
     final DomHTMLInputElement inputElement = textFieldRole.editableElement as DomHTMLInputElement;
 
     // TODO(yjbanov): this used to attempt to test that value="hello" but the

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -48,11 +48,11 @@ void runSemanticsTests() {
   group('longestIncreasingSubsequence', () {
     _testLongestIncreasingSubsequence();
   });
-  group(PrimaryRoleManager, () {
-    _testPrimaryRoleManager();
+  group(SemanticRole, () {
+    _testSemanticRole();
   });
-  group('Role managers', () {
-    _testRoleManagerLifecycle();
+  group('Roles', () {
+    _testRoleLifecycle();
   });
   group('Text', () {
     _testText();
@@ -113,7 +113,7 @@ void runSemanticsTests() {
   });
 }
 
-void _testPrimaryRoleManager() {
+void _testSemanticRole() {
   test('Sets id and flt-semantics-identifier on the element', () {
     semantics()
       ..debugOverrideTimestampFunction(() => _testTime)
@@ -175,7 +175,7 @@ void _testPrimaryRoleManager() {
   });
 }
 
-void _testRoleManagerLifecycle() {
+void _testRoleLifecycle() {
   test('Semantic behaviors are added upon node initialization', () {
     semantics()
       ..debugOverrideTimestampFunction(() => _testTime)
@@ -194,9 +194,9 @@ void _testRoleManagerLifecycle() {
       tester.expectSemantics('<sem role="button"></sem>');
 
       final SemanticsObject node = owner().debugSemanticsTree![0]!;
-      expect(node.primaryRole?.role, PrimaryRole.button);
+      expect(node.semanticRole?.role, SemanticRoleId.button);
       expect(
-        node.primaryRole?.debugSemanticBehaviorTypes,
+        node.semanticRole?.debugSemanticBehaviorTypes,
         containsAll(<Type>[Focusable, Tappable, LabelAndValue]),
       );
       expect(tester.getSemanticsObject(0).element.tabIndex, -1);
@@ -217,9 +217,9 @@ void _testRoleManagerLifecycle() {
       tester.expectSemantics('<sem role="button">a label</sem>');
 
       final SemanticsObject node = owner().debugSemanticsTree![0]!;
-      expect(node.primaryRole?.role, PrimaryRole.button);
+      expect(node.semanticRole?.role, SemanticRoleId.button);
       expect(
-        node.primaryRole?.debugSemanticBehaviorTypes,
+        node.semanticRole?.debugSemanticBehaviorTypes,
         containsAll(<Type>[Focusable, Tappable, LabelAndValue]),
       );
       expect(tester.getSemanticsObject(0).element.tabIndex, 0);
@@ -661,16 +661,16 @@ void _testEngineSemanticsOwner() {
       SemanticsUpdatePhase.idle,
     );
 
-    // Rudely replace the role manager with a mock, and trigger an update.
-    final MockRoleManager mockRoleManager = MockRoleManager(PrimaryRole.generic, semanticsObject);
-    semanticsObject.primaryRole = mockRoleManager;
+    // Rudely replace the role with a mock, and trigger an update.
+    final MockRole mockRole = MockRole(SemanticRoleId.generic, semanticsObject);
+    semanticsObject.semanticRole = mockRole;
 
     pumpSemantics(label: 'World');
 
     expect(
       reason: 'While updating must be in SemanticsUpdatePhase.updating phase',
-      mockRoleManager.log,
-      <MockRoleManagerLogEntry>[
+      mockRole.log,
+      <MockRoleLogEntry>[
         (method: 'update', phase: SemanticsUpdatePhase.updating),
       ],
     );
@@ -679,15 +679,15 @@ void _testEngineSemanticsOwner() {
   });
 }
 
-typedef MockRoleManagerLogEntry = ({
+typedef MockRoleLogEntry = ({
   String method,
   SemanticsUpdatePhase phase,
 });
 
-class MockRoleManager extends PrimaryRoleManager {
-  MockRoleManager(super.role, super.semanticsObject) : super.blank();
+class MockRole extends SemanticRole {
+  MockRole(super.role, super.semanticsObject) : super.blank();
 
-  final List<MockRoleManagerLogEntry> log = <MockRoleManagerLogEntry>[];
+  final List<MockRoleLogEntry> log = <MockRoleLogEntry>[];
 
   void _log(String method) {
     log.add((
@@ -882,9 +882,9 @@ void _testText() {
     );
 
     final SemanticsObject node = owner().debugSemanticsTree![0]!;
-    expect(node.primaryRole?.role, PrimaryRole.generic);
+    expect(node.semanticRole?.role, SemanticRoleId.generic);
     expect(
-      node.primaryRole!.behaviors!.map((m) => m.runtimeType).toList(),
+      node.semanticRole!.behaviors!.map((m) => m.runtimeType).toList(),
       <Type>[
         Focusable,
         LiveRegion,
@@ -915,9 +915,9 @@ void _testText() {
     );
 
     final SemanticsObject node = owner().debugSemanticsTree![0]!;
-    expect(node.primaryRole?.role, PrimaryRole.generic);
+    expect(node.semanticRole?.role, SemanticRoleId.generic);
     expect(
-      node.primaryRole!.behaviors!.map((m) => m.runtimeType).toList(),
+      node.semanticRole!.behaviors!.map((m) => m.runtimeType).toList(),
       <Type>[
         Focusable,
         LiveRegion,
@@ -1710,10 +1710,10 @@ void _testIncrementables() {
 </sem>''');
 
     final SemanticsObject node = owner().debugSemanticsTree![0]!;
-    expect(node.primaryRole?.role, PrimaryRole.incrementable);
+    expect(node.semanticRole?.role, SemanticRoleId.incrementable);
     expect(
       reason: 'Incrementables use custom focus management',
-      node.primaryRole!.debugSemanticBehaviorTypes,
+      node.semanticRole!.debugSemanticBehaviorTypes,
       isNot(contains(Focusable)),
     );
 
@@ -1905,7 +1905,7 @@ void _testTextField() {
 
 
     final SemanticsObject node = owner().debugSemanticsTree![0]!;
-    final TextField textFieldRole = node.primaryRole! as TextField;
+    final TextField textFieldRole = node.semanticRole! as TextField;
     final DomHTMLInputElement inputElement = textFieldRole.editableElement as DomHTMLInputElement;
 
     // TODO(yjbanov): this used to attempt to test that value="hello" but the
@@ -1914,10 +1914,10 @@ void _testTextField() {
     //                https://github.com/flutter/flutter/issues/147200
     expect(inputElement.value, '');
 
-    expect(node.primaryRole?.role, PrimaryRole.textField);
+    expect(node.semanticRole?.role, SemanticRoleId.textField);
     expect(
       reason: 'Text fields use custom focus management',
-      node.primaryRole!.debugSemanticBehaviorTypes,
+      node.semanticRole!.debugSemanticBehaviorTypes,
       isNot(contains(Focusable)),
     );
 
@@ -1952,10 +1952,10 @@ void _testCheckables() {
 ''');
 
     final SemanticsObject node = owner().debugSemanticsTree![0]!;
-    expect(node.primaryRole?.role, PrimaryRole.checkable);
+    expect(node.semanticRole?.role, SemanticRoleId.checkable);
     expect(
       reason: 'Checkables use generic semantic behaviors',
-      node.primaryRole!.debugSemanticBehaviorTypes,
+      node.semanticRole!.debugSemanticBehaviorTypes,
       containsAll(<Type>[Focusable, Tappable]),
     );
 
@@ -2253,9 +2253,9 @@ void _testTappable() {
 ''');
 
     final SemanticsObject node = owner().debugSemanticsTree![0]!;
-    expect(node.primaryRole?.role, PrimaryRole.button);
+    expect(node.semanticRole?.role, SemanticRoleId.button);
     expect(
-      node.primaryRole?.debugSemanticBehaviorTypes,
+      node.semanticRole?.debugSemanticBehaviorTypes,
       containsAll(<Type>[Focusable, Tappable]),
     );
     expect(tester.getSemanticsObject(0).element.tabIndex, 0);
@@ -2999,8 +2999,8 @@ void _testDialog() {
     ''');
 
     expect(
-      owner().debugSemanticsTree![0]!.primaryRole?.role,
-      PrimaryRole.dialog,
+      owner().debugSemanticsTree![0]!.semanticRole?.role,
+      SemanticRoleId.dialog,
     );
 
     semantics().semanticsEnabled = false;
@@ -3044,8 +3044,8 @@ void _testDialog() {
     ''');
 
     expect(
-      owner().debugSemanticsTree![0]!.primaryRole?.role,
-      PrimaryRole.dialog,
+      owner().debugSemanticsTree![0]!.semanticRole?.role,
+      SemanticRoleId.dialog,
     );
 
     semantics().semanticsEnabled = false;
@@ -3093,15 +3093,15 @@ void _testDialog() {
     pumpSemantics(label: 'Dialog label');
 
     expect(
-      owner().debugSemanticsTree![0]!.primaryRole?.role,
-      PrimaryRole.dialog,
+      owner().debugSemanticsTree![0]!.semanticRole?.role,
+      SemanticRoleId.dialog,
     );
     expect(
-      owner().debugSemanticsTree![2]!.primaryRole?.role,
-      PrimaryRole.generic,
+      owner().debugSemanticsTree![2]!.semanticRole?.role,
+      SemanticRoleId.generic,
     );
     expect(
-      owner().debugSemanticsTree![2]!.primaryRole?.debugSemanticBehaviorTypes,
+      owner().debugSemanticsTree![2]!.semanticRole?.debugSemanticBehaviorTypes,
       contains(RouteName),
     );
 
@@ -3131,11 +3131,11 @@ void _testDialog() {
     ''');
 
     expect(
-      owner().debugSemanticsTree![0]!.primaryRole?.role,
-      PrimaryRole.dialog,
+      owner().debugSemanticsTree![0]!.semanticRole?.role,
+      SemanticRoleId.dialog,
     );
     expect(
-      owner().debugSemanticsTree![0]!.primaryRole?.behaviors,
+      owner().debugSemanticsTree![0]!.semanticRole?.behaviors,
       isNot(contains(RouteName)),
     );
 
@@ -3179,11 +3179,11 @@ void _testDialog() {
     ''');
 
     expect(
-      owner().debugSemanticsTree![0]!.primaryRole?.role,
-      PrimaryRole.generic,
+      owner().debugSemanticsTree![0]!.semanticRole?.role,
+      SemanticRoleId.generic,
     );
     expect(
-      owner().debugSemanticsTree![2]!.primaryRole?.debugSemanticBehaviorTypes,
+      owner().debugSemanticsTree![2]!.semanticRole?.debugSemanticBehaviorTypes,
       contains(RouteName),
     );
 
@@ -3550,11 +3550,11 @@ void _testFocusable() {
     final SemanticsObject node = owner().debugSemanticsTree![1]!;
     expect(node.isFocusable, isTrue);
     expect(
-      node.primaryRole?.role,
-      PrimaryRole.generic,
+      node.semanticRole?.role,
+      SemanticRoleId.generic,
     );
     expect(
-      node.primaryRole?.debugSemanticBehaviorTypes,
+      node.semanticRole?.debugSemanticBehaviorTypes,
       contains(Focusable),
     );
 

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -176,7 +176,7 @@ void _testPrimaryRoleManager() {
 }
 
 void _testRoleManagerLifecycle() {
-  test('Secondary role managers are added upon node initialization', () {
+  test('Semantic behaviors are added upon node initialization', () {
     semantics()
       ..debugOverrideTimestampFunction(() => _testTime)
       ..semanticsEnabled = true;
@@ -884,7 +884,7 @@ void _testText() {
     final SemanticsObject node = owner().debugSemanticsTree![0]!;
     expect(node.primaryRole?.role, PrimaryRole.generic);
     expect(
-      node.primaryRole!.secondaryRoleManagers!.map((RoleManager m) => m.runtimeType).toList(),
+      node.primaryRole!.behaviors!.map((m) => m.runtimeType).toList(),
       <Type>[
         Focusable,
         LiveRegion,
@@ -917,7 +917,7 @@ void _testText() {
     final SemanticsObject node = owner().debugSemanticsTree![0]!;
     expect(node.primaryRole?.role, PrimaryRole.generic);
     expect(
-      node.primaryRole!.secondaryRoleManagers!.map((RoleManager m) => m.runtimeType).toList(),
+      node.primaryRole!.behaviors!.map((m) => m.runtimeType).toList(),
       <Type>[
         Focusable,
         LiveRegion,
@@ -1954,7 +1954,7 @@ void _testCheckables() {
     final SemanticsObject node = owner().debugSemanticsTree![0]!;
     expect(node.primaryRole?.role, PrimaryRole.checkable);
     expect(
-      reason: 'Checkables use generic secondary roles',
+      reason: 'Checkables use generic semantic behaviors',
       node.primaryRole!.debugSecondaryRoles,
       containsAll(<Role>[Role.focusable, Role.tappable]),
     );
@@ -3135,7 +3135,7 @@ void _testDialog() {
       PrimaryRole.dialog,
     );
     expect(
-      owner().debugSemanticsTree![0]!.primaryRole?.secondaryRoleManagers,
+      owner().debugSemanticsTree![0]!.primaryRole?.behaviors,
       isNot(contains(Role.routeName)),
     );
 

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -196,8 +196,8 @@ void _testRoleManagerLifecycle() {
       final SemanticsObject node = owner().debugSemanticsTree![0]!;
       expect(node.primaryRole?.role, PrimaryRole.button);
       expect(
-        node.primaryRole?.debugSecondaryRoles,
-        containsAll(<Role>[Role.focusable, Role.tappable, Role.labelAndValue]),
+        node.primaryRole?.debugSemanticBehaviorTypes,
+        containsAll(<Type>[Focusable, Tappable, LabelAndValue]),
       );
       expect(tester.getSemanticsObject(0).element.tabIndex, -1);
     }
@@ -219,8 +219,8 @@ void _testRoleManagerLifecycle() {
       final SemanticsObject node = owner().debugSemanticsTree![0]!;
       expect(node.primaryRole?.role, PrimaryRole.button);
       expect(
-        node.primaryRole?.debugSecondaryRoles,
-        containsAll(<Role>[Role.focusable, Role.tappable, Role.labelAndValue]),
+        node.primaryRole?.debugSemanticBehaviorTypes,
+        containsAll(<Type>[Focusable, Tappable, LabelAndValue]),
       );
       expect(tester.getSemanticsObject(0).element.tabIndex, 0);
     }
@@ -1713,8 +1713,8 @@ void _testIncrementables() {
     expect(node.primaryRole?.role, PrimaryRole.incrementable);
     expect(
       reason: 'Incrementables use custom focus management',
-      node.primaryRole!.debugSecondaryRoles,
-      isNot(contains(Role.focusable)),
+      node.primaryRole!.debugSemanticBehaviorTypes,
+      isNot(contains(Focusable)),
     );
 
     semantics().semanticsEnabled = false;
@@ -1917,8 +1917,8 @@ void _testTextField() {
     expect(node.primaryRole?.role, PrimaryRole.textField);
     expect(
       reason: 'Text fields use custom focus management',
-      node.primaryRole!.debugSecondaryRoles,
-      isNot(contains(Role.focusable)),
+      node.primaryRole!.debugSemanticBehaviorTypes,
+      isNot(contains(Focusable)),
     );
 
     semantics().semanticsEnabled = false;
@@ -1955,8 +1955,8 @@ void _testCheckables() {
     expect(node.primaryRole?.role, PrimaryRole.checkable);
     expect(
       reason: 'Checkables use generic semantic behaviors',
-      node.primaryRole!.debugSecondaryRoles,
-      containsAll(<Role>[Role.focusable, Role.tappable]),
+      node.primaryRole!.debugSemanticBehaviorTypes,
+      containsAll(<Type>[Focusable, Tappable]),
     );
 
     semantics().semanticsEnabled = false;
@@ -2255,8 +2255,8 @@ void _testTappable() {
     final SemanticsObject node = owner().debugSemanticsTree![0]!;
     expect(node.primaryRole?.role, PrimaryRole.button);
     expect(
-      node.primaryRole?.debugSecondaryRoles,
-      containsAll(<Role>[Role.focusable, Role.tappable]),
+      node.primaryRole?.debugSemanticBehaviorTypes,
+      containsAll(<Type>[Focusable, Tappable]),
     );
     expect(tester.getSemanticsObject(0).element.tabIndex, 0);
 
@@ -3101,8 +3101,8 @@ void _testDialog() {
       PrimaryRole.generic,
     );
     expect(
-      owner().debugSemanticsTree![2]!.primaryRole?.debugSecondaryRoles,
-      contains(Role.routeName),
+      owner().debugSemanticsTree![2]!.primaryRole?.debugSemanticBehaviorTypes,
+      contains(RouteName),
     );
 
     pumpSemantics(label: 'Updated dialog label');
@@ -3136,7 +3136,7 @@ void _testDialog() {
     );
     expect(
       owner().debugSemanticsTree![0]!.primaryRole?.behaviors,
-      isNot(contains(Role.routeName)),
+      isNot(contains(RouteName)),
     );
 
     semantics().semanticsEnabled = false;
@@ -3183,8 +3183,8 @@ void _testDialog() {
       PrimaryRole.generic,
     );
     expect(
-      owner().debugSemanticsTree![2]!.primaryRole?.debugSecondaryRoles,
-      contains(Role.routeName),
+      owner().debugSemanticsTree![2]!.primaryRole?.debugSemanticBehaviorTypes,
+      contains(RouteName),
     );
 
     semantics().semanticsEnabled = false;
@@ -3554,8 +3554,8 @@ void _testFocusable() {
       PrimaryRole.generic,
     );
     expect(
-      node.primaryRole?.debugSecondaryRoles,
-      contains(Role.focusable),
+      node.primaryRole?.debugSemanticBehaviorTypes,
+      contains(Focusable),
     );
 
     final DomElement element = node.element;

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -194,7 +194,7 @@ void _testRoleLifecycle() {
       tester.expectSemantics('<sem role="button"></sem>');
 
       final SemanticsObject node = owner().debugSemanticsTree![0]!;
-      expect(node.semanticRole?.role, SemanticRoleId.button);
+      expect(node.semanticRole?.kind, SemanticRoleKind.button);
       expect(
         node.semanticRole?.debugSemanticBehaviorTypes,
         containsAll(<Type>[Focusable, Tappable, LabelAndValue]),
@@ -217,7 +217,7 @@ void _testRoleLifecycle() {
       tester.expectSemantics('<sem role="button">a label</sem>');
 
       final SemanticsObject node = owner().debugSemanticsTree![0]!;
-      expect(node.semanticRole?.role, SemanticRoleId.button);
+      expect(node.semanticRole?.kind, SemanticRoleKind.button);
       expect(
         node.semanticRole?.debugSemanticBehaviorTypes,
         containsAll(<Type>[Focusable, Tappable, LabelAndValue]),
@@ -662,7 +662,7 @@ void _testEngineSemanticsOwner() {
     );
 
     // Rudely replace the role with a mock, and trigger an update.
-    final MockRole mockRole = MockRole(SemanticRoleId.generic, semanticsObject);
+    final MockRole mockRole = MockRole(SemanticRoleKind.generic, semanticsObject);
     semanticsObject.semanticRole = mockRole;
 
     pumpSemantics(label: 'World');
@@ -882,7 +882,7 @@ void _testText() {
     );
 
     final SemanticsObject node = owner().debugSemanticsTree![0]!;
-    expect(node.semanticRole?.role, SemanticRoleId.generic);
+    expect(node.semanticRole?.kind, SemanticRoleKind.generic);
     expect(
       node.semanticRole!.behaviors!.map((m) => m.runtimeType).toList(),
       <Type>[
@@ -915,7 +915,7 @@ void _testText() {
     );
 
     final SemanticsObject node = owner().debugSemanticsTree![0]!;
-    expect(node.semanticRole?.role, SemanticRoleId.generic);
+    expect(node.semanticRole?.kind, SemanticRoleKind.generic);
     expect(
       node.semanticRole!.behaviors!.map((m) => m.runtimeType).toList(),
       <Type>[
@@ -1710,7 +1710,7 @@ void _testIncrementables() {
 </sem>''');
 
     final SemanticsObject node = owner().debugSemanticsTree![0]!;
-    expect(node.semanticRole?.role, SemanticRoleId.incrementable);
+    expect(node.semanticRole?.kind, SemanticRoleKind.incrementable);
     expect(
       reason: 'Incrementables use custom focus management',
       node.semanticRole!.debugSemanticBehaviorTypes,
@@ -1914,7 +1914,7 @@ void _testTextField() {
     //                https://github.com/flutter/flutter/issues/147200
     expect(inputElement.value, '');
 
-    expect(node.semanticRole?.role, SemanticRoleId.textField);
+    expect(node.semanticRole?.kind, SemanticRoleKind.textField);
     expect(
       reason: 'Text fields use custom focus management',
       node.semanticRole!.debugSemanticBehaviorTypes,
@@ -1952,7 +1952,7 @@ void _testCheckables() {
 ''');
 
     final SemanticsObject node = owner().debugSemanticsTree![0]!;
-    expect(node.semanticRole?.role, SemanticRoleId.checkable);
+    expect(node.semanticRole?.kind, SemanticRoleKind.checkable);
     expect(
       reason: 'Checkables use generic semantic behaviors',
       node.semanticRole!.debugSemanticBehaviorTypes,
@@ -2253,7 +2253,7 @@ void _testTappable() {
 ''');
 
     final SemanticsObject node = owner().debugSemanticsTree![0]!;
-    expect(node.semanticRole?.role, SemanticRoleId.button);
+    expect(node.semanticRole?.kind, SemanticRoleKind.button);
     expect(
       node.semanticRole?.debugSemanticBehaviorTypes,
       containsAll(<Type>[Focusable, Tappable]),
@@ -2999,8 +2999,8 @@ void _testDialog() {
     ''');
 
     expect(
-      owner().debugSemanticsTree![0]!.semanticRole?.role,
-      SemanticRoleId.dialog,
+      owner().debugSemanticsTree![0]!.semanticRole?.kind,
+      SemanticRoleKind.dialog,
     );
 
     semantics().semanticsEnabled = false;
@@ -3044,8 +3044,8 @@ void _testDialog() {
     ''');
 
     expect(
-      owner().debugSemanticsTree![0]!.semanticRole?.role,
-      SemanticRoleId.dialog,
+      owner().debugSemanticsTree![0]!.semanticRole?.kind,
+      SemanticRoleKind.dialog,
     );
 
     semantics().semanticsEnabled = false;
@@ -3093,12 +3093,12 @@ void _testDialog() {
     pumpSemantics(label: 'Dialog label');
 
     expect(
-      owner().debugSemanticsTree![0]!.semanticRole?.role,
-      SemanticRoleId.dialog,
+      owner().debugSemanticsTree![0]!.semanticRole?.kind,
+      SemanticRoleKind.dialog,
     );
     expect(
-      owner().debugSemanticsTree![2]!.semanticRole?.role,
-      SemanticRoleId.generic,
+      owner().debugSemanticsTree![2]!.semanticRole?.kind,
+      SemanticRoleKind.generic,
     );
     expect(
       owner().debugSemanticsTree![2]!.semanticRole?.debugSemanticBehaviorTypes,
@@ -3131,8 +3131,8 @@ void _testDialog() {
     ''');
 
     expect(
-      owner().debugSemanticsTree![0]!.semanticRole?.role,
-      SemanticRoleId.dialog,
+      owner().debugSemanticsTree![0]!.semanticRole?.kind,
+      SemanticRoleKind.dialog,
     );
     expect(
       owner().debugSemanticsTree![0]!.semanticRole?.behaviors,
@@ -3179,8 +3179,8 @@ void _testDialog() {
     ''');
 
     expect(
-      owner().debugSemanticsTree![0]!.semanticRole?.role,
-      SemanticRoleId.generic,
+      owner().debugSemanticsTree![0]!.semanticRole?.kind,
+      SemanticRoleKind.generic,
     );
     expect(
       owner().debugSemanticsTree![2]!.semanticRole?.debugSemanticBehaviorTypes,
@@ -3550,8 +3550,8 @@ void _testFocusable() {
     final SemanticsObject node = owner().debugSemanticsTree![1]!;
     expect(node.isFocusable, isTrue);
     expect(
-      node.semanticRole?.role,
-      SemanticRoleId.generic,
+      node.semanticRole?.kind,
+      SemanticRoleKind.generic,
     );
     expect(
       node.semanticRole?.debugSemanticBehaviorTypes,

--- a/lib/web_ui/test/engine/semantics/semantics_tester.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_tester.dart
@@ -401,3 +401,8 @@ class SemanticsActionLogger {
   Stream<ui.SemanticsAction> get actionLog => _actionLog;
   late Stream<ui.SemanticsAction> _actionLog;
 }
+
+extension SemanticRoleExtension on PrimaryRoleManager {
+  /// Types of semantics behaviors used by this primary role manager.
+  List<Type> get debugSemanticBehaviorTypes => behaviors?.map((behavior) => behavior.runtimeType).toList() ?? const <Type>[];
+}

--- a/lib/web_ui/test/engine/semantics/semantics_tester.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_tester.dart
@@ -338,9 +338,9 @@ class SemanticsTester {
     return owner.debugSemanticsTree![id]!;
   }
 
-  /// Locates the [TextField] role of the semantics object with the give [id].
-  TextField getTextField(int id) {
-    return getSemanticsObject(id).semanticRole! as TextField;
+  /// Locates the [SemanticTextField] role of the semantics object with the give [id].
+  SemanticTextField getTextField(int id) {
+    return getSemanticsObject(id).semanticRole! as SemanticTextField;
   }
 
   void expectSemantics(String semanticsHtml) {

--- a/lib/web_ui/test/engine/semantics/semantics_tester.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_tester.dart
@@ -338,9 +338,9 @@ class SemanticsTester {
     return owner.debugSemanticsTree![id]!;
   }
 
-  /// Locates the [TextField] role manager of the semantics object with the give [id].
+  /// Locates the [TextField] role of the semantics object with the give [id].
   TextField getTextField(int id) {
-    return getSemanticsObject(id).primaryRole! as TextField;
+    return getSemanticsObject(id).semanticRole! as TextField;
   }
 
   void expectSemantics(String semanticsHtml) {
@@ -402,7 +402,7 @@ class SemanticsActionLogger {
   late Stream<ui.SemanticsAction> _actionLog;
 }
 
-extension SemanticRoleExtension on PrimaryRoleManager {
-  /// Types of semantics behaviors used by this primary role manager.
+extension SemanticRoleExtension on SemanticRole {
+  /// Types of semantics behaviors used by this role.
   List<Type> get debugSemanticBehaviorTypes => behaviors?.map((behavior) => behavior.runtimeType).toList() ?? const <Type>[];
 }

--- a/lib/web_ui/test/engine/semantics/semantics_text_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_text_test.dart
@@ -49,7 +49,7 @@ Future<void> testMain() async {
       );
 
       final SemanticsObject node = owner().debugSemanticsTree![0]!;
-      expect(node.semanticRole?.role, SemanticRoleId.generic);
+      expect(node.semanticRole?.kind, SemanticRoleKind.generic);
       expect(
         reason: 'A node with a label should get a LabelAndValue role',
         node.semanticRole!.debugSemanticBehaviorTypes,

--- a/lib/web_ui/test/engine/semantics/semantics_text_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_text_test.dart
@@ -52,8 +52,8 @@ Future<void> testMain() async {
       expect(node.primaryRole?.role, PrimaryRole.generic);
       expect(
         reason: 'A node with a label should get a LabelAndValue role',
-        node.primaryRole!.debugSecondaryRoles,
-        contains(Role.labelAndValue),
+        node.primaryRole!.debugSemanticBehaviorTypes,
+        contains(LabelAndValue),
       );
     }
 

--- a/lib/web_ui/test/engine/semantics/semantics_text_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_text_test.dart
@@ -49,10 +49,10 @@ Future<void> testMain() async {
       );
 
       final SemanticsObject node = owner().debugSemanticsTree![0]!;
-      expect(node.primaryRole?.role, PrimaryRole.generic);
+      expect(node.semanticRole?.role, SemanticRoleId.generic);
       expect(
         reason: 'A node with a label should get a LabelAndValue role',
-        node.primaryRole!.debugSemanticBehaviorTypes,
+        node.semanticRole!.debugSemanticBehaviorTypes,
         contains(LabelAndValue),
       );
     }
@@ -213,7 +213,7 @@ Future<void> testMain() async {
     final DomElement span = node.element.querySelector('span')!;
 
     expect(span.getAttribute('tabindex'), isNull);
-    node.primaryRole!.focusAsRouteDefault();
+    node.semanticRole!.focusAsRouteDefault();
     expect(span.getAttribute('tabindex'), '-1');
     expect(domDocument.activeElement, span);
 
@@ -237,7 +237,7 @@ Future<void> testMain() async {
     final SemanticsObject node = owner().debugSemanticsTree![0]!;
 
     // Set DOM text as preferred representation
-    final LabelAndValue lav = node.primaryRole!.labelAndValue!;
+    final LabelAndValue lav = node.semanticRole!.labelAndValue!;
     lav.preferredRepresentation = LabelRepresentation.domText;
     lav.update();
 
@@ -246,7 +246,7 @@ Future<void> testMain() async {
     );
 
     expect(node.element.getAttribute('tabindex'), isNull);
-    node.primaryRole!.focusAsRouteDefault();
+    node.semanticRole!.focusAsRouteDefault();
     expect(node.element.getAttribute('tabindex'), '-1');
     expect(domDocument.activeElement, node.element);
 
@@ -270,7 +270,7 @@ Future<void> testMain() async {
     final SemanticsObject node = owner().debugSemanticsTree![0]!;
 
     // Set DOM text as preferred representation
-    final LabelAndValue lav = node.primaryRole!.labelAndValue!;
+    final LabelAndValue lav = node.semanticRole!.labelAndValue!;
     lav.preferredRepresentation = LabelRepresentation.ariaLabel;
     lav.update();
 
@@ -279,7 +279,7 @@ Future<void> testMain() async {
     );
 
     expect(node.element.getAttribute('tabindex'), isNull);
-    node.primaryRole!.focusAsRouteDefault();
+    node.semanticRole!.focusAsRouteDefault();
     expect(node.element.getAttribute('tabindex'), '-1');
     expect(domDocument.activeElement, node.element);
 

--- a/lib/web_ui/test/engine/semantics/text_field_test.dart
+++ b/lib/web_ui/test/engine/semantics/text_field_test.dart
@@ -60,7 +60,7 @@ void testMain() {
         value: 'hi',
         isFocused: true,
       );
-      final TextField textField = textFieldSemantics.primaryRole! as TextField;
+      final TextField textField = textFieldSemantics.semanticRole! as TextField;
 
       // ensureInitialized() isn't called prior to calling dispose() here.
       // Since we are conditionally calling dispose() on our
@@ -102,7 +102,7 @@ void testMain() {
       //                make sure it tests the right things:
       //                https://github.com/flutter/flutter/issues/147200
       final SemanticsObject node = owner().debugSemanticsTree![0]!;
-      final TextField textFieldRole = node.primaryRole! as TextField;
+      final TextField textFieldRole = node.semanticRole! as TextField;
       final DomHTMLInputElement inputElement =
           textFieldRole.editableElement as DomHTMLInputElement;
       expect(inputElement.tagName.toLowerCase(), 'input');
@@ -114,7 +114,7 @@ void testMain() {
       createTextFieldSemantics(isEnabled: false, value: 'hello');
       expectSemanticsTree(owner(), '''<sem><input /></sem>''');
       final SemanticsObject node = owner().debugSemanticsTree![0]!;
-      final TextField textFieldRole = node.primaryRole! as TextField;
+      final TextField textFieldRole = node.semanticRole! as TextField;
       final DomHTMLInputElement inputElement =
           textFieldRole.editableElement as DomHTMLInputElement;
       expect(inputElement.tagName.toLowerCase(), 'input');
@@ -170,7 +170,7 @@ void testMain() {
         rect: const ui.Rect.fromLTWH(0, 0, 10, 15),
       );
 
-      final TextField textField = textFieldSemantics.primaryRole! as TextField;
+      final TextField textField = textFieldSemantics.semanticRole! as TextField;
       expect(owner().semanticsHost.ownerDocument?.activeElement,
           strategy.domElement);
       expect(textField.editableElement, strategy.domElement);
@@ -238,7 +238,7 @@ void testMain() {
           isFocused: true,
           rect: const ui.Rect.fromLTWH(0, 0, 10, 15));
 
-      final TextField textField = textFieldSemantics.primaryRole! as TextField;
+      final TextField textField = textFieldSemantics.semanticRole! as TextField;
       final DomHTMLInputElement editableElement =
           textField.editableElement as DomHTMLInputElement;
 
@@ -269,7 +269,7 @@ void testMain() {
           isFocused: true,
           rect: const ui.Rect.fromLTWH(0, 0, 10, 15));
 
-      final TextField textField = textFieldSemantics.primaryRole! as TextField;
+      final TextField textField = textFieldSemantics.semanticRole! as TextField;
       final DomHTMLInputElement editableElement =
           textField.editableElement as DomHTMLInputElement;
 
@@ -311,7 +311,7 @@ void testMain() {
         isFocused: true,
       );
 
-      final TextField textField = textFieldSemantics.primaryRole! as TextField;
+      final TextField textField = textFieldSemantics.semanticRole! as TextField;
       expect(textField.editableElement, strategy.domElement);
       expect(owner().semanticsHost.ownerDocument?.activeElement,
           strategy.domElement);
@@ -347,7 +347,7 @@ void testMain() {
       expect(strategy.domElement, isNull);
 
       // It doesn't remove the DOM element.
-      final TextField textField = textFieldSemantics.primaryRole! as TextField;
+      final TextField textField = textFieldSemantics.semanticRole! as TextField;
       expect(owner().semanticsHost.contains(textField.editableElement), isTrue);
       // Editing element is not enabled.
       expect(strategy.isEnabled, isFalse);

--- a/lib/web_ui/test/engine/semantics/text_field_test.dart
+++ b/lib/web_ui/test/engine/semantics/text_field_test.dart
@@ -60,7 +60,7 @@ void testMain() {
         value: 'hi',
         isFocused: true,
       );
-      final TextField textField = textFieldSemantics.semanticRole! as TextField;
+      final SemanticTextField textField = textFieldSemantics.semanticRole! as SemanticTextField;
 
       // ensureInitialized() isn't called prior to calling dispose() here.
       // Since we are conditionally calling dispose() on our
@@ -102,7 +102,7 @@ void testMain() {
       //                make sure it tests the right things:
       //                https://github.com/flutter/flutter/issues/147200
       final SemanticsObject node = owner().debugSemanticsTree![0]!;
-      final TextField textFieldRole = node.semanticRole! as TextField;
+      final SemanticTextField textFieldRole = node.semanticRole! as SemanticTextField;
       final DomHTMLInputElement inputElement =
           textFieldRole.editableElement as DomHTMLInputElement;
       expect(inputElement.tagName.toLowerCase(), 'input');
@@ -114,7 +114,7 @@ void testMain() {
       createTextFieldSemantics(isEnabled: false, value: 'hello');
       expectSemanticsTree(owner(), '''<sem><input /></sem>''');
       final SemanticsObject node = owner().debugSemanticsTree![0]!;
-      final TextField textFieldRole = node.semanticRole! as TextField;
+      final SemanticTextField textFieldRole = node.semanticRole! as SemanticTextField;
       final DomHTMLInputElement inputElement =
           textFieldRole.editableElement as DomHTMLInputElement;
       expect(inputElement.tagName.toLowerCase(), 'input');
@@ -170,7 +170,7 @@ void testMain() {
         rect: const ui.Rect.fromLTWH(0, 0, 10, 15),
       );
 
-      final TextField textField = textFieldSemantics.semanticRole! as TextField;
+      final SemanticTextField textField = textFieldSemantics.semanticRole! as SemanticTextField;
       expect(owner().semanticsHost.ownerDocument?.activeElement,
           strategy.domElement);
       expect(textField.editableElement, strategy.domElement);
@@ -238,7 +238,7 @@ void testMain() {
           isFocused: true,
           rect: const ui.Rect.fromLTWH(0, 0, 10, 15));
 
-      final TextField textField = textFieldSemantics.semanticRole! as TextField;
+      final SemanticTextField textField = textFieldSemantics.semanticRole! as SemanticTextField;
       final DomHTMLInputElement editableElement =
           textField.editableElement as DomHTMLInputElement;
 
@@ -269,7 +269,7 @@ void testMain() {
           isFocused: true,
           rect: const ui.Rect.fromLTWH(0, 0, 10, 15));
 
-      final TextField textField = textFieldSemantics.semanticRole! as TextField;
+      final SemanticTextField textField = textFieldSemantics.semanticRole! as SemanticTextField;
       final DomHTMLInputElement editableElement =
           textField.editableElement as DomHTMLInputElement;
 
@@ -311,7 +311,7 @@ void testMain() {
         isFocused: true,
       );
 
-      final TextField textField = textFieldSemantics.semanticRole! as TextField;
+      final SemanticTextField textField = textFieldSemantics.semanticRole! as SemanticTextField;
       expect(textField.editableElement, strategy.domElement);
       expect(owner().semanticsHost.ownerDocument?.activeElement,
           strategy.domElement);
@@ -347,7 +347,7 @@ void testMain() {
       expect(strategy.domElement, isNull);
 
       // It doesn't remove the DOM element.
-      final TextField textField = textFieldSemantics.semanticRole! as TextField;
+      final SemanticTextField textField = textFieldSemantics.semanticRole! as SemanticTextField;
       expect(owner().semanticsHost.contains(textField.editableElement), isTrue);
       // Editing element is not enabled.
       expect(strategy.isEnabled, isFalse);


### PR DESCRIPTION
A few non-functional clean-ups in semantics:

* Rename `RoleManager` to `SemanticBehavior`.
* Rename `PrimaryRoleManager` to `SemanticRole`.
* Remove the `Role` enum. Move the enum docs into the respective classes.

## Why?

Previous naming was confusing. It's not clear what the difference is between a "role manager" and a "primary role manager". The word "manager" is a meaningless addition; the `Semantic*` prefix is much more meaningful. The `Role` enum was only used for tests, but tests can just use `SemanticRole.runtimeType`.

## New state of the world

After this PR the semantics system has "objects" (class `SemanticsObject`), "roles" (class `SemanticRole`), and "behaviors" (class `SemanticBehavior`).

- A semantic _object_ is an object attached to the framework-side `SemanticNode`. It lives as long as the semantic node does, and provides basic functionality that's common across all nodes.
- A semantic object has exactly one semantic _role_. This role is determined from the flags set on the semantic node. Flags can change, causing a semantic object to change its role, which is why these are two separate classes. If an object had just one permanent role, we could combine these classes into one (maybe one day we'll do it, as changing roles dynamically is weird, but that needs major changes in the framework).
- A semantic role may have zero or more semantic _behaviors_. A behavior supplies a piece of functionality, such as focusability, clickability/tappability, live regions, etc. A behavior can be shared by multiple roles. For example, both `Button` and `Checkable` roles use the `Tappable` behavior. This is why there's a many-to-many relationship between roles and behaviors.

Or in entity relationship terms:

```mermaid
---
title: Semantic object relationships
---
erDiagram
    SemanticsNode ||--|| SemanticsObject : managed-by
    SemanticsObject ||--o{ SemanticRole : has-a
    SemanticRole }o--o{ SemanticBehavior : has
```
