### PR TITLE
[impeller] adds test for catching shimmer in gaussian blur

### DIFF
--- a/impeller/display_list/BUILD.gn
+++ b/impeller/display_list/BUILD.gn
@@ -91,6 +91,7 @@ template("display_list_unittests_component") {
     deps += [
       ":display_list",
       "../playground:playground_test",
+      "//flutter/impeller/golden_tests:screenshot",
       "//flutter/impeller/scene",
       "//flutter/impeller/typographer/backends/stb:typographer_stb_backend",
       "//flutter/third_party/txt",

--- a/impeller/display_list/dl_golden_blur_unittests.cc
+++ b/impeller/display_list/dl_golden_blur_unittests.cc
@@ -114,10 +114,10 @@ TEST_P(DlGoldenTest, TextBlurMaskFilterDisrespectCTM) {
 namespace {
 double CalculateDistance(const uint8_t* left, const uint8_t* right) {
   double diff[4] = {
-      static_cast<double>(left[0] - right[0]),  //
-      static_cast<double>(left[1] - right[1]),  //
-      static_cast<double>(left[2] - right[2]),  //
-      static_cast<double>(left[3] - right[3])   //
+      static_cast<double>(left[0]) - right[0],  //
+      static_cast<double>(left[1]) - right[1],  //
+      static_cast<double>(left[2]) - right[2],  //
+      static_cast<double>(left[3]) - right[3]   //
   };
   return sqrt((diff[0] * diff[0]) +  //
               (diff[1] * diff[1]) +  //

--- a/impeller/display_list/dl_golden_blur_unittests.cc
+++ b/impeller/display_list/dl_golden_blur_unittests.cc
@@ -192,10 +192,20 @@ TEST_P(DlGoldenTest, ShimmerTest) {
     double rmse = RMSE(left.get(), right.get());
     average_rmse += rmse;
 
+    // To debug this output the frames can be written out to disk then
+    // transformed to a video with ffmpeg.
+    //
+    // ## save images command
     // std::stringstream ss;
     // ss << "_" << std::setw(3) << std::setfill('0') << (i - 1);
     // SaveScreenshot(std::move(left), ss.str());
     // left = std::move(right);
+    //
+    // ## ffmpeg command
+    // ```
+    // ffmpeg -framerate 30 -pattern_type glob -i '*.png' \
+    //   -c:v libx264 -pix_fmt yuv420p out.mp4
+    // ```
   }
 
   average_rmse = average_rmse / sample_count;

--- a/impeller/display_list/dl_golden_blur_unittests.cc
+++ b/impeller/display_list/dl_golden_blur_unittests.cc
@@ -146,6 +146,12 @@ double RMSE(const impeller::testing::Screenshot* left,
 }
 }  // namespace
 
+// This is a test to make sure that we don't regress "shimmering" in the
+// gaussian blur. Shimmering is abrupt changes in signal when making tiny
+// changes to the blur parameters.
+//
+// See also:
+//   - https://github.com/flutter/flutter/issues/152195
 TEST_P(DlGoldenTest, ShimmerTest) {
   impeller::Point content_scale = GetContentScale();
   auto draw = [&](DlCanvas* canvas, const std::vector<sk_sp<DlImage>>& images,
@@ -210,7 +216,13 @@ TEST_P(DlGoldenTest, ShimmerTest) {
 
   average_rmse = average_rmse / sample_count;
 
+  // This is a somewhat arbitrary threshold. It could be increased if we wanted.
+  // In the problematic cases previously we should values like 28. Before
+  // increasing this you should manually inspect the behavior in
+  // `AiksTest.GaussianBlurAnimatedBackdrop`. Average RMSE is a able to catch
+  // shimmer but it isn't perfect.
   EXPECT_TRUE(average_rmse < 1.0) << "average_rmse: " << average_rmse;
+  // An average rmse of 0 would mean that the blur isn't blurring.
   EXPECT_TRUE(average_rmse >= 0.0) << "average_rmse: " << average_rmse;
 }
 

--- a/impeller/display_list/dl_golden_blur_unittests.cc
+++ b/impeller/display_list/dl_golden_blur_unittests.cc
@@ -125,7 +125,7 @@ double CalculateDistance(const uint8_t* left, const uint8_t* right) {
               (diff[3] * diff[3]));
 }
 
-double RMSE(impeller::testing::Screenshot* left,
+[[maybe_unused]] double RMSE(impeller::testing::Screenshot* left,
             impeller::testing::Screenshot* right) {
   FML_CHECK(left);
   FML_CHECK(right);
@@ -153,12 +153,16 @@ TEST_P(DlGoldenTest, ShimmerTest) {
     canvas->DrawColor(DlColor(0xff111111));
     canvas->Scale(content_scale.x, content_scale.y);
 
+    canvas->Save();
+    canvas->Scale(2, 2);
     DlPaint paint;
-    canvas->DrawImage(images[0], SkPoint::Make(100.0, 100.0),
+    canvas->DrawImage(images[0], SkPoint::Make(10.0, 10.0),
                       DlImageSampling::kLinear, &paint);
+    canvas->Restore();
 
     SkRect save_layer_bounds = SkRect::MakeLTRB(0, 0, 1024, 768);
     DlBlurImageFilter blur(sigma, sigma, DlTileMode::kDecal);
+    canvas->ClipRect(SkRect::MakeLTRB(11.25, 10, 911.25, 755.3333));
     canvas->SaveLayer(&save_layer_bounds, /*paint=*/nullptr, &blur);
     canvas->Restore();
   };
@@ -175,15 +179,15 @@ TEST_P(DlGoldenTest, ShimmerTest) {
     return screenshot;
   };
 
-  float start_sigma = 20.0f;
+  float start_sigma = 10.0f;
   std::unique_ptr<impeller::testing::Screenshot> left =
       make_screenshot(start_sigma);
   if (!left) {
     GTEST_SKIP() << "making screenshots not supported.";
   }
 
-  for (int i = 1; i <= 500; ++i) {
-    float sigma = start_sigma + (i / 10.f);
+  for (int i = 1; i <= 200; ++i) {
+    float sigma = start_sigma + (i / 2.f);
     std::unique_ptr<impeller::testing::Screenshot> right =
         make_screenshot(sigma);
     double rmse = RMSE(left.get(), right.get());

--- a/impeller/display_list/dl_golden_blur_unittests.cc
+++ b/impeller/display_list/dl_golden_blur_unittests.cc
@@ -186,15 +186,14 @@ TEST_P(DlGoldenTest, ShimmerTest) {
     GTEST_SKIP() << "making screenshots not supported.";
   }
 
-  int32_t jump_count = 0;
-  for (int i = 1; i <= 200; ++i) {
+  double average_rmse = 0.0;
+  const int32_t sample_count = 200;
+  for (int i = 1; i <= sample_count; ++i) {
     float sigma = start_sigma + (i / 2.f);
     std::unique_ptr<impeller::testing::Screenshot> right =
         make_screenshot(sigma);
     double rmse = RMSE(left.get(), right.get());
-    if (rmse >= 1.0) {
-      jump_count += 1;
-    }
+    average_rmse += rmse;
 
     // std::stringstream ss;
     // ss << "_" << (i - 1);
@@ -202,7 +201,9 @@ TEST_P(DlGoldenTest, ShimmerTest) {
     left = std::move(right);
   }
 
-  EXPECT_TRUE(jump_count < 30) << "jump_count: " << jump_count;
+  average_rmse = average_rmse / sample_count;
+
+  EXPECT_TRUE(average_rmse < 0.86) << "average_rmse: " << average_rmse;
 }
 
 }  // namespace testing

--- a/impeller/display_list/dl_golden_blur_unittests.cc
+++ b/impeller/display_list/dl_golden_blur_unittests.cc
@@ -202,8 +202,7 @@ TEST_P(DlGoldenTest, ShimmerTest) {
     left = std::move(right);
   }
 
-  EXPECT_TRUE(jump_count < 30)
-      << "jump_count: " << jump_count;
+  EXPECT_TRUE(jump_count < 30) << "jump_count: " << jump_count;
 }
 
 }  // namespace testing

--- a/impeller/display_list/dl_golden_blur_unittests.cc
+++ b/impeller/display_list/dl_golden_blur_unittests.cc
@@ -153,22 +153,19 @@ TEST_P(DlGoldenTest, ShimmerTest) {
     canvas->DrawColor(DlColor(0xff111111));
     canvas->Scale(content_scale.x, content_scale.y);
 
-    canvas->Save();
-    canvas->Scale(2, 2);
     DlPaint paint;
-    canvas->DrawImage(images[0], SkPoint::Make(10.0, 10.0),
+    canvas->DrawImage(images[0], SkPoint::Make(10.135, 10.36334),
                       DlImageSampling::kLinear, &paint);
-    canvas->Restore();
 
     SkRect save_layer_bounds = SkRect::MakeLTRB(0, 0, 1024, 768);
     DlBlurImageFilter blur(sigma, sigma, DlTileMode::kDecal);
-    canvas->ClipRect(SkRect::MakeLTRB(11.25, 10, 911.25, 755.3333));
+    canvas->ClipRect(SkRect::MakeLTRB(11.125, 10.3737, 911.25, 755.3333));
     canvas->SaveLayer(&save_layer_bounds, /*paint=*/nullptr, &blur);
     canvas->Restore();
   };
 
   std::vector<sk_sp<DlImage>> images;
-  images.emplace_back(CreateDlImageForFixture("kalimba.jpg"));
+  images.emplace_back(CreateDlImageForFixture("boston.jpg"));
 
   auto make_screenshot = [&](float sigma) {
     DisplayListBuilder builder;
@@ -196,14 +193,15 @@ TEST_P(DlGoldenTest, ShimmerTest) {
     average_rmse += rmse;
 
     // std::stringstream ss;
-    // ss << "_" << (i - 1);
+    // ss << "_" << std::setw(3) << std::setfill('0') << (i - 1);
     // SaveScreenshot(std::move(left), ss.str());
-    left = std::move(right);
+    // left = std::move(right);
   }
 
   average_rmse = average_rmse / sample_count;
 
-  EXPECT_TRUE(average_rmse < 0.86) << "average_rmse: " << average_rmse;
+  EXPECT_TRUE(average_rmse < 0.59) << "average_rmse: " << average_rmse;
+  EXPECT_TRUE(average_rmse > 0.58) << "average_rmse: " << average_rmse;
 }
 
 }  // namespace testing

--- a/impeller/display_list/dl_golden_blur_unittests.cc
+++ b/impeller/display_list/dl_golden_blur_unittests.cc
@@ -175,17 +175,24 @@ TEST_P(DlGoldenTest, ShimmerTest) {
     return screenshot;
   };
 
-  std::unique_ptr<impeller::testing::Screenshot> left = make_screenshot(0);
+  float start_sigma = 20.0f;
+  std::unique_ptr<impeller::testing::Screenshot> left =
+      make_screenshot(start_sigma);
   if (!left) {
     GTEST_SKIP() << "making screenshots not supported.";
   }
 
   for (int i = 1; i <= 500; ++i) {
-    float sigma = i;
+    float sigma = start_sigma + (i / 10.f);
     std::unique_ptr<impeller::testing::Screenshot> right =
         make_screenshot(sigma);
     double rmse = RMSE(left.get(), right.get());
-    EXPECT_TRUE(rmse < 1.0) << "sigma:" << sigma << " rmse: " << rmse;
+    EXPECT_TRUE(rmse < 1.0)
+        << "i: " << i << " sigma:" << sigma << " rmse: " << rmse;
+
+    std::stringstream ss;
+    ss << "_" << (i-1);
+    SaveScreenshot(std::move(left), ss.str());
     left = std::move(right);
   }
 }

--- a/impeller/display_list/dl_golden_blur_unittests.cc
+++ b/impeller/display_list/dl_golden_blur_unittests.cc
@@ -6,11 +6,11 @@
 
 #include "flutter/display_list/dl_builder.h"
 #include "flutter/display_list/effects/dl_mask_filter.h"
+#include "flutter/impeller/golden_tests/screenshot.h"
 #include "flutter/testing/testing.h"
 #include "gtest/gtest.h"
 #include "impeller/typographer/backends/skia/text_frame_skia.h"
 #include "txt/platform.h"
-#include "flutter/impeller/golden_tests/screenshot.h"
 
 namespace flutter {
 namespace testing {
@@ -133,12 +133,11 @@ TEST_P(DlGoldenTest, ShimmerTest) {
   DisplayListBuilder builder;
   draw(&builder, images);
 
-  std::unique_ptr<impeller::testing::Screenshot> screenshot = MakeScreenshot(builder.Build());
+  std::unique_ptr<impeller::testing::Screenshot> screenshot =
+      MakeScreenshot(builder.Build());
   if (!screenshot) {
     GTEST_SKIP() << "making screenshots not supported.";
   }
-
-  
 }
 
 }  // namespace testing

--- a/impeller/display_list/dl_golden_blur_unittests.cc
+++ b/impeller/display_list/dl_golden_blur_unittests.cc
@@ -126,7 +126,7 @@ double CalculateDistance(const uint8_t* left, const uint8_t* right) {
 }
 
 [[maybe_unused]] double RMSE(impeller::testing::Screenshot* left,
-            impeller::testing::Screenshot* right) {
+                             impeller::testing::Screenshot* right) {
   FML_CHECK(left);
   FML_CHECK(right);
   FML_CHECK(left->GetWidth() == right->GetWidth());
@@ -186,19 +186,24 @@ TEST_P(DlGoldenTest, ShimmerTest) {
     GTEST_SKIP() << "making screenshots not supported.";
   }
 
+  int32_t jump_count = 0;
   for (int i = 1; i <= 200; ++i) {
     float sigma = start_sigma + (i / 2.f);
     std::unique_ptr<impeller::testing::Screenshot> right =
         make_screenshot(sigma);
     double rmse = RMSE(left.get(), right.get());
-    EXPECT_TRUE(rmse < 1.0)
-        << "i: " << i << " sigma:" << sigma << " rmse: " << rmse;
+    if (rmse >= 1.0) {
+      jump_count += 1;
+    }
 
-    std::stringstream ss;
-    ss << "_" << (i-1);
-    SaveScreenshot(std::move(left), ss.str());
+    // std::stringstream ss;
+    // ss << "_" << (i - 1);
+    // SaveScreenshot(std::move(left), ss.str());
     left = std::move(right);
   }
+
+  EXPECT_TRUE(jump_count < 30)
+      << "jump_count: " << jump_count;
 }
 
 }  // namespace testing

--- a/impeller/display_list/dl_golden_blur_unittests.cc
+++ b/impeller/display_list/dl_golden_blur_unittests.cc
@@ -110,5 +110,30 @@ TEST_P(DlGoldenTest, TextBlurMaskFilterDisrespectCTM) {
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
+TEST_P(DlGoldenTest, ShimmerTest) {
+  impeller::Point content_scale = GetContentScale();
+  auto draw = [&](DlCanvas* canvas,
+                  const std::vector<sk_sp<DlImage>>& images) {
+    canvas->DrawColor(DlColor(0xff111111));
+    canvas->Scale(content_scale.x, content_scale.y);
+
+    DlPaint paint;
+    canvas->DrawImage(images[0], SkPoint::Make(100.0, 100.0),
+                      DlImageSampling::kLinear, &paint);
+
+    SkRect save_layer_bounds = SkRect::MakeLTRB(0, 0, 1024, 768);
+    DlBlurImageFilter blur(/*sigma_x=*/40, /*sigma_y=*/40, DlTileMode::kDecal);
+    canvas->SaveLayer(&save_layer_bounds, /*paint=*/nullptr, &blur);
+    canvas->Restore();
+  };
+
+  DisplayListBuilder builder;
+  std::vector<sk_sp<DlImage>> images;
+  images.emplace_back(CreateDlImageForFixture("kalimba.jpg"));
+  draw(&builder, images);
+
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/impeller/display_list/dl_golden_blur_unittests.cc
+++ b/impeller/display_list/dl_golden_blur_unittests.cc
@@ -199,13 +199,13 @@ TEST_P(DlGoldenTest, ShimmerTest) {
     // std::stringstream ss;
     // ss << "_" << std::setw(3) << std::setfill('0') << (i - 1);
     // SaveScreenshot(std::move(left), ss.str());
-    // left = std::move(right);
     //
     // ## ffmpeg command
     // ```
     // ffmpeg -framerate 30 -pattern_type glob -i '*.png' \
     //   -c:v libx264 -pix_fmt yuv420p out.mp4
     // ```
+    left = std::move(right);
   }
 
   average_rmse = average_rmse / sample_count;

--- a/impeller/display_list/dl_golden_blur_unittests.cc
+++ b/impeller/display_list/dl_golden_blur_unittests.cc
@@ -200,8 +200,8 @@ TEST_P(DlGoldenTest, ShimmerTest) {
 
   average_rmse = average_rmse / sample_count;
 
-  EXPECT_TRUE(average_rmse < 0.59) << "average_rmse: " << average_rmse;
-  EXPECT_TRUE(average_rmse > 0.58) << "average_rmse: " << average_rmse;
+  EXPECT_TRUE(average_rmse < 1.0) << "average_rmse: " << average_rmse;
+  EXPECT_TRUE(average_rmse >= 0.0) << "average_rmse: " << average_rmse;
 }
 
 }  // namespace testing

--- a/impeller/display_list/dl_golden_blur_unittests.cc
+++ b/impeller/display_list/dl_golden_blur_unittests.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "impeller/typographer/backends/skia/text_frame_skia.h"
 #include "txt/platform.h"
+#include "flutter/impeller/golden_tests/screenshot.h"
 
 namespace flutter {
 namespace testing {
@@ -112,8 +113,7 @@ TEST_P(DlGoldenTest, TextBlurMaskFilterDisrespectCTM) {
 
 TEST_P(DlGoldenTest, ShimmerTest) {
   impeller::Point content_scale = GetContentScale();
-  auto draw = [&](DlCanvas* canvas,
-                  const std::vector<sk_sp<DlImage>>& images) {
+  auto draw = [&](DlCanvas* canvas, const std::vector<sk_sp<DlImage>>& images) {
     canvas->DrawColor(DlColor(0xff111111));
     canvas->Scale(content_scale.x, content_scale.y);
 
@@ -127,12 +127,18 @@ TEST_P(DlGoldenTest, ShimmerTest) {
     canvas->Restore();
   };
 
-  DisplayListBuilder builder;
   std::vector<sk_sp<DlImage>> images;
   images.emplace_back(CreateDlImageForFixture("kalimba.jpg"));
+
+  DisplayListBuilder builder;
   draw(&builder, images);
 
-  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+  std::unique_ptr<impeller::testing::Screenshot> screenshot = MakeScreenshot(builder.Build());
+  if (!screenshot) {
+    GTEST_SKIP() << "making screenshots not supported.";
+  }
+
+  
 }
 
 }  // namespace testing

--- a/impeller/display_list/dl_golden_blur_unittests.cc
+++ b/impeller/display_list/dl_golden_blur_unittests.cc
@@ -111,6 +111,41 @@ TEST_P(DlGoldenTest, TextBlurMaskFilterDisrespectCTM) {
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
+namespace {
+double CalculateDistance(const uint8_t* left, const uint8_t* right) {
+  double diff[4] = {
+      static_cast<double>(left[0] - right[0]),  //
+      static_cast<double>(left[1] - right[1]),  //
+      static_cast<double>(left[2] - right[2]),  //
+      static_cast<double>(left[3] - right[3])   //
+  };
+  return sqrt((diff[0] * diff[0]) +  //
+              (diff[1] * diff[1]) +  //
+              (diff[2] * diff[2]) +  //
+              (diff[3] * diff[3]));
+}
+
+double RMSE(impeller::testing::Screenshot* left,
+            impeller::testing::Screenshot* right) {
+  FML_CHECK(left);
+  FML_CHECK(right);
+  FML_CHECK(left->GetWidth() == right->GetWidth());
+  FML_CHECK(left->GetHeight() == right->GetHeight());
+
+  int64_t samples = left->GetWidth() * left->GetHeight();
+  double tally = 0;
+
+  const uint8_t* left_ptr = left->GetBytes();
+  const uint8_t* right_ptr = right->GetBytes();
+  for (int64_t i = 0; i < samples; ++i, left_ptr += 4, right_ptr += 4) {
+    double distance = CalculateDistance(left_ptr, right_ptr);
+    tally += distance * distance;
+  }
+
+  return sqrt(tally / static_cast<double>(samples));
+}
+}  // namespace
+
 TEST_P(DlGoldenTest, ShimmerTest) {
   impeller::Point content_scale = GetContentScale();
   auto draw = [&](DlCanvas* canvas, const std::vector<sk_sp<DlImage>>& images,
@@ -145,10 +180,12 @@ TEST_P(DlGoldenTest, ShimmerTest) {
     GTEST_SKIP() << "making screenshots not supported.";
   }
 
-  for (int i = 1; i < 500; ++i) {
+  for (int i = 1; i <= 500; ++i) {
     float sigma = i;
     std::unique_ptr<impeller::testing::Screenshot> right =
         make_screenshot(sigma);
+    double rmse = RMSE(left.get(), right.get());
+    EXPECT_TRUE(rmse < 1.0) << "sigma:" << sigma << " rmse: " << rmse;
     left = std::move(right);
   }
 }

--- a/impeller/display_list/dl_golden_blur_unittests.cc
+++ b/impeller/display_list/dl_golden_blur_unittests.cc
@@ -125,8 +125,8 @@ double CalculateDistance(const uint8_t* left, const uint8_t* right) {
               (diff[3] * diff[3]));
 }
 
-[[maybe_unused]] double RMSE(impeller::testing::Screenshot* left,
-                             impeller::testing::Screenshot* right) {
+double RMSE(const impeller::testing::Screenshot* left,
+            const impeller::testing::Screenshot* right) {
   FML_CHECK(left);
   FML_CHECK(right);
   FML_CHECK(left->GetWidth() == right->GetWidth());

--- a/impeller/display_list/dl_golden_blur_unittests.cc
+++ b/impeller/display_list/dl_golden_blur_unittests.cc
@@ -145,8 +145,8 @@ TEST_P(DlGoldenTest, ShimmerTest) {
     GTEST_SKIP() << "making screenshots not supported.";
   }
 
-  for (int i = 1; i < 5000; ++i) {
-    float sigma = i / 10.0f;
+  for (int i = 1; i < 500; ++i) {
+    float sigma = i;
     std::unique_ptr<impeller::testing::Screenshot> right =
         make_screenshot(sigma);
     left = std::move(right);

--- a/impeller/display_list/dl_playground.cc
+++ b/impeller/display_list/dl_playground.cc
@@ -71,6 +71,11 @@ bool DlPlayground::OpenPlaygroundHere(DisplayListPlaygroundCallback callback) {
       });
 }
 
+std::unique_ptr<testing::Screenshot> DlPlayground::MakeScreenshot(
+    const sk_sp<flutter::DisplayList>& list) {
+  return nullptr;
+}
+
 SkFont DlPlayground::CreateTestFontOfSize(SkScalar scalar) {
   static constexpr const char* kTestFontFixture = "Roboto-Regular.ttf";
   auto mapping = flutter::testing::OpenFixtureAsSkData(kTestFontFixture);

--- a/impeller/display_list/dl_playground.h
+++ b/impeller/display_list/dl_playground.h
@@ -7,6 +7,7 @@
 
 #include "flutter/display_list/display_list.h"
 #include "flutter/display_list/dl_builder.h"
+#include "flutter/impeller/golden_tests/screenshot.h"
 #include "impeller/playground/playground_test.h"
 #include "third_party/skia/include/core/SkFont.h"
 
@@ -26,6 +27,9 @@ class DlPlayground : public PlaygroundTest {
   bool OpenPlaygroundHere(sk_sp<flutter::DisplayList> list);
 
   bool OpenPlaygroundHere(DisplayListPlaygroundCallback callback);
+
+  std::unique_ptr<testing::Screenshot> MakeScreenshot(
+      const sk_sp<flutter::DisplayList>& list);
 
   SkFont CreateTestFontOfSize(SkScalar scalar);
 

--- a/impeller/golden_tests/BUILD.gn
+++ b/impeller/golden_tests/BUILD.gn
@@ -12,6 +12,7 @@ impeller_component("golden_playground_test") {
 
   deps = [
     ":digest",
+    ":screenshot",
     "//flutter/fml",
     "//flutter/impeller/aiks",
     "//flutter/impeller/display_list:display_list",
@@ -44,6 +45,15 @@ impeller_component("digest") {
   deps = [ "//flutter/fml" ]
 }
 
+
+impeller_component("screenshot") {
+  testonly = true
+  sources = [
+    "screenshot.h",
+  ]
+}
+
+
 if (is_mac) {
   impeller_component("metal_screenshot") {
     testonly = true
@@ -53,13 +63,13 @@ if (is_mac) {
       "metal_screenshot.mm",
       "metal_screenshotter.h",
       "metal_screenshotter.mm",
-      "screenshot.h",
       "screenshotter.h",
       "vulkan_screenshotter.h",
       "vulkan_screenshotter.mm",
     ]
 
     deps = [
+      ":screenshot",
       "//flutter/impeller/aiks",
       "//flutter/impeller/display_list",
       "//flutter/impeller/playground",

--- a/impeller/golden_tests/BUILD.gn
+++ b/impeller/golden_tests/BUILD.gn
@@ -45,14 +45,10 @@ impeller_component("digest") {
   deps = [ "//flutter/fml" ]
 }
 
-
 impeller_component("screenshot") {
   testonly = true
-  sources = [
-    "screenshot.h",
-  ]
+  sources = [ "screenshot.h" ]
 }
-
 
 if (is_mac) {
   impeller_component("metal_screenshot") {

--- a/impeller/golden_tests/golden_playground_test.h
+++ b/impeller/golden_tests/golden_playground_test.h
@@ -10,12 +10,12 @@
 #include "flutter/display_list/display_list.h"
 #include "flutter/display_list/image/dl_image.h"
 #include "flutter/impeller/aiks/aiks_context.h"
+#include "flutter/impeller/golden_tests/screenshot.h"
 #include "flutter/impeller/playground/playground.h"
 #include "flutter/impeller/renderer/render_target.h"
 #include "flutter/testing/testing.h"
 #include "impeller/typographer/typographer_context.h"
 #include "third_party/imgui/imgui.h"
-#include "flutter/impeller/golden_tests/screenshot.h"
 
 #if FML_OS_MACOSX
 #include "flutter/fml/platform/darwin/scoped_nsautorelease_pool.h"
@@ -54,6 +54,9 @@ class GoldenPlaygroundTest
 
   std::unique_ptr<testing::Screenshot> MakeScreenshot(
       const sk_sp<flutter::DisplayList>& list);
+
+  static bool SaveScreenshot(std::unique_ptr<testing::Screenshot> screenshot,
+                             const std::string& postfix = "");
 
   static bool ImGuiBegin(const char* name,
                          bool* p_open,

--- a/impeller/golden_tests/golden_playground_test.h
+++ b/impeller/golden_tests/golden_playground_test.h
@@ -15,6 +15,7 @@
 #include "flutter/testing/testing.h"
 #include "impeller/typographer/typographer_context.h"
 #include "third_party/imgui/imgui.h"
+#include "flutter/impeller/golden_tests/screenshot.h"
 
 #if FML_OS_MACOSX
 #include "flutter/fml/platform/darwin/scoped_nsautorelease_pool.h"
@@ -50,6 +51,9 @@ class GoldenPlaygroundTest
   bool OpenPlaygroundHere(const AiksDlPlaygroundCallback& callback);
 
   bool OpenPlaygroundHere(const sk_sp<flutter::DisplayList>& list);
+
+  std::unique_ptr<testing::Screenshot> MakeScreenshot(
+      const sk_sp<flutter::DisplayList>& list);
 
   static bool ImGuiBegin(const char* name,
                          bool* p_open,

--- a/impeller/golden_tests/golden_playground_test_mac.cc
+++ b/impeller/golden_tests/golden_playground_test_mac.cc
@@ -140,17 +140,20 @@ std::string GetTestName() {
   return result;
 }
 
-std::string GetGoldenFilename() {
-  return GetTestName() + ".png";
+std::string GetGoldenFilename(const std::string& postfix) {
+  return GetTestName() + postfix + ".png";
 }
+}  // namespace
 
-bool SaveScreenshot(std::unique_ptr<testing::Screenshot> screenshot) {
+bool GoldenPlaygroundTest::SaveScreenshot(
+    std::unique_ptr<testing::Screenshot> screenshot,
+    const std::string& postfix) {
   if (!screenshot || !screenshot->GetBytes()) {
     FML_LOG(ERROR) << "Failed to collect screenshot for test " << GetTestName();
     return false;
   }
   std::string test_name = GetTestName();
-  std::string filename = GetGoldenFilename();
+  std::string filename = GetGoldenFilename(postfix);
   testing::GoldenDigest::Instance()->AddImage(
       test_name, filename, screenshot->GetWidth(), screenshot->GetHeight());
   if (!screenshot->WriteToPNG(
@@ -160,8 +163,6 @@ bool SaveScreenshot(std::unique_ptr<testing::Screenshot> screenshot) {
   }
   return true;
 }
-
-}  // namespace
 
 struct GoldenPlaygroundTest::GoldenPlaygroundTestImpl {
   std::unique_ptr<PlaygroundImpl> test_vulkan_playground;
@@ -407,7 +408,7 @@ std::unique_ptr<testing::Screenshot> GoldenPlaygroundTest::MakeScreenshot(
   std::unique_ptr<testing::Screenshot> screenshot =
       pimpl_->screenshotter->MakeScreenshot(renderer, picture,
                                             pimpl_->window_size);
-  
+
   return screenshot;
 }
 

--- a/impeller/golden_tests/golden_playground_test_mac.cc
+++ b/impeller/golden_tests/golden_playground_test_mac.cc
@@ -396,4 +396,19 @@ fml::Status GoldenPlaygroundTest::SetCapabilities(
   return pimpl_->screenshotter->GetPlayground().SetCapabilities(capabilities);
 }
 
+std::unique_ptr<testing::Screenshot> GoldenPlaygroundTest::MakeScreenshot(
+    const sk_sp<flutter::DisplayList>& list) {
+  AiksContext renderer(GetContext(), typographer_context_);
+
+  DlDispatcher dispatcher;
+  list->Dispatch(dispatcher);
+  Picture picture = dispatcher.EndRecordingAsPicture();
+
+  std::unique_ptr<testing::Screenshot> screenshot =
+      pimpl_->screenshotter->MakeScreenshot(renderer, picture,
+                                            pimpl_->window_size);
+  
+  return screenshot;
+}
+
 }  // namespace impeller

--- a/impeller/golden_tests/golden_playground_test_stub.cc
+++ b/impeller/golden_tests/golden_playground_test_stub.cc
@@ -89,4 +89,9 @@ fml::Status GoldenPlaygroundTest::SetCapabilities(
       "GoldenPlaygroundTest-Stub doesn't support SetCapabilities.");
 }
 
+std::unique_ptr<testing::Screenshot> GoldenPlaygroundTest::MakeScreenshot(
+    const sk_sp<flutter::DisplayList>& list) {
+  return nullptr;
+}
+
 }  // namespace impeller

--- a/impeller/golden_tests/metal_screenshotter.mm
+++ b/impeller/golden_tests/metal_screenshotter.mm
@@ -44,7 +44,7 @@ std::unique_ptr<Screenshot> MetalScreenshotter::MakeScreenshot(
     CGColorSpaceRef color_space = CGColorSpaceCreateDeviceRGB();
     CIImage* ciImage = [[CIImage alloc]
         initWithMTLTexture:metal_texture
-                    options:@{kCIImageColorSpace : (__bridge id)color_space}];
+                   options:@{kCIImageColorSpace : (__bridge id)color_space}];
     CGColorSpaceRelease(color_space);
     FML_CHECK(ciImage);
 
@@ -59,7 +59,7 @@ std::unique_ptr<Screenshot> MetalScreenshotter::MakeScreenshot(
         imageByApplyingOrientation:kCGImagePropertyOrientationDownMirrored];
 
     CGImageRef cgImage = [cicontext createCGImage:flipped
-                                        fromRect:[ciImage extent]];
+                                         fromRect:[ciImage extent]];
 
     return std::unique_ptr<MetalScreenshot>(new MetalScreenshot(cgImage));
   }

--- a/impeller/golden_tests/metal_screenshotter.mm
+++ b/impeller/golden_tests/metal_screenshotter.mm
@@ -37,30 +37,32 @@ std::unique_ptr<Screenshot> MetalScreenshotter::MakeScreenshot(
 std::unique_ptr<Screenshot> MetalScreenshotter::MakeScreenshot(
     AiksContext& aiks_context,
     const std::shared_ptr<Texture> texture) {
-  id<MTLTexture> metal_texture =
-      std::static_pointer_cast<TextureMTL>(texture)->GetMTLTexture();
+  @autoreleasepool {
+    id<MTLTexture> metal_texture =
+        std::static_pointer_cast<TextureMTL>(texture)->GetMTLTexture();
 
-  CGColorSpaceRef color_space = CGColorSpaceCreateDeviceRGB();
-  CIImage* ciImage = [[CIImage alloc]
-      initWithMTLTexture:metal_texture
-                 options:@{kCIImageColorSpace : (__bridge id)color_space}];
-  CGColorSpaceRelease(color_space);
-  FML_CHECK(ciImage);
+    CGColorSpaceRef color_space = CGColorSpaceCreateDeviceRGB();
+    CIImage* ciImage = [[CIImage alloc]
+        initWithMTLTexture:metal_texture
+                    options:@{kCIImageColorSpace : (__bridge id)color_space}];
+    CGColorSpaceRelease(color_space);
+    FML_CHECK(ciImage);
 
-  std::shared_ptr<Context> context = playground_->GetContext();
-  std::shared_ptr<ContextMTL> context_mtl =
-      std::static_pointer_cast<ContextMTL>(context);
-  CIContext* cicontext =
-      [CIContext contextWithMTLDevice:context_mtl->GetMTLDevice()];
-  FML_CHECK(context);
+    std::shared_ptr<Context> context = playground_->GetContext();
+    std::shared_ptr<ContextMTL> context_mtl =
+        std::static_pointer_cast<ContextMTL>(context);
+    CIContext* cicontext =
+        [CIContext contextWithMTLDevice:context_mtl->GetMTLDevice()];
+    FML_CHECK(context);
 
-  CIImage* flipped = [ciImage
-      imageByApplyingOrientation:kCGImagePropertyOrientationDownMirrored];
+    CIImage* flipped = [ciImage
+        imageByApplyingOrientation:kCGImagePropertyOrientationDownMirrored];
 
-  CGImageRef cgImage = [cicontext createCGImage:flipped
-                                       fromRect:[ciImage extent]];
+    CGImageRef cgImage = [cicontext createCGImage:flipped
+                                        fromRect:[ciImage extent]];
 
-  return std::unique_ptr<MetalScreenshot>(new MetalScreenshot(cgImage));
+    return std::unique_ptr<MetalScreenshot>(new MetalScreenshot(cgImage));
+  }
 }
 
 }  // namespace testing


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/152195

Part of a series of gaussian blur changes:
1) https://github.com/flutter/engine/pull/54148
1) https://github.com/flutter/engine/pull/54116
1) https://github.com/flutter/engine/pull/54150
1) https://github.com/flutter/engine/pull/54149

Note: this test won't pass until https://github.com/flutter/engine/pull/54148 lands.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
