### PR TITLE
Remove obsolete dependency

### DIFF
--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -171,7 +171,6 @@ source_set("ui") {
   ]
 
   deps = [
-    "$dart_src/runtime/bin:concurrent_api",
     "$dart_src/runtime/bin:dart_io_api",
     "//flutter/assets",
     "//flutter/common",

--- a/shell/platform/fuchsia/dart_runner/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/BUILD.gn
@@ -32,13 +32,11 @@ template("runner_sources") {
     dart_public_deps = []
     if (!invoker.product) {
       dart_public_deps += [
-        "$dart_src/runtime/bin:concurrent_api",
         "$dart_src/runtime/bin:dart_io_api",
         "//flutter/shell/platform/fuchsia/runtime/dart/utils:utils",
       ]
     } else {
       dart_public_deps += [
-        "$dart_src/runtime/bin:concurrent_api_product",
         "$dart_src/runtime/bin:dart_io_api_product",
         "//flutter/shell/platform/fuchsia/runtime/dart/utils:utils_product",
       ]

--- a/shell/platform/fuchsia/runtime/dart/utils/BUILD.gn
+++ b/shell/platform/fuchsia/runtime/dart/utils/BUILD.gn
@@ -101,7 +101,6 @@ executable("dart_utils_unittests") {
     ":utils",
     ":utils_fixtures",
     "$dart_src/runtime:libdart_jit",
-    "$dart_src/runtime/bin:concurrent_api",
     "$dart_src/runtime/bin:dart_io_api",
     "${fuchsia_sdk}/pkg/inspect_component_cpp",
     "${fuchsia_sdk}/pkg/sys_cpp",

--- a/shell/testing/BUILD.gn
+++ b/shell/testing/BUILD.gn
@@ -37,7 +37,6 @@ executable("testing") {
 
   deps = [
     "$dart_src/runtime:libdart_jit",
-    "$dart_src/runtime/bin:concurrent_api",
     "$dart_src/runtime/bin:dart_io_api",
     "//flutter/assets",
     "//flutter/common",


### PR DESCRIPTION
The concurrent_api/concurrent_api_product targets were made obsolete by https://github.com/dart-lang/sdk/commit/95f5efc6976c4645db5fbad9e501e755579a58eb