### PR TITLE
Use getBoundingRects to add support inset MediaQuery/SafeArea when in freeform mode controls are shown. 

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -228,6 +228,7 @@ android_java_sources = [
   "io/flutter/embedding/android/FlutterSurfaceView.java",
   "io/flutter/embedding/android/FlutterTextureView.java",
   "io/flutter/embedding/android/FlutterView.java",
+  "io/flutter/embedding/android/FlutterViewDelegate.java",
   "io/flutter/embedding/android/KeyChannelResponder.java",
   "io/flutter/embedding/android/KeyData.java",
   "io/flutter/embedding/android/KeyEmbedderResponder.java",
@@ -357,6 +358,7 @@ android_java_sources = [
   "io/flutter/view/FlutterNativeView.java",
   "io/flutter/view/FlutterRunArguments.java",
   "io/flutter/view/FlutterView.java",
+  "io/flutter/view/FlutterViewDelegate.java",
   "io/flutter/view/TextureRegistry.java",
   "io/flutter/view/VsyncWaiter.java",
 ]

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -358,7 +358,6 @@ android_java_sources = [
   "io/flutter/view/FlutterNativeView.java",
   "io/flutter/view/FlutterRunArguments.java",
   "io/flutter/view/FlutterView.java",
-  "io/flutter/view/FlutterViewDelegate.java",
   "io/flutter/view/TextureRegistry.java",
   "io/flutter/view/VsyncWaiter.java",
 ]

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -772,6 +772,15 @@ public class FlutterView extends FrameLayout
       viewportMetrics.viewInsetLeft = 0;
     }
 
+    // The caption bar inset is a new addition, and the APIs called to query it utilize a list of
+    // bounding Rects instead of an Insets object, which is a newer API method, as compared to the
+    // existing Insets-based method calls above.
+    if (Build.VERSION.SDK_INT >= API_LEVELS.API_35) {
+      delegate.growViewportMetricsToCaptionBar(getContext(), viewportMetrics);
+    } else {
+      Log.w(TAG, "API level " + Build.VERSION.SDK_INT + " is too low to query bounding rects.");
+    }
+
     Log.v(
         TAG,
         "Updating window insets (onApplyWindowInsets()):\n"
@@ -1467,12 +1476,6 @@ public class FlutterView extends FrameLayout
 
     viewportMetrics.devicePixelRatio = getResources().getDisplayMetrics().density;
     viewportMetrics.physicalTouchSlop = ViewConfiguration.get(getContext()).getScaledTouchSlop();
-
-    if (Build.VERSION.SDK_INT >= API_LEVELS.API_35) {
-      delegate.growViewportMetricsToCaptionBar(getContext(), viewportMetrics);
-    } else {
-      Log.w(TAG, "API level " + Build.VERSION.SDK_INT + " is too low to query bounding rects.");
-    }
 
     flutterEngine.getRenderer().setViewportMetrics(viewportMetrics);
   }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -1469,15 +1469,7 @@ public class FlutterView extends FrameLayout
     viewportMetrics.physicalTouchSlop = ViewConfiguration.get(getContext()).getScaledTouchSlop();
 
     if (Build.VERSION.SDK_INT >= API_LEVELS.API_35) {
-      List<Rect> boundingRects = delegate.getCaptionBarInsets(getContext());
-      if (boundingRects != null && boundingRects.size() == 1) {
-        // The value getCaptionBarInset returns is only the bounding rects of the caption bar.
-        // When assigning the new value of viewPaddingTop, the maximum is taken with its old value
-        // to ensure that any previous top padding that is greater than that from the caption bar
-        // is not destroyed by this operation.
-        viewportMetrics.viewPaddingTop =
-            Math.max(boundingRects.get(0).bottom, viewportMetrics.viewPaddingTop);
-      }
+      delegate.growViewportMetricsToCaptionBar(getContext(), viewportMetrics);
     } else {
       Log.w(TAG, "API level " + Build.VERSION.SDK_INT + " is too low to query bounding rects.");
     }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -1471,6 +1471,10 @@ public class FlutterView extends FrameLayout
     if (Build.VERSION.SDK_INT >= API_LEVELS.API_35) {
       List<Rect> boundingRects = delegate.getCaptionBarInsets(getContext());
       if (boundingRects != null && boundingRects.size() == 1) {
+        // The value getCaptionBarInset returns is only the bounding rects of the caption bar.
+        // When assigning the new value of viewPaddingTop, the maximum is taken with its old value
+        // to ensure that any previous top padding that is greater than that from the caption bar
+        // is not destroyed by this operation.
         viewportMetrics.viewPaddingTop =
             Math.max(boundingRects.get(0).bottom, viewportMetrics.viewPaddingTop);
       }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -1450,34 +1450,6 @@ public class FlutterView extends FrameLayout
         .send();
   }
 
-  /** A delegate class that performs the task of retrieving the bounding rect values. */
-  public static class FlutterViewDelegate {
-
-    /**
-     * Return the WindowInsets object for the provided Context, or null if there is no associated
-     * activity.
-     */
-    @RequiresApi(api = API_LEVELS.API_23)
-    @VisibleForTesting
-    public WindowInsets getWindowInsets(Context context) {
-      Activity activity = ViewUtils.getActivity(context);
-      if (activity == null) {
-        return null;
-      }
-      return activity.getWindow().getDecorView().getRootWindowInsets();
-    }
-
-    @RequiresApi(api = API_LEVELS.API_35)
-    @VisibleForTesting
-    public List<Rect> getCaptionBarInsets(Context context) {
-      WindowInsets insets = getWindowInsets(context);
-      if (insets == null) {
-        return Collections.emptyList();
-      }
-      return insets.getBoundingRects(WindowInsets.Type.captionBar());
-    }
-  }
-
   private FlutterViewDelegate delegate = new FlutterViewDelegate();
 
   /** Set the FlutterViewDelegate, such as to a mock for testing. */

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -72,7 +72,6 @@ import io.flutter.view.AccessibilityBridge;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -1455,7 +1455,6 @@ public class FlutterView extends FrameLayout
 
     @VisibleForTesting
     public WindowInsets getWindowInsets(Context context) {
-      Log.w(TAG, "getWindowInsets called for " + Build.VERSION.SDK_INT);
       Activity activity = ViewUtils.getActivity(context);
       if (activity == null || Build.VERSION.SDK_INT < 23) {
         return null;
@@ -1465,12 +1464,10 @@ public class FlutterView extends FrameLayout
 
     @VisibleForTesting
     public List<Rect> getCaptionBarInsets(Context context) {
-      Log.w(TAG, "getCaptionBarInsets called for " + Build.VERSION.SDK_INT);
       WindowInsets insets = getWindowInsets(context);
       if (insets == null || Build.VERSION.SDK_INT < 35) {
         return Collections.emptyList();
       }
-      Log.w(TAG, "Called inner method: " + insets.getBoundingRects(WindowInsets.Type.captionBar()));
       return insets.getBoundingRects(WindowInsets.Type.captionBar());
     }
   }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -1451,7 +1451,6 @@ public class FlutterView extends FrameLayout
 
   private FlutterViewDelegate delegate = new FlutterViewDelegate();
 
-  /** Set the FlutterViewDelegate, such as to a mock for testing. */
   @VisibleForTesting
   public void setDelegate(FlutterViewDelegate delegate) {
     this.delegate = delegate;

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -1452,7 +1452,7 @@ public class FlutterView extends FrameLayout
   private FlutterViewDelegate delegate = new FlutterViewDelegate();
 
   @VisibleForTesting
-  public void setDelegate(FlutterViewDelegate delegate) {
+  public void setDelegate(@NonNull FlutterViewDelegate delegate) {
     this.delegate = delegate;
   }
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -1498,7 +1498,8 @@ public class FlutterView extends FrameLayout
     if (Build.VERSION.SDK_INT >= API_LEVELS.API_35) {
       List<Rect> boundingRects = delegate.getCaptionBarInsets(getContext());
       if (boundingRects != null && boundingRects.size() == 1) {
-        viewportMetrics.viewPaddingTop = boundingRects.get(0).bottom;
+        viewportMetrics.viewPaddingTop =
+            Math.max(boundingRects.get(0).bottom, viewportMetrics.viewPaddingTop);
       }
     } else {
       Log.w(TAG, "API level " + Build.VERSION.SDK_INT + " is too low to query bounding rects.");

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -1453,19 +1453,25 @@ public class FlutterView extends FrameLayout
   /** A delegate class that performs the task of retrieving the bounding rect values. */
   public static class FlutterViewDelegate {
 
+    /**
+     * Return the WindowInsets object for the provided Context, or null if there is no associated
+     * activity.
+     */
+    @RequiresApi(api = API_LEVELS.API_23)
     @VisibleForTesting
     public WindowInsets getWindowInsets(Context context) {
       Activity activity = ViewUtils.getActivity(context);
-      if (activity == null || Build.VERSION.SDK_INT < 23) {
+      if (activity == null) {
         return null;
       }
       return activity.getWindow().getDecorView().getRootWindowInsets();
     }
 
+    @RequiresApi(api = API_LEVELS.API_35)
     @VisibleForTesting
     public List<Rect> getCaptionBarInsets(Context context) {
       WindowInsets insets = getWindowInsets(context);
-      if (insets == null || Build.VERSION.SDK_INT < 35) {
+      if (insets == null) {
         return Collections.emptyList();
       }
       return insets.getBoundingRects(WindowInsets.Type.captionBar());

--- a/shell/platform/android/io/flutter/embedding/android/FlutterViewDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterViewDelegate.java
@@ -12,6 +12,7 @@ import android.view.WindowInsets;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
 import io.flutter.Build;
+import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import io.flutter.util.ViewUtils;
 import java.util.Collections;
 import java.util.List;
@@ -45,5 +46,18 @@ public class FlutterViewDelegate {
       return Collections.emptyList();
     }
     return insets.getBoundingRects(WindowInsets.Type.captionBar());
+  }
+
+  @RequiresApi(api = Build.API_LEVELS.API_35)
+  public void growViewportMetricsToCaptionBar(Context context, FlutterRenderer.ViewportMetrics viewportMetrics) {
+    List<Rect> boundingRects = getCaptionBarInsets(context);
+    if (boundingRects.size() != 1) {
+      return;
+    }
+    // The value getCaptionBarInset returns is only the bounding rects of the caption bar.
+    // When assigning the new value of viewPaddingTop, the maximum is taken with its old value
+    // to ensure that any previous top padding that is greater than that from the caption bar
+    // is not destroyed by this operation.
+    viewportMetrics.viewPaddingTop = Math.max(viewportMetrics.viewPaddingTop, boundingRects.get(0).bottom);
   }
 }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterViewDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterViewDelegate.java
@@ -17,7 +17,11 @@ import io.flutter.util.ViewUtils;
 import java.util.Collections;
 import java.util.List;
 
-/** A delegate class that performs the task of retrieving the bounding rect values. */
+/**
+ * A delegate class that performs the task of retrieving the bounding rect values. Logic that is
+ * independent of the engine, or that tests must access in the absence of an engine, shall reside
+ * within this class.
+ */
 public class FlutterViewDelegate {
   /**
    * Return the WindowInsets object for the provided Context. Returns null if there is no associated
@@ -39,7 +43,6 @@ public class FlutterViewDelegate {
   }
 
   @RequiresApi(api = Build.API_LEVELS.API_35)
-  @VisibleForTesting
   public List<Rect> getCaptionBarInsets(Context context) {
     WindowInsets insets = getWindowInsets(context);
     if (insets == null) {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterViewDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterViewDelegate.java
@@ -56,12 +56,9 @@ public class FlutterViewDelegate {
   public void growViewportMetricsToCaptionBar(
       Context context, FlutterRenderer.ViewportMetrics viewportMetrics) {
     List<Rect> boundingRects = getCaptionBarInsets(context);
-    int padding = viewportMetrics.viewPaddingTop;
+    int viewPaddingTop = viewportMetrics.viewPaddingTop;
     for (Rect rect : boundingRects) {
-      padding = Math.max(padding, rect.bottom);
-    }
-    if (boundingRects.size() != 1) {
-      return;
+      viewPaddingTop = Math.max(viewPaddingTop, rect.bottom);
     }
     // The value getCaptionBarInset returns is only the bounding rects of the caption bar.
     // When assigning the new value of viewPaddingTop, the maximum is taken with its old value
@@ -69,6 +66,6 @@ public class FlutterViewDelegate {
     // is not destroyed by this operation.
     // Any potential update that will allow the caption bar to be positioned somewhere other than
     // the top of the app window will require that this method be rewritten.
-    viewportMetrics.viewPaddingTop = padding;
+    viewportMetrics.viewPaddingTop = viewPaddingTop;
   }
 }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterViewDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterViewDelegate.java
@@ -19,8 +19,9 @@ import java.util.List;
 /** A delegate class that performs the task of retrieving the bounding rect values. */
 public class FlutterViewDelegate {
   /**
-   * Return the WindowInsets object for the provided Context, or null if there is no associated
-   * activity.
+   * Return the WindowInsets object for the provided Context. Returns null if there is no associated
+   * activity, the window of the associated activity is null, or the root window insets of the
+   * activity's window is null.
    */
   @RequiresApi(api = Build.API_LEVELS.API_23)
   @VisibleForTesting

--- a/shell/platform/android/io/flutter/embedding/android/FlutterViewDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterViewDelegate.java
@@ -49,7 +49,8 @@ public class FlutterViewDelegate {
   }
 
   @RequiresApi(api = Build.API_LEVELS.API_35)
-  public void growViewportMetricsToCaptionBar(Context context, FlutterRenderer.ViewportMetrics viewportMetrics) {
+  public void growViewportMetricsToCaptionBar(
+      Context context, FlutterRenderer.ViewportMetrics viewportMetrics) {
     List<Rect> boundingRects = getCaptionBarInsets(context);
     if (boundingRects.size() != 1) {
       return;
@@ -58,6 +59,7 @@ public class FlutterViewDelegate {
     // When assigning the new value of viewPaddingTop, the maximum is taken with its old value
     // to ensure that any previous top padding that is greater than that from the caption bar
     // is not destroyed by this operation.
-    viewportMetrics.viewPaddingTop = Math.max(viewportMetrics.viewPaddingTop, boundingRects.get(0).bottom);
+    viewportMetrics.viewPaddingTop =
+        Math.max(viewportMetrics.viewPaddingTop, boundingRects.get(0).bottom);
   }
 }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterViewDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterViewDelegate.java
@@ -1,0 +1,46 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.embedding.android;
+
+import android.app.Activity;
+import android.content.Context;
+import android.graphics.Rect;
+import android.view.WindowInsets;
+
+import androidx.annotation.RequiresApi;
+import androidx.annotation.VisibleForTesting;
+
+import java.util.Collections;
+import java.util.List;
+
+import io.flutter.Build;
+import io.flutter.util.ViewUtils;
+
+/** A delegate class that performs the task of retrieving the bounding rect values. */
+public class FlutterViewDelegate {
+    /**
+     * Return the WindowInsets object for the provided Context, or null if there is no associated
+     * activity.
+     */
+    @RequiresApi(api = Build.API_LEVELS.API_23)
+    @VisibleForTesting
+    public WindowInsets getWindowInsets(Context context) {
+      Activity activity = ViewUtils.getActivity(context);
+      if (activity == null) {
+        return null;
+      }
+      return activity.getWindow().getDecorView().getRootWindowInsets();
+    }
+
+    @RequiresApi(api = Build.API_LEVELS.API_35)
+    @VisibleForTesting
+    public List<Rect> getCaptionBarInsets(Context context) {
+      WindowInsets insets = getWindowInsets(context);
+      if (insets == null) {
+        return Collections.emptyList();
+      }
+      return insets.getBoundingRects(WindowInsets.Type.captionBar());
+    }
+}

--- a/shell/platform/android/io/flutter/embedding/android/FlutterViewDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterViewDelegate.java
@@ -24,9 +24,10 @@ import java.util.List;
  */
 public class FlutterViewDelegate {
   /**
-   * Return the WindowInsets object for the provided Context. Returns null if there is no associated
-   * activity, the window of the associated activity is null, or the root window insets of the
-   * activity's window is null.
+   * Return the WindowInsets object for the provided Context. A Context will only have a window if
+   * it is an instance of Activity. If context does not have a window, or it is not an activity,
+   * this method will return null. Otherwise, this method will return the WindowInsets for the
+   * provided activity's window.
    */
   @RequiresApi(api = Build.API_LEVELS.API_23)
   @VisibleForTesting
@@ -55,6 +56,10 @@ public class FlutterViewDelegate {
   public void growViewportMetricsToCaptionBar(
       Context context, FlutterRenderer.ViewportMetrics viewportMetrics) {
     List<Rect> boundingRects = getCaptionBarInsets(context);
+    int padding = viewportMetrics.viewPaddingTop;
+    for (Rect rect : boundingRects) {
+      padding = Math.max(padding, rect.bottom);
+    }
     if (boundingRects.size() != 1) {
       return;
     }
@@ -62,7 +67,8 @@ public class FlutterViewDelegate {
     // When assigning the new value of viewPaddingTop, the maximum is taken with its old value
     // to ensure that any previous top padding that is greater than that from the caption bar
     // is not destroyed by this operation.
-    viewportMetrics.viewPaddingTop =
-        Math.max(viewportMetrics.viewPaddingTop, boundingRects.get(0).bottom);
+    // Any potential update that will allow the caption bar to be positioned somewhere other than
+    // the top of the app window will require that this method be rewritten.
+    viewportMetrics.viewPaddingTop = padding;
   }
 }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterViewDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterViewDelegate.java
@@ -7,6 +7,7 @@ package io.flutter.embedding.android;
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.Rect;
+import android.view.Window;
 import android.view.WindowInsets;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
@@ -28,7 +29,11 @@ public class FlutterViewDelegate {
     if (activity == null) {
       return null;
     }
-    return activity.getWindow().getDecorView().getRootWindowInsets();
+    Window window = activity.getWindow();
+    if (window == null) {
+      return null;
+    }
+    return window.getDecorView().getRootWindowInsets();
   }
 
   @RequiresApi(api = Build.API_LEVELS.API_35)

--- a/shell/platform/android/io/flutter/embedding/android/FlutterViewDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterViewDelegate.java
@@ -8,39 +8,36 @@ import android.app.Activity;
 import android.content.Context;
 import android.graphics.Rect;
 import android.view.WindowInsets;
-
 import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
-
+import io.flutter.Build;
+import io.flutter.util.ViewUtils;
 import java.util.Collections;
 import java.util.List;
 
-import io.flutter.Build;
-import io.flutter.util.ViewUtils;
-
 /** A delegate class that performs the task of retrieving the bounding rect values. */
 public class FlutterViewDelegate {
-    /**
-     * Return the WindowInsets object for the provided Context, or null if there is no associated
-     * activity.
-     */
-    @RequiresApi(api = Build.API_LEVELS.API_23)
-    @VisibleForTesting
-    public WindowInsets getWindowInsets(Context context) {
-      Activity activity = ViewUtils.getActivity(context);
-      if (activity == null) {
-        return null;
-      }
-      return activity.getWindow().getDecorView().getRootWindowInsets();
+  /**
+   * Return the WindowInsets object for the provided Context, or null if there is no associated
+   * activity.
+   */
+  @RequiresApi(api = Build.API_LEVELS.API_23)
+  @VisibleForTesting
+  public WindowInsets getWindowInsets(Context context) {
+    Activity activity = ViewUtils.getActivity(context);
+    if (activity == null) {
+      return null;
     }
+    return activity.getWindow().getDecorView().getRootWindowInsets();
+  }
 
-    @RequiresApi(api = Build.API_LEVELS.API_35)
-    @VisibleForTesting
-    public List<Rect> getCaptionBarInsets(Context context) {
-      WindowInsets insets = getWindowInsets(context);
-      if (insets == null) {
-        return Collections.emptyList();
-      }
-      return insets.getBoundingRects(WindowInsets.Type.captionBar());
+  @RequiresApi(api = Build.API_LEVELS.API_35)
+  @VisibleForTesting
+  public List<Rect> getCaptionBarInsets(Context context) {
+    WindowInsets insets = getWindowInsets(context);
+    if (insets == null) {
+      return Collections.emptyList();
     }
+    return insets.getBoundingRects(WindowInsets.Type.captionBar());
+  }
 }

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -1271,6 +1271,9 @@ public class FlutterRenderer implements TextureRegistry {
     public float devicePixelRatio = 1.0f;
     public int width = 0;
     public int height = 0;
+    // The fields prefixed with viewPadding and viewInset are used to calculate the padding,
+    // viewPadding, and viewInsets of ViewConfiguration in Dart. This calculation is performed at
+    // https://github.com/flutter/engine/blob/main/lib/ui/hooks.dart#L139-L155.
     public int viewPaddingTop = 0;
     public int viewPaddingRight = 0;
     public int viewPaddingBottom = 0;


### PR DESCRIPTION
Original Title: Add FlutterViewDelegate and BoundingRect methods

Check the bounding rect for caption bar when sending viewport metrics to Flutter to account for freeform mode. Use the more recent `getBoundingRects` over `getInsets`.

Tests will need to be kept separate until Robolectric publishes a version that supports API level 35.
Roboletric tests for this pr will be part of google testing until then. 
Pr for tests here https://critique.corp.google.com/cl/657302386. 

https://github.com/flutter/flutter/issues/146658

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [x] All existing and new tests are passing.

