### PR TITLE
Remove obsolete dependency from few more targets.

### DIFF
--- a/lib/io/BUILD.gn
+++ b/lib/io/BUILD.gn
@@ -12,7 +12,6 @@ source_set("io") {
 
   deps = [
     "$dart_src/runtime:dart_api",
-    "$dart_src/runtime/bin:concurrent_api",
     "$dart_src/runtime/bin:dart_io_api",
     "//flutter/fml",
     "//flutter/third_party/tonic",

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -100,7 +100,6 @@ template("embedder_source_set") {
     public_deps = [ ":embedder_headers" ]
     deps = [
       ":embedder_gpu_configuration",
-      "$dart_src/runtime/bin:concurrent_api",
       "$dart_src/runtime/bin:dart_io_api",
       "$dart_src/runtime/bin:elf_loader",
       "//flutter/assets",


### PR DESCRIPTION
Follow-up to b0d1df5cfb98241fa8a881df0796a6046acf860a - remove obsolete dependency from few more places that were missed.

