### PR TITLE
[DisplayList] bookmarks allow random access dispatching

### DIFF
--- a/display_list/dl_builder.cc
+++ b/display_list/dl_builder.cc
@@ -130,6 +130,14 @@ DisplayListBuilder::DisplayListBuilder(const SkRect& cull_rect,
 }
 
 void DisplayListBuilder::Init(bool prepare_rtree) {
+  // Ensure that DisplayList's invalid offset would not be an aligned
+  // offset within a display list buffer.
+  static_assert(SkAlignPtr(DisplayList::kInvalidOffset) !=
+                DisplayList::kInvalidOffset);
+  // Ensure that aligned values are considered valid offsets within
+  // a display list buffer.
+  static_assert(
+      DisplayList::IsValidOffset(SkAlignPtr(DisplayList::kInvalidOffset)));
   FML_DCHECK(save_stack_.empty());
   FML_DCHECK(!rtree_data_.has_value());
 


### PR DESCRIPTION
Being able to reorder rendering commands leads to optimization opportunities in the graphics package. A graphics package being fed from a DisplayList either has to take the commands in the order given or implement their own storage format for the rendering data.

With this new dispatching mechanism, the graphics package can do analysis on the properties of the rendering operations and then remember bookmarks into the operations so that they can later be dispatched in any order it prefers.