### PR TITLE
[Impeller] made Vector3 naming match Vector2 naming.

### DIFF
--- a/impeller/aiks/paint.cc
+++ b/impeller/aiks/paint.cc
@@ -208,7 +208,8 @@ std::shared_ptr<FilterContents> Paint::MaskBlurDescriptor::CreateMaskBlur(
     const Matrix& ctm) const {
   Vector2 blur_sigma(sigma.sigma, sigma.sigma);
   if (!respect_ctm) {
-    blur_sigma /= Vector2(ctm.GetBasisX().Length(), ctm.GetBasisY().Length());
+    blur_sigma /=
+        Vector2(ctm.GetBasisX().GetLength(), ctm.GetBasisY().GetLength());
   }
   if (is_solid_color) {
     return FilterContents::MakeGaussianBlur(input, Sigma(blur_sigma.x),

--- a/impeller/geometry/matrix.cc
+++ b/impeller/geometry/matrix.cc
@@ -290,7 +290,7 @@ std::optional<MatrixDecomposition> Matrix::Decompose() const {
   /*
    *  Compute X scale factor and normalize first row.
    */
-  result.scale.x = row[0].Length();
+  result.scale.x = row[0].GetLength();
   row[0] = row[0].Normalize();
 
   /*
@@ -302,7 +302,7 @@ std::optional<MatrixDecomposition> Matrix::Decompose() const {
   /*
    *  Compute Y scale and normalize 2nd row.
    */
-  result.scale.y = row[1].Length();
+  result.scale.y = row[1].GetLength();
   row[1] = row[1].Normalize();
   result.shear.xy /= result.scale.y;
 
@@ -317,7 +317,7 @@ std::optional<MatrixDecomposition> Matrix::Decompose() const {
   /*
    *  Next, get Z scale and normalize 3rd row.
    */
-  result.scale.z = row[2].Length();
+  result.scale.z = row[2].GetLength();
   row[2] = row[2].Normalize();
 
   result.shear.xz /= result.scale.z;

--- a/impeller/geometry/matrix.h
+++ b/impeller/geometry/matrix.h
@@ -309,13 +309,13 @@ struct Matrix {
   constexpr Vector3 GetBasisZ() const { return Vector3(m[8], m[9], m[10]); }
 
   constexpr Vector3 GetScale() const {
-    return Vector3(GetBasisX().Length(), GetBasisY().Length(),
-                   GetBasisZ().Length());
+    return Vector3(GetBasisX().GetLength(), GetBasisY().GetLength(),
+                   GetBasisZ().GetLength());
   }
 
   constexpr Scalar GetDirectionScale(Vector3 direction) const {
-    return 1.0f / (this->Basis().Invert() * direction.Normalize()).Length() *
-           direction.Length();
+    return 1.0f / (this->Basis().Invert() * direction.Normalize()).GetLength() *
+           direction.GetLength();
   }
 
   constexpr bool IsAffine() const {

--- a/impeller/geometry/vector.h
+++ b/impeller/geometry/vector.h
@@ -44,10 +44,10 @@ struct Vector3 {
    *
    *  @return the calculated length.
    */
-  constexpr Scalar Length() const { return sqrt(x * x + y * y + z * z); }
+  constexpr Scalar GetLength() const { return sqrt(x * x + y * y + z * z); }
 
   constexpr Vector3 Normalize() const {
-    const auto len = Length();
+    const auto len = GetLength();
     return {x / len, y / len, z / len};
   }
 


### PR DESCRIPTION
Vector2 has `GetLength()` but Vector3 had `Length()`.  This unifies the naming.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
