### PR TITLE
[Impeller] hacked together example of better render target reuse.

### DIFF
--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -818,9 +818,16 @@ std::optional<Entity> GaussianBlurFilterContents::RenderFilter(
                .opacity = input_snapshot->opacity},
       entity.GetBlendMode());
 
-  return ApplyBlurStyle(mask_blur_style_, entity, inputs[0],
-                        input_snapshot.value(), std::move(blur_output_entity),
-                        mask_geometry_, blur_info.source_space_scalar);
+  auto result =
+      ApplyBlurStyle(mask_blur_style_, entity, inputs[0],
+                     input_snapshot.value(), std::move(blur_output_entity),
+                     mask_geometry_, blur_info.source_space_scalar);
+
+  renderer.GetRenderTargetCache()->Reclaim(pass1_out.value());
+  renderer.GetRenderTargetCache()->Reclaim(pass2_out.value());
+  renderer.GetRenderTargetCache()->Reclaim(pass3_out.value());
+
+  return result;
 }
 
 Scalar GaussianBlurFilterContents::CalculateBlurRadius(Scalar sigma) {

--- a/impeller/entity/inline_pass_context.cc
+++ b/impeller/entity/inline_pass_context.cc
@@ -79,6 +79,7 @@ bool InlinePassContext::EndPass() {
            .ok()) {
     return false;
   }
+  renderer_.GetRenderTargetCache()->Reclaim(GetPassTarget().GetRenderTarget());
 
   pass_ = nullptr;
   command_buffer_ = nullptr;

--- a/impeller/entity/render_target_cache.h
+++ b/impeller/entity/render_target_cache.h
@@ -25,6 +25,7 @@ class RenderTargetCache : public RenderTargetAllocator {
   // |RenderTargetAllocator|
   void End() override;
 
+  // |RenderTargetAllocator|
   RenderTarget CreateOffscreen(
       const Context& context,
       ISize size,
@@ -38,6 +39,7 @@ class RenderTargetCache : public RenderTargetAllocator {
       const std::shared_ptr<Texture>& existing_depth_stencil_texture =
           nullptr) override;
 
+  // |RenderTargetAllocator|
   RenderTarget CreateOffscreenMSAA(
       const Context& context,
       ISize size,
@@ -52,12 +54,16 @@ class RenderTargetCache : public RenderTargetAllocator {
       const std::shared_ptr<Texture>& existing_depth_stencil_texture =
           nullptr) override;
 
+  // |RenderTargetAllocator|
+  void Reclaim(const RenderTarget& render_target) override;
+
   // visible for testing.
   size_t CachedTextureCount() const;
 
  private:
   struct RenderTargetData {
     bool used_this_frame;
+    bool safe_for_use;
     RenderTargetConfig config;
     RenderTarget render_target;
   };

--- a/impeller/renderer/render_target.cc
+++ b/impeller/renderer/render_target.cc
@@ -228,6 +228,14 @@ size_t RenderTarget::GetTotalAttachmentCount() const {
   return count;
 }
 
+void RenderTarget::SetFrameKey(std::optional<size_t> value) {
+  frame_key_ = value;
+}
+
+std::optional<size_t> RenderTarget::GetFrameKey() const {
+  return frame_key_;
+}
+
 std::string RenderTarget::ToString() const {
   std::stringstream stream;
 
@@ -409,6 +417,8 @@ RenderTarget RenderTargetAllocator::CreateOffscreenMSAA(
 
   return target;
 }
+
+void RenderTargetAllocator::Reclaim(const RenderTarget& render_target) {}
 
 void RenderTarget::SetupDepthStencilAttachments(
     const Context& context,

--- a/impeller/renderer/render_target.h
+++ b/impeller/renderer/render_target.h
@@ -131,7 +131,18 @@ class RenderTarget final {
         .has_depth_stencil = depth_.has_value() && stencil_.has_value()};
   }
 
+  /// @brief Update the key used by this render target.
+  ///
+  /// See also: [RenderTargetAllocator::Reclaim].
+  void SetFrameKey(std::optional<size_t> value);
+
+  /// @brief Retrieve the key used by this render target.
+  ///
+  /// See also: [RenderTargetAllocator::Reclaim].
+  std::optional<size_t> GetFrameKey() const;
+
  private:
+  std::optional<size_t> frame_key_ = std::nullopt;
   std::map<size_t, ColorAttachment> colors_;
   std::optional<DepthAttachment> depth_;
   std::optional<StencilAttachment> stencil_;
@@ -144,6 +155,12 @@ class RenderTargetAllocator {
   explicit RenderTargetAllocator(std::shared_ptr<Allocator> allocator);
 
   virtual ~RenderTargetAllocator() = default;
+
+  /// @brief Mark this render target as safe for re-use within the current
+  /// frame.
+  ///
+  /// The value of the render target key is used as a lookup.
+  virtual void Reclaim(const RenderTarget& render_target);
 
   virtual RenderTarget CreateOffscreen(
       const Context& context,


### PR DESCRIPTION
FYI @chinmaygarde .

On the gaussian blur microbenchmark, this reduces the number of allocated textures from ~250 to ~6. This may fix the issue where we have unstable worst frame times, as it appears that it may be due to deallocation of a large number of textures.

The current design here is a bit rough. It would be preferable if there was a more RAII-y way to do this, but there isn't an existing object that has a matching lifecycle. besides the render pass, but the render pass isn't aware of the render target cache.
