### PR TITLE
[iOS] Rename Flutter.dSYM to Flutter.framework.dSYM

### DIFF
--- a/sky/tools/create_full_ios_framework.py
+++ b/sky/tools/create_full_ios_framework.py
@@ -147,8 +147,8 @@ def create_framework(  # pylint: disable=too-many-arguments
   framework_dsym = None
   simulator_dsym = None
   if args.dsym:
-    framework_dsym = os.path.splitext(framework)[0] + '.dSYM'
-    simulator_dsym = os.path.splitext(simulator_framework)[0] + '.dSYM'
+    framework_dsym = framework + '.dSYM'
+    simulator_dsym = simulator_framework + '.dSYM'
 
   # Emit the framework for physical devices.
   shutil.rmtree(framework, True)
@@ -218,10 +218,25 @@ def zip_archive(dst):
       'extension_safe/Flutter.xcframework',
   ],
                         cwd=dst)
-  if os.path.exists(os.path.join(dst, 'Flutter.dSYM')):
+
+  # Generate Flutter.dSYM.zip for manual symbolification.
+  #
+  # Historically, the framework dSYM was named Flutter.dSYM, so in order to
+  # remain backward-compatible with existing instructions in docs/Crashes.md
+  # and existing tooling such as dart-lang/dart_ci, we rename back to that name
+  #
+  # TODO(cbracken): remove these archives and the upload steps once we bundle
+  # dSYMs in app archives. https://github.com/flutter/flutter/issues/116493
+  framework_dsym = os.path.join(dst, 'Flutter.framework.dSYM')
+  if os.path.exists(framework_dsym):
+    renamed_dsym = framework_dsym.replace('Flutter.framework.dSYM', 'Flutter.dSYM')
+    os.rename(framework_dsym, renamed_dsym)
     subprocess.check_call(['zip', '-r', 'Flutter.dSYM.zip', 'Flutter.dSYM'], cwd=dst)
 
-  if os.path.exists(os.path.join(dst, 'extension_safe', 'Flutter.dSYM')):
+  extension_safe_dsym = os.path.join(dst, 'extension_safe', 'Flutter.framework.dSYM')
+  if os.path.exists(extension_safe_dsym):
+    renamed_dsym = extension_safe_dsym.replace('Flutter.framework.dSYM', 'Flutter.dSYM')
+    os.rename(extension_safe_dsym, renamed_dsym)
     subprocess.check_call(['zip', '-r', 'extension_safe_Flutter.dSYM.zip', 'Flutter.dSYM'], cwd=dst)
 
 


### PR DESCRIPTION
Renames our Flutter framework dSYM to `Flutter.framework.dSYM` for consistency with all other dSYM bundle names. In iOS release archives, all other dSYM files are:

* `App.framework`: `App.framework.dSYM`
* `Runner.app`: `Runner.app.dSYM`

We continue to archive the dSYM to `Flutter.dSYM.zip` for backward compatibility with the existing instructions for manual symbolification in `docs/Crashes.md` and to remain compatible with dart-lang/dart-ci's symbolizer which expects `Flutter.dSYM` in [`Symbolizer._symbolizeIosFrames`][symbolizer].

Followup to: flutter/engine#54414
Issue: https://github.com/flutter/flutter/issues/116493
Motto: [Embrace the yak shave][yak_shave].

[symbolizer]: https://github.com/dart-lang/dart_ci/blob/e9fd9884a2c76184f4d20eb8a1cb48f92ec63ab5/github-label-notifier/symbolizer/lib/symbolizer.dart#L530
[yak_shave]: https://suno.com/song/f638a681-8d27-4cd7-a8bf-47de1443bbad

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
