### PR TITLE
[DisplayList] Allow random access to ops through indexing

### DIFF
--- a/display_list/display_list.cc
+++ b/display_list/display_list.cc
@@ -29,6 +29,21 @@ DisplayList::DisplayList()
       root_is_unbounded_(false),
       max_root_blend_mode_(DlBlendMode::kClear) {}
 
+// Eventually we should rework DisplayListBuilder to compute these and
+// deliver the vector alongside the storage.
+static std::vector<size_t> MakeOffsets(const DisplayListStorage& storage,
+                                       size_t byte_count) {
+  std::vector<size_t> offsets;
+  const uint8_t* start = storage.get();
+  const uint8_t* end = start + byte_count;
+  const uint8_t* ptr = start;
+  while (ptr < end) {
+    offsets.push_back(ptr - start);
+    ptr += reinterpret_cast<const DLOp*>(ptr)->size;
+  }
+  return offsets;
+}
+
 DisplayList::DisplayList(DisplayListStorage&& storage,
                          size_t byte_count,
                          uint32_t op_count,
@@ -44,6 +59,7 @@ DisplayList::DisplayList(DisplayListStorage&& storage,
                          bool root_is_unbounded,
                          sk_sp<const DlRTree> rtree)
     : storage_(std::move(storage)),
+      offsets_(MakeOffsets(storage_, byte_count)),
       byte_count_(byte_count),
       op_count_(op_count),
       nested_byte_count_(nested_byte_count),
@@ -73,86 +89,114 @@ uint32_t DisplayList::next_unique_id() {
   return id;
 }
 
-class Culler {
- public:
-  virtual ~Culler() = default;
-  virtual bool init(DispatchContext& context) = 0;
-  virtual void update(DispatchContext& context) = 0;
+struct SaveInfo {
+  SaveInfo(DlIndex previous_restore_index, bool save_was_needed)
+      : previous_restore_index(previous_restore_index),
+        save_was_needed(save_was_needed) {}
+
+  DlIndex previous_restore_index;
+  bool save_was_needed;
 };
-class NopCuller final : public Culler {
- public:
-  static NopCuller instance;
 
-  ~NopCuller() = default;
-
-  bool init(DispatchContext& context) override {
-    // Setting next_render_index to 0 means that
-    // all rendering ops will be at or after that
-    // index so they will execute and all restore
-    // indices will be after it as well so all
-    // clip and transform operations will execute.
-    context.next_render_index = 0;
-    return true;
+void DisplayList::RTreeResultsToIndexVector(
+    std::vector<DlIndex>& indices,
+    const std::vector<int>& rtree_results) const {
+  FML_DCHECK(rtree_);
+  auto cur_rect = rtree_results.begin();
+  auto end_rect = rtree_results.end();
+  if (cur_rect >= end_rect) {
+    return;
   }
-  void update(DispatchContext& context) override {}
-};
-NopCuller NopCuller::instance = NopCuller();
-class VectorCuller final : public Culler {
- public:
-  VectorCuller(const DlRTree* rtree, const std::vector<int>& rect_indices)
-      : rtree_(rtree), cur_(rect_indices.begin()), end_(rect_indices.end()) {}
-
-  ~VectorCuller() = default;
-
-  bool init(DispatchContext& context) override {
-    if (cur_ < end_) {
-      context.next_render_index = rtree_->id(*cur_++);
-      return true;
-    } else {
-      // Setting next_render_index to MAX_INT means that
-      // all rendering ops will be "before" that index and
-      // they will skip themselves and all clip and transform
-      // ops will see that the next render index is not
-      // before the next restore index (even if both are MAX_INT)
-      // and so they will also not execute.
-      // None of this really matters because returning false
-      // here should cause the Dispatch operation to abort,
-      // but this value is conceptually correct if that short
-      // circuit optimization isn't used.
-      context.next_render_index = std::numeric_limits<int>::max();
-      return false;
-    }
-  }
-  void update(DispatchContext& context) override {
-    if (++context.cur_index > context.next_render_index) {
-      while (cur_ < end_) {
-        context.next_render_index = rtree_->id(*cur_++);
-        if (context.next_render_index >= context.cur_index) {
-          // It should be rare that we have duplicate indices
-          // but if we do, then having a while loop is a cheap
-          // insurance for those cases.
-          // The main cause of duplicate indices is when a
-          // DrawDisplayListOp was added to this DisplayList and
-          // both are computing an R-Tree, in which case the
-          // builder method will forward all of the child
-          // DisplayList's rects to this R-Tree with the same
-          // op_index.
-          return;
+  DlIndex next_render_index = rtree_->id(*cur_rect++);
+  DlIndex next_restore_index = std::numeric_limits<DlIndex>::max();
+  std::vector<SaveInfo> save_infos;
+  for (DlIndex index = 0u; index < offsets_.size(); index++) {
+    while (index > next_render_index) {
+      if (cur_rect < end_rect) {
+        next_render_index = rtree_->id(*cur_rect++);
+      } else {
+        // Nothing left to render.
+        // Nothing left to do, but match our restores from the stack.
+        while (!save_infos.empty()) {
+          SaveInfo& info = save_infos.back();
+          // stack top boolean tells us whether the local variable
+          // next_restore_index should be executed. The local variable
+          // then gets reset to the value stored in the stack top
+          if (info.save_was_needed) {
+            FML_DCHECK(next_restore_index < offsets_.size());
+            indices.push_back(next_restore_index);
+          }
+          next_restore_index = info.previous_restore_index;
+          save_infos.pop_back();
         }
+        return;
       }
-      context.next_render_index = std::numeric_limits<int>::max();
+    }
+    const uint8_t* ptr = storage_.get() + offsets_[index];
+    const DLOp* op = reinterpret_cast<const DLOp*>(ptr);
+    switch (GetOpCategory(op->type)) {
+      case DisplayListOpCategory::kAttribute:
+        // Attributes are always needed
+        indices.push_back(index);
+        break;
+
+      case DisplayListOpCategory::kTransform:
+      case DisplayListOpCategory::kClip:
+        if (next_render_index < next_restore_index) {
+          indices.push_back(index);
+        }
+        break;
+
+      case DisplayListOpCategory::kRendering:
+      case DisplayListOpCategory::kSubDisplayList:
+        if (index == next_render_index) {
+          indices.push_back(index);
+        }
+        break;
+
+      case DisplayListOpCategory::kSave:
+      case DisplayListOpCategory::kSaveLayer: {
+        bool needed = (index < next_restore_index);
+        save_infos.emplace_back(next_restore_index, needed);
+        switch (op->type) {
+          case DisplayListOpType::kSave:
+          case DisplayListOpType::kSaveLayer:
+          case DisplayListOpType::kSaveLayerBackdrop:
+            next_restore_index =
+                static_cast<const SaveOpBase*>(op)->restore_index;
+            break;
+          default:
+            FML_UNREACHABLE();
+        }
+        if (needed) {
+          indices.push_back(index);
+        }
+        break;
+      }
+
+      case DisplayListOpCategory::kRestore: {
+        FML_DCHECK(!save_infos.empty());
+        FML_DCHECK(index == next_restore_index);
+        SaveInfo& info = save_infos.back();
+        next_restore_index = info.previous_restore_index;
+        if (info.save_was_needed) {
+          indices.push_back(index);
+        }
+        save_infos.pop_back();
+        break;
+      }
+
+      case DisplayListOpCategory::kInvalidCategory:
+        FML_UNREACHABLE();
     }
   }
-
- private:
-  const DlRTree* rtree_;
-  std::vector<int>::const_iterator cur_;
-  std::vector<int>::const_iterator end_;
-};
+}
 
 void DisplayList::Dispatch(DlOpReceiver& receiver) const {
-  const uint8_t* ptr = storage_.get();
-  Dispatch(receiver, ptr, ptr + byte_count_, NopCuller::instance);
+  const uint8_t* base = storage_.get();
+  for (size_t offset : offsets_) {
+    DispatchOneOp(receiver, base + offset);
+  }
 }
 
 void DisplayList::Dispatch(DlOpReceiver& receiver,
@@ -167,52 +211,36 @@ void DisplayList::Dispatch(DlOpReceiver& receiver,
   }
   if (!has_rtree() || cull_rect.contains(bounds())) {
     Dispatch(receiver);
-    return;
+  } else {
+    auto op_indices = GetCulledIndices(cull_rect);
+    const uint8_t* base = storage_.get();
+    for (DlIndex index : op_indices) {
+      DispatchOneOp(receiver, base + offsets_[index]);
+    }
   }
-  const DlRTree* rtree = this->rtree().get();
-  FML_DCHECK(rtree != nullptr);
-  const uint8_t* ptr = storage_.get();
-  std::vector<int> rect_indices;
-  rtree->search(cull_rect, &rect_indices);
-  VectorCuller culler(rtree, rect_indices);
-  Dispatch(receiver, ptr, ptr + byte_count_, culler);
 }
 
-void DisplayList::Dispatch(DlOpReceiver& receiver,
-                           const uint8_t* ptr,
-                           const uint8_t* end,
-                           Culler& culler) const {
-  DispatchContext context = {
-      .receiver = receiver,
-      .cur_index = 0,
-      // next_render_index will be initialized by culler.init()
-      .next_restore_index = std::numeric_limits<int>::max(),
-  };
-  if (!culler.init(context)) {
-    return;
-  }
-  while (ptr < end) {
-    auto op = reinterpret_cast<const DLOp*>(ptr);
-    ptr += op->size;
-    FML_DCHECK(ptr <= end);
-    switch (op->type) {
-#define DL_OP_DISPATCH(name)                             \
-  case DisplayListOpType::k##name:                       \
-    static_cast<const name##Op*>(op)->dispatch(context); \
+void DisplayList::DispatchOneOp(DlOpReceiver& receiver,
+                                const uint8_t* ptr) const {
+  auto op = reinterpret_cast<const DLOp*>(ptr);
+  switch (op->type) {
+#define DL_OP_DISPATCH(name)                              \
+  case DisplayListOpType::k##name:                        \
+    static_cast<const name##Op*>(op)->dispatch(receiver); \
     break;
 
-      FOR_EACH_DISPLAY_LIST_OP(DL_OP_DISPATCH)
+    FOR_EACH_DISPLAY_LIST_OP(DL_OP_DISPATCH)
+
 #ifdef IMPELLER_ENABLE_3D
-      DL_OP_DISPATCH(SetSceneColorSource)
+    DL_OP_DISPATCH(SetSceneColorSource)
 #endif  // IMPELLER_ENABLE_3D
 
 #undef DL_OP_DISPATCH
 
-      default:
-        FML_DCHECK(false);
-        return;
-    }
-    culler.update(context);
+    case DisplayListOpType::kInvalidOp:
+    default:
+      FML_DCHECK(false) << "Unrecognized op type: "
+                        << static_cast<int>(op->type);
   }
 }
 
@@ -230,6 +258,7 @@ void DisplayList::DisposeOps(const uint8_t* ptr, const uint8_t* end) {
     break;
 
       FOR_EACH_DISPLAY_LIST_OP(DL_OP_DISPOSE)
+
 #ifdef IMPELLER_ENABLE_3D
       DL_OP_DISPOSE(SetSceneColorSource)
 #endif  // IMPELLER_ENABLE_3D
@@ -240,6 +269,154 @@ void DisplayList::DisposeOps(const uint8_t* ptr, const uint8_t* end) {
         FML_UNREACHABLE();
     }
   }
+}
+
+DisplayListOpCategory DisplayList::GetOpCategory(DlIndex index) const {
+  return GetOpCategory(GetOpType(index));
+}
+
+DisplayListOpCategory DisplayList::GetOpCategory(DisplayListOpType type) {
+  switch (type) {
+    case DisplayListOpType::kSetAntiAlias:
+    case DisplayListOpType::kSetInvertColors:
+    case DisplayListOpType::kSetStrokeCap:
+    case DisplayListOpType::kSetStrokeJoin:
+    case DisplayListOpType::kSetStyle:
+    case DisplayListOpType::kSetStrokeWidth:
+    case DisplayListOpType::kSetStrokeMiter:
+    case DisplayListOpType::kSetColor:
+    case DisplayListOpType::kSetBlendMode:
+    case DisplayListOpType::kClearColorFilter:
+    case DisplayListOpType::kSetPodColorFilter:
+    case DisplayListOpType::kClearColorSource:
+    case DisplayListOpType::kSetPodColorSource:
+    case DisplayListOpType::kSetImageColorSource:
+    case DisplayListOpType::kSetRuntimeEffectColorSource:
+    case DisplayListOpType::kClearImageFilter:
+    case DisplayListOpType::kSetPodImageFilter:
+    case DisplayListOpType::kSetSharedImageFilter:
+    case DisplayListOpType::kClearMaskFilter:
+    case DisplayListOpType::kSetPodMaskFilter:
+#ifdef IMPELLER_ENABLE_3D
+    case DisplayListOpType::kSetSceneColorSource:
+#endif  // IMPELLER_ENABLE_3D
+      return DisplayListOpCategory::kAttribute;
+
+    case DisplayListOpType::kSave:
+      return DisplayListOpCategory::kSave;
+    case DisplayListOpType::kSaveLayer:
+    case DisplayListOpType::kSaveLayerBackdrop:
+      return DisplayListOpCategory::kSaveLayer;
+    case DisplayListOpType::kRestore:
+      return DisplayListOpCategory::kRestore;
+
+    case DisplayListOpType::kTranslate:
+    case DisplayListOpType::kScale:
+    case DisplayListOpType::kRotate:
+    case DisplayListOpType::kSkew:
+    case DisplayListOpType::kTransform2DAffine:
+    case DisplayListOpType::kTransformFullPerspective:
+    case DisplayListOpType::kTransformReset:
+      return DisplayListOpCategory::kTransform;
+
+    case DisplayListOpType::kClipIntersectRect:
+    case DisplayListOpType::kClipIntersectOval:
+    case DisplayListOpType::kClipIntersectRRect:
+    case DisplayListOpType::kClipIntersectPath:
+    case DisplayListOpType::kClipDifferenceRect:
+    case DisplayListOpType::kClipDifferenceOval:
+    case DisplayListOpType::kClipDifferenceRRect:
+    case DisplayListOpType::kClipDifferencePath:
+      return DisplayListOpCategory::kClip;
+
+    case DisplayListOpType::kDrawPaint:
+    case DisplayListOpType::kDrawColor:
+    case DisplayListOpType::kDrawLine:
+    case DisplayListOpType::kDrawDashedLine:
+    case DisplayListOpType::kDrawRect:
+    case DisplayListOpType::kDrawOval:
+    case DisplayListOpType::kDrawCircle:
+    case DisplayListOpType::kDrawRRect:
+    case DisplayListOpType::kDrawDRRect:
+    case DisplayListOpType::kDrawArc:
+    case DisplayListOpType::kDrawPath:
+    case DisplayListOpType::kDrawPoints:
+    case DisplayListOpType::kDrawLines:
+    case DisplayListOpType::kDrawPolygon:
+    case DisplayListOpType::kDrawVertices:
+    case DisplayListOpType::kDrawImage:
+    case DisplayListOpType::kDrawImageWithAttr:
+    case DisplayListOpType::kDrawImageRect:
+    case DisplayListOpType::kDrawImageNine:
+    case DisplayListOpType::kDrawImageNineWithAttr:
+    case DisplayListOpType::kDrawAtlas:
+    case DisplayListOpType::kDrawAtlasCulled:
+    case DisplayListOpType::kDrawTextBlob:
+    case DisplayListOpType::kDrawTextFrame:
+    case DisplayListOpType::kDrawShadow:
+    case DisplayListOpType::kDrawShadowTransparentOccluder:
+      return DisplayListOpCategory::kRendering;
+
+    case DisplayListOpType::kDrawDisplayList:
+      return DisplayListOpCategory::kSubDisplayList;
+
+    case DisplayListOpType::kInvalidOp:
+      return DisplayListOpCategory::kInvalidCategory;
+  }
+}
+
+DisplayListOpType DisplayList::GetOpType(DlIndex index) const {
+  // Assert unsigned type so we can eliminate >= 0 comparison
+  static_assert(std::is_unsigned_v<DlIndex>);
+  if (index >= offsets_.size()) {
+    return DisplayListOpType::kInvalidOp;
+  }
+
+  size_t offset = offsets_[index];
+  FML_DCHECK(offset < byte_count_);
+  auto ptr = storage_.get() + offset;
+  auto op = reinterpret_cast<const DLOp*>(ptr);
+  FML_DCHECK(ptr + op->size <= storage_.get() + byte_count_);
+  return op->type;
+}
+
+static void FillAllIndices(std::vector<DlIndex>& indices, DlIndex size) {
+  indices.reserve(size);
+  for (DlIndex i = 0u; i < size; i++) {
+    indices.push_back(i);
+  }
+}
+
+std::vector<DlIndex> DisplayList::GetCulledIndices(
+    const SkRect& cull_rect) const {
+  std::vector<DlIndex> indices;
+  if (!cull_rect.isEmpty()) {
+    if (rtree_) {
+      std::vector<int> rect_indices;
+      rtree_->search(cull_rect, &rect_indices);
+      RTreeResultsToIndexVector(indices, rect_indices);
+    } else {
+      FillAllIndices(indices, offsets_.size());
+    }
+  }
+  return indices;
+}
+
+bool DisplayList::Dispatch(DlOpReceiver& receiver, DlIndex index) const {
+  // Assert unsigned type so we can eliminate >= 0 comparison
+  static_assert(std::is_unsigned_v<DlIndex>);
+  if (index >= offsets_.size()) {
+    return false;
+  }
+
+  size_t offset = offsets_[index];
+  FML_DCHECK(offset < byte_count_);
+  auto ptr = storage_.get() + offset;
+  FML_DCHECK(offset + reinterpret_cast<const DLOp*>(ptr)->size <= byte_count_);
+
+  DispatchOneOp(receiver, ptr);
+
+  return true;
 }
 
 static bool CompareOps(const uint8_t* ptrA,
@@ -270,6 +447,7 @@ static bool CompareOps(const uint8_t* ptrA,
     break;
 
       FOR_EACH_DISPLAY_LIST_OP(DL_OP_EQUALS)
+
 #ifdef IMPELLER_ENABLE_3D
       DL_OP_EQUALS(SetSceneColorSource)
 #endif  // IMPELLER_ENABLE_3D

--- a/display_list/display_list.h
+++ b/display_list/display_list.h
@@ -142,11 +142,29 @@ namespace flutter {
 #define DL_OP_TO_ENUM_VALUE(name) k##name,
 enum class DisplayListOpType {
   FOR_EACH_DISPLAY_LIST_OP(DL_OP_TO_ENUM_VALUE)
+
 #ifdef IMPELLER_ENABLE_3D
       DL_OP_TO_ENUM_VALUE(SetSceneColorSource)
 #endif  // IMPELLER_ENABLE_3D
+
+  // empty comment to make formatter happy
+  kInvalidOp,
+  kMaxOp = kInvalidOp,
 };
 #undef DL_OP_TO_ENUM_VALUE
+
+enum class DisplayListOpCategory {
+  kAttribute,
+  kTransform,
+  kClip,
+  kSave,
+  kSaveLayer,
+  kRestore,
+  kRendering,
+  kSubDisplayList,
+  kInvalidCategory,
+  kMaxCategory = kInvalidCategory,
+};
 
 class DlOpReceiver;
 class DisplayListBuilder;
@@ -270,7 +288,7 @@ class DisplayListStorage {
   std::unique_ptr<uint8_t, FreeDeleter> ptr_;
 };
 
-class Culler;
+using DlIndex = uint32_t;
 
 // The base class that contains a sequence of rendering operations
 // for dispatch to a DlOpReceiver. These objects must be instantiated
@@ -360,6 +378,158 @@ class DisplayList : public SkRefCnt {
   /// be required for the indicated blend mode to do its work.
   DlBlendMode max_root_blend_mode() const { return max_root_blend_mode_; }
 
+  /// @brief   Iterator utility class used for the |DisplayList::begin|
+  ///          and |DisplayList::end| methods. It implements just the
+  ///          basic methods to enable iteration-style for loops.
+  class Iterator {
+   public:
+    DlIndex operator*() const { return value_; }
+    bool operator!=(const Iterator& other) { return value_ != other.value_; }
+    Iterator& operator++() {
+      value_++;
+      return *this;
+    }
+
+   private:
+    explicit Iterator(DlIndex value) : value_(value) {}
+
+    DlIndex value_;
+
+    friend class DisplayList;
+  };
+
+  /// @brief   Return the number of stored records in the DisplayList.
+  ///
+  /// Each stored record represents a dispatchable operation that will be
+  /// sent to a |DlOpReceiver| by the |Dispatch| method. You can directly
+  /// simulate the |Dispatch| method using a simple for loop on the indices:
+  ///
+  /// {
+  ///   for (DlIndex i = 0u; i < display_list->GetRecordCount(); i++) {
+  ///     display_list->Dispatch(my_receiver, i);
+  ///   }
+  /// }
+  ///
+  /// @see |Dispatch(receiver, index)|
+  /// @see |begin|
+  /// @see |end|
+  /// @see |GetCulledIndices|
+  DlIndex GetRecordCount() const { return offsets_.size(); }
+
+  /// @brief   Return an iterator to the start of the stored records,
+  ///          enabling the iteration form of a for loop.
+  ///
+  /// Each stored record represents a dispatchable operation that will be
+  /// sent to a |DlOpReceiver| by the |Dispatch| method. You can directly
+  /// simulate the |Dispatch| method using a simple for loop on the indices:
+  ///
+  /// {
+  ///   for (DlIndex i : *display_list) {
+  ///     display_list->Dispatch(my_receiver, i);
+  ///   }
+  /// }
+  ///
+  /// @see |end|
+  /// @see |GetCulledIndices|
+  Iterator begin() const { return Iterator(0u); }
+
+  /// @brief   Return an iterator to the end of the stored records,
+  ///          enabling the iteration form of a for loop.
+  ///
+  /// Each stored record represents a dispatchable operation that will be
+  /// sent to a |DlOpReceiver| by the |Dispatch| method. You can directly
+  /// simulate the |Dispatch| method using a simple for loop on the indices:
+  ///
+  /// {
+  ///   for (DlIndex i : *display_list) {
+  ///     display_list->Dispatch(my_receiver, i);
+  ///   }
+  /// }
+  ///
+  /// @see |begin|
+  /// @see |GetCulledIndices|
+  Iterator end() const { return Iterator(offsets_.size()); }
+
+  /// @brief   Dispatch a single stored operation by its index.
+  ///
+  /// Each stored record represents a dispatchable operation that will be
+  /// sent to a |DlOpReceiver| by the |Dispatch| method. You can use this
+  /// method to dispatch a single operation to your receiver with an index
+  /// between |0u| (inclusive) and |GetRecordCount()| (exclusive), as in:
+  ///
+  /// {
+  ///   for (DlIndex i = 0u; i < display_list->GetRecordCount(); i++) {
+  ///     display_list->Dispatch(my_receiver, i);
+  ///   }
+  /// }
+  ///
+  /// If the index is out of the range of the stored records, this method
+  /// will not call any methods on the receiver and return false. You can
+  /// check the return value for true if you want to make sure you are
+  /// using valid indices.
+  ///
+  /// @see |GetRecordCount|
+  /// @see |begin|
+  /// @see |end|
+  /// @see |GetCulledIndices|
+  bool Dispatch(DlOpReceiver& receiver, DlIndex index) const;
+
+  /// @brief   Return an enum describing the specific op type stored at
+  ///          the indicated index.
+  ///
+  /// The specific types of the records are subject to change without notice
+  /// as the DisplayList code is developed and optimized. These values are
+  /// useful mostly for debugging purposes and should not be used in
+  /// production code.
+  ///
+  /// @see |GetOpCategory| for a more stable description of the records
+  DisplayListOpType GetOpType(DlIndex index) const;
+
+  /// @brief   Return an enum describing the general category of the
+  ///          operation record stored at the indicated index.
+  ///
+  /// The categories are general and stable and can be used fairly safely
+  /// in production code to plan how to dispatch or reorder ops during
+  /// final rendering.
+  ///
+  /// @see |GetOpType| for a more detailed description of the records
+  ///                  primarily for debugging use
+  DisplayListOpCategory GetOpCategory(DlIndex index) const;
+
+  /// @brief   Return an enum describing the general category of the
+  ///          operation record with the given type.
+  ///
+  /// @see |GetOpType| for a more detailed description of the records
+  ///                  primarily for debugging use
+  static DisplayListOpCategory GetOpCategory(DisplayListOpType type);
+
+  /// @brief   Return a vector of valid indices for records stored in
+  ///          the DisplayList that must be dispatched if you are
+  ///          restricted to the indicated cull_rect.
+  ///
+  /// This method can be used along with indexed dispatching to implement
+  /// RTree culling while still maintaining control over planning of
+  /// operations to be rendered, as in:
+  ///
+  /// {
+  ///   std::vector<DlIndex> indices =
+  ///       display_list->GetCulledIndices(cull-rect);
+  ///   for (DlIndex i : indices) {
+  ///     display_list->Dispatch(my_receiver, i);
+  ///   }
+  /// }
+  ///
+  /// The indices returned in the vector will automatically deal with
+  /// including or culling related operations such as attributes, clips
+  /// and transforms that will provide state for any rendering operations
+  /// selected by the culling checks.
+  ///
+  /// @see |GetOpType| for a more detailed description of the records
+  ///                  primarily for debugging use
+  ///
+  /// @see |Dispatch(receiver, index)|
+  std::vector<DlIndex> GetCulledIndices(const SkRect& cull_rect) const;
+
  private:
   DisplayList(DisplayListStorage&& ptr,
               size_t byte_count,
@@ -381,6 +551,7 @@ class DisplayList : public SkRefCnt {
   static void DisposeOps(const uint8_t* ptr, const uint8_t* end);
 
   const DisplayListStorage storage_;
+  const std::vector<size_t> offsets_;
   const size_t byte_count_;
   const uint32_t op_count_;
 
@@ -401,10 +572,10 @@ class DisplayList : public SkRefCnt {
 
   const sk_sp<const DlRTree> rtree_;
 
-  void Dispatch(DlOpReceiver& ctx,
-                const uint8_t* ptr,
-                const uint8_t* end,
-                Culler& culler) const;
+  void DispatchOneOp(DlOpReceiver& receiver, const uint8_t* ptr) const;
+
+  void RTreeResultsToIndexVector(std::vector<DlIndex>& indices,
+                                 const std::vector<int>& rtree_results) const;
 
   friend class DisplayListBuilder;
 };

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -253,6 +253,70 @@ TEST_F(DisplayListTest, EmptyRebuild) {
   ASSERT_TRUE(dl2->Equals(dl3));
 }
 
+TEST_F(DisplayListTest, GeneralReceiverInitialValues) {
+  DisplayListGeneralReceiver receiver;
+
+  EXPECT_EQ(receiver.GetOpsReceived(), 0u);
+
+  auto max_type = static_cast<int>(DisplayListOpType::kMaxOp);
+  for (int i = 0; i <= max_type; i++) {
+    DisplayListOpType type = static_cast<DisplayListOpType>(i);
+    EXPECT_EQ(receiver.GetOpsReceived(type), 0u) << type;
+  }
+
+  auto max_category = static_cast<int>(DisplayListOpCategory::kMaxCategory);
+  for (int i = 0; i <= max_category; i++) {
+    DisplayListOpCategory category = static_cast<DisplayListOpCategory>(i);
+    EXPECT_EQ(receiver.GetOpsReceived(category), 0u) << category;
+  }
+}
+
+TEST_F(DisplayListTest, Iteration) {
+  DisplayListBuilder builder;
+  builder.DrawRect({10, 10, 20, 20}, DlPaint());
+  auto dl = builder.Build();
+  for (DlIndex i : *dl) {
+    EXPECT_EQ(dl->GetOpType(i), DisplayListOpType::kDrawRect)  //
+        << "at " << i;
+    EXPECT_EQ(dl->GetOpCategory(i), DisplayListOpCategory::kRendering)
+        << "at " << i;
+  }
+}
+
+TEST_F(DisplayListTest, InvalidIndices) {
+  DisplayListBuilder builder;
+  builder.DrawRect(kTestBounds, DlPaint());
+  auto dl = builder.Build();
+  DisplayListGeneralReceiver receiver;
+
+  EXPECT_FALSE(dl->Dispatch(receiver, -1));
+  EXPECT_FALSE(dl->Dispatch(receiver, dl->GetRecordCount()));
+  EXPECT_EQ(dl->GetOpType(-1), DisplayListOpType::kInvalidOp);
+  EXPECT_EQ(dl->GetOpType(dl->GetRecordCount()), DisplayListOpType::kInvalidOp);
+  EXPECT_EQ(dl->GetOpCategory(-1), DisplayListOpCategory::kInvalidCategory);
+  EXPECT_EQ(dl->GetOpCategory(dl->GetRecordCount()),
+            DisplayListOpCategory::kInvalidCategory);
+  EXPECT_EQ(dl->GetOpCategory(-1), DisplayListOpCategory::kInvalidCategory);
+  EXPECT_EQ(dl->GetOpCategory(DisplayListOpType::kInvalidOp),
+            DisplayListOpCategory::kInvalidCategory);
+  EXPECT_EQ(dl->GetOpCategory(DisplayListOpType::kMaxOp),
+            DisplayListOpCategory::kInvalidCategory);
+  EXPECT_EQ(receiver.GetOpsReceived(), 0u);
+}
+
+TEST_F(DisplayListTest, ValidIndices) {
+  DisplayListBuilder builder;
+  builder.DrawRect(kTestBounds, DlPaint());
+  auto dl = builder.Build();
+  DisplayListGeneralReceiver receiver;
+
+  EXPECT_EQ(dl->GetRecordCount(), 1u);
+  EXPECT_TRUE(dl->Dispatch(receiver, 0u));
+  EXPECT_EQ(dl->GetOpType(0u), DisplayListOpType::kDrawRect);
+  EXPECT_EQ(dl->GetOpCategory(0u), DisplayListOpCategory::kRendering);
+  EXPECT_EQ(receiver.GetOpsReceived(), 1u);
+}
+
 TEST_F(DisplayListTest, BuilderCanBeReused) {
   DisplayListBuilder builder(kTestBounds);
   builder.DrawRect(kTestBounds, DlPaint());
@@ -678,6 +742,38 @@ TEST_F(DisplayListTest, SingleOpDisplayListsRecapturedAreEqual) {
           group.op_name + "(variant " + std::to_string(i + 1) + " == copy)";
       ASSERT_TRUE(DisplayListsEQ_Verbose(dl, copy));
       ASSERT_EQ(copy->op_count(false), dl->op_count(false)) << desc;
+      ASSERT_EQ(copy->GetRecordCount(), dl->GetRecordCount());
+      ASSERT_EQ(copy->bytes(false), dl->bytes(false)) << desc;
+      ASSERT_EQ(copy->op_count(true), dl->op_count(true)) << desc;
+      ASSERT_EQ(copy->bytes(true), dl->bytes(true)) << desc;
+      ASSERT_EQ(copy->total_depth(), dl->total_depth()) << desc;
+      ASSERT_EQ(copy->bounds(), dl->bounds()) << desc;
+      ASSERT_TRUE(copy->Equals(*dl)) << desc;
+      ASSERT_TRUE(dl->Equals(*copy)) << desc;
+    }
+  }
+}
+
+TEST_F(DisplayListTest, SingleOpDisplayListsRecapturedByIndexAreEqual) {
+  for (auto& group : allGroups) {
+    for (size_t i = 0; i < group.variants.size(); i++) {
+      sk_sp<DisplayList> dl = Build(group.variants[i]);
+      // Verify recapturing the replay of the display list is Equals()
+      // when dispatching directly from the DL to another builder
+      DisplayListBuilder copy_builder;
+      DlOpReceiver& r = ToReceiver(copy_builder);
+      for (DlIndex i = 0; i < dl->GetRecordCount(); i++) {
+        EXPECT_NE(dl->GetOpType(i), DisplayListOpType::kInvalidOp);
+        EXPECT_NE(dl->GetOpCategory(i),
+                  DisplayListOpCategory::kInvalidCategory);
+        EXPECT_TRUE(dl->Dispatch(r, i));
+      }
+      sk_sp<DisplayList> copy = copy_builder.Build();
+      auto desc =
+          group.op_name + "(variant " + std::to_string(i + 1) + " == copy)";
+      ASSERT_TRUE(DisplayListsEQ_Verbose(dl, copy));
+      ASSERT_EQ(copy->op_count(false), dl->op_count(false)) << desc;
+      ASSERT_EQ(copy->GetRecordCount(), dl->GetRecordCount());
       ASSERT_EQ(copy->bytes(false), dl->bytes(false)) << desc;
       ASSERT_EQ(copy->op_count(true), dl->op_count(true)) << desc;
       ASSERT_EQ(copy->bytes(true), dl->bytes(true)) << desc;
@@ -3140,27 +3236,55 @@ TEST_F(DisplayListTest, RTreeOfClippedSaveLayerFilterScene) {
 }
 
 TEST_F(DisplayListTest, RTreeRenderCulling) {
+  SkRect rect1 = SkRect::MakeLTRB(0, 0, 10, 10);
+  SkRect rect2 = SkRect::MakeLTRB(20, 0, 30, 10);
+  SkRect rect3 = SkRect::MakeLTRB(0, 20, 10, 30);
+  SkRect rect4 = SkRect::MakeLTRB(20, 20, 30, 30);
+  DlPaint paint1 = DlPaint().setColor(DlColor::kRed());
+  DlPaint paint2 = DlPaint().setColor(DlColor::kGreen());
+  DlPaint paint3 = DlPaint().setColor(DlColor::kBlue());
+  DlPaint paint4 = DlPaint().setColor(DlColor::kMagenta());
+
   DisplayListBuilder main_builder(true);
-  DlOpReceiver& main_receiver = ToReceiver(main_builder);
-  main_receiver.drawRect({0, 0, 10, 10});
-  main_receiver.drawRect({20, 0, 30, 10});
-  main_receiver.drawRect({0, 20, 10, 30});
-  main_receiver.drawRect({20, 20, 30, 30});
+  main_builder.DrawRect(rect1, paint1);
+  main_builder.DrawRect(rect2, paint2);
+  main_builder.DrawRect(rect3, paint3);
+  main_builder.DrawRect(rect4, paint4);
   auto main = main_builder.Build();
 
-  auto test = [main](SkIRect cull_rect, const sk_sp<DisplayList>& expected) {
+  auto test = [main](SkIRect cull_rect, const sk_sp<DisplayList>& expected,
+                     const std::string& label) {
+    SkRect cull_rectf = SkRect::Make(cull_rect);
+
     {  // Test SkIRect culling
       DisplayListBuilder culling_builder;
       main->Dispatch(ToReceiver(culling_builder), cull_rect);
 
-      EXPECT_TRUE(DisplayListsEQ_Verbose(culling_builder.Build(), expected));
+      EXPECT_TRUE(DisplayListsEQ_Verbose(culling_builder.Build(), expected))
+          << "using cull rect " << cull_rect  //
+          << " where " << label;
     }
 
     {  // Test SkRect culling
       DisplayListBuilder culling_builder;
-      main->Dispatch(ToReceiver(culling_builder), SkRect::Make(cull_rect));
+      main->Dispatch(ToReceiver(culling_builder), cull_rectf);
 
-      EXPECT_TRUE(DisplayListsEQ_Verbose(culling_builder.Build(), expected));
+      EXPECT_TRUE(DisplayListsEQ_Verbose(culling_builder.Build(), expected))
+          << "using cull rect " << cull_rectf  //
+          << " where " << label;
+    }
+
+    {  // Test using vector of culled indices
+      DisplayListBuilder culling_builder;
+      DlOpReceiver& receiver = ToReceiver(culling_builder);
+      auto indices = main->GetCulledIndices(cull_rectf);
+      for (DlIndex i : indices) {
+        EXPECT_TRUE(main->Dispatch(receiver, i));
+      }
+
+      EXPECT_TRUE(DisplayListsEQ_Verbose(culling_builder.Build(), expected))
+          << "using culled indices on cull rect " << cull_rectf  //
+          << " where " << label;
     }
   };
 
@@ -3170,57 +3294,62 @@ TEST_F(DisplayListTest, RTreeRenderCulling) {
     DisplayListBuilder expected_builder;
     auto expected = expected_builder.Build();
 
-    test(cull_rect, expected);
+    test(cull_rect, expected, "no rects intersect");
   }
 
   {  // Rect 1
     SkIRect cull_rect = {9, 9, 19, 19};
 
     DisplayListBuilder expected_builder;
-    DlOpReceiver& expected_receiver = ToReceiver(expected_builder);
-    expected_receiver.drawRect({0, 0, 10, 10});
+    expected_builder.DrawRect(rect1, paint1);
     auto expected = expected_builder.Build();
 
-    test(cull_rect, expected);
+    test(cull_rect, expected, "rect 1 intersects");
   }
 
   {  // Rect 2
     SkIRect cull_rect = {11, 9, 21, 19};
 
     DisplayListBuilder expected_builder;
-    DlOpReceiver& expected_receiver = ToReceiver(expected_builder);
-    expected_receiver.drawRect({20, 0, 30, 10});
+    // Unfortunately we don't cull attribute records (yet?) until the last op
+    ToReceiver(expected_builder).setColor(paint1.getColor());
+    expected_builder.DrawRect(rect2, paint2);
     auto expected = expected_builder.Build();
 
-    test(cull_rect, expected);
+    test(cull_rect, expected, "rect 2 intersects");
   }
 
   {  // Rect 3
     SkIRect cull_rect = {9, 11, 19, 21};
 
     DisplayListBuilder expected_builder;
-    DlOpReceiver& expected_receiver = ToReceiver(expected_builder);
-    expected_receiver.drawRect({0, 20, 10, 30});
+    // Unfortunately we don't cull attribute records (yet?) until the last op
+    ToReceiver(expected_builder).setColor(paint1.getColor());
+    ToReceiver(expected_builder).setColor(paint2.getColor());
+    expected_builder.DrawRect(rect3, paint3);
     auto expected = expected_builder.Build();
 
-    test(cull_rect, expected);
+    test(cull_rect, expected, "rect 3 intersects");
   }
 
   {  // Rect 4
     SkIRect cull_rect = {11, 11, 21, 21};
 
     DisplayListBuilder expected_builder;
-    DlOpReceiver& expected_receiver = ToReceiver(expected_builder);
-    expected_receiver.drawRect({20, 20, 30, 30});
+    // Unfortunately we don't cull attribute records (yet?) until the last op
+    ToReceiver(expected_builder).setColor(paint1.getColor());
+    ToReceiver(expected_builder).setColor(paint2.getColor());
+    ToReceiver(expected_builder).setColor(paint3.getColor());
+    expected_builder.DrawRect(rect4, paint4);
     auto expected = expected_builder.Build();
 
-    test(cull_rect, expected);
+    test(cull_rect, expected, "rect 4 intersects");
   }
 
   {  // All 4 rects
     SkIRect cull_rect = {9, 9, 21, 21};
 
-    test(cull_rect, main);
+    test(cull_rect, main, "all rects intersect");
   }
 }
 

--- a/display_list/dl_builder.h
+++ b/display_list/dl_builder.h
@@ -510,7 +510,7 @@ class DisplayListBuilder final : public virtual DlCanvas,
   // Most rendering ops will use 1 depth value, but some attributes may
   // require an additional depth value (due to implicit saveLayers)
   uint32_t render_op_depth_cost_ = 1u;
-  int op_index_ = 0;
+  DlIndex op_index_ = 0;
 
   // bytes and ops from |drawPicture| and |drawDisplayList|
   size_t nested_bytes_ = 0;

--- a/testing/display_list_testing.cc
+++ b/testing/display_list_testing.cc
@@ -55,6 +55,8 @@ using DlVertexMode = flutter::DlVertexMode;
 using DlTileMode = flutter::DlTileMode;
 using DlImageSampling = flutter::DlImageSampling;
 using SaveLayerOptions = flutter::SaveLayerOptions;
+using DisplayListOpType = flutter::DisplayListOpType;
+using DisplayListOpCategory = flutter::DisplayListOpCategory;
 
 using DisplayListStreamDispatcher = flutter::testing::DisplayListStreamDispatcher;
 
@@ -99,43 +101,83 @@ std::ostream& operator<<(std::ostream& os, const DlPaint& paint) {
   return os << ")";
 }
 
+#define DLT_OSTREAM_CASE(enum_name, value_name) \
+  case enum_name::k##value_name: return os << #enum_name "::k" #value_name
+
 std::ostream& operator<<(std::ostream& os, const DlBlendMode& mode) {
   switch (mode) {
-    case DlBlendMode::kClear:      return os << "BlendMode::kClear";
-    case DlBlendMode::kSrc:        return os << "BlendMode::kSrc";
-    case DlBlendMode::kDst:        return os << "BlendMode::kDst";
-    case DlBlendMode::kSrcOver:    return os << "BlendMode::kSrcOver";
-    case DlBlendMode::kDstOver:    return os << "BlendMode::kDstOver";
-    case DlBlendMode::kSrcIn:      return os << "BlendMode::kSrcIn";
-    case DlBlendMode::kDstIn:      return os << "BlendMode::kDstIn";
-    case DlBlendMode::kSrcOut:     return os << "BlendMode::kSrcOut";
-    case DlBlendMode::kDstOut:     return os << "BlendMode::kDstOut";
-    case DlBlendMode::kSrcATop:    return os << "BlendMode::kSrcATop";
-    case DlBlendMode::kDstATop:    return os << "BlendMode::kDstATop";
-    case DlBlendMode::kXor:        return os << "BlendMode::kXor";
-    case DlBlendMode::kPlus:       return os << "BlendMode::kPlus";
-    case DlBlendMode::kModulate:   return os << "BlendMode::kModulate";
-    case DlBlendMode::kScreen:     return os << "BlendMode::kScreen";
+    DLT_OSTREAM_CASE(DlBlendMode, Clear);
+    DLT_OSTREAM_CASE(DlBlendMode, Src);
+    DLT_OSTREAM_CASE(DlBlendMode, Dst);
+    DLT_OSTREAM_CASE(DlBlendMode, SrcOver);
+    DLT_OSTREAM_CASE(DlBlendMode, DstOver);
+    DLT_OSTREAM_CASE(DlBlendMode, SrcIn);
+    DLT_OSTREAM_CASE(DlBlendMode, DstIn);
+    DLT_OSTREAM_CASE(DlBlendMode, SrcOut);
+    DLT_OSTREAM_CASE(DlBlendMode, DstOut);
+    DLT_OSTREAM_CASE(DlBlendMode, SrcATop);
+    DLT_OSTREAM_CASE(DlBlendMode, DstATop);
+    DLT_OSTREAM_CASE(DlBlendMode, Xor);
+    DLT_OSTREAM_CASE(DlBlendMode, Plus);
+    DLT_OSTREAM_CASE(DlBlendMode, Modulate);
+    DLT_OSTREAM_CASE(DlBlendMode, Screen);
 
-    case DlBlendMode::kOverlay:    return os << "BlendMode::kOverlay";
-    case DlBlendMode::kDarken:     return os << "BlendMode::kDarken";
-    case DlBlendMode::kLighten:    return os << "BlendMode::kLighten";
-    case DlBlendMode::kColorDodge: return os << "BlendMode::kColorDodge";
-    case DlBlendMode::kColorBurn:  return os << "BlendMode::kColorBurn";
-    case DlBlendMode::kHardLight:  return os << "BlendMode::kHardLight";
-    case DlBlendMode::kSoftLight:  return os << "BlendMode::kSoftLight";
-    case DlBlendMode::kDifference: return os << "BlendMode::kDifference";
-    case DlBlendMode::kExclusion:  return os << "BlendMode::kExclusion";
-    case DlBlendMode::kMultiply:   return os << "BlendMode::kMultiply";
+    DLT_OSTREAM_CASE(DlBlendMode, Overlay);
+    DLT_OSTREAM_CASE(DlBlendMode, Darken);
+    DLT_OSTREAM_CASE(DlBlendMode, Lighten);
+    DLT_OSTREAM_CASE(DlBlendMode, ColorDodge);
+    DLT_OSTREAM_CASE(DlBlendMode, ColorBurn);
+    DLT_OSTREAM_CASE(DlBlendMode, HardLight);
+    DLT_OSTREAM_CASE(DlBlendMode, SoftLight);
+    DLT_OSTREAM_CASE(DlBlendMode, Difference);
+    DLT_OSTREAM_CASE(DlBlendMode, Exclusion);
+    DLT_OSTREAM_CASE(DlBlendMode, Multiply);
 
-    case DlBlendMode::kHue:        return os << "BlendMode::kHue";
-    case DlBlendMode::kSaturation: return os << "BlendMode::kSaturation";
-    case DlBlendMode::kColor:      return os << "BlendMode::kColor";
-    case DlBlendMode::kLuminosity: return os << "BlendMode::kLuminosity";
-
-    default: return os << "BlendMode::????";
+    DLT_OSTREAM_CASE(DlBlendMode, Hue);
+    DLT_OSTREAM_CASE(DlBlendMode, Saturation);
+    DLT_OSTREAM_CASE(DlBlendMode, Color);
+    DLT_OSTREAM_CASE(DlBlendMode, Luminosity);
   }
+  // Not a valid enum, should never happen, but in case we encounter bad data.
+  return os << "DlBlendMode::????";
 }
+
+extern std::ostream& operator<<(std::ostream& os,
+                                const flutter::DisplayListOpType& type) {
+  switch (type) {
+#define DLT_OP_TYPE_CASE(V) DLT_OSTREAM_CASE(DisplayListOpType, V);
+    FOR_EACH_DISPLAY_LIST_OP(DLT_OP_TYPE_CASE)
+    DLT_OP_TYPE_CASE(InvalidOp)
+
+#ifdef IMPELLER_ENABLE_3D
+    DLT_OP_TYPE_CASE(SetSceneColorSource)
+#endif  // IMPELLER_ENABLE_3D
+
+
+#undef DLT_OP_TYPE_CASE
+  }
+  // Not a valid enum, should never happen, but in case we encounter bad data.
+  return os << "DisplayListOpType::???";
+}
+
+extern std::ostream& operator<<(
+    std::ostream& os, const flutter::DisplayListOpCategory& category) {
+  switch (category) {
+    DLT_OSTREAM_CASE(DisplayListOpCategory, Attribute);
+    DLT_OSTREAM_CASE(DisplayListOpCategory, Transform);
+    DLT_OSTREAM_CASE(DisplayListOpCategory, Clip);
+    DLT_OSTREAM_CASE(DisplayListOpCategory, Save);
+    DLT_OSTREAM_CASE(DisplayListOpCategory, SaveLayer);
+    DLT_OSTREAM_CASE(DisplayListOpCategory, Restore);
+    DLT_OSTREAM_CASE(DisplayListOpCategory, Rendering);
+    DLT_OSTREAM_CASE(DisplayListOpCategory, SubDisplayList);
+    DLT_OSTREAM_CASE(DisplayListOpCategory, InvalidCategory);
+  }
+  // Not a valid enum, should never happen, but in case we encounter bad data.
+  return os << "DisplayListOpCategory::???";
+}
+
+#undef DLT_OSTREAM_CASE
 
 std::ostream& operator<<(std::ostream& os, const SaveLayerOptions& options) {
   return os << "SaveLayerOptions("
@@ -480,6 +522,12 @@ void DisplayListStreamDispatcher::setColorSource(const DlColorSource* source) {
                                  << sweep_src->tile_mode() << ", " << sweep_src->matrix_ptr() << ")";
       break;
     }
+#ifdef IMPELLER_ENABLE_3D
+    case DlColorSourceType::kScene: {
+      os_ << "DlSceneColorSource()";
+      break;
+    }
+#endif  // IMPELLER_ENABLE_3D
     default:
       os_ << "?DlUnknownColorSource?()";
       break;

--- a/testing/display_list_testing.h
+++ b/testing/display_list_testing.h
@@ -75,6 +75,10 @@ extern std::ostream& operator<<(std::ostream& os,
                                 const flutter::DlImage* image);
 extern std::ostream& operator<<(std::ostream& os,
                                 const flutter::SaveLayerOptions& image);
+extern std::ostream& operator<<(std::ostream& os,
+                                const flutter::DisplayListOpType& type);
+extern std::ostream& operator<<(std::ostream& os,
+                                const flutter::DisplayListOpCategory& category);
 
 }  // namespace std
 
@@ -207,6 +211,398 @@ class DisplayListStreamDispatcher final : public DlOpReceiver {
   void out(const DlColorFilter* filter);
   void out(const DlImageFilter& filter);
   void out(const DlImageFilter* filter);
+};
+
+class DisplayListGeneralReceiver : public DlOpReceiver {
+ public:
+  DisplayListGeneralReceiver() {
+    type_counts_.fill(0u);
+    category_counts_.fill(0u);
+  }
+
+  void setAntiAlias(bool aa) override {
+    RecordByType(DisplayListOpType::kSetAntiAlias);
+  }
+  void setInvertColors(bool invert) override {
+    RecordByType(DisplayListOpType::kSetInvertColors);
+  }
+  void setStrokeCap(DlStrokeCap cap) override {
+    RecordByType(DisplayListOpType::kSetStrokeCap);
+  }
+  void setStrokeJoin(DlStrokeJoin join) override {
+    RecordByType(DisplayListOpType::kSetStrokeJoin);
+  }
+  void setDrawStyle(DlDrawStyle style) override {
+    RecordByType(DisplayListOpType::kSetStyle);
+  }
+  void setStrokeWidth(float width) override {
+    RecordByType(DisplayListOpType::kSetStrokeWidth);
+  }
+  void setStrokeMiter(float limit) override {
+    RecordByType(DisplayListOpType::kSetStrokeMiter);
+  }
+  void setColor(DlColor color) override {
+    RecordByType(DisplayListOpType::kSetColor);
+  }
+  void setBlendMode(DlBlendMode mode) override {
+    RecordByType(DisplayListOpType::kSetBlendMode);
+  }
+  void setColorSource(const DlColorSource* source) override {
+    if (source) {
+      switch (source->type()) {
+        case DlColorSourceType::kImage:
+          RecordByType(DisplayListOpType::kSetImageColorSource);
+          break;
+        case DlColorSourceType::kRuntimeEffect:
+          RecordByType(DisplayListOpType::kSetRuntimeEffectColorSource);
+          break;
+        case DlColorSourceType::kColor:
+        case DlColorSourceType::kLinearGradient:
+        case DlColorSourceType::kRadialGradient:
+        case DlColorSourceType::kConicalGradient:
+        case DlColorSourceType::kSweepGradient:
+          RecordByType(DisplayListOpType::kSetPodColorSource);
+          break;
+#ifdef IMPELLER_ENABLE_3D
+        case DlColorSourceType::kScene:
+          RecordByType(DisplayListOpType::kSetSceneColorSource);
+          break;
+#endif  // IMPELLER_ENABLE_3D
+      }
+    } else {
+      RecordByType(DisplayListOpType::kClearColorSource);
+    }
+  }
+  void setImageFilter(const DlImageFilter* filter) override {
+    if (filter) {
+      switch (filter->type()) {
+        case DlImageFilterType::kBlur:
+        case DlImageFilterType::kDilate:
+        case DlImageFilterType::kErode:
+        case DlImageFilterType::kMatrix:
+          RecordByType(DisplayListOpType::kSetPodImageFilter);
+          break;
+        case DlImageFilterType::kCompose:
+        case DlImageFilterType::kLocalMatrix:
+        case DlImageFilterType::kColorFilter:
+          RecordByType(DisplayListOpType::kSetSharedImageFilter);
+          break;
+      }
+    } else {
+      RecordByType(DisplayListOpType::kClearImageFilter);
+    }
+  }
+  void setColorFilter(const DlColorFilter* filter) override {
+    if (filter) {
+      switch (filter->type()) {
+        case DlColorFilterType::kBlend:
+        case DlColorFilterType::kMatrix:
+        case DlColorFilterType::kLinearToSrgbGamma:
+        case DlColorFilterType::kSrgbToLinearGamma:
+          RecordByType(DisplayListOpType::kSetPodColorFilter);
+          break;
+      }
+    } else {
+      RecordByType(DisplayListOpType::kClearColorFilter);
+    }
+  }
+  void setMaskFilter(const DlMaskFilter* filter) override {
+    if (filter) {
+      switch (filter->type()) {
+        case DlMaskFilterType::kBlur:
+          RecordByType(DisplayListOpType::kSetPodMaskFilter);
+          break;
+      }
+    } else {
+      RecordByType(DisplayListOpType::kClearMaskFilter);
+    }
+  }
+
+  void translate(SkScalar tx, SkScalar ty) override {
+    RecordByType(DisplayListOpType::kTranslate);
+  }
+  void scale(SkScalar sx, SkScalar sy) override {
+    RecordByType(DisplayListOpType::kScale);
+  }
+  void rotate(SkScalar degrees) override {
+    RecordByType(DisplayListOpType::kRotate);
+  }
+  void skew(SkScalar sx, SkScalar sy) override {
+    RecordByType(DisplayListOpType::kSkew);
+  }
+  // clang-format off
+  // 2x3 2D affine subset of a 4x4 transform in row major order
+  void transform2DAffine(SkScalar mxx, SkScalar mxy, SkScalar mxt,
+                         SkScalar myx, SkScalar myy, SkScalar myt) override {
+    RecordByType(DisplayListOpType::kTransform2DAffine);
+  }
+  // full 4x4 transform in row major order
+  void transformFullPerspective(
+      SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
+      SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
+      SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
+      SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) override {
+    RecordByType(DisplayListOpType::kTransformFullPerspective);
+  }
+  // clang-format on
+  void transformReset() override {
+    RecordByType(DisplayListOpType::kTransformReset);
+  }
+
+  void clipRect(const SkRect& rect,
+                DlCanvas::ClipOp clip_op,
+                bool is_aa) override {
+    switch (clip_op) {
+      case DlCanvas::ClipOp::kIntersect:
+        RecordByType(DisplayListOpType::kClipIntersectRect);
+        break;
+      case DlCanvas::ClipOp::kDifference:
+        RecordByType(DisplayListOpType::kClipDifferenceRect);
+        break;
+    }
+  }
+  void clipOval(const SkRect& bounds,
+                DlCanvas::ClipOp clip_op,
+                bool is_aa) override {
+    switch (clip_op) {
+      case DlCanvas::ClipOp::kIntersect:
+        RecordByType(DisplayListOpType::kClipIntersectOval);
+        break;
+      case DlCanvas::ClipOp::kDifference:
+        RecordByType(DisplayListOpType::kClipDifferenceOval);
+        break;
+    }
+  }
+  void clipRRect(const SkRRect& rrect,
+                 DlCanvas::ClipOp clip_op,
+                 bool is_aa) override {
+    switch (clip_op) {
+      case DlCanvas::ClipOp::kIntersect:
+        RecordByType(DisplayListOpType::kClipIntersectRRect);
+        break;
+      case DlCanvas::ClipOp::kDifference:
+        RecordByType(DisplayListOpType::kClipDifferenceRRect);
+        break;
+    }
+  }
+  void clipPath(const SkPath& path,
+                DlCanvas::ClipOp clip_op,
+                bool is_aa) override {
+    switch (clip_op) {
+      case DlCanvas::ClipOp::kIntersect:
+        RecordByType(DisplayListOpType::kClipIntersectPath);
+        break;
+      case DlCanvas::ClipOp::kDifference:
+        RecordByType(DisplayListOpType::kClipDifferencePath);
+        break;
+    }
+  }
+
+  void save() override { RecordByType(DisplayListOpType::kSave); }
+  void saveLayer(const SkRect& bounds,
+                 const SaveLayerOptions options,
+                 const DlImageFilter* backdrop) override {
+    if (backdrop) {
+      RecordByType(DisplayListOpType::kSaveLayerBackdrop);
+    } else {
+      RecordByType(DisplayListOpType::kSaveLayer);
+    }
+  }
+  void restore() override { RecordByType(DisplayListOpType::kRestore); }
+
+  void drawColor(DlColor color, DlBlendMode mode) override {
+    RecordByType(DisplayListOpType::kDrawColor);
+  }
+  void drawPaint() override { RecordByType(DisplayListOpType::kDrawPaint); }
+  void drawLine(const SkPoint& p0, const SkPoint& p1) override {
+    RecordByType(DisplayListOpType::kDrawLine);
+  }
+  void drawDashedLine(const DlPoint& p0,
+                      const DlPoint& p1,
+                      DlScalar on_length,
+                      DlScalar off_length) override {
+    RecordByType(DisplayListOpType::kDrawDashedLine);
+  }
+  void drawRect(const SkRect& rect) override {
+    RecordByType(DisplayListOpType::kDrawRect);
+  }
+  void drawOval(const SkRect& bounds) override {
+    RecordByType(DisplayListOpType::kDrawOval);
+  }
+  void drawCircle(const SkPoint& center, SkScalar radius) override {
+    RecordByType(DisplayListOpType::kDrawCircle);
+  }
+  void drawRRect(const SkRRect& rrect) override {
+    RecordByType(DisplayListOpType::kDrawRRect);
+  }
+  void drawDRRect(const SkRRect& outer, const SkRRect& inner) override {
+    RecordByType(DisplayListOpType::kDrawDRRect);
+  }
+  void drawPath(const SkPath& path) override {
+    RecordByType(DisplayListOpType::kDrawPath);
+  }
+  void drawArc(const SkRect& oval_bounds,
+               SkScalar start_degrees,
+               SkScalar sweep_degrees,
+               bool use_center) override {
+    RecordByType(DisplayListOpType::kDrawArc);
+  }
+  void drawPoints(DlCanvas::PointMode mode,
+                  uint32_t count,
+                  const SkPoint points[]) override {
+    switch (mode) {
+      case DlCanvas::PointMode::kPoints:
+        RecordByType(DisplayListOpType::kDrawPoints);
+        break;
+      case DlCanvas::PointMode::kLines:
+        RecordByType(DisplayListOpType::kDrawLines);
+        break;
+      case DlCanvas::PointMode::kPolygon:
+        RecordByType(DisplayListOpType::kDrawPolygon);
+        break;
+    }
+  }
+  void drawVertices(const std::shared_ptr<DlVertices>& vertices,
+                    DlBlendMode mode) override {
+    RecordByType(DisplayListOpType::kDrawVertices);
+  }
+  void drawImage(const sk_sp<DlImage> image,
+                 const SkPoint point,
+                 DlImageSampling sampling,
+                 bool render_with_attributes) override {
+    if (render_with_attributes) {
+      RecordByType(DisplayListOpType::kDrawImageWithAttr);
+    } else {
+      RecordByType(DisplayListOpType::kDrawImage);
+    }
+  }
+  void drawImageRect(const sk_sp<DlImage> image,
+                     const SkRect& src,
+                     const SkRect& dst,
+                     DlImageSampling sampling,
+                     bool render_with_attributes,
+                     SrcRectConstraint constraint) override {
+    RecordByType(DisplayListOpType::kDrawImageRect);
+  }
+  void drawImageNine(const sk_sp<DlImage> image,
+                     const SkIRect& center,
+                     const SkRect& dst,
+                     DlFilterMode filter,
+                     bool render_with_attributes) override {
+    if (render_with_attributes) {
+      RecordByType(DisplayListOpType::kDrawImageNineWithAttr);
+    } else {
+      RecordByType(DisplayListOpType::kDrawImageNine);
+    }
+  }
+  void drawAtlas(const sk_sp<DlImage> atlas,
+                 const SkRSXform xform[],
+                 const SkRect tex[],
+                 const DlColor colors[],
+                 int count,
+                 DlBlendMode mode,
+                 DlImageSampling sampling,
+                 const SkRect* cull_rect,
+                 bool render_with_attributes) override {
+    if (cull_rect) {
+      RecordByType(DisplayListOpType::kDrawAtlasCulled);
+    } else {
+      RecordByType(DisplayListOpType::kDrawAtlas);
+    }
+  }
+  void drawDisplayList(const sk_sp<DisplayList> display_list,
+                       SkScalar opacity) override {
+    RecordByType(DisplayListOpType::kDrawDisplayList);
+  }
+  void drawTextBlob(const sk_sp<SkTextBlob> blob,
+                    SkScalar x,
+                    SkScalar y) override {
+    RecordByType(DisplayListOpType::kDrawTextBlob);
+  }
+  void drawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
+                     SkScalar x,
+                     SkScalar y) override {
+    RecordByType(DisplayListOpType::kDrawTextFrame);
+  }
+  void drawShadow(const SkPath& path,
+                  const DlColor color,
+                  const SkScalar elevation,
+                  bool transparent_occluder,
+                  SkScalar dpr) override {
+    if (transparent_occluder) {
+      RecordByType(DisplayListOpType::kDrawShadowTransparentOccluder);
+    } else {
+      RecordByType(DisplayListOpType::kDrawShadow);
+    }
+  }
+
+  uint32_t GetOpsReceived() { return op_count_; }
+  uint32_t GetOpsReceived(DisplayListOpCategory category) {
+    return category_counts_[static_cast<int>(category)];
+  }
+  uint32_t GetOpsReceived(DisplayListOpType type) {
+    return type_counts_[static_cast<int>(type)];
+  }
+
+ protected:
+  virtual void RecordByType(DisplayListOpType type) {
+    type_counts_[static_cast<int>(type)]++;
+    RecordByCategory(DisplayList::GetOpCategory(type));
+  }
+
+  virtual void RecordByCategory(DisplayListOpCategory category) {
+    category_counts_[static_cast<int>(category)]++;
+    switch (category) {
+      case DisplayListOpCategory::kAttribute:
+        RecordAttribute();
+        break;
+      case DisplayListOpCategory::kTransform:
+        RecordTransform();
+        break;
+      case DisplayListOpCategory::kClip:
+        RecordClip();
+        break;
+      case DisplayListOpCategory::kSave:
+        RecordSave();
+        break;
+      case DisplayListOpCategory::kSaveLayer:
+        RecordSaveLayer();
+        break;
+      case DisplayListOpCategory::kRestore:
+        RecordRestore();
+        break;
+      case DisplayListOpCategory::kRendering:
+        RecordRendering();
+        break;
+      case DisplayListOpCategory::kSubDisplayList:
+        RecordSubDisplayList();
+        break;
+      case DisplayListOpCategory::kInvalidCategory:
+        RecordInvalid();
+        break;
+    }
+  }
+
+  virtual void RecordAttribute() { RecordOp(); }
+  virtual void RecordTransform() { RecordOp(); }
+  virtual void RecordClip() { RecordOp(); }
+  virtual void RecordSave() { RecordOp(); }
+  virtual void RecordSaveLayer() { RecordOp(); }
+  virtual void RecordRestore() { RecordOp(); }
+  virtual void RecordRendering() { RecordOp(); }
+  virtual void RecordSubDisplayList() { RecordOp(); }
+  virtual void RecordInvalid() { RecordOp(); }
+
+  virtual void RecordOp() { op_count_++; }
+
+  static constexpr size_t kTypeCount =
+      static_cast<size_t>(DisplayListOpType::kMaxOp) + 1;
+  static constexpr size_t kCategoryCount =
+      static_cast<size_t>(DisplayListOpCategory::kMaxCategory) + 1;
+
+  std::array<uint32_t, kTypeCount> type_counts_;
+  std::array<uint32_t, kCategoryCount> category_counts_;
+  uint32_t op_count_ = 0u;
 };
 
 }  // namespace testing


### PR DESCRIPTION
Being able to reorder rendering commands leads to optimization opportunities in the graphics package. A graphics package being fed from a DisplayList either has to take the commands in the order given or implement their own storage format for the rendering data.

With this new dispatching mechanism, the graphics package can both query basic information about the recorded ops and even dispatch them by the index into the list. Query information includes either the "category" of the op (clip/transform/render, etc.) or a specific op type enum. The package can dispatch some categories (or ops) immediately and remember other categories (or ops) along with their state for dispatching later.