### PR TITLE
Migrates the bulk of flutter/engine to pub workspaces.

### DIFF
--- a/build/dart/rules.gni
+++ b/build/dart/rules.gni
@@ -303,12 +303,21 @@ template("flutter_snapshot") {
 template("application_snapshot") {
   assert(defined(invoker.main_dart), "Must specify 'main_dart'")
   assert(defined(invoker.training_args), "Must specify 'training_args'")
-  assert(defined(invoker.package_config), "Must specify 'package_config'")
 
   main_dart = invoker.main_dart
   training_args = invoker.training_args
-  package_config = rebase_path(invoker.package_config)
   name = target_name
+
+  package_config = ""
+  if (defined(invoker.package_config)) {
+    package_config = rebase_path(invoker.package_config, root_build_dir)
+  } else {
+    # Use the root engine package config by default.
+    # As we move towards a single pub workspace for the engine, this will be
+    # the correct package config to use, as we will no longer have a per-package
+    # .dart_tool/package_config.json.
+    package_config = rebase_path("//flutter/.dart_tool/package_config.json")
+  }
 
   extra_deps = []
   if (defined(invoker.deps)) {

--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -3189,7 +3189,6 @@
 ../../../flutter/tools/licenses/analysis_options.yaml
 ../../../flutter/tools/licenses/data
 ../../../flutter/tools/licenses/lib/README
-../../../flutter/tools/licenses/pubspec.lock
 ../../../flutter/tools/licenses/pubspec.yaml
 ../../../flutter/tools/licenses/test
 ../../../flutter/web_sdk

--- a/ci/pubspec.yaml
+++ b/ci/pubspec.yaml
@@ -4,17 +4,13 @@
 
 name: ci_scripts
 publish_to: none
+
+# Required for workspace support.
 environment:
-  sdk: '>=3.2.0-0 <4.0.0'
+  sdk: ^3.5.0-294.0.dev
 
-# Do not add any dependencies that require more than what is provided in
-# //third_party/pkg, //third_party/dart/pkg, or
-# //third_party/dart/third_party/pkg. In particular, package:test is not usable
-# here.
-
-# If you do add packages here, make sure you can run `pub get --offline`, and
-# check the .packages and .package_config to make sure all the paths are
-# relative to this directory into //third_party/dart
+# This package is managed as part of the engine workspace.
+resolution: workspace
 
 dependencies:
   args: any
@@ -27,31 +23,3 @@ dev_dependencies:
   async_helper: any
   expect: any
   litetest: any
-
-dependency_overrides:
-  args:
-    path: ../third_party/dart/third_party/pkg/args
-  async:
-    path: ../third_party/dart/third_party/pkg/async
-  async_helper:
-    path: ../third_party/dart/pkg/async_helper
-  collection:
-    path: ../third_party/dart/third_party/pkg/collection
-  expect:
-    path: ../third_party/dart/pkg/expect
-  file:
-    path: ../third_party/dart/third_party/pkg/file/packages/file
-  litetest:
-    path: ../testing/litetest
-  meta:
-    path: ../third_party/dart/pkg/meta
-  path:
-    path: ../third_party/dart/third_party/pkg/path
-  platform:
-    path: ../third_party/pkg/platform
-  process:
-    path: ../third_party/pkg/process
-  process_runner:
-    path: ../third_party/pkg/process_runner
-  smith:
-    path: ../third_party/dart/pkg/smith

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -80,15 +80,33 @@ environment:
 
 # Declare all packages that are part of the workspace.
 workspace:
+  - ci
   - testing/benchmark
   - testing/dart
   - testing/litetest
   - testing/pkg_test_demo
   - testing/scenario_app
   - testing/skia_gold_client
+  - testing/smoke_test_failure
   - testing/symbols
+  - tools/android_lint
+  - tools/api_check
+  - tools/build_bucket_golden_scraper
+  - tools/clang_tidy
+  - tools/clangd_check
+  - tools/compare_goldens
+  - tools/const_finder
+  - tools/dir_contents_diff
   - tools/engine_tool
+  - tools/header_guard_check
+  - tools/gen_web_locale_keymap
+  - tools/githooks
+  - tools/licenses
+  - tools/path_ops/dart
   - tools/golden_tests_harvester
+  - tools/pkg/engine_build_configs
+  - tools/pkg/engine_repo_tools
+  - tools/pkg/git_repo_tools
   - tools/pkg/process_fakes
 
 # Declare all dependencies that are used by one or more packages.
@@ -154,6 +172,8 @@ dependency_overrides:
     path: ./third_party/dart/pkg/_macros
   analyzer:
     path: ./third_party/dart/pkg/analyzer
+  archive:
+    path: ./third_party/pkg/archive
   args:
     path: ./third_party/dart/third_party/pkg/args
   async:
@@ -170,12 +190,6 @@ dependency_overrides:
     path: ./third_party/pkg/coverage
   crypto:
     path: ./third_party/dart/third_party/pkg/crypto
-  dir_contents_diff:
-    path: ./tools/dir_contents_diff
-  engine_build_configs:
-    path: ./tools/pkg/engine_build_configs
-  engine_repo_tools:
-    path: ./tools/pkg/engine_repo_tools
   equatable:
     path: ./third_party/pkg/equatable
   expect:
@@ -190,8 +204,6 @@ dependency_overrides:
     path: ./third_party/dart/third_party/pkg/webdev/frontend_server_client
   gcloud:
     path: ./third_party/pkg/gcloud
-  git_repo_tools:
-    path: ./tools/pkg/git_repo_tools
   glob:
     path: ./third_party/dart/third_party/pkg/glob
   googleapis:
@@ -208,6 +220,8 @@ dependency_overrides:
     path: ./third_party/pkg/io
   js:
     path: ./third_party/dart/pkg/js
+  kernel:
+    path: ./third_party/dart/pkg/kernel
   logging:
     path: ./third_party/dart/third_party/pkg/logging
   macros:

--- a/testing/smoke_test_failure/BUILD.gn
+++ b/testing/smoke_test_failure/BUILD.gn
@@ -10,7 +10,6 @@ foreach(test, tests) {
   flutter_frontend_server("compile_$test") {
     main_dart = test
     kernel_output = "$root_gen_dir/$test.dill"
-    package_config = ".dart_tool/package_config.json"
   }
 }
 

--- a/testing/smoke_test_failure/pubspec.yaml
+++ b/testing/smoke_test_failure/pubspec.yaml
@@ -4,28 +4,13 @@
 
 name: smoke_test_failure
 publish_to: none
+
+# Required for workspace support.
 environment:
-  sdk: '>=3.2.0-0 <4.0.0'
+  sdk: ^3.5.0-294.0.dev
 
-# Do not add any dependencies that require more than what is provided in
-# //third_party/dart/pkg or //third_party/dart/third_party/pkg.
-# In particular, package:test is not usable here.
-
-# If you do add packages here, make sure you can run `pub get --offline`, and
-# check the .packages and .package_config to make sure all the paths are
-# relative to this directory into //third_party/dart
+# This package is managed as part of the engine workspace.
+resolution: workspace
 
 dependencies:
   litetest: any
-
-dependency_overrides:
-  async_helper:
-    path: ../../third_party/dart/pkg/async_helper
-  expect:
-    path: ../../third_party/dart/pkg/expect
-  litetest:
-    path: ../litetest
-  meta:
-    path: ../../third_party/dart/pkg/meta
-  smith:
-    path: ../../third_party/dart/pkg/smith

--- a/tools/android_lint/pubspec.yaml
+++ b/tools/android_lint/pubspec.yaml
@@ -3,33 +3,15 @@
 # found in the LICENSE file.
 
 name: android_lint
+publish_to: none
+
+# Required for workspace support.
 environment:
-  sdk: '>=3.2.0-0 <4.0.0'
+  sdk: ^3.5.0-294.0.dev
 
-# Do not add any dependencies that require more than what is provided in
-# //third_party.pkg, //third_party/dart/pkg, or
-# //third_party/dart/third_party/pkg. In particular, package:test is not usable
-# here.
-
-# If you do add packages here, make sure you can run `pub get --offline`, and
-# check the .packages and .package_config to make sure all the paths are
-# relative to this directory into //third_party/dart
-
+# This package is managed as part of the engine workspace.
+resolution: workspace
 dependencies:
   args: any
   path: any
   process: any
-
-dependency_overrides:
-  args:
-    path: ../../third_party/dart/third_party/pkg/args
-  file:
-    path: ../../third_party/dart/third_party/pkg/file/packages/file
-  meta:
-    path: ../../third_party/dart/pkg/meta
-  path:
-    path: ../../third_party/dart/third_party/pkg/path
-  platform:
-    path: ../../third_party/pkg/platform
-  process:
-    path: ../../third_party/pkg/process

--- a/tools/api_check/pubspec.yaml
+++ b/tools/api_check/pubspec.yaml
@@ -5,25 +5,12 @@
 name: apicheck
 publish_to: none
 
-# Do not add any dependencies that require more than what is provided in
-# //third_party/dart/pkg or //third_party/dart/third_party/pkg.
-# In particular, package:test is not usable here.
-
-# If you do add packages here, make sure you can run `pub get --offline`, and
-# check the .packages and .package_config to make sure all the paths are
-# relative to this directory into //third_party/dart
-
+# Required for workspace support.
 environment:
-  sdk: '>=3.2.0-0 <4.0.0'
+  sdk: ^3.5.0-294.0.dev
 
-# Do not add any dependencies that require more than what is provided in
-# //third_party/pkg, //third_party/dart/pkg, or
-# //third_party/dart/third_party/pkg. In particular, package:test is not usable
-# here.
-
-# If you do add packages here, make sure you can run `pub get --offline`, and
-# check the .packages and .package_config to make sure all the paths are
-# relative to this directory into //third_party/dart
+# This package is managed as part of the engine workspace.
+resolution: workspace
 
 dependencies:
   analyzer: any
@@ -36,55 +23,3 @@ dev_dependencies:
   litetest: any
   path: any
   smith: any
-
-dependency_overrides:
-  _fe_analyzer_shared:
-    path: ../../third_party/dart/pkg/_fe_analyzer_shared
-  _macros:
-    path: ../../third_party/dart/pkg/_macros
-  analyzer:
-    path: ../../third_party/dart/pkg/analyzer
-  async:
-    path: ../../third_party/dart/third_party/pkg/async
-  async_helper:
-    path: ../../third_party/dart/pkg/async_helper
-  collection:
-    path: ../../third_party/dart/third_party/pkg/collection
-  convert:
-    path: ../../third_party/dart/third_party/pkg/convert
-  crypto:
-    path: ../../third_party/dart/third_party/pkg/crypto
-  dart_internal:
-    path: ../../third_party/dart/pkg/dart_internal
-  expect:
-    path: ../../third_party/dart/pkg/expect
-  file:
-    path: ../../third_party/dart/third_party/pkg/file/packages/file
-  glob:
-    path: ../../third_party/dart/third_party/pkg/glob
-  litetest:
-    path: ../../testing/litetest
-  meta:
-    path: ../../third_party/dart/pkg/meta
-  macros:
-    path: ../../third_party/dart/pkg/macros
-  package_config:
-    path: ../../third_party/dart/third_party/pkg/package_config
-  path:
-    path: ../../third_party/dart/third_party/pkg/path
-  pub_semver:
-    path: ../../third_party/dart/third_party/pkg/pub_semver
-  source_span:
-    path: ../../third_party/dart/third_party/pkg/source_span
-  string_scanner:
-    path: ../../third_party/dart/third_party/pkg/string_scanner
-  term_glyph:
-    path: ../../third_party/dart/third_party/pkg/term_glyph
-  typed_data:
-    path: ../../third_party/dart/third_party/pkg/typed_data
-  watcher:
-    path: ../../third_party/dart/third_party/pkg/watcher
-  yaml:
-    path: ../../third_party/dart/third_party/pkg/yaml
-  smith:
-    path: ../../third_party/dart/pkg/smith

--- a/tools/build_bucket_golden_scraper/pubspec.yaml
+++ b/tools/build_bucket_golden_scraper/pubspec.yaml
@@ -4,17 +4,12 @@
 
 name: build_bucket_golden_scraper
 publish_to: none
+# Required for workspace support.
 environment:
-  sdk: '>=3.2.0-0 <4.0.0'
+  sdk: ^3.5.0-294.0.dev
 
-# Do not add any dependencies that require more than what is provided in
-# //third_party/pkg, //third_party/dart/pkg, or
-# //third_party/dart/third_party/pkg. In particular, package:test is not usable
-# here.
-
-# If you do add packages here, make sure you can run `pub get --offline`, and
-# check the .packages and .package_config to make sure all the paths are
-# relative to this directory into //third_party/dart
+# This package is managed as part of the engine workspace.
+resolution: workspace
 
 dependencies:
   args: any
@@ -27,21 +22,3 @@ dev_dependencies:
   expect: any
   litetest: any
   smith: any
-
-dependency_overrides:
-  async_helper:
-    path: ../../third_party/dart/pkg/async_helper
-  args:
-    path: ../../third_party/dart/third_party/pkg/args
-  engine_repo_tools:
-    path: ../pkg/engine_repo_tools
-  expect:
-    path: ../../third_party/dart/pkg/expect
-  litetest:
-    path: ../../testing/litetest
-  meta:
-    path: ../../third_party/dart/pkg/meta
-  path:
-    path: ../../third_party/dart/third_party/pkg/path
-  smith:
-    path: ../../third_party/dart/pkg/smith

--- a/tools/clang_tidy/pubspec.yaml
+++ b/tools/clang_tidy/pubspec.yaml
@@ -4,17 +4,13 @@
 
 name: clang_tidy
 publish_to: none
+
+# Required for workspace support.
 environment:
-  sdk: '>=3.2.0-0 <4.0.0'
+  sdk: ^3.5.0-294.0.dev
 
-# Do not add any dependencies that require more than what is provided in
-# //third_party/pkg, //third_party/dart/pkg, or
-# //third_party/dart/third_party/pkg. In particular, package:test is not usable
-# here.
-
-# If you do add packages here, make sure you can run `pub get --offline`, and
-# check the .packages and .package_config to make sure all the paths are
-# relative to this directory into //third_party/dart
+# This package is managed as part of the engine workspace.
+resolution: workspace
 
 dependencies:
   args: any
@@ -32,45 +28,3 @@ dev_dependencies:
   process_fakes: any
   smith: any
   yaml: any
-
-dependency_overrides:
-  args:
-    path: ../../third_party/dart/third_party/pkg/args
-  async:
-    path: ../../third_party/dart/third_party/pkg/async
-  async_helper:
-    path: ../../third_party/dart/pkg/async_helper
-  collection:
-    path: ../../third_party/dart/third_party/pkg/collection
-  engine_repo_tools:
-    path: ../pkg/engine_repo_tools
-  expect:
-    path: ../../third_party/dart/pkg/expect
-  file:
-    path: ../../third_party/dart/third_party/pkg/file/packages/file
-  git_repo_tools:
-    path: ../pkg/git_repo_tools
-  litetest:
-    path: ../../testing/litetest
-  meta:
-    path: ../../third_party/dart/pkg/meta
-  path:
-    path: ../../third_party/dart/third_party/pkg/path
-  platform:
-    path: ../../third_party/pkg/platform
-  process:
-    path: ../../third_party/pkg/process
-  process_fakes:
-    path: ../pkg/process_fakes
-  process_runner:
-    path: ../../third_party/pkg/process_runner
-  source_span:
-    path: ../../third_party/dart/third_party/pkg/source_span
-  smith:
-    path: ../../third_party/dart/pkg/smith
-  string_scanner:
-    path: ../../third_party/dart/third_party/pkg/string_scanner
-  term_glyph:
-    path: ../../third_party/dart/third_party/pkg/term_glyph
-  yaml:
-    path: ../../third_party/dart/third_party/pkg/yaml

--- a/tools/clangd_check/pubspec.yaml
+++ b/tools/clangd_check/pubspec.yaml
@@ -5,16 +5,12 @@
 name: clangd_check
 publish_to: none
 
-# Do not add any dependencies that require more than what is provided in
-# //third_party/dart/pkg or //third_party/dart/third_party/pkg.
-# In particular, package:test is not usable here.
-
-# If you do add packages here, make sure you can run `pub get --offline`, and
-# check the .packages and .package_config to make sure all the paths are
-# relative to this directory into //third_party/dart
-
+# Required for workspace support.
 environment:
-  sdk: '>=3.2.0-0 <4.0.0'
+  sdk: ^3.5.0-294.0.dev
+
+# This package is managed as part of the engine workspace.
+resolution: workspace
 
 dependencies:
   args: any
@@ -28,41 +24,3 @@ dev_dependencies:
   litetest: any
   process_fakes: any
   smith: any
-
-dependency_overrides:
-  args:
-    path: ../../third_party/dart/third_party/pkg/args
-  async:
-    path: ../../third_party/dart/third_party/pkg/async
-  async_helper:
-    path: ../../third_party/dart/pkg/async_helper
-  collection:
-    path: ../../third_party/dart/third_party/pkg/collection
-  engine_repo_tools:
-    path: ../pkg/engine_repo_tools
-  expect:
-    path: ../../third_party/dart/pkg/expect
-  file:
-    path: ../../third_party/dart/third_party/pkg/file/packages/file
-  git_repo_tools:
-    path: ../pkg/git_repo_tools
-  litetest:
-    path: ../../testing/litetest
-  meta:
-    path: ../../third_party/dart/pkg/meta
-  path:
-    path: ../../third_party/dart/third_party/pkg/path
-  platform:
-    path: ../../third_party/pkg/platform
-  process:
-    path: ../../third_party/pkg/process
-  process_fakes:
-    path: ../pkg/process_fakes
-  process_runner:
-    path: ../../third_party/pkg/process_runner
-  smith:
-    path: ../../third_party/dart/pkg/smith
-  source_span:
-    path: ../../third_party/dart/third_party/pkg/source_span
-  term_glyph:
-    path: ../../third_party/dart/third_party/pkg/term_glyph

--- a/tools/compare_goldens/pubspec.yaml
+++ b/tools/compare_goldens/pubspec.yaml
@@ -1,3 +1,9 @@
 name: compare_goldens
+publish_to: none
+
+# Required for workspace support.
 environment:
-  sdk: '>=3.2.0-0 <4.0.0'
+  sdk: ^3.5.0-294.0.dev
+
+# This package is managed as part of the engine workspace.
+resolution: workspace

--- a/tools/const_finder/BUILD.gn
+++ b/tools/const_finder/BUILD.gn
@@ -12,7 +12,6 @@ application_snapshot("const_finder") {
 
   inputs = [
     "bin/main.dart",
-    ".dart_tool/package_config.json",
   ]
 
   deps = [ "//flutter/flutter_frontend_server:frontend_server" ]

--- a/tools/const_finder/BUILD.gn
+++ b/tools/const_finder/BUILD.gn
@@ -10,9 +10,7 @@ application_snapshot("const_finder") {
 
   training_args = [ "--help" ]
 
-  inputs = [
-    "bin/main.dart",
-  ]
+  inputs = [ "bin/main.dart" ]
 
   deps = [ "//flutter/flutter_frontend_server:frontend_server" ]
 }

--- a/tools/const_finder/BUILD.gn
+++ b/tools/const_finder/BUILD.gn
@@ -6,7 +6,6 @@ import("//flutter/build/dart/rules.gni")
 
 application_snapshot("const_finder") {
   main_dart = "bin/main.dart"
-  package_config = ".dart_tool/package_config.json"
   snapshot_kind = "kernel"
 
   training_args = [ "--help" ]

--- a/tools/const_finder/pubspec.yaml
+++ b/tools/const_finder/pubspec.yaml
@@ -5,35 +5,17 @@
 name: const_finder
 publish_to: none
 
+# Required for workspace support.
 environment:
-  sdk: '>=3.2.0-0 <4.0.0'
+  sdk: ^3.5.0-294.0.dev
 
-# Do not add any dependencies that require more than what is provided in
-# //third_party/dart/pkg or //third_party/dart/third_party/pkg.
-# In particular, package:test is not usable here.
-
-# If you do add packages here, make sure you can run `pub get --offline`, and
-# check the .packages and .package_config to make sure all the paths are
-# relative to this directory into //third_party/dart
+# This package is managed as part of the engine workspace.
+resolution: workspace
 
 dependencies:
   args: any
-  collection: any
   kernel: any
 
 dev_dependencies:
+  collection: any
   path: any
-
-dependency_overrides:
-  _fe_analyzer_shared:
-    path: ../../third_party/dart/pkg/_fe_analyzer_shared
-  args:
-    path: ../../third_party/dart/third_party/pkg/args
-  collection:
-    path: ../../third_party/dart/third_party/pkg/collection
-  kernel:
-    path: ../../third_party/dart/pkg/kernel
-  meta:
-    path: ../../third_party/dart/pkg/meta
-  path:
-    path: ../../third_party/dart/third_party/pkg/path

--- a/tools/dir_contents_diff/pubspec.yaml
+++ b/tools/dir_contents_diff/pubspec.yaml
@@ -1,19 +1,13 @@
 name: dir_contents_diff
+publish_to: none
+
+# Required for workspace support.
 environment:
-  sdk: '>=3.2.0-0 <4.0.0'
+  sdk: ^3.5.0-294.0.dev
+
+# This package is managed as part of the engine workspace.
+resolution: workspace
+
 dev_dependencies:
   litetest: any
   path: any
-dependency_overrides:
-  async_helper:
-    path: ../../third_party/dart/pkg/async_helper
-  expect:
-    path: ../../third_party/dart/pkg/expect
-  litetest:
-    path: ../../testing/litetest
-  meta:
-    path: ../../third_party/dart/pkg/meta
-  path:
-    path: ../../third_party/dart/third_party/pkg/path
-  smith:
-    path: ../../third_party/dart/pkg/smith

--- a/tools/find_pubspecs_to_workspacify.sh
+++ b/tools/find_pubspecs_to_workspacify.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -e
+
+# This script finds `pubspec.yaml` files that do not contain a top-level
+# `resolution: workspace` key-value pair, in order to help identify packages
+# as part of <https://github.com/flutter/flutter/issues/147883>.
+#
+# Usage:
+#   tools/find_pubspecs_to_workspacify.sh
+
+# On Mac OS, readlink -f doesn't work, so follow_links traverses the path one
+# link at a time, and then cds into the link destination and find out where it
+# ends up.
+#
+# The function is enclosed in a subshell to avoid changing the working directory
+# of the caller.
+function follow_links() (
+  cd -P "$(dirname -- "$1")"
+  file="$PWD/$(basename -- "$1")"
+  while [[ -L "$file" ]]; do
+    cd -P "$(dirname -- "$file")"
+    file="$(readlink -- "$file")"
+    cd -P "$(dirname -- "$file")"
+    file="$PWD/$(basename -- "$file")"
+  done
+  echo "$file"
+)
+
+SCRIPT_DIR=$(follow_links "$(dirname -- "${BASH_SOURCE[0]}")")
+SRC_DIR="$(
+  cd "$SCRIPT_DIR/../.."
+  pwd -P
+)"
+FLUTTER_DIR="$(
+  cd "$SRC_DIR/flutter"
+  pwd -P
+)"
+
+# Patterns, that, if matched, should be ignored.
+IGNORE_PATTERNS=(
+  # Root pubspec.yaml file.
+  '.*flutter\/pubspec.yaml'
+
+  # Anything fuchsia-related.
+  '.*shell\/platform\/fuchsia.*'
+
+  # Anything web-related.
+  '.*web_sdk.*'
+
+  # Anything in the `prebuilts` directory.
+  '.*prebuilts.*'
+
+  # Anything in the `third_party` directory.
+  '.*third_party.*'
+)
+
+# Find all pubspec.yaml files that do not contain a top-level `resolution: workspace` key-value pair.
+find "$FLUTTER_DIR" -name pubspec.yaml -print0 | while IFS= read -r -d '' pubspec; do
+  # Check if the pubspec.yaml file should be ignored.
+  for pattern in "${IGNORE_PATTERNS[@]}"; do
+    if [[ "$pubspec" =~ $pattern ]]; then
+      continue 2
+    fi
+  done
+
+  # Check if the pubspec.yaml file contains a top-level `resolution: workspace` key-value pair.
+  if ! grep -q '^resolution: workspace' "$pubspec"; then
+    echo "$pubspec"
+  fi
+done

--- a/tools/gen_web_locale_keymap/pubspec.yaml
+++ b/tools/gen_web_locale_keymap/pubspec.yaml
@@ -1,37 +1,16 @@
 name: gen_web_keyboard_keymap
 description: Generates keyboard layouts for Web from external sources.
+publish_to: none
 
+# Required for workspace support.
 environment:
-  sdk: '>=3.2.0-0 <4.0.0'
+  sdk: ^3.5.0-294.0.dev
+
+# This package is managed as part of the engine workspace.
+resolution: workspace
 
 dependencies:
   args: any
   http: any
   path: any
   meta: any
-
-dependency_overrides:
-  args:
-    path: ../../third_party/dart/third_party/pkg/args
-  async:
-    path: ../../third_party/dart/third_party/pkg/async
-  collection:
-    path: ../../third_party/dart/third_party/pkg/collection
-  http:
-    path: ../../third_party/dart/third_party/pkg/http/pkgs/http
-  http_parser:
-    path: ../../third_party/dart/third_party/pkg/http_parser
-  meta:
-    path: ../../third_party/dart/pkg/meta
-  path:
-    path: ../../third_party/dart/third_party/pkg/path
-  source_span:
-    path: ../../third_party/dart/third_party/pkg/source_span
-  string_scanner:
-    path: ../../third_party/dart/third_party/pkg/string_scanner
-  term_glyph:
-    path: ../../third_party/dart/third_party/pkg/term_glyph
-  typed_data:
-    path: ../../third_party/dart/third_party/pkg/typed_data
-  web:
-    path: ../../third_party/dart/third_party/pkg/web

--- a/tools/githooks/pubspec.yaml
+++ b/tools/githooks/pubspec.yaml
@@ -4,17 +4,13 @@
 
 name: githooks
 publish_to: none
+
+# Required for workspace support.
 environment:
-  sdk: '>=3.2.0-0 <4.0.0'
+  sdk: ^3.5.0-294.0.dev
 
-# Do not add any dependencies that require more than what is provided in
-# //third_party.pkg, //third_party/dart/pkg, or
-# //third_party/dart/third_party/pkg. In particular, package:test is not usable
-# here.
-
-# If you do add packages here, make sure you can run `pub get --offline`, and
-# check the .packages and .package_config to make sure all the paths are
-# relative to this directory into //third_party/dart
+# This package is managed as part of the engine workspace.
+resolution: workspace
 
 dependencies:
   args: any
@@ -27,37 +23,3 @@ dev_dependencies:
   expect: any
   litetest: any
   smith: any
-
-dependency_overrides:
-  args:
-    path: ../../third_party/dart/third_party/pkg/args
-  async:
-    path: ../../third_party/dart/third_party/pkg/async
-  async_helper:
-    path: ../../third_party/dart/pkg/async_helper
-  clang_tidy:
-    path: ../clang_tidy
-  collection:
-    path: ../../third_party/dart/third_party/pkg/collection
-  engine_repo_tools:
-    path: ../pkg/engine_repo_tools
-  expect:
-    path: ../../third_party/dart/pkg/expect
-  file:
-    path: ../../third_party/dart/third_party/pkg/file/packages/file
-  git_repo_tools:
-    path: ../pkg/git_repo_tools
-  litetest:
-    path: ../../testing/litetest
-  meta:
-    path: ../../third_party/dart/pkg/meta
-  path:
-    path: ../../third_party/dart/third_party/pkg/path
-  platform:
-    path: ../../third_party/pkg/platform
-  process:
-    path: ../../third_party/pkg/process
-  process_runner:
-    path: ../../third_party/pkg/process_runner
-  smith:
-    path: ../../third_party/dart/pkg/smith

--- a/tools/header_guard_check/pubspec.yaml
+++ b/tools/header_guard_check/pubspec.yaml
@@ -5,16 +5,12 @@
 name: header_guard_check
 publish_to: none
 
-# Do not add any dependencies that require more than what is provided in
-# //third_party/dart/pkg or //third_party/dart/third_party/pkg.
-# In particular, package:test is not usable here.
-
-# If you do add packages here, make sure you can run `pub get --offline`, and
-# check the .packages and .package_config to make sure all the paths are
-# relative to this directory into //third_party/dart
-
+# Required for workspace support.
 environment:
-  sdk: '>=3.2.0-0 <4.0.0'
+  sdk: ^3.5.0-294.0.dev
+
+# This package is managed as part of the engine workspace.
+resolution: workspace
 
 dependencies:
   args: any
@@ -30,41 +26,3 @@ dev_dependencies:
   litetest: any
   process_fakes: any
   smith: any
-
-dependency_overrides:
-  args:
-    path: ../../third_party/dart/third_party/pkg/args
-  async:
-    path: ../../third_party/dart/third_party/pkg/async
-  async_helper:
-    path: ../../third_party/dart/pkg/async_helper
-  collection:
-    path: ../../third_party/dart/third_party/pkg/collection
-  engine_repo_tools:
-    path: ../pkg/engine_repo_tools
-  expect:
-    path: ../../third_party/dart/pkg/expect
-  file:
-    path: ../../third_party/dart/third_party/pkg/file/packages/file
-  git_repo_tools:
-    path: ../pkg/git_repo_tools
-  litetest:
-    path: ../../testing/litetest
-  meta:
-    path: ../../third_party/dart/pkg/meta
-  path:
-    path: ../../third_party/dart/third_party/pkg/path
-  platform:
-    path: ../../third_party/pkg/platform
-  process:
-    path: ../../third_party/pkg/process
-  process_fakes:
-    path: ../pkg/process_fakes
-  process_runner:
-    path: ../../third_party/pkg/process_runner
-  smith:
-    path: ../../third_party/dart/pkg/smith
-  source_span:
-    path: ../../third_party/dart/third_party/pkg/source_span
-  term_glyph:
-    path: ../../third_party/dart/third_party/pkg/term_glyph

--- a/tools/licenses/pubspec.yaml
+++ b/tools/licenses/pubspec.yaml
@@ -4,18 +4,13 @@
 
 name: licenses
 publish_to: none
+
+# Required for workspace support.
 environment:
-  sdk: '>=3.2.0-0 <4.0.0'
+  sdk: ^3.5.0-294.0.dev
 
-# Do not add any dependencies that require more than what is provided
-# in //third_party.pkg, //third_party/dart/pkg, or
-# //third_party/dart/third_party/pkg.
-
-# In particular, package:test is not usable here.
-
-# If you do add packages here, make sure you can run `pub get
-# --offline`, and check the .packages and .package_config to make sure
-# all the paths are relative to this directory into //third_party/dart
+# This package is managed as part of the engine workspace.
+resolution: workspace
 
 dependencies:
   archive: any
@@ -27,27 +22,3 @@ dependencies:
 
 dev_dependencies:
   litetest: any
-
-dependency_overrides:
-  archive:
-    path: ../../third_party/pkg/archive
-  args:
-    path: ../../third_party/dart/third_party/pkg/args
-  async_helper:
-    path: ../../third_party/dart/pkg/async_helper
-  collection:
-    path: ../../third_party/dart/third_party/pkg/collection
-  crypto:
-    path: ../../third_party/dart/third_party/pkg/crypto
-  expect:
-    path: ../../third_party/dart/pkg/expect
-  litetest:
-    path: ../../testing/litetest
-  meta:
-    path: ../../third_party/dart/pkg/meta
-  path:
-    path: ../../third_party/dart/third_party/pkg/path
-  smith:
-    path: ../../third_party/dart/pkg/smith
-  typed_data:
-    path: ../../third_party/dart/third_party/pkg/typed_data

--- a/tools/path_ops/dart/pubspec.yaml
+++ b/tools/path_ops/dart/pubspec.yaml
@@ -2,25 +2,14 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 name: path_ops
-description: A Dart FFI wrapper for Skia PathKit.
-version: 0.0.0
 publish_to: none
-homepage: https://github.com/flutter/engine/tree/main/tools/path_ops
 
+# Required for workspace support.
 environment:
-  sdk: '>=3.2.0-0 <4.0.0'
+  sdk: ^3.5.0-294.0.dev
+
+# This package is managed as part of the engine workspace.
+resolution: workspace
 
 dev_dependencies:
   litetest: any
-
-dependency_overrides:
-  async_helper:
-    path: ../../../third_party/dart/pkg/async_helper
-  expect:
-    path: ../../../third_party/dart/pkg/expect
-  litetest:
-    path: ../../../testing/litetest
-  meta:
-    path: ../../../third_party/dart/pkg/meta
-  smith:
-    path: ../../../third_party/dart/pkg/smith

--- a/tools/pkg/engine_build_configs/pubspec.yaml
+++ b/tools/pkg/engine_build_configs/pubspec.yaml
@@ -4,22 +4,17 @@
 
 name: engine_build_configs
 publish_to: none
+
+# Required for workspace support.
 environment:
-  sdk: '>=3.2.0-0 <4.0.0'
+  sdk: ^3.5.0-294.0.dev
 
-# Do not add any dependencies that require more than what is provided in
-# //third_party/pkg, //third_party/dart/pkg, or
-# //third_party/dart/third_party/pkg. In particular, package:test is not usable
-# here.
-
-# If you do add packages here, make sure you can run `pub get --offline`, and
-# check the .packages and .package_config to make sure all the paths are
-# relative to this directory into //third_party/dart
+# This package is managed as part of the engine workspace.
+resolution: workspace
 
 dependencies:
   args: any
-  engine_repo_tools:
-    path: ../engine_repo_tools
+  engine_repo_tools: any
   file: any
   meta: any
   path: any
@@ -31,43 +26,6 @@ dev_dependencies:
   async_helper: any
   expect: any
   litetest: any
-  process_fakes:
-    path: ../process_fakes
+  process_fakes: any
   smith: any
   source_span: any
-
-dependency_overrides:
-  args:
-    path: ../../../third_party/dart/third_party/pkg/args
-  async:
-    path: ../../../third_party/dart/third_party/pkg/async
-  async_helper:
-    path: ../../../third_party/dart/pkg/async_helper
-  collection:
-    path: ../../../third_party/dart/third_party/pkg/collection
-  expect:
-    path: ../../../third_party/dart/pkg/expect
-  file:
-    path: ../../../third_party/dart/third_party/pkg/file/packages/file
-  litetest:
-    path: ../../../testing/litetest
-  meta:
-    path: ../../../third_party/dart/pkg/meta
-  path:
-    path: ../../../third_party/dart/third_party/pkg/path
-  platform:
-    path: ../../../third_party/pkg/platform
-  process:
-    path: ../../../third_party/pkg/process
-  process_runner:
-    path: ../../../third_party/pkg/process_runner
-  smith:
-    path: ../../../third_party/dart/pkg/smith
-  source_span:
-    path: ../../../third_party/dart/third_party/pkg/source_span
-  string_scanner:
-    path: ../../../third_party/dart/third_party/pkg/string_scanner
-  term_glyph:
-    path: ../../../third_party/dart/third_party/pkg/term_glyph
-  yaml:
-    path: ../../../third_party/dart/third_party/pkg/yaml

--- a/tools/pkg/engine_repo_tools/pubspec.yaml
+++ b/tools/pkg/engine_repo_tools/pubspec.yaml
@@ -4,17 +4,13 @@
 
 name: engine_repo_tools
 publish_to: none
+
+# Required for workspace support.
 environment:
-  sdk: '>=3.2.0-0 <4.0.0'
+  sdk: ^3.5.0-294.0.dev
 
-# Do not add any dependencies that require more than what is provided in
-# //third_party/pkg, //third_party/dart/pkg, or
-# //third_party/dart/third_party/pkg. In particular, package:test is not usable
-# here.
-
-# If you do add packages here, make sure you can run `pub get --offline`, and
-# check the .packages and .package_config to make sure all the paths are
-# relative to this directory into //third_party/dart
+# This package is managed as part of the engine workspace.
+resolution: workspace
 
 dependencies:
   meta: any
@@ -25,17 +21,3 @@ dev_dependencies:
   expect: any
   litetest: any
   smith: any
-
-dependency_overrides:
-  async_helper:
-    path: ../../../third_party/dart/pkg/async_helper
-  expect:
-    path: ../../../third_party/dart/pkg/expect
-  litetest:
-    path: ../../../testing/litetest
-  meta:
-    path: ../../../third_party/dart/pkg/meta
-  path:
-    path: ../../../third_party/dart/third_party/pkg/path
-  smith:
-    path: ../../../third_party/dart/pkg/smith

--- a/tools/pkg/git_repo_tools/pubspec.yaml
+++ b/tools/pkg/git_repo_tools/pubspec.yaml
@@ -4,17 +4,13 @@
 
 name: git_repo_tools
 publish_to: none
+
+# Required for workspace support.
 environment:
-  sdk: '>=3.2.0-0 <4.0.0'
+  sdk: ^3.5.0-294.0.dev
 
-# Do not add any dependencies that require more than what is provided in
-# //third_party/pkg, //third_party/dart/pkg, or
-# //third_party/dart/third_party/pkg. In particular, package:test is not usable
-# here.
-
-# If you do add packages here, make sure you can run `pub get --offline`, and
-# check the .packages and .package_config to make sure all the paths are
-# relative to this directory into //third_party/dart
+# This package is managed as part of the engine workspace.
+resolution: workspace
 
 dependencies:
   meta: any
@@ -28,33 +24,3 @@ dev_dependencies:
   litetest: any
   process_fakes: any
   smith: any
-
-dependency_overrides:
-  args:
-    path: ../../../third_party/dart/third_party/pkg/args
-  async:
-    path: ../../../third_party/dart/third_party/pkg/async
-  async_helper:
-    path: ../../../third_party/dart/pkg/async_helper
-  collection:
-    path: ../../../third_party/dart/third_party/pkg/collection
-  expect:
-    path: ../../../third_party/dart/pkg/expect
-  file:
-    path: ../../../third_party/dart/third_party/pkg/file/packages/file
-  litetest:
-    path: ../../../testing/litetest
-  meta:
-    path: ../../../third_party/dart/pkg/meta
-  path:
-    path: ../../../third_party/dart/third_party/pkg/path
-  platform:
-    path: ../../../third_party/pkg/platform
-  process:
-    path: ../../../third_party/pkg/process
-  process_fakes:
-    path: ../process_fakes
-  process_runner:
-    path: ../../../third_party/pkg/process_runner
-  smith:
-    path: ../../../third_party/dart/pkg/smith


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/147883.

Excluding Fuchsia and the Web SDK, the remaining scripts are:

```sh
$ ./tools/find_pubspecs_to_workspacify.sh

/Users/matanl/Developer/engine/src/flutter/impeller/tessellator/dart/pubspec.yaml
/Users/matanl/Developer/engine/src/flutter/sky/packages/sky_engine/pubspec.yaml
/Users/matanl/Developer/engine/src/flutter/shell/vmservice/pubspec.yaml
/Users/matanl/Developer/engine/src/flutter/lib/snapshot/pubspec.yaml
/Users/matanl/Developer/engine/src/flutter/lib/gpu/pubspec.yaml
/Users/matanl/Developer/engine/src/flutter/lib/web_ui/pubspec.yaml
/Users/matanl/Developer/engine/src/flutter/flutter_frontend_server/pubspec.yaml
```

These could be the trickiest, so I'm doing them separately.