### PR TITLE
Disable FlutterMetalLayer by default.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -424,14 +424,14 @@ extern CFTimeInterval display_link_target;
 }
 
 + (BOOL)enabled {
-  static BOOL enabled = YES;
+  static BOOL enabled = NO;
   static BOOL didCheckInfoPlist = NO;
   if (!didCheckInfoPlist) {
     didCheckInfoPlist = YES;
     NSNumber* use_flutter_metal_layer =
         [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FLTUseFlutterMetalLayer"];
-    if (use_flutter_metal_layer != nil && ![use_flutter_metal_layer boolValue]) {
-      enabled = NO;
+    if (use_flutter_metal_layer != nil && [use_flutter_metal_layer boolValue]) {
+      enabled = YES;
     }
   }
   return enabled;


### PR DESCRIPTION
Backing textures aren't getting deallocated, which is causing memory leaks and crashing devicelab.
