### PR TITLE
Add a precision to the fragment shader

### DIFF
--- a/shell/platform/linux/fl_renderer.cc
+++ b/shell/platform/linux/fl_renderer.cc
@@ -25,6 +25,10 @@ static const char* vertex_shader_src =
 
 // Fragment shader to draw Flutter window contents.
 static const char* fragment_shader_src =
+    "#ifdef GL_ES\n"
+    "precision mediump float;\n"
+    "#endif\n"
+    "\n"
     "uniform sampler2D texture;\n"
     "varying vec2 texcoord;\n"
     "\n"


### PR DESCRIPTION
This is required for OpenGL ES.

See https://registry.khronos.org/OpenGL/specs/es/3.2/GLSL_ES_Specification_3.20.html#precision-and-precision-qualifiers

https://github.com/flutter/flutter/issues/152297

