### PR TITLE
[iOS][macOS] Eliminate use of bitcode_strip

### DIFF
--- a/sky/tools/create_full_ios_framework.py
+++ b/sky/tools/create_full_ios_framework.py
@@ -243,7 +243,7 @@ def _generate_gen_snapshot(gen_snapshot_path, destination):
     print('Cannot find gen_snapshot at %s' % gen_snapshot_path)
     sys.exit(1)
 
-  subprocess.check_call(['xcrun', 'bitcode_strip', '-r', gen_snapshot_path, '-o', destination])
+  shutil.copy2(gen_snapshot_path, destination)
 
 
 if __name__ == '__main__':

--- a/sky/tools/create_macos_gen_snapshots.py
+++ b/sky/tools/create_macos_gen_snapshots.py
@@ -5,6 +5,7 @@
 # found in the LICENSE file.
 
 import argparse
+import shutil
 import subprocess
 import sys
 import os
@@ -69,7 +70,7 @@ def generate_gen_snapshot(gen_snapshot_path, destination):
     print('Cannot find gen_snapshot at %s' % gen_snapshot_path)
     sys.exit(1)
 
-  subprocess.check_call(['xcrun', 'bitcode_strip', '-r', gen_snapshot_path, '-o', destination])
+  shutil.copy2(gen_snapshot_path, destination)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Our executables are no longer built with bitcode enabled and thus `bitcode_strip -r SOURCE -o DEST` is just copying the file in question to the output location.

Use of Bitcode was eliminated in Flutter in 2022. See linked issue for details.

This is a reland of https://github.com/flutter/engine/pull/54240 which was reverted in https://github.com/flutter/engine/pull/54250.

The the previous version was reverted because Python's `shutil.copyfile` doesn't set the unix permissions of the source file on the destination file. However, when overwriting an existing destination file, it preserves any permissions on that file. One can imagine how this might be problematic if you test the script by running before and after the change with the same output directory. `shutil.copy2` attempts to preserve source file metadata when writing the copy.

Issue: https://github.com/flutter/flutter/issues/107884

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
