### PR TITLE
[Impeller] Enable on-by-default on Android.

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -223,7 +223,7 @@ struct Settings {
 
   // Enable the Impeller renderer on supported platforms. Ignored if Impeller is
   // not supported on the platform.
-#if FML_OS_IOS || FML_OS_IOS_SIMULATOR
+#if FML_OS_ANDROID || FML_OS_IOS || FML_OS_IOS_SIMULATOR
   bool enable_impeller = true;
 #else
   bool enable_impeller = false;

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterShellArgs.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterShellArgs.java
@@ -44,8 +44,9 @@ public class FlutterShellArgs {
   public static final String ARG_TRACE_SYSTRACE = "--trace-systrace";
   public static final String ARG_KEY_TRACE_TO_FILE = "trace-to-file";
   public static final String ARG_TRACE_TO_FILE = "--trace-to-file";
-  public static final String ARG_KEY_ENABLE_IMPELLER = "enable-impeller";
-  public static final String ARG_ENABLE_IMPELLER = "--enable-impeller";
+  public static final String ARG_KEY_TOGGLE_IMPELLER = "enable-impeller";
+  public static final String ARG_ENABLE_IMPELLER = "--enable-impeller=true";
+  public static final String ARG_DISABLE_IMPELLER = "--enable-impeller=false";
   public static final String ARG_KEY_ENABLE_VULKAN_VALIDATION = "enable-vulkan-validation";
   public static final String ARG_ENABLE_VULKAN_VALIDATION = "--enable-vulkan-validation";
   public static final String ARG_KEY_DUMP_SHADER_SKP_ON_SHADER_COMPILATION =
@@ -121,8 +122,12 @@ public class FlutterShellArgs {
     if (intent.hasExtra(ARG_KEY_TRACE_TO_FILE)) {
       args.add(ARG_TRACE_TO_FILE + "=" + intent.getStringExtra(ARG_KEY_TRACE_TO_FILE));
     }
-    if (intent.getBooleanExtra(ARG_KEY_ENABLE_IMPELLER, false)) {
-      args.add(ARG_ENABLE_IMPELLER);
+    if (intent.hasExtra(ARG_KEY_TOGGLE_IMPELLER)) {
+      if (intent.getBooleanExtra(ARG_KEY_TOGGLE_IMPELLER, false)) {
+        args.add(ARG_ENABLE_IMPELLER);
+      } else {
+        args.add(ARG_DISABLE_IMPELLER);
+      }
     }
     if (intent.getBooleanExtra(ARG_KEY_ENABLE_VULKAN_VALIDATION, false)) {
       args.add(ARG_ENABLE_VULKAN_VALIDATION);

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -345,8 +345,12 @@ public class FlutterLoader {
       shellArgs.add("--prefetched-default-font-manager");
 
       if (metaData != null) {
-        if (metaData.getBoolean(ENABLE_IMPELLER_META_DATA_KEY, false)) {
-          shellArgs.add("--enable-impeller");
+        if (metaData.containsKey(ENABLE_IMPELLER_META_DATA_KEY)) {
+          if (metaData.getBoolean(ENABLE_IMPELLER_META_DATA_KEY)) {
+            shellArgs.add("--enable-impeller=true");
+          } else {
+            shellArgs.add("--enable-impeller=false");
+          }
         }
         if (metaData.getBoolean(ENABLE_VULKAN_VALIDATION_META_DATA_KEY, false)) {
           shellArgs.add("--enable-vulkan-validation");

--- a/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
@@ -228,7 +228,7 @@ public class FlutterLoaderTest {
     flutterLoader.ensureInitializationComplete(ctx, null);
     shadowOf(getMainLooper()).idle();
 
-    final String enableImpellerArg = "--enable-impeller";
+    final String enableImpellerArg = "--enable-impeller=true";
     ArgumentCaptor<String[]> shellArgsCaptor = ArgumentCaptor.forClass(String[].class);
     verify(mockFlutterJNI, times(1))
         .init(eq(ctx), shellArgsCaptor.capture(), anyString(), anyString(), anyString(), anyLong());

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -176,10 +176,6 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
   settings.enable_wide_gamut = enableWideGamut;
 #endif
 
-  // TODO(dnfield): We should reverse the order for all these settings so that command line options
-  // are preferred to plist settings. https://github.com/flutter/flutter/issues/124049
-  // Whether to enable Impeller. If the command line explicitly
-  // specified an option for this, ignore what's in the plist.
   if (!command_line.HasOption("enable-impeller")) {
     // Next, look in the app bundle.
     NSNumber* enableImpeller = [bundle objectForInfoDictionaryKey:@"FLTEnableImpeller"];

--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/TestRunner.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/TestRunner.java
@@ -23,6 +23,8 @@ public class TestRunner extends AndroidJUnitRunner {
             "--enable-impeller=true",
             "--impeller-backend=" + arguments.getString("impeller-backend", "vulkan")
           };
+    } else {
+      engineArguments = new String[]{"--enable-impeller=false"};
     }
     FlutterRenderer.debugDisableSurfaceClear = true;
     if ("true".equals(arguments.getString("force-surface-producer-surface-texture"))) {

--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/TestRunner.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/TestRunner.java
@@ -24,7 +24,7 @@ public class TestRunner extends AndroidJUnitRunner {
             "--impeller-backend=" + arguments.getString("impeller-backend", "vulkan")
           };
     } else {
-      engineArguments = new String[]{"--enable-impeller=false"};
+      engineArguments = new String[] {"--enable-impeller=false"};
     }
     FlutterRenderer.debugDisableSurfaceClear = true;
     if ("true".equals(arguments.getString("force-surface-producer-surface-texture"))) {

--- a/testing/scenario_app/bin/run_android_tests.dart
+++ b/testing/scenario_app/bin/run_android_tests.dart
@@ -417,7 +417,9 @@ Future<void> _run({
         if (smokeTestFullPath != null)
           '-e class $smokeTestFullPath',
         if (enableImpeller)
-          '-e enable-impeller true',
+          '-e enable-impeller true'
+        else
+          '-e enable-impeller false',
         if (impellerBackend != null)
           '-e impeller-backend ${impellerBackend.name}',
         if (forceSurfaceProducerSurfaceTexture)


### PR DESCRIPTION
Developers can control the backend in the following ways:

* **Do nothing**: Impeller with Vulkan is used where Vulkan is available with a fallback to Skia with OpenGL.
* **In `AndroidManifest.xml`, specify `io.flutter.embedding.android.EnableImpeller` as `false`**: Skia with OpenGL is used.
* **On the command line, specify `--no-enable-impeller`**: Skia with OpenGL is used.

Manifest options will take priority command line options when there is a conflict. This matches iOS behavior per https://github.com/flutter/flutter/issues/124049 (closed as WAI).

Fixes https://github.com/flutter/flutter/issues/149360