### PR TITLE
[iOS] fix Flutter Metal Layer retain cycle.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h
@@ -20,6 +20,8 @@
 @property(nullable) CGColorSpaceRef colorspace;
 @property BOOL wantsExtendedDynamicRangeContent;
 
+- (void)invalidate;
+
 - (nullable id<CAMetalDrawable>)nextDrawable;
 
 /// Returns whether the Metal layer is enabled.

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -190,6 +190,12 @@ extern CFTimeInterval display_link_target;
   return self;
 }
 
+- (void)invalidate {
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
+  [_displayLink invalidate];
+  _displayLink = nil;  // Break retain cycle.
+}
+
 - (void)setMaxRefreshRate:(double)refreshRate forceMax:(BOOL)forceMax {
   // This is copied from vsync_waiter_ios.mm. The vsync waiter has display link scheduled on UI
   // thread which does not trigger actual core animation frame. As a workaround FlutterMetalLayer

--- a/shell/platform/darwin/ios/ios_surface_metal_impeller.mm
+++ b/shell/platform/darwin/ios/ios_surface_metal_impeller.mm
@@ -7,6 +7,7 @@
 #include "flutter/impeller/renderer/backend/metal/formats_mtl.h"
 #include "flutter/impeller/renderer/context.h"
 #include "flutter/shell/gpu/gpu_surface_metal_impeller.h"
+#include "flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h"
 
 FLUTTER_ASSERT_ARC
 
@@ -25,7 +26,11 @@ IOSSurfaceMetalImpeller::IOSSurfaceMetalImpeller(const fml::scoped_nsobject<CAMe
 }
 
 // |IOSSurface|
-IOSSurfaceMetalImpeller::~IOSSurfaceMetalImpeller() = default;
+IOSSurfaceMetalImpeller::~IOSSurfaceMetalImpeller() {
+  if ([layer_ isKindOfClass:[FlutterMetalLayer class]]) {
+    [(FlutterMetalLayer*)layer_.get() invalidate];
+  }
+}
 
 // |IOSSurface|
 bool IOSSurfaceMetalImpeller::IsValid() const {

--- a/shell/platform/darwin/ios/ios_surface_metal_skia.mm
+++ b/shell/platform/darwin/ios/ios_surface_metal_skia.mm
@@ -8,13 +8,10 @@
 
 #include "flutter/shell/gpu/gpu_surface_metal_delegate.h"
 #include "flutter/shell/gpu/gpu_surface_metal_skia.h"
+#include "flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h"
 #include "flutter/shell/platform/darwin/ios/ios_context_metal_skia.h"
 
 FLUTTER_ASSERT_ARC
-
-@protocol FlutterMetalDrawable <MTLDrawable>
-- (void)flutterPrepareForPresent:(nonnull id<MTLCommandBuffer>)commandBuffer;
-@end
 
 namespace flutter {
 
@@ -36,7 +33,11 @@ IOSSurfaceMetalSkia::IOSSurfaceMetalSkia(const fml::scoped_nsobject<CAMetalLayer
 }
 
 // |IOSSurface|
-IOSSurfaceMetalSkia::~IOSSurfaceMetalSkia() = default;
+IOSSurfaceMetalSkia::~IOSSurfaceMetalSkia() {
+  if ([layer_ isKindOfClass:[FlutterMetalLayer class]]) {
+    [(FlutterMetalLayer*)layer_.get() invalidate];
+  }
+}
 
 // |IOSSurface|
 bool IOSSurfaceMetalSkia::IsValid() const {


### PR DESCRIPTION
The display link and/or notification observer was keeping the FlutterMetalLayer alive. Add an invalidate method and call it in the IOSSurface dtor.

How do we test this?