### PR TITLE
[DisplayList] Optimize ClipRRect and ClipPath to ClipOval when appropriate

### DIFF
--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -4863,8 +4863,6 @@ TEST_F(DisplayListTest, ClipPathOvalNonCulling) {
   auto non_encompassing_oval = clip.makeOutset(2.071f, 2.071f);
   SkPath path;
   path.addOval(non_encompassing_oval);
-  SkRRect rrect;
-  rrect.setOval(non_encompassing_oval);
 
   DisplayListBuilder cull_builder;
   cull_builder.ClipRect(clip, ClipOp::kIntersect, false);
@@ -4873,9 +4871,8 @@ TEST_F(DisplayListTest, ClipPathOvalNonCulling) {
 
   CLIP_EXPECTOR(expector);
   expector.addExpectation(clip, ClipOp::kIntersect, false);
-  // Builder will not cull this clip, but it will turn it into a ClipRRect
-  // Eventually it should turn it into a ClipOval
-  expector.addExpectation(rrect, ClipOp::kIntersect, false);
+  // Builder will not cull this clip, but it will turn it into a ClipOval
+  expector.addOvalExpectation(non_encompassing_oval, ClipOp::kIntersect, false);
   cull_dl->Dispatch(expector);
 }
 
@@ -5088,9 +5085,7 @@ TEST_F(DisplayListTest, ClipOvalRRectPromoteToClipOval) {
   expected.DrawRect(draw_rect, DlPaint());
   auto expect_dl = expected.Build();
 
-  // Support for this will be re-added soon, until then verify that we
-  // do not promote.
-  ASSERT_TRUE(DisplayListsNE_Verbose(dl, expect_dl));
+  ASSERT_TRUE(DisplayListsEQ_Verbose(dl, expect_dl));
 }
 
 TEST_F(DisplayListTest, ClipRectPathPromoteToClipRect) {
@@ -5132,9 +5127,7 @@ TEST_F(DisplayListTest, ClipOvalPathPromoteToClipOval) {
   expected.DrawRect(draw_rect, DlPaint());
   auto expect_dl = expected.Build();
 
-  // Support for this will be re-added soon, until then verify that we
-  // do not promote.
-  ASSERT_TRUE(DisplayListsNE_Verbose(dl, expect_dl));
+  ASSERT_TRUE(DisplayListsEQ_Verbose(dl, expect_dl));
 }
 
 TEST_F(DisplayListTest, ClipRRectPathPromoteToClipRRect) {
@@ -5273,9 +5266,7 @@ TEST_F(DisplayListTest, ClipOvalRRectPathPromoteToClipOval) {
   expected.DrawRect(draw_rect, DlPaint());
   auto expect_dl = expected.Build();
 
-  // Support for this will be re-added soon, until then verify that we
-  // do not promote.
-  ASSERT_TRUE(DisplayListsNE_Verbose(dl, expect_dl));
+  ASSERT_TRUE(DisplayListsEQ_Verbose(dl, expect_dl));
 }
 
 TEST_F(DisplayListTest, BoundedRenderOpsDoNotReportUnbounded) {

--- a/display_list/dl_builder.cc
+++ b/display_list/dl_builder.cc
@@ -1005,7 +1005,11 @@ void DisplayListBuilder::ClipRRect(const SkRRect& rrect,
                                    ClipOp clip_op,
                                    bool is_aa) {
   if (rrect.isRect()) {
-    clipRect(rrect.rect(), clip_op, is_aa);
+    ClipRect(rrect.rect(), clip_op, is_aa);
+    return;
+  }
+  if (rrect.isOval()) {
+    ClipOval(rrect.rect(), clip_op, is_aa);
     return;
   }
   if (current_info().is_nop) {
@@ -1043,17 +1047,16 @@ void DisplayListBuilder::ClipPath(const SkPath& path,
   if (!path.isInverseFillType()) {
     SkRect rect;
     if (path.isRect(&rect)) {
-      this->clipRect(rect, clip_op, is_aa);
+      ClipRect(rect, clip_op, is_aa);
+      return;
+    }
+    if (path.isOval(&rect)) {
+      ClipOval(rect, clip_op, is_aa);
       return;
     }
     SkRRect rrect;
-    if (path.isOval(&rect)) {
-      rrect.setOval(rect);
-      this->clipRRect(rrect, clip_op, is_aa);
-      return;
-    }
     if (path.isRRect(&rrect)) {
-      this->clipRRect(rrect, clip_op, is_aa);
+      ClipRRect(rrect, clip_op, is_aa);
       return;
     }
   }

--- a/display_list/testing/dl_test_snippets.cc
+++ b/display_list/testing/dl_test_snippets.cc
@@ -503,8 +503,8 @@ std::vector<DisplayListInvocationGroup> CreateAllClipOps() {
             [](DlOpReceiver& r) {
               r.clipPath(kTestPathRect, DlCanvas::ClipOp::kIntersect, true);
             }},
-           // clipPath(oval) becomes clipRRect
-           {1, 64, 0,
+           // clipPath(oval) becomes clipOval
+           {1, 24, 0,
             [](DlOpReceiver& r) {
               r.clipPath(kTestPathOval, DlCanvas::ClipOp::kIntersect, true);
             }},


### PR DESCRIPTION
Fixes: https://github.com/flutter/flutter/issues/151850

Re-adding an optimization originally included in https://github.com/flutter/engine/pull/53642 that detects when ClipRRect and ClipPath operations are actually ovals and redirects them to the ClipOval path during recording to save space and reduce the need for dispatchers to do the same detections and optimizations.