### PR TITLE
Reland: Partial repaint platform views

### DIFF
--- a/flow/diff_context.cc
+++ b/flow/diff_context.cc
@@ -162,10 +162,6 @@ bool DiffContext::PushCullRect(const SkRect& clip) {
   return !state_.matrix_clip.device_cull_rect().isEmpty();
 }
 
-void DiffContext::ForceFullRepaint() {
-  damage_ = SkRect::MakeIWH(frame_size_.width(), frame_size_.height());
-}
-
 SkMatrix DiffContext::GetTransform3x3() const {
   return state_.matrix_clip.matrix_3x3();
 }
@@ -205,6 +201,12 @@ void DiffContext::AddLayerBounds(const SkRect& rect) {
       AddDamage(transformed_rect);
     }
   }
+}
+
+void DiffContext::RepaintEntireFrame() {
+  auto frame_rect = SkRect::MakeIWH(frame_size_.width(), frame_size_.height());
+  rects_->push_back(frame_rect);
+  AddDamage(frame_rect);
 }
 
 void DiffContext::MarkSubtreeHasVolatileLayer() {

--- a/flow/diff_context.h
+++ b/flow/diff_context.h
@@ -77,9 +77,6 @@ class DiffContext {
   // Pushes cull rect for current subtree
   bool PushCullRect(const SkRect& clip);
 
-  // Marks entire frame as dirty.
-  void ForceFullRepaint();
-
   // Function that adjusts layer bounds (in device coordinates) depending
   // on filter.
   using FilterBoundsAdjustment = std::function<SkRect(SkRect)>;
@@ -118,6 +115,9 @@ class DiffContext {
   // Add layer bounds to current paint region; rect is in "local" (layer)
   // coordinates.
   void AddLayerBounds(const SkRect& rect);
+
+  // Marks entire frame as dirty.
+  void RepaintEntireFrame();
 
   // Add entire paint region of retained layer for current subtree. This can
   // only be used in subtrees that are not dirty, otherwise ancestor transforms

--- a/flow/diff_context.h
+++ b/flow/diff_context.h
@@ -77,6 +77,9 @@ class DiffContext {
   // Pushes cull rect for current subtree
   bool PushCullRect(const SkRect& clip);
 
+  // Marks entire frame as dirty.
+  void ForceFullRepaint();
+
   // Function that adjusts layer bounds (in device coordinates) depending
   // on filter.
   using FilterBoundsAdjustment = std::function<SkRect(SkRect)>;
@@ -107,9 +110,10 @@ class DiffContext {
 
   bool IsSubtreeDirty() const { return state_.dirty; }
 
-  // Marks that current subtree contains a TextureLayer. This is needed to
-  // ensure that we'll Diff the TextureLayer even if inside retained layer.
-  void MarkSubtreeHasTextureLayer();
+  // Marks that current subtree contains a volatile layer. A volatile layer will
+  // do diffing even if it is a retained subtree. Necessary for TextureLayer
+  // and PlatformViewLayer.
+  void MarkSubtreeHasVolatileLayer();
 
   // Add layer bounds to current paint region; rect is in "local" (layer)
   // coordinates.
@@ -231,7 +235,7 @@ class DiffContext {
     bool has_filter_bounds_adjustment = false;
 
     // Whether there is a texture layer in this subtree.
-    bool has_texture = false;
+    bool has_volatile_layer = false;
   };
 
   void MakeTransformIntegral(DisplayListMatrixClipState& matrix_clip);

--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -78,7 +78,7 @@ void ContainerLayer::DiffChildren(DiffContext* context,
       auto prev_layer = prev_layers[i_prev];
       auto paint_region = context->GetOldLayerPaintRegion(prev_layer.get());
       if (layer == prev_layer && !paint_region.has_readback() &&
-          !paint_region.has_texture()) {
+          !paint_region.has_volatile_layer()) {
         // for retained layers, stop processing the subtree and add existing
         // region; We know current subtree is not dirty (every ancestor up to
         // here matches) so the retained subtree will render identically to

--- a/flow/layers/platform_view_layer.cc
+++ b/flow/layers/platform_view_layer.cc
@@ -13,6 +13,17 @@ PlatformViewLayer::PlatformViewLayer(const SkPoint& offset,
                                      int64_t view_id)
     : offset_(offset), size_(size), view_id_(view_id) {}
 
+void PlatformViewLayer::Diff(DiffContext* context, const Layer* old_layer) {
+  DiffContext::AutoSubtreeRestore subtree(context);
+  // Ensure that Diff is called again even if this layer is in retained subtree.
+  context->MarkSubtreeHasVolatileLayer();
+  // It is not necessary to track the actual paint region for the layer due to
+  // forced full repaint below, but the paint region carries the volatile layer
+  // flag.
+  context->SetLayerPaintRegion(this, context->CurrentSubtreeRegion());
+  context->ForceFullRepaint();
+}
+
 void PlatformViewLayer::Preroll(PrerollContext* context) {
   set_paint_bounds(SkRect::MakeXYWH(offset_.x(), offset_.y(), size_.width(),
                                     size_.height()));

--- a/flow/layers/platform_view_layer.cc
+++ b/flow/layers/platform_view_layer.cc
@@ -17,11 +17,11 @@ void PlatformViewLayer::Diff(DiffContext* context, const Layer* old_layer) {
   DiffContext::AutoSubtreeRestore subtree(context);
   // Ensure that Diff is called again even if this layer is in retained subtree.
   context->MarkSubtreeHasVolatileLayer();
-  // It is not necessary to track the actual paint region for the layer due to
-  // forced full repaint below, but the paint region carries the volatile layer
-  // flag.
+  // Partial repaint is disabled when platform view is present. This will also
+  // set whole frame as the layer paint region, which will ensure full repaint
+  // when the layer is removed.
+  context->RepaintEntireFrame();
   context->SetLayerPaintRegion(this, context->CurrentSubtreeRegion());
-  context->ForceFullRepaint();
 }
 
 void PlatformViewLayer::Preroll(PrerollContext* context) {

--- a/flow/layers/platform_view_layer.h
+++ b/flow/layers/platform_view_layer.h
@@ -16,6 +16,7 @@ class PlatformViewLayer : public Layer {
  public:
   PlatformViewLayer(const SkPoint& offset, const SkSize& size, int64_t view_id);
 
+  void Diff(DiffContext* context, const Layer* old_layer) override;
   void Preroll(PrerollContext* context) override;
   void Paint(PaintContext& context) const override;
 

--- a/flow/layers/platform_view_layer_unittests.cc
+++ b/flow/layers/platform_view_layer_unittests.cc
@@ -6,6 +6,7 @@
 #include "flutter/flow/layers/platform_view_layer.h"
 #include "flutter/flow/layers/transform_layer.h"
 
+#include "flutter/flow/testing/diff_context_test.h"
 #include "flutter/flow/testing/layer_test.h"
 #include "flutter/flow/testing/mock_embedder.h"
 #include "flutter/flow/testing/mock_layer.h"
@@ -137,6 +138,26 @@ TEST_F(PlatformViewLayerTest, StateTransfer) {
   PaintContext& paint_ctx = paint_context();
   paint_ctx.view_embedder = &embedder;
   transform_layer1->Paint(paint_ctx);
+}
+
+using PlatformViewLayerDiffTest = DiffContextTest;
+
+TEST_F(PlatformViewLayerDiffTest, PlatformViewRetainedLayer) {
+  MockLayerTree tree1(SkISize::Make(800, 600));
+  auto container = std::make_shared<ContainerLayer>();
+  tree1.root()->Add(container);
+  auto layer = std::make_shared<PlatformViewLayer>(SkPoint::Make(100, 100),
+                                                   SkSize::Make(100, 100), 0);
+  container->Add(layer);
+
+  MockLayerTree tree2(SkISize::Make(800, 600));
+  tree2.root()->Add(container);  // retained layer
+
+  auto damage = DiffLayerTree(tree1, MockLayerTree(SkISize::Make(800, 600)));
+  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(0, 0, 800, 600));
+
+  damage = DiffLayerTree(tree2, tree1);
+  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(0, 0, 800, 600));
 }
 
 }  // namespace testing

--- a/flow/layers/platform_view_layer_unittests.cc
+++ b/flow/layers/platform_view_layer_unittests.cc
@@ -160,5 +160,25 @@ TEST_F(PlatformViewLayerDiffTest, PlatformViewRetainedLayer) {
   EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(0, 0, 800, 600));
 }
 
+TEST_F(PlatformViewLayerDiffTest, FullRepaintAfterRemovingLayer) {
+  MockLayerTree tree1(SkISize::Make(800, 600));
+  auto container = std::make_shared<ContainerLayer>();
+  tree1.root()->Add(container);
+  auto layer = std::make_shared<PlatformViewLayer>(SkPoint::Make(100, 100),
+                                                   SkSize::Make(100, 100), 0);
+  container->Add(layer);
+
+  auto damage = DiffLayerTree(tree1, MockLayerTree(SkISize::Make(800, 600)));
+  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(0, 0, 800, 600));
+
+  // Second layer tree with the PlatformViewLayer removed.
+  MockLayerTree tree2(SkISize::Make(800, 600));
+  auto container2 = std::make_shared<ContainerLayer>();
+  tree2.root()->Add(container2);
+
+  damage = DiffLayerTree(tree2, tree1);
+  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(0, 0, 800, 600));
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/flow/layers/texture_layer.cc
+++ b/flow/layers/texture_layer.cc
@@ -34,7 +34,7 @@ void TextureLayer::Diff(DiffContext* context, const Layer* old_layer) {
   // TextureLayer is inside retained layer.
   // See ContainerLayer::DiffChildren
   // https://github.com/flutter/flutter/issues/92925
-  context->MarkSubtreeHasTextureLayer();
+  context->MarkSubtreeHasVolatileLayer();
   context->AddLayerBounds(SkRect::MakeXYWH(offset_.x(), offset_.y(),
                                            size_.width(), size_.height()));
   context->SetLayerPaintRegion(this, context->CurrentSubtreeRegion());

--- a/flow/paint_region.h
+++ b/flow/paint_region.h
@@ -30,12 +30,12 @@ class PaintRegion {
               size_t from,
               size_t to,
               bool has_readback,
-              bool has_texture)
+              bool has_volatile_layer)
       : rects_(std::move(rects)),
         from_(from),
         to_(to),
         has_readback_(has_readback),
-        has_texture_(has_texture) {}
+        has_volatile_layer_(has_volatile_layer) {}
 
   std::vector<SkRect>::const_iterator begin() const {
     FML_DCHECK(is_valid());
@@ -56,16 +56,16 @@ class PaintRegion {
   // that performs readback
   bool has_readback() const { return has_readback_; }
 
-  // Returns whether there is a TextureLayer in subtree represented by this
-  // region.
-  bool has_texture() const { return has_texture_; }
+  // Returns whether there is a TextureLayer or PlatformViewLayer in subtree
+  // represented by this region.
+  bool has_volatile_layer() const { return has_volatile_layer_; }
 
  private:
   std::shared_ptr<std::vector<SkRect>> rects_;
   size_t from_ = 0;
   size_t to_ = 0;
   bool has_readback_ = false;
-  bool has_texture_ = false;
+  bool has_volatile_layer_ = false;
 };
 
 }  // namespace flutter

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -743,17 +743,9 @@ DrawSurfaceStatus Rasterizer::DrawToSurfaceUnsafe(
     // when leaf layer tracing is enabled we wish to repaint the whole frame
     // for accurate performance metrics.
     if (frame->framebuffer_info().supports_partial_repaint) {
-      // Disable partial repaint if external_view_embedder_ SubmitFlutterView is
-      // involved - ExternalViewEmbedder unconditionally clears the entire
-      // surface and also partial repaint with platform view present is
-      // something that still need to be figured out.
-      bool force_full_repaint =
-          external_view_embedder_ &&
-          (!raster_thread_merger_ || raster_thread_merger_->IsMerged());
-
       damage = std::make_unique<FrameDamage>();
       auto existing_damage = frame->framebuffer_info().existing_damage;
-      if (existing_damage.has_value() && !force_full_repaint) {
+      if (existing_damage.has_value()) {
         damage->SetPreviousLayerTree(GetLastLayerTree(view_id));
         damage->AddAdditionalDamage(existing_damage.value());
         damage->SetClipAlignment(


### PR DESCRIPTION
Relands https://github.com/flutter/engine/pull/54219 reverted in https://github.com/flutter/engine/pull/54230.

The tracked area of `PlatformViewLayer` now covers entire frame ensuring full repaint when platform view is removed. 
Added `FullRepaintAfterRemovingLayer` test.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
