### PR TITLE
[Impeller] perform final blit and gpu end frame tracing earlier.

### DIFF
--- a/impeller/renderer/backend/metal/surface_mtl.h
+++ b/impeller/renderer/backend/metal/surface_mtl.h
@@ -85,6 +85,7 @@ class SurfaceMTL final : public Surface {
   std::optional<IRect> clip_rect_;
   bool frame_boundary_ = false;
   bool present_with_transaction_ = false;
+  bool prepared_ = false;
 
   static bool ShouldPerformPartialRepaint(std::optional<IRect> damage_rect);
 

--- a/impeller/renderer/backend/metal/surface_mtl.h
+++ b/impeller/renderer/backend/metal/surface_mtl.h
@@ -65,6 +65,9 @@ class SurfaceMTL final : public Surface {
     present_with_transaction_ = present_with_transaction;
   }
 
+  /// @brief Perform the final blit and trigger end of frame workloads.
+  bool PreparePresent();
+
   // |Surface|
   bool Present() const override;
 

--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -259,11 +259,13 @@ bool SurfaceMTL::PreparePresent() {
 #ifdef IMPELLER_DEBUG
   ContextMTL::Cast(context.get())->GetGPUTracer()->MarkFrameEnd();
 #endif  // IMPELLER_DEBUG
+  prepared_ = true;
   return true;
 }
 
 // |Surface|
 bool SurfaceMTL::Present() const {
+  FML_CHECK(prepared_);
   auto context = context_.lock();
   if (!context) {
     return false;

--- a/impeller/renderer/backend/metal/surface_mtl.mm
+++ b/impeller/renderer/backend/metal/surface_mtl.mm
@@ -222,8 +222,7 @@ IRect SurfaceMTL::coverage() const {
   return IRect::MakeSize(resolve_texture_->GetSize());
 }
 
-// |Surface|
-bool SurfaceMTL::Present() const {
+bool SurfaceMTL::PreparePresent() {
   auto context = context_.lock();
   if (!context) {
     return false;
@@ -260,6 +259,15 @@ bool SurfaceMTL::Present() const {
 #ifdef IMPELLER_DEBUG
   ContextMTL::Cast(context.get())->GetGPUTracer()->MarkFrameEnd();
 #endif  // IMPELLER_DEBUG
+  return true;
+}
+
+// |Surface|
+bool SurfaceMTL::Present() const {
+  auto context = context_.lock();
+  if (!context) {
+    return false;
+  }
 
   if (drawable_) {
     id<MTLCommandBuffer> command_buffer =


### PR DESCRIPTION
Fixes the reported GPU time regression when rendering platform views. The problem was that we delayed the tracing of the end of the frame until the CATransaction, which artificially stretches out GPU frame time. Instead add a new method SurfaceMTL::PreparePResent which performs the final blit and tracing, call this in the encode callback.

Fixes: https://flutter-flutter-perf.skia.org/e/?queries=sub_result%3Daverage_gpu_frame_time%26test%3Dplatform_views_scroll_perf_ios__timeline_summary&selected=commit%3D41853%26name%3D%252Carch%253Dintel%252Cbranch%253Dmaster%252Cconfig%253Ddefault%252Cdevice_type%253DiPhone_11%252Cdevice_version%253Dnone%252Chost_type%253Dmac%252Csub_result%253Daverage_gpu_frame_time%252Ctest%253Dplatform_views_scroll_perf_ios__timeline_summary%252C

Test: benchmarks.