### PR TITLE
Revert "FlutterFragment predictive back"

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -1056,14 +1056,6 @@ public class FlutterFragment extends Fragment
     delegate.onAttach(context);
     if (getArguments().getBoolean(ARG_SHOULD_AUTOMATICALLY_HANDLE_ON_BACK_PRESSED, false)) {
       requireActivity().getOnBackPressedDispatcher().addCallback(this, onBackPressedCallback);
-      // When Android handles a back gesture, it pops an Activity or goes back
-      // to the home screen. When Flutter handles a back gesture, it pops a
-      // route inside of the Flutter part of the app. By default, Android
-      // handles back gestures, so this callback is disabled. If, for example,
-      // the Flutter app has routes for which it wants to handle the back
-      // gesture, then it will enable this callback using
-      // setFrameworkHandlesBack.
-      onBackPressedCallback.setEnabled(false);
     }
     context.registerComponentCallbacks(this);
   }
@@ -1671,27 +1663,14 @@ public class FlutterFragment extends Fragment
         // Unless we disable the callback, the dispatcher call will trigger it. This will then
         // trigger the fragment's onBackPressed() implementation, which will call through to the
         // dart side and likely call back through to this method, creating an infinite call loop.
-        boolean enabledAtStart = onBackPressedCallback.isEnabled();
-        if (enabledAtStart) {
-          onBackPressedCallback.setEnabled(false);
-        }
+        onBackPressedCallback.setEnabled(false);
         activity.getOnBackPressedDispatcher().onBackPressed();
-        if (enabledAtStart) {
-          onBackPressedCallback.setEnabled(true);
-        }
+        onBackPressedCallback.setEnabled(true);
         return true;
       }
     }
     // Hook for subclass. No-op if returns false.
     return false;
-  }
-
-  @Override
-  public void setFrameworkHandlesBack(boolean frameworkHandlesBack) {
-    if (!getArguments().getBoolean(ARG_SHOULD_AUTOMATICALLY_HANDLE_ON_BACK_PRESSED, false)) {
-      return;
-    }
-    onBackPressedCallback.setEnabled(frameworkHandlesBack);
   }
 
   @VisibleForTesting

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -518,7 +518,6 @@ public class FlutterFragmentActivity extends FragmentActivity
             ? TransparencyMode.opaque
             : TransparencyMode.transparent;
     final boolean shouldDelayFirstAndroidViewDraw = renderMode == RenderMode.surface;
-    final boolean shouldAutomaticallyHandleOnBackPressed = true;
 
     if (getCachedEngineId() != null) {
       Log.v(
@@ -543,7 +542,6 @@ public class FlutterFragmentActivity extends FragmentActivity
           .shouldAttachEngineToActivity(shouldAttachEngineToActivity())
           .destroyEngineWithFragment(shouldDestroyEngineWithHost())
           .shouldDelayFirstAndroidViewDraw(shouldDelayFirstAndroidViewDraw)
-          .shouldAutomaticallyHandleOnBackPressed(shouldAutomaticallyHandleOnBackPressed)
           .build();
     } else {
       Log.v(
@@ -579,7 +577,6 @@ public class FlutterFragmentActivity extends FragmentActivity
             .transparencyMode(transparencyMode)
             .shouldAttachEngineToActivity(shouldAttachEngineToActivity())
             .shouldDelayFirstAndroidViewDraw(shouldDelayFirstAndroidViewDraw)
-            .shouldAutomaticallyHandleOnBackPressed(shouldAutomaticallyHandleOnBackPressed)
             .build();
       }
 
@@ -595,7 +592,6 @@ public class FlutterFragmentActivity extends FragmentActivity
           .transparencyMode(transparencyMode)
           .shouldAttachEngineToActivity(shouldAttachEngineToActivity())
           .shouldDelayFirstAndroidViewDraw(shouldDelayFirstAndroidViewDraw)
-          .shouldAutomaticallyHandleOnBackPressed(shouldAutomaticallyHandleOnBackPressed)
           .build();
     }
   }
@@ -618,6 +614,12 @@ public class FlutterFragmentActivity extends FragmentActivity
     // Forward Intents to our FlutterFragment in case it cares.
     flutterFragment.onNewIntent(intent);
     super.onNewIntent(intent);
+  }
+
+  @Override
+  @SuppressWarnings("MissingSuperCall")
+  public void onBackPressed() {
+    flutterFragment.onBackPressed();
   }
 
   @Override

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
@@ -290,7 +290,7 @@ public class FlutterFragmentTest {
   }
 
   @Test
-  public void itDelegatesOnBackPressedWithSetFrameworkHandlesBack() {
+  public void itDelegatesOnBackPressedAutomaticallyWhenEnabled() {
     // We need to mock FlutterJNI to avoid triggering native code.
     FlutterJNI flutterJNI = mock(FlutterJNI.class);
     when(flutterJNI.isAttached()).thenReturn(true);
@@ -301,8 +301,6 @@ public class FlutterFragmentTest {
 
     FlutterFragment fragment =
         FlutterFragment.withCachedEngine("my_cached_engine")
-            // This enables the use of onBackPressedCallback, which is what
-            // sends backs to the framework if setFrameworkHandlesBack is true.
             .shouldAutomaticallyHandleOnBackPressed(true)
             .build();
     FragmentActivity activity = getMockFragmentActivity();
@@ -320,15 +318,8 @@ public class FlutterFragmentTest {
     TestDelegateFactory delegateFactory = new TestDelegateFactory(mockDelegate);
     fragment.setDelegateFactory(delegateFactory);
 
-    // Calling onBackPressed now will still be handled by Android (the default),
-    // until setFrameworkHandlesBack is set to true.
     activity.getOnBackPressedDispatcher().onBackPressed();
-    verify(mockDelegate, times(0)).onBackPressed();
 
-    // Setting setFrameworkHandlesBack to true means the delegate will receive
-    // the back and Android won't handle it.
-    fragment.setFrameworkHandlesBack(true);
-    activity.getOnBackPressedDispatcher().onBackPressed();
     verify(mockDelegate, times(1)).onBackPressed();
   }
 
@@ -370,20 +361,10 @@ public class FlutterFragmentTest {
     TestDelegateFactory delegateFactory = new TestDelegateFactory(mockDelegate);
     fragment.setDelegateFactory(delegateFactory);
 
-    assertTrue(callback.isEnabled());
-
     assertTrue(fragment.popSystemNavigator());
 
     verify(mockDelegate, never()).onBackPressed();
     assertTrue(onBackPressedCalled.get());
-    assertTrue(callback.isEnabled());
-
-    callback.setEnabled(false);
-    assertFalse(callback.isEnabled());
-    assertTrue(fragment.popSystemNavigator());
-
-    verify(mockDelegate, never()).onBackPressed();
-    assertFalse(callback.isEnabled());
   }
 
   @Test


### PR DESCRIPTION
Reverts flutter/engine#52302, which seems to have broken back gestures for certain Google customers.

At least 2 Google-specific bugs caused by this:
b/354579427
b/355556397