### PR TITLE
[Impeller] remove frames in flight semaphore.

### DIFF
--- a/impeller/renderer/renderer.cc
+++ b/impeller/renderer/renderer.cc
@@ -12,11 +12,8 @@
 
 namespace impeller {
 
-Renderer::Renderer(std::shared_ptr<Context> context,
-                   size_t max_frames_in_flight)
-    : frames_in_flight_sema_(std::make_shared<fml::Semaphore>(
-          std::max<std::size_t>(1u, max_frames_in_flight))),
-      context_(std::move(context)) {
+Renderer::Renderer(std::shared_ptr<Context> context)
+    : context_(std::move(context)) {
   if (!context_ || !context_->IsValid()) {
     return;
   }
@@ -47,13 +44,7 @@ bool Renderer::Render(std::unique_ptr<Surface> surface,
     return false;
   }
 
-  if (!frames_in_flight_sema_->Wait()) {
-    return false;
-  }
-
   const auto present_result = surface->Present();
-
-  frames_in_flight_sema_->Signal();
 
   return present_result;
 }

--- a/impeller/renderer/renderer.h
+++ b/impeller/renderer/renderer.h
@@ -8,7 +8,6 @@
 #include <functional>
 #include <memory>
 
-#include "flutter/fml/synchronization/semaphore.h"
 #include "impeller/renderer/context.h"
 #include "impeller/renderer/render_target.h"
 
@@ -18,12 +17,9 @@ class Surface;
 
 class Renderer {
  public:
-  static constexpr size_t kDefaultMaxFramesInFlight = 3u;
-
   using RenderCallback = std::function<bool(RenderTarget& render_target)>;
 
-  explicit Renderer(std::shared_ptr<Context> context,
-                    size_t max_frames_in_flight = kDefaultMaxFramesInFlight);
+  explicit Renderer(std::shared_ptr<Context> context);
 
   ~Renderer();
 
@@ -35,7 +31,6 @@ class Renderer {
   std::shared_ptr<Context> GetContext() const;
 
  private:
-  std::shared_ptr<fml::Semaphore> frames_in_flight_sema_;
   std::shared_ptr<Context> context_;
   bool is_valid_ = false;
 


### PR DESCRIPTION
This semaphore doesn't actually do anything. Frames in flight is managed by platform specific swapchains.