### PR TITLE
[Android] Revert "Reset IME state on clear text input client"

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -546,22 +546,15 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
     }
     mEditable.removeEditingStateListener(this);
     notifyViewExited();
-
-    boolean needsRestart =
-        configuration.inputAction == null
-            || configuration.inputAction == EditorInfo.IME_ACTION_DONE
-            || configuration.inputAction == EditorInfo.IME_ACTION_NONE;
     configuration = null;
     updateAutofillConfigurationIfNeeded(null);
     inputTarget = new InputTarget(InputTarget.Type.NO_TARGET, 0);
     unlockPlatformViewInputConnection();
     lastClientRect = null;
 
-    if (needsRestart) {
-      // Call restartInput to reset IME internal states. Otherwise some IMEs (Gboard for instance)
-      // keep reacting based on the previous input configuration until a new configuration is set.
-      mImm.restartInput(mView);
-    }
+    // Call restartInput to reset IME internal states. Otherwise some IMEs (Gboard for instance)
+    // keep reacting based on the previous input configuration until a new configuration is set.
+    mImm.restartInput(mView);
   }
 
   private static class InputTarget {

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -551,10 +551,6 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
     inputTarget = new InputTarget(InputTarget.Type.NO_TARGET, 0);
     unlockPlatformViewInputConnection();
     lastClientRect = null;
-
-    // Call restartInput to reset IME internal states. Otherwise some IMEs (Gboard for instance)
-    // keep reacting based on the previous input configuration until a new configuration is set.
-    mImm.restartInput(mView);
   }
 
   private static class InputTarget {

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -1131,7 +1131,7 @@ public class TextInputPluginTest {
   }
 
   @Test
-  public void clearTextInputClient_restartsImmWhenInputActionIsNull() {
+  public void clearTextInputClient_alwaysRestartsImm() {
     // Initialize a general TextInputPlugin.
     InputMethodSubtype inputMethodSubtype = mock(InputMethodSubtype.class);
     TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
@@ -1163,115 +1163,6 @@ public class TextInputPluginTest {
     // A restart is always forced when calling clearTextInputClient().
     textInputPlugin.clearTextInputClient();
     assertEquals(2, testImm.getRestartCount(testView));
-  }
-
-  @Test
-  public void clearTextInputClient_restartsImmWhenInputActionIsDone() {
-    // Initialize a general TextInputPlugin.
-    InputMethodSubtype inputMethodSubtype = mock(InputMethodSubtype.class);
-    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
-    testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-    View testView = new View(ctx);
-    TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
-    TextInputPlugin textInputPlugin =
-        new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
-    textInputPlugin.setTextInputClient(
-        0,
-        new TextInputChannel.Configuration(
-            false,
-            false,
-            true,
-            true,
-            false,
-            TextInputChannel.TextCapitalization.NONE,
-            null,
-            EditorInfo.IME_ACTION_DONE,
-            null,
-            null,
-            null,
-            null));
-    // There's a pending restart since we initialized the text input client. Flush that now.
-    textInputPlugin.setTextInputEditingState(
-        testView, new TextInputChannel.TextEditState("", 0, 0, -1, -1));
-    assertEquals(1, testImm.getRestartCount(testView));
-
-    // A restart should be forced when calling clearTextInputClient() and input action is
-    // EditorInfo.IME_ACTION_DONE.
-    textInputPlugin.clearTextInputClient();
-    assertEquals(2, testImm.getRestartCount(testView));
-  }
-
-  @Test
-  public void clearTextInputClient_restartsImmWhenInputActionIsNone() {
-    // Initialize a general TextInputPlugin.
-    InputMethodSubtype inputMethodSubtype = mock(InputMethodSubtype.class);
-    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
-    testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-    View testView = new View(ctx);
-    TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
-    TextInputPlugin textInputPlugin =
-        new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
-    textInputPlugin.setTextInputClient(
-        0,
-        new TextInputChannel.Configuration(
-            false,
-            false,
-            true,
-            true,
-            false,
-            TextInputChannel.TextCapitalization.NONE,
-            null,
-            EditorInfo.IME_ACTION_NONE,
-            null,
-            null,
-            null,
-            null));
-    // There's a pending restart since we initialized the text input client. Flush that now.
-    textInputPlugin.setTextInputEditingState(
-        testView, new TextInputChannel.TextEditState("", 0, 0, -1, -1));
-    assertEquals(1, testImm.getRestartCount(testView));
-
-    // A restart should be forced when calling clearTextInputClient() and input action is
-    // EditorInfo.IME_ACTION_NONE.
-    textInputPlugin.clearTextInputClient();
-    assertEquals(2, testImm.getRestartCount(testView));
-  }
-
-  @Test
-  public void clearTextInputClient_doesNotRestartImmWhenInputActionIsNext() {
-    // Regression test for https://github.com/flutter/flutter/issues/148673.
-    // Initialize a general TextInputPlugin.
-    InputMethodSubtype inputMethodSubtype = mock(InputMethodSubtype.class);
-    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
-    testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-    View testView = new View(ctx);
-    TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
-    TextInputPlugin textInputPlugin =
-        new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
-    textInputPlugin.setTextInputClient(
-        0,
-        new TextInputChannel.Configuration(
-            false,
-            false,
-            true,
-            true,
-            false,
-            TextInputChannel.TextCapitalization.NONE,
-            null,
-            EditorInfo.IME_ACTION_NEXT,
-            null,
-            null,
-            null,
-            null));
-    // There's a pending restart since we initialized the text input client. Flush that now.
-    textInputPlugin.setTextInputEditingState(
-        testView, new TextInputChannel.TextEditState("", 0, 0, -1, -1));
-    assertEquals(1, testImm.getRestartCount(testView));
-
-    // No restart is forced when calling clearTextInputClient() and input action is
-    // EditorInfo.IME_ACTION_NEXT.
-    textInputPlugin.clearTextInputClient();
-    assertEquals(1, testImm.getRestartCount(testView));
   }
 
   @Test

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -1131,41 +1131,6 @@ public class TextInputPluginTest {
   }
 
   @Test
-  public void clearTextInputClient_alwaysRestartsImm() {
-    // Initialize a general TextInputPlugin.
-    InputMethodSubtype inputMethodSubtype = mock(InputMethodSubtype.class);
-    TestImm testImm = Shadow.extract(ctx.getSystemService(Context.INPUT_METHOD_SERVICE));
-    testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-    View testView = new View(ctx);
-    TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
-    TextInputPlugin textInputPlugin =
-        new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
-    textInputPlugin.setTextInputClient(
-        0,
-        new TextInputChannel.Configuration(
-            false,
-            false,
-            true,
-            true,
-            false,
-            TextInputChannel.TextCapitalization.NONE,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null));
-    // There's a pending restart since we initialized the text input client. Flush that now.
-    textInputPlugin.setTextInputEditingState(
-        testView, new TextInputChannel.TextEditState("", 0, 0, -1, -1));
-    assertEquals(1, testImm.getRestartCount(testView));
-
-    // A restart is always forced when calling clearTextInputClient().
-    textInputPlugin.clearTextInputClient();
-    assertEquals(2, testImm.getRestartCount(testView));
-  }
-
-  @Test
   public void destroy_clearTextInputMethodHandler() {
     View testView = new View(ctx);
     TextInputChannel textInputChannel = spy(new TextInputChannel(mock(DartExecutor.class)));


### PR DESCRIPTION
## Description

This PR reverts two commits https://github.com/flutter/engine/pull/49829 and https://github.com/flutter/engine/pull/53662.

The main change was in https://github.com/flutter/engine/pull/49829. https://github.com/flutter/engine/pull/53662 was a follow-up to mitigate the impact of https://github.com/flutter/engine/pull/49829.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/148530
Fixes https://github.com/flutter/flutter/issues/152620

Reopens https://github.com/flutter/flutter/issues/70546.
Reopens https://github.com/flutter/flutter/issues/51478



