### PR TITLE
[iOS] Switch to FlutterMetalLayer by default.

### DIFF
--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "impeller/renderer/backend/metal/context_mtl.h"
+#include <Metal/Metal.h>
 
 #include <memory>
 
@@ -134,6 +135,7 @@ ContextMTL::ContextMTL(
   command_queue_ip_ = std::make_shared<CommandQueue>();
 #ifdef IMPELLER_DEBUG
   gpu_tracer_ = std::make_shared<GPUTracerMTL>();
+  capture_manager_ = std::make_shared<ImpellerMetalCaptureManager>(device_);
 #endif  // IMPELLER_DEBUG
   is_valid_ = true;
 }
@@ -402,6 +404,34 @@ void ContextMTL::SyncSwitchObserver::OnSyncSwitchUpdate(bool new_is_disabled) {
 // |Context|
 std::shared_ptr<CommandQueue> ContextMTL::GetCommandQueue() const {
   return command_queue_ip_;
+}
+
+const std::shared_ptr<ImpellerMetalCaptureManager> ContextMTL::GetCaptureManager() const {
+  return capture_manager_;
+}
+
+ImpellerMetalCaptureManager::ImpellerMetalCaptureManager(id<MTLDevice> device) {
+  current_capture_scope_ = [[MTLCaptureManager sharedCaptureManager]
+      newCaptureScopeWithDevice:device];
+  [current_capture_scope_ setLabel:@"Impeller Frame"];
+}
+
+bool ImpellerMetalCaptureManager::CaptureScopeActive() const {
+  return scope_active_;
+}
+
+void ImpellerMetalCaptureManager::StartCapture() {
+  if (scope_active_) {
+    return;
+  }
+  scope_active_ = true;
+  [current_capture_scope_ beginScope];
+}
+
+void ImpellerMetalCaptureManager::FinishCapture() {
+  FML_DCHECK(scope_active_);
+  [current_capture_scope_ endScope];
+  scope_active_ = false;
 }
 
 }  // namespace impeller

--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -406,10 +406,12 @@ std::shared_ptr<CommandQueue> ContextMTL::GetCommandQueue() const {
   return command_queue_ip_;
 }
 
+#ifdef IMPELLER_DEBUG
 const std::shared_ptr<ImpellerMetalCaptureManager>
 ContextMTL::GetCaptureManager() const {
   return capture_manager_;
 }
+#endif  // IMPELLER_DEBUG
 
 ImpellerMetalCaptureManager::ImpellerMetalCaptureManager(id<MTLDevice> device) {
   current_capture_scope_ = [[MTLCaptureManager sharedCaptureManager]

--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -406,7 +406,8 @@ std::shared_ptr<CommandQueue> ContextMTL::GetCommandQueue() const {
   return command_queue_ip_;
 }
 
-const std::shared_ptr<ImpellerMetalCaptureManager> ContextMTL::GetCaptureManager() const {
+const std::shared_ptr<ImpellerMetalCaptureManager>
+ContextMTL::GetCaptureManager() const {
   return capture_manager_;
 }
 

--- a/impeller/renderer/backend/metal/surface_mtl.h
+++ b/impeller/renderer/backend/metal/surface_mtl.h
@@ -61,6 +61,10 @@ class SurfaceMTL final : public Surface {
   // |Surface|
   bool Present() const override;
 
+  void SetFrameBoundary(bool frame_boundary) {
+    frame_boundary_ = frame_boundary;
+  }
+
  private:
   std::weak_ptr<Context> context_;
   std::shared_ptr<Texture> resolve_texture_;
@@ -69,6 +73,7 @@ class SurfaceMTL final : public Surface {
   std::shared_ptr<Texture> destination_texture_;
   bool requires_blit_ = false;
   std::optional<IRect> clip_rect_;
+  bool frame_boundary_ = false;
 
   static bool ShouldPerformPartialRepaint(std::optional<IRect> damage_rect);
 

--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -197,14 +197,7 @@ SurfaceMTL::SurfaceMTL(const std::weak_ptr<Context>& context,
       source_texture_(std::move(source_texture)),
       destination_texture_(std::move(destination_texture)),
       requires_blit_(requires_blit),
-      clip_rect_(clip_rect) {
-#ifdef IMPELLER_DEBUG
-  auto mtl_context = context_.lock();
-  if (mtl_context) {
-    ContextMTL::Cast(mtl_context.get())->GetCaptureManager()->StartCapture();
-  }
-#endif  // IMPELLER_DEBUG
-}
+      clip_rect_(clip_rect) {}
 
 // |Surface|
 SurfaceMTL::~SurfaceMTL() = default;

--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -197,7 +197,14 @@ SurfaceMTL::SurfaceMTL(const std::weak_ptr<Context>& context,
       source_texture_(std::move(source_texture)),
       destination_texture_(std::move(destination_texture)),
       requires_blit_(requires_blit),
-      clip_rect_(clip_rect) {}
+      clip_rect_(clip_rect) {
+#ifdef IMPELLER_DEBUG
+  auto mtl_context = context_.lock();
+  if (mtl_context) {
+    ContextMTL::Cast(mtl_context.get())->GetCaptureManager()->StartCapture();
+  }
+#endif  // IMPELLER_DEBUG
+}
 
 // |Surface|
 SurfaceMTL::~SurfaceMTL() = default;
@@ -231,6 +238,9 @@ bool SurfaceMTL::Present() const {
 
 #ifdef IMPELLER_DEBUG
   context->GetResourceAllocator()->DebugTraceMemoryStatistics();
+  if (frame_boundary_) {
+    ContextMTL::Cast(context.get())->GetCaptureManager()->FinishCapture();
+  }
 #endif  // IMPELLER_DEBUG
 
   if (requires_blit_) {

--- a/shell/gpu/gpu_surface_metal_impeller.mm
+++ b/shell/gpu/gpu_surface_metal_impeller.mm
@@ -186,6 +186,7 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromCAMetalLa
         display_list->Dispatch(impeller_dispatcher, sk_cull_rect);
         auto picture = impeller_dispatcher.EndRecordingAsPicture();
         const bool reset_host_buffer = surface_frame.submit_info().frame_boundary;
+        surface->SetFrameBoundary(surface_frame.submit_info().frame_boundary);
 
         return renderer->Render(
             std::move(surface),

--- a/shell/gpu/gpu_surface_metal_impeller.mm
+++ b/shell/gpu/gpu_surface_metal_impeller.mm
@@ -106,6 +106,10 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromCAMetalLa
     last_texture_.reset([drawable.texture retain]);
   }
 
+#ifdef IMPELLER_DEBUG
+  impeller::ContextMTL::Cast(*impeller_renderer_->GetContext()).GetCaptureManager()->StartCapture();
+#endif  // IMPELLER_DEBUG
+
   id<MTLTexture> last_texture = static_cast<id<MTLTexture>>(last_texture_);
   SurfaceFrame::SubmitCallback submit_callback =
       fml::MakeCopyable([damage = damage_,
@@ -233,6 +237,10 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromMTLTextur
   if (Settings::kSurfaceDataAccessible) {
     last_texture_.reset([mtl_texture retain]);
   }
+
+#ifdef IMPELLER_DEBUG
+  impeller::ContextMTL::Cast(*impeller_renderer_->GetContext()).GetCaptureManager()->StartCapture();
+#endif  // IMPELLER_DEBUG
 
   SurfaceFrame::SubmitCallback submit_callback =
       fml::MakeCopyable([disable_partial_repaint = disable_partial_repaint_,  //

--- a/shell/gpu/gpu_surface_metal_impeller_unittests.mm
+++ b/shell/gpu/gpu_surface_metal_impeller_unittests.mm
@@ -124,6 +124,7 @@ TEST(GPUSurfaceMetalImpeller, ResetHostBufferBasedOnFrameBoundary) {
   EXPECT_EQ(host_buffer.GetStateForTest().current_frame, 1u);
 }
 
+#ifdef IMPELLER_DEBUG
 TEST(GPUSurfaceMetalImpeller, CreatesImpellerCaptureScope) {
   auto delegate = std::make_shared<TestGPUSurfaceMetalDelegate>();
   delegate->SetDevice();
@@ -151,6 +152,7 @@ TEST(GPUSurfaceMetalImpeller, CreatesImpellerCaptureScope) {
   ASSERT_TRUE(frame_2->Submit());
   EXPECT_FALSE(context->GetCaptureManager()->CaptureScopeActive());
 }
+#endif  // IMPELLER_DEBUG
 
 }  // namespace testing
 }  // namespace flutter

--- a/shell/gpu/gpu_surface_metal_impeller_unittests.mm
+++ b/shell/gpu/gpu_surface_metal_impeller_unittests.mm
@@ -103,7 +103,7 @@ TEST(GPUSurfaceMetalImpeller, ResetHostBufferBasedOnFrameBoundary) {
 
   auto context = CreateImpellerContext();
   std::unique_ptr<Surface> surface =
-      std::make_unique<GPUSurfaceMetalImpeller>(delegate.get(), CreateImpellerContext());
+      std::make_unique<GPUSurfaceMetalImpeller>(delegate.get(), context);
 
   ASSERT_TRUE(surface->IsValid());
 
@@ -122,6 +122,34 @@ TEST(GPUSurfaceMetalImpeller, ResetHostBufferBasedOnFrameBoundary) {
 
   ASSERT_TRUE(frame->Submit());
   EXPECT_EQ(host_buffer.GetStateForTest().current_frame, 1u);
+}
+
+TEST(GPUSurfaceMetalImpeller, CreatesImpellerCaptureScope) {
+  auto delegate = std::make_shared<TestGPUSurfaceMetalDelegate>();
+  delegate->SetDevice();
+
+  auto context = CreateImpellerContext();
+
+  EXPECT_FALSE(context->GetCaptureManager()->CaptureScopeActive());
+
+  std::unique_ptr<Surface> surface =
+      std::make_unique<GPUSurfaceMetalImpeller>(delegate.get(), context);
+  auto frame_1 = surface->AcquireFrame(SkISize::Make(100, 100));
+  frame_1->set_submit_info({.frame_boundary = false});
+
+  EXPECT_TRUE(context->GetCaptureManager()->CaptureScopeActive());
+
+  std::unique_ptr<Surface> surface_2 =
+      std::make_unique<GPUSurfaceMetalImpeller>(delegate.get(), context);
+  auto frame_2 = surface->AcquireFrame(SkISize::Make(100, 100));
+  frame_2->set_submit_info({.frame_boundary = true});
+
+  EXPECT_TRUE(context->GetCaptureManager()->CaptureScopeActive());
+
+  ASSERT_TRUE(frame_1->Submit());
+  EXPECT_TRUE(context->GetCaptureManager()->CaptureScopeActive());
+  ASSERT_TRUE(frame_2->Submit());
+  EXPECT_FALSE(context->GetCaptureManager()->CaptureScopeActive());
 }
 
 }  // namespace testing

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -424,15 +424,14 @@ extern CFTimeInterval display_link_target;
 }
 
 + (BOOL)enabled {
-  static BOOL enabled = NO;
+  static BOOL enabled = YES;
   static BOOL didCheckInfoPlist = NO;
   if (!didCheckInfoPlist) {
     didCheckInfoPlist = YES;
     NSNumber* use_flutter_metal_layer =
         [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FLTUseFlutterMetalLayer"];
-    if (use_flutter_metal_layer != nil && [use_flutter_metal_layer boolValue]) {
-      enabled = YES;
-      FML_LOG(WARNING) << "Using FlutterMetalLayer. This is an experimental feature.";
+    if (use_flutter_metal_layer != nil && ![use_flutter_metal_layer boolValue]) {
+      enabled = NO;
     }
   }
   return enabled;


### PR DESCRIPTION
For this to work, we need to provide our own capture scope otherwise the default scope won't capture our commands.

This is required as part of the work to switch to unmerged threads for PVs (https://github.com/flutter/engine/pull/53826), as I can confirm @knopp 's observations that the performance is much worse with the default CAMetalLayer.


Fixes https://github.com/flutter/flutter/issues/140901
