### PR TITLE
[Impeller] Allow jumpstarts to pipeline readiness.

### DIFF
--- a/impeller/base/BUILD.gn
+++ b/impeller/base/BUILD.gn
@@ -14,6 +14,8 @@ impeller_component("base") {
     "comparable.cc",
     "comparable.h",
     "config.h",
+    "job_queue.cc",
+    "job_queue.h",
     "mask.h",
     "promise.cc",
     "promise.h",

--- a/impeller/base/job_queue.cc
+++ b/impeller/base/job_queue.cc
@@ -1,0 +1,104 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/base/job_queue.h"
+
+#include "flutter/fml/trace_event.h"
+#include "impeller/base/validation.h"
+
+namespace impeller {
+
+JobQueue::JobQueue(std::shared_ptr<fml::ConcurrentTaskRunner> task_runner)
+    : task_runner_(std::move(task_runner)) {}
+
+JobQueue::~JobQueue() = default;
+
+std::shared_ptr<JobQueue> JobQueue::Make(
+    std::shared_ptr<fml::ConcurrentTaskRunner> task_runner) {
+  return std::shared_ptr<JobQueue>(new JobQueue(std::move(task_runner)));
+}
+
+UniqueID JobQueue::AddJob(fml::closure job) {
+  auto id = UniqueID{};
+  {
+    Lock lock(jobs_mutex_);
+    jobs_[id] = job;
+  }
+  ScheduleAndRunJob(id);
+  return id;
+}
+
+void JobQueue::ScheduleAndRunJob(UniqueID id) {
+  task_runner_->PostTask([weak = weak_from_this(), id]() {
+    if (auto thiz = weak.lock()) {
+      thiz->RunJobNow(id);
+    }
+  });
+}
+
+void JobQueue::PrioritizeJob(UniqueID id) {
+  Lock lock(jobs_mutex_);
+  high_priority_job_ids_.push_back(id);
+}
+
+void JobQueue::RunJobNow(UniqueID id) {
+  while (RunHighPriorityJob()) {
+  }
+  fml::closure job;
+  {
+    Lock lock(jobs_mutex_);
+    job = TakeJob(id);
+  }
+  if (job) {
+    TRACE_EVENT0("impeller", "RegularJob");
+    job();
+  }
+}
+
+bool JobQueue::RunHighPriorityJob() {
+  fml::closure job;
+  {
+    Lock lock(jobs_mutex_);
+    if (high_priority_job_ids_.empty()) {
+      return false;
+    }
+    auto job_id = high_priority_job_ids_.front();
+    high_priority_job_ids_.pop_front();
+    job = TakeJob(job_id);
+  }
+  if (job) {
+    TRACE_EVENT0("impeller", "HighPriorityJob");
+    job();
+  }
+  return true;
+}
+
+void JobQueue::DoJobNow(UniqueID id) {
+  fml::closure job;
+  {
+    Lock lock(jobs_mutex_);
+    job = TakeJob(id);
+  }
+  if (job) {
+    TRACE_EVENT0("impeller", "EagerJob");
+    job();
+  }
+}
+
+fml::closure JobQueue::TakeJob(UniqueID id) {
+  auto found = jobs_.find(id);
+  if (found == jobs_.end()) {
+    return nullptr;
+  }
+  auto job = found->second;
+  jobs_.erase(found);
+  return job;
+}
+
+const std::shared_ptr<fml::ConcurrentTaskRunner>& JobQueue::GetTaskRunner()
+    const {
+  return task_runner_;
+}
+
+}  // namespace impeller

--- a/impeller/base/job_queue.h
+++ b/impeller/base/job_queue.h
@@ -1,0 +1,107 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_BASE_JOB_QUEUE_H_
+#define FLUTTER_IMPELLER_BASE_JOB_QUEUE_H_
+
+#include <deque>
+#include <map>
+#include <memory>
+
+#include "flutter/fml/closure.h"
+#include "flutter/fml/concurrent_message_loop.h"
+#include "impeller/base/comparable.h"
+#include "impeller/base/thread.h"
+
+namespace impeller {
+
+//------------------------------------------------------------------------------
+/// @brief      Manages a queue of jobs that execute on a concurrent task
+///             runner. Jobs execute as soon as resources are available. Callers
+///             have the ability to re-prioritize jobs or perform jobs eagerly
+///             on their own threads if needed.
+///
+///             The job queue and all its methods are thread-safe.
+///
+class JobQueue final : public std::enable_shared_from_this<JobQueue> {
+ public:
+  //----------------------------------------------------------------------------
+  /// @brief      Creates a job queue which schedules tasks on the given
+  ///             concurrent task runner.
+  ///
+  /// @param[in]  task_runner  The task runner
+  ///
+  /// @return     A job queue if one can be created.
+  ///
+  static std::shared_ptr<JobQueue> Make(
+      std::shared_ptr<fml::ConcurrentTaskRunner> task_runner);
+
+  //----------------------------------------------------------------------------
+  /// @brief      Destroys the job queue.
+  ///
+  ~JobQueue();
+
+  JobQueue(const JobQueue&) = delete;
+
+  JobQueue& operator=(const JobQueue&) = delete;
+
+  //----------------------------------------------------------------------------
+  /// @brief      Adds a job to the job queue and schedules it for execution at
+  ///             a later point in time. The job ID obtained may be used to
+  ///             re-prioritize the job within the queue at a later point.
+  ///
+  /// @param[in]  job   The job
+  ///
+  /// @return     The unique id for the job.
+  ///
+  UniqueID AddJob(fml::closure job);
+
+  //----------------------------------------------------------------------------
+  /// @brief      Prioritize a previously added job for immediate execution on
+  ///             the concurrent task runner.
+  ///
+  /// @param[in]  id    The job identifier.
+  ///
+  void PrioritizeJob(UniqueID id);
+
+  //----------------------------------------------------------------------------
+  /// @brief      If the job has not already been completed, executes the job
+  ///             immediately on the callers thread.
+  ///
+  ///             This is useful if the current thread is going to idle anyway
+  ///             and wants to participate in performing the job of the
+  ///             concurrent task runner.
+  ///
+  /// @param[in]  id    The job identifier.
+  ///
+  void DoJobNow(UniqueID id);
+
+  //----------------------------------------------------------------------------
+  /// @brief      Gets the task runner for the queue.
+  ///
+  /// @return     The task runner.
+  ///
+  const std::shared_ptr<fml::ConcurrentTaskRunner>& GetTaskRunner() const;
+
+ private:
+  std::shared_ptr<fml::ConcurrentTaskRunner> task_runner_;
+  Mutex jobs_mutex_;
+  std::map<UniqueID, fml::closure> jobs_ IPLR_GUARDED_BY(jobs_mutex_);
+  std::deque<UniqueID> high_priority_job_ids_ IPLR_GUARDED_BY(jobs_mutex_);
+
+  JobQueue(std::shared_ptr<fml::ConcurrentTaskRunner> task_runner);
+
+  void ScheduleAndRunJob(UniqueID id);
+
+  void RunJobNow(UniqueID id);
+
+  bool RunHighPriorityJob();
+
+  [[nodiscard]]
+  fml::closure TakeJob(UniqueID id) IPLR_REQUIRES(jobs_mutex_);
+};
+
+}  // namespace impeller
+
+#endif  // FLUTTER_IMPELLER_BASE_JOB_QUEUE_H_

--- a/impeller/base/timing.h
+++ b/impeller/base/timing.h
@@ -9,6 +9,7 @@
 
 namespace impeller {
 
+using Nanoseconds = std::chrono::nanoseconds;
 using MillisecondsF = std::chrono::duration<float, std::milli>;
 using SecondsF = std::chrono::duration<float>;
 using Clock = std::chrono::high_resolution_clock;

--- a/impeller/renderer/backend/vulkan/pipeline_library_vk.h
+++ b/impeller/renderer/backend/vulkan/pipeline_library_vk.h
@@ -10,6 +10,7 @@
 #include "flutter/fml/concurrent_message_loop.h"
 #include "flutter/fml/unique_fd.h"
 #include "impeller/base/backend_cast.h"
+#include "impeller/base/job_queue.h"
 #include "impeller/base/thread.h"
 #include "impeller/renderer/backend/vulkan/compute_pipeline_vk.h"
 #include "impeller/renderer/backend/vulkan/pipeline_cache_vk.h"
@@ -39,7 +40,7 @@ class PipelineLibraryVK final
 
   std::weak_ptr<DeviceHolderVK> device_holder_;
   std::shared_ptr<PipelineCacheVK> pso_cache_;
-  std::shared_ptr<fml::ConcurrentTaskRunner> worker_task_runner_;
+  std::shared_ptr<JobQueue> job_queue_;
   Mutex pipelines_mutex_;
   PipelineMap pipelines_ IPLR_GUARDED_BY(pipelines_mutex_);
   Mutex compute_pipelines_mutex_;

--- a/impeller/renderer/backend/vulkan/pipeline_vk.cc
+++ b/impeller/renderer/backend/vulkan/pipeline_vk.cc
@@ -451,7 +451,8 @@ std::unique_ptr<PipelineVK> PipelineVK::Create(
     const std::shared_ptr<DeviceHolderVK>& device_holder,
     const std::weak_ptr<PipelineLibrary>& weak_library,
     std::shared_ptr<SamplerVK> immutable_sampler) {
-  TRACE_EVENT0("flutter", "PipelineVK::Create");
+  TRACE_EVENT1("flutter", "PipelineVK::Create", "Name",
+               desc.GetLabel().c_str());
 
   auto library = weak_library.lock();
 


### PR DESCRIPTION
Under normal circumstances, all Impeller pipelines are ready well before the first frame begins processing. This is true even in cases where there is no existing pipeline cache. When there is a pipeline cache, startup is even faster. A device specific pipeline cache is saved after first-start.

However, low-end devices like the Mokey are... really low-end. Pipeline setup (via the ContentContext) may be the bottleneck. In such cases, the observation is that not all pipelines need to be ready for frame rendering to begin. But the pipelines that are needed for the first frame must be prioritized before the rest.

This patch adds a job queue where job priorities can be controlled by augmenting blocking accesses to the pipeline futures by making them bump up the priority of the pending job in the job queue.

On most devices, this will do nothing as all pipelines will be ready. On really low-end devices, this will time to first frame on first launch.

Additionally, traces have been augmented to make it more apparent which pipeline is causing the startup stall. This can aid in reordering first-frame critical pipelines on low-end devices. If you click on the `PipelineVK::Create` call, the name of the pipeline being created will be added to the metadata.

This change in itself reduces the raster time of the first frame on the mokey from ~555 ms to ~130 ms. The additional tracing also shows that the entire remaining stall is caused by the glyph atlas pipeline. Moving that for eager construction should get back nullify all regressions due to pipeline setup even on the Mokey.

Verified this is does nothing on all other devices.

## Before

Notice the first frame raster time.

<img width="2084" alt="Screenshot 2024-08-05 at 3 55 48 PM" src="https://github.com/user-attachments/assets/b1b52f90-fb80-48f3-8fe2-6a4cd4edcb73">

[mokey_before.json.zip](https://github.com/user-attachments/files/16503451/mokey_before.json.zip)


## After

The traces end after the first frame in the after because of `--trace-startup`. But the pipeline continue being built as before.

<img width="2085" alt="Screenshot 2024-08-05 at 3 56 42 PM" src="https://github.com/user-attachments/assets/e0193f91-03eb-48cd-b467-00452a436cd1">

[mokey_after.json.zip](https://github.com/user-attachments/files/16503452/mokey_after.json.zip)

