### PR TITLE
Minimize decodeImageFromPixels CanvasKit / Skwasm heap usage

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -731,5 +731,3 @@ class LazyImageSource extends ImageSource {
   @override
   DomCanvasImageSource get canvasImageSource => imageData;
 }
-
-

--- a/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -538,6 +538,10 @@ class CkImage implements ui.Image, StackTraceDebugger {
           return readPixelsFromVideoFrame(videoFrame, format);
         }
       case LazyImageSource():
+        if(imageSource!.canvasImageSource.toJSAnyShallow.instanceof(imageDataConstructor) && format == ui.ImageByteFormat.rawRgba) {
+          final DomImageData imageData = imageSource!.canvasImageSource as DomImageData;
+          return Future<ByteData>.value(ByteData.view(imageData.data.buffer));
+        }
         return Future<ByteData>.value(_readPixelsFromImageViaSurface(format));
       case null:
     }

--- a/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -537,6 +537,8 @@ class CkImage implements ui.Image, StackTraceDebugger {
             videoFrame.format != 'I422') {
           return readPixelsFromVideoFrame(videoFrame, format);
         }
+      case LazyImageSource():
+        return Future<ByteData>.value(_readPixelsFromImageViaSurface(format));
       case null:
     }
     ByteData? data = _readPixelsFromSkImage(format);
@@ -709,3 +711,25 @@ class ImageBitmapImageSource extends ImageSource {
   @override
   DomCanvasImageSource get canvasImageSource => imageBitmap;
 }
+
+class LazyImageSource extends ImageSource {
+  LazyImageSource(this.imageData, { required this.width, required this.height });
+
+  DomCanvasImageSource imageData;
+
+  @override
+  void close() {
+    // do nothing, let browser garbage collect
+  }
+
+  @override
+  final int height;
+
+  @override
+  final int width;
+
+  @override
+  DomCanvasImageSource get canvasImageSource => imageData;
+}
+
+

--- a/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
@@ -260,7 +260,7 @@ class CanvasKitRenderer implements Renderer {
     if (skImage == null) {
       throw Exception('Failed to convert image bitmap to an SkImage.');
     }
-    return CkImage(skImage);
+    return CkImage(skImage, imageSource: LazyImageSource(object as DomCanvasImageSource, width: width, height: height));
   }
 
   @override
@@ -298,8 +298,7 @@ class CanvasKitRenderer implements Renderer {
     final BitmapSize? size = scaledImageSize(width, height, targetWidth, targetHeight);
 
     final FutureOr<ui.Image> image = createImageFromTextureSource(
-        ImageData(convertedPixels.toJS, width, height.toJS,
-            <String,dynamic>{ 'colorSpace' : 'srgb' }.toJSAnyShallow ).toJSAnyShallow,
+        createDomImageData(convertedPixels.toJS, width, height).toJSAnyShallow,
         width: size?.width ?? width,
         height: size?.height ?? height,
         transferOwnership: true);

--- a/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
@@ -269,12 +269,46 @@ class CanvasKitRenderer implements Renderer {
           {int? rowBytes,
           int? targetWidth,
           int? targetHeight,
-          bool allowUpscaling = true}) =>
-      skiaDecodeImageFromPixels(pixels, width, height, format, callback,
-          rowBytes: rowBytes,
-          targetWidth: targetWidth,
-          targetHeight: targetHeight,
-          allowUpscaling: allowUpscaling);
+          bool allowUpscaling = true}) {
+
+    if (targetWidth != null) {
+      assert(allowUpscaling || targetWidth <= width);
+    }
+    if (targetHeight != null) {
+      assert(allowUpscaling || targetHeight <= height);
+    }
+
+    late final Uint8ClampedList convertedPixels;
+    if(format == ui.PixelFormat.bgra8888) {
+      convertedPixels = Uint8ClampedList(width * height * 4);
+      var offset = 0;
+      for (var y = 0; y < height; y++) {
+        for (var x = 0; x < width; x++) {
+          convertedPixels[offset] = pixels[offset + 2]; // r
+          convertedPixels[offset + 1] = pixels[offset + 1]; // g
+          convertedPixels[offset + 2] = pixels[offset]; // b
+          convertedPixels[offset + 3] = pixels[offset + 3]; // a
+          offset+=4;
+        }
+      }
+    } else {
+      convertedPixels = Uint8ClampedList.view(pixels.buffer);
+    }
+
+    final BitmapSize? size = scaledImageSize(width, height, targetWidth, targetHeight);
+
+    final FutureOr<ui.Image> image = createImageFromTextureSource(
+        ImageData(convertedPixels.toJS, width, height.toJS,
+            <String,dynamic>{ 'colorSpace' : 'srgb' }.toJSAnyShallow ).toJSAnyShallow,
+        width: size?.width ?? width,
+        height: size?.height ?? height,
+        transferOwnership: true);
+
+    (() async {
+      callback(await image);
+    })();
+
+  }
 
   @override
   ui.ImageShader createImageShader(

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -1509,6 +1509,9 @@ class DomImageData {
   external factory DomImageData._empty(JSNumber sw, JSNumber sh);
 }
 
+@JS('ImageData')
+external JSFunction get imageDataConstructor;
+
 DomImageData createDomImageData(Object data, int sw, int sh) =>
     DomImageData._(data.toJSAnyShallow, sw.toJS, sh.toJS);
 DomImageData createBlankDomImageData(int sw, int sh) =>

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -225,60 +225,6 @@ typedef PredefinedColorSpace = String;
 
 @JS()
 @staticInterop
-class ImageData  {
-   external factory ImageData(
-    JSAny dataOrSw,
-    int shOrSw, [
-    JSAny settingsOrSh,
-    JSAny settings,
-  ]);
-}
-
-
-/// The **`ImageData`** interface represents the underlying pixel data of an
-/// area of a `canvas` element.
-///
-/// It is created using the [ImageData.ImageData] constructor or creator methods
-/// on the [CanvasRenderingContext2D] object associated with a canvas:
-/// [CanvasRenderingContext2D.createImageData] and
-/// [CanvasRenderingContext2D.getImageData]. It can also be used to set a part
-/// of the canvas by using [CanvasRenderingContext2D.putImageData].
-///
-/// ---
-///
-/// API documentation sourced from
-/// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/ImageData).
-extension ImageDataExtension on ImageData {
-
-  /// The readonly **`ImageData.width`** property returns the number
-  /// of pixels per row in the [ImageData] object.
-  external int get width;
-
-  /// The readonly **`ImageData.height`** property returns the number
-  /// of rows in the [ImageData] object.
-  external int get height;
-
-  /// The readonly **`ImageData.data`** property returns a
-  /// `Uint8ClampedArray` that contains the [ImageData] object's
-  /// pixel data. Data is stored as a one-dimensional array in the RGBA order,
-  /// with integer
-  /// values between `0` and `255` (inclusive).
-  external JSUint8ClampedArray get data;
-
-  /// The read-only **`ImageData.colorSpace`** property is a string indicating
-  /// the color space of the image data.
-  ///
-  /// The color space can be set during `ImageData` initialization using either
-  /// the
-  /// [`ImageData()`](https://developer.mozilla.org/en-US/docs/Web/API/ImageData/ImageData)
-  /// constructor or the
-  /// [`createImageData()`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/createImageData)
-  /// method.
-  external PredefinedColorSpace get colorSpace;
-}
-
-@JS()
-@staticInterop
 class DomNavigator {}
 
 extension DomNavigatorExtension on DomNavigator {
@@ -1572,8 +1518,10 @@ extension DomImageDataExtension on DomImageData {
   @JS('data')
   external JSUint8ClampedArray get _data;
   Uint8ClampedList get data => _data.toDart;
+  external int get width;
+  external int get height;
+  external PredefinedColorSpace get colorSpace;
 }
-
 
 @JS('Uint8ClampedArray')
 @staticInterop

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -220,6 +220,63 @@ Future<DomImageBitmap> createImageBitmap(JSAny source,
   return js_util.promiseToFuture<DomImageBitmap>(jsPromise);
 }
 
+typedef PredefinedColorSpace = String;
+
+
+@JS()
+@staticInterop
+class ImageData  {
+   external factory ImageData(
+    JSAny dataOrSw,
+    int shOrSw, [
+    JSAny settingsOrSh,
+    JSAny settings,
+  ]);
+}
+
+
+/// The **`ImageData`** interface represents the underlying pixel data of an
+/// area of a `canvas` element.
+///
+/// It is created using the [ImageData.ImageData] constructor or creator methods
+/// on the [CanvasRenderingContext2D] object associated with a canvas:
+/// [CanvasRenderingContext2D.createImageData] and
+/// [CanvasRenderingContext2D.getImageData]. It can also be used to set a part
+/// of the canvas by using [CanvasRenderingContext2D.putImageData].
+///
+/// ---
+///
+/// API documentation sourced from
+/// [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/ImageData).
+extension ImageDataExtension on ImageData {
+
+  /// The readonly **`ImageData.width`** property returns the number
+  /// of pixels per row in the [ImageData] object.
+  external int get width;
+
+  /// The readonly **`ImageData.height`** property returns the number
+  /// of rows in the [ImageData] object.
+  external int get height;
+
+  /// The readonly **`ImageData.data`** property returns a
+  /// `Uint8ClampedArray` that contains the [ImageData] object's
+  /// pixel data. Data is stored as a one-dimensional array in the RGBA order,
+  /// with integer
+  /// values between `0` and `255` (inclusive).
+  external JSUint8ClampedArray get data;
+
+  /// The read-only **`ImageData.colorSpace`** property is a string indicating
+  /// the color space of the image data.
+  ///
+  /// The color space can be set during `ImageData` initialization using either
+  /// the
+  /// [`ImageData()`](https://developer.mozilla.org/en-US/docs/Web/API/ImageData/ImageData)
+  /// constructor or the
+  /// [`createImageData()`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/createImageData)
+  /// method.
+  external PredefinedColorSpace get colorSpace;
+}
+
 @JS()
 @staticInterop
 class DomNavigator {}
@@ -1515,6 +1572,18 @@ extension DomImageDataExtension on DomImageData {
   @JS('data')
   external JSUint8ClampedArray get _data;
   Uint8ClampedList get data => _data.toDart;
+}
+
+
+@JS('Uint8ClampedArray')
+@staticInterop
+class JSUint8ClampedArrayData {
+  external factory JSUint8ClampedArrayData(JSAny any);
+}
+
+extension JSUint8ClampedArrayDataExtension on JSUint8ClampedArrayData {
+  external ExternalDartReference operator [](int index);
+  external void operator []=(int index, ExternalDartReference value);
 }
 
 @JS('ImageBitmap')

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/image.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/image.dart
@@ -82,6 +82,11 @@ class SkwasmImage extends SkwasmObjectWrapper<RawImage> implements ui.Image {
     }
   }
 
+  Future<Uint8ClampedList> toUint8ClampedList(
+      {ui.ImageByteFormat format = ui.ImageByteFormat.rawRgba}) async {
+    return (renderer as SkwasmRenderer).surface.rasterizeImageJS(this, format);
+  }
+
   @override
   ui.ColorSpace get colorSpace => ui.ColorSpace.sRGB;
 

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
@@ -349,8 +349,7 @@ class SkwasmRenderer implements Renderer {
 
     try {
       (() async {
-        final JSAny imageData = ImageData((await pixelImage.toUint8ClampedList()).toJSAnyShallow, width, height.toJS,
-              <String,dynamic>{ 'colorSpace' : 'srgb' }.toJSAnyShallow).toJSAnyShallow;
+        final JSAny imageData = createDomImageData((await pixelImage.toUint8ClampedList()).toJSAnyShallow, width, height).toJSAnyShallow;
 
         final BitmapSize? size = scaledImageSize(width, height, targetWidth, targetHeight);
 


### PR DESCRIPTION
This PR minimizes the heap usage in CanvasKit and SkWasm when using decodeImageFromPixels, by utilizing the new createImageFromTextureSource API to keep the image data off the CanvasKit heap. 

Fixes: https://github.com/flutter/flutter/issues/153184

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
