### PR TITLE
Fix a race in file I/O done by a BuildRunner test

### DIFF
--- a/tools/pkg/engine_build_configs/test/build_config_runner_test.dart
+++ b/tools/pkg/engine_build_configs/test/build_config_runner_test.dart
@@ -834,7 +834,7 @@ void main() {
             ..createSync(recursive: true);
       final io.File file =
           io.File(path.join(hostDebug.path, 'compile_commands.json'));
-      file.writeAsString(
+      file.writeAsStringSync(
         r'''
 [
   {


### PR DESCRIPTION
This test failure had been seen in some recent auto-roller jobs on CI.