### PR TITLE
Add `format` field to EGL surface backing store

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -868,7 +868,7 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
     const FlutterOpenGLSurface* surface) {
 #ifdef SHELL_ENABLE_GL
   GrGLFramebufferInfo framebuffer_info = {};
-  framebuffer_info.fFormat = GL_BGRA8_EXT;
+  framebuffer_info.fFormat = SAFE_ACCESS(surface, format, GL_BGRA8_EXT);
   framebuffer_info.fFBOID = 0;
 
   auto backend_render_target =

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -881,11 +881,17 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
 
   SkSurfaceProps surface_properties(0, kUnknown_SkPixelGeometry);
 
+  std::optional<SkColorType> color_type =
+      FlutterFormatToSkColorType(surface->format);
+  if (!color_type) {
+    return nullptr;
+  }
+
   auto sk_surface = SkSurfaces::WrapBackendRenderTarget(
       context,                      //  context
       backend_render_target,        // backend render target
       kBottomLeft_GrSurfaceOrigin,  // surface origin
-      kN32_SkColorType,             // color type
+      color_type.value(),           // color type
       SkColorSpace::MakeSRGB(),     // color space
       &surface_properties,          // surface properties
       static_cast<SkSurfaces::RenderTargetReleaseProc>(

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -458,6 +458,13 @@ typedef struct {
   ///
   /// @attention required. (non-null)
   VoidCallback destruction_callback;
+
+  /// The surface format.
+  ///
+  /// Allowed values:
+  ///   - GL_RGBA8
+  ///   - GL_BGRA8_EXT
+  uint32_t format;
 } FlutterOpenGLSurface;
 
 typedef bool (*BoolCallback)(void* /* user data */);

--- a/shell/platform/embedder/tests/embedder_assertions.h
+++ b/shell/platform/embedder/tests/embedder_assertions.h
@@ -70,7 +70,7 @@ inline bool operator==(const FlutterOpenGLFramebuffer& a,
 inline bool operator==(const FlutterOpenGLSurface& a,
                        const FlutterOpenGLSurface& b) {
   return a.make_current_callback == b.make_current_callback &&
-         a.user_data == b.user_data &&
+         a.user_data == b.user_data && a.format == b.format &&
          a.destruction_callback == b.destruction_callback;
 }
 
@@ -309,7 +309,8 @@ inline std::ostream& operator<<(std::ostream& out,
                                 const FlutterOpenGLSurface& item) {
   return out << "(FlutterOpenGLSurface) Make Current Callback: "
              << reinterpret_cast<void*>(item.make_current_callback)
-             << " User Data: " << item.user_data << " Destruction Callback: "
+             << " User Data: " << item.user_data << "Format: " << item.format
+             << " Destruction Callback: "
              << reinterpret_cast<void*>(item.destruction_callback);
 }
 

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
@@ -258,6 +258,7 @@ bool EmbedderTestBackingStoreProducer::CreateSurface(
   backing_store_out->open_gl.surface.clear_current_callback = clear_current;
   backing_store_out->open_gl.surface.destruction_callback =
       destruction_callback;
+  backing_store_out->open_gl.surface.format = 0x93A1 /* GL_BGRA8_EXT */;
 
   return true;
 #else


### PR DESCRIPTION
Trying to use the `GL_BGRA8_EXT` format for the EGL surface backing store on *desktop* OpenGL platforms would fail at: https://github.com/flutter/engine/blob/bde314b856850155d0678632b62c23c84f49afab/shell/platform/embedder/embedder.cc#L869

This seems to be a known issue and both the Linux and Windows embedders have some logic to pick a different format depending on the OpenGL context information:

https://github.com/flutter/engine/blob/088dcfa6cf934088413c5d8af754de1ef7b0d1ca/shell/platform/windows/compositor_opengl.cc#L23-L34

https://github.com/flutter/engine/blob/088dcfa6cf934088413c5d8af754de1ef7b0d1ca/shell/platform/linux/fl_framebuffer.cc#L81-L104

This pull-request gets rid of the hard-coded `GL_BGRA8_EXT` format and makes it configurable by adding a `format` field to the `FlutterOpenGLSurface` struct.

_Disclaimer_: This has only been tested on desktop Linux (Wayland) using the `GR_GL_RGBA8` format which seemed to work as expected.

This change is related to the recently introduced EGL surface backing store: https://github.com/flutter/flutter/issues/58363

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
