### PR TITLE
[Impeller] check allocation failures.

### DIFF
--- a/impeller/core/host_buffer.h
+++ b/impeller/core/host_buffer.h
@@ -147,7 +147,11 @@ class HostBuffer {
 
   size_t GetLength() const { return offset_; }
 
-  void MaybeCreateNewBuffer();
+  /// Attempt to create a new internal buffer if the existing capacity is not
+  /// sufficient.
+  ///
+  /// A false return value indicates an unrecoverable allocation failure.
+  [[nodiscard]] bool MaybeCreateNewBuffer();
 
   const std::shared_ptr<DeviceBuffer>& GetCurrentBuffer() const;
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/151084

If allocating a host buffer fails, log a validation error but don't cause an NPE by inserting a nullptr into the host buffer set.