### PR TITLE
[Impeller] Reorder pipeline construction in content context.

### DIFF
--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -334,6 +334,24 @@ ContentContext::ContentContext(
         std::make_unique<ClipPipeline>(*context_, clip_pipeline_descriptor));
   }
 
+  glyph_atlas_pipelines_.CreateDefault(
+      *context_, options,
+      {static_cast<Scalar>(
+          GetContext()->GetCapabilities()->GetDefaultGlyphAtlasFormat() ==
+          PixelFormat::kA8UNormInt)});
+  texture_downsample_pipelines_.CreateDefault(*context_, options_trianglestrip);
+  rrect_blur_pipelines_.CreateDefault(*context_, options_trianglestrip);
+  texture_strict_src_pipelines_.CreateDefault(*context_, options);
+  tiled_texture_pipelines_.CreateDefault(*context_, options, {supports_decal});
+  gaussian_blur_pipelines_.CreateDefault(*context_, options_trianglestrip,
+                                         {supports_decal});
+  border_mask_blur_pipelines_.CreateDefault(*context_, options_trianglestrip);
+  color_matrix_color_filter_pipelines_.CreateDefault(*context_,
+                                                     options_trianglestrip);
+  porter_duff_blend_pipelines_.CreateDefault(*context_, options_trianglestrip,
+                                             {supports_decal});
+  vertices_uber_shader_.CreateDefault(*context_, options, {supports_decal});
+
   if (context_->GetCapabilities()->SupportsFramebufferFetch()) {
     framebuffer_blend_color_pipelines_.CreateDefault(
         *context_, options_trianglestrip,
@@ -428,30 +446,14 @@ ContentContext::ContentContext(
         {static_cast<Scalar>(BlendSelectValues::kSoftLight), supports_decal});
   }
 
-  texture_downsample_pipelines_.CreateDefault(*context_, options_trianglestrip);
-  rrect_blur_pipelines_.CreateDefault(*context_, options_trianglestrip);
-  texture_strict_src_pipelines_.CreateDefault(*context_, options);
-  tiled_texture_pipelines_.CreateDefault(*context_, options, {supports_decal});
-  gaussian_blur_pipelines_.CreateDefault(*context_, options_trianglestrip,
-                                         {supports_decal});
-  border_mask_blur_pipelines_.CreateDefault(*context_, options_trianglestrip);
   morphology_filter_pipelines_.CreateDefault(*context_, options_trianglestrip,
                                              {supports_decal});
-  color_matrix_color_filter_pipelines_.CreateDefault(*context_,
-                                                     options_trianglestrip);
   linear_to_srgb_filter_pipelines_.CreateDefault(*context_,
                                                  options_trianglestrip);
   srgb_to_linear_filter_pipelines_.CreateDefault(*context_,
                                                  options_trianglestrip);
-  glyph_atlas_pipelines_.CreateDefault(
-      *context_, options,
-      {static_cast<Scalar>(
-          GetContext()->GetCapabilities()->GetDefaultGlyphAtlasFormat() ==
-          PixelFormat::kA8UNormInt)});
   yuv_to_rgb_filter_pipelines_.CreateDefault(*context_, options_trianglestrip);
-  porter_duff_blend_pipelines_.CreateDefault(*context_, options_trianglestrip,
-                                             {supports_decal});
-  vertices_uber_shader_.CreateDefault(*context_, options, {supports_decal});
+
   // GLES only shader that is unsupported on macOS.
 #if defined(IMPELLER_ENABLE_OPENGLES) && !defined(FML_OS_MACOSX)
   if (GetContext()->GetBackendType() == Context::BackendType::kOpenGLES) {

--- a/impeller/renderer/backend/vulkan/pipeline_vk.cc
+++ b/impeller/renderer/backend/vulkan/pipeline_vk.cc
@@ -451,7 +451,8 @@ std::unique_ptr<PipelineVK> PipelineVK::Create(
     const std::shared_ptr<DeviceHolderVK>& device_holder,
     const std::weak_ptr<PipelineLibrary>& weak_library,
     std::shared_ptr<SamplerVK> immutable_sampler) {
-  TRACE_EVENT0("flutter", "PipelineVK::Create");
+  TRACE_EVENT1("flutter", "PipelineVK::Create", "Name",
+               desc.GetLabel().c_str());
 
   auto library = weak_library.lock();
 


### PR DESCRIPTION
Fixes the regression to the first-frame time on the Mokey.

Also add a trace that should allow for easier identification of problematic pipelines.

A more involved job-queue that allows construction jobs to skip the queue was written in https://github.com/flutter/engine/pull/54355. But the Mokey case is not important enough for the additional complexity. See the context in the linked patch.



<img width="2137" alt="Screenshot 2024-08-06 at 1 20 26 PM" src="https://github.com/user-attachments/assets/aed671c1-b7f7-4c9f-8553-485f8c0dd35e">

[start_up_timeline.json.zip](https://github.com/user-attachments/files/16515389/start_up_timeline.json.zip)
