### PR TITLE
[iOS] Do not archive/upload Flutter.dSYM to cloud

### DIFF
--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -540,16 +540,6 @@
             "source": "out/release/artifacts.zip",
             "destination": "ios-release/artifacts.zip",
             "realm": "production"
-        },
-        {
-            "source": "out/release/Flutter.dSYM.zip",
-            "destination": "ios-release/Flutter.dSYM.zip",
-            "realm": "production"
-        },
-        {
-            "source": "out/release/extension_safe_Flutter.dSYM.zip",
-            "destination": "ios-release/extension_safe_Flutter.dSYM.zip",
-            "realm": "production"
         }
     ]
 }

--- a/sky/tools/create_full_ios_framework.py
+++ b/sky/tools/create_full_ios_framework.py
@@ -219,26 +219,6 @@ def zip_archive(dst):
   ],
                         cwd=dst)
 
-  # Generate Flutter.dSYM.zip for manual symbolification.
-  #
-  # Historically, the framework dSYM was named Flutter.dSYM, so in order to
-  # remain backward-compatible with existing instructions in docs/Crashes.md
-  # and existing tooling such as dart-lang/dart_ci, we rename back to that name
-  #
-  # TODO(cbracken): remove these archives and the upload steps once we bundle
-  # dSYMs in app archives. https://github.com/flutter/flutter/issues/116493
-  framework_dsym = os.path.join(dst, 'Flutter.framework.dSYM')
-  if os.path.exists(framework_dsym):
-    renamed_dsym = framework_dsym.replace('Flutter.framework.dSYM', 'Flutter.dSYM')
-    os.rename(framework_dsym, renamed_dsym)
-    subprocess.check_call(['zip', '-r', 'Flutter.dSYM.zip', 'Flutter.dSYM'], cwd=dst)
-
-  extension_safe_dsym = os.path.join(dst, 'extension_safe', 'Flutter.framework.dSYM')
-  if os.path.exists(extension_safe_dsym):
-    renamed_dsym = extension_safe_dsym.replace('Flutter.framework.dSYM', 'Flutter.dSYM')
-    os.rename(extension_safe_dsym, renamed_dsym)
-    subprocess.check_call(['zip', '-r', 'extension_safe_Flutter.dSYM.zip', 'Flutter.dSYM'], cwd=dst)
-
 
 def process_framework(args, dst, framework_binary, dsym):
   if dsym:


### PR DESCRIPTION
As of the following three patches, we now bundle Flutter.framework.dSYM as part of Flutter.xcframework and bundle them in the .xcarchive bundles produced by `flutter build ipa` / Xcode Product > Archive for upload to the iOS App Store.

* https://github.com/flutter/engine/pull/54414
* https://github.com/flutter/engine/pull/54458
* https://github.com/flutter/flutter/pull/153215

The .dSYM bundle is now available both in the uploaded .xcarchive and in the xcframework in Flutter's internal artifact cache. For developers with CI toolchains that do additional manual handling or local archiving of .dSYMs, the dSYMs no longer need to be downloaded from cloud storage as previously detailed in `docs/Crashes.md`, but can instead be copied up from the appropriate dSYM subdirectory in the framework cache:

* `flutter/bin/cache/artifacts/engine/ios-release/Flutter.xcframework`

Issue: https://github.com/flutter/flutter/issues/116493
Credo: [Embrace the yak shave](https://suno.com/song/37cb7c43-85ad-40f2-87e6-9aec7baa0419)

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
