### PR TITLE
Preserve background frame damage

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/platform_views_controller.mm
+++ b/shell/platform/darwin/ios/framework/Source/platform_views_controller.mm
@@ -679,7 +679,12 @@ bool PlatformViewsController::SubmitFrame(GrDirectContext* gr_context,
     overlay_id++;
   }
 
-  background_frame->set_submit_info({.present_with_transaction = true});
+  auto previous_submit_info = background_frame->submit_info();
+  background_frame->set_submit_info({
+      .frame_damage = previous_submit_info.frame_damage,
+      .buffer_damage = previous_submit_info.buffer_damage,
+      .present_with_transaction = true,
+  });
   background_frame->Encode();
   surface_frames.push_back(std::move(background_frame));
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/153335

When platform views are present, we always repaint entire frame. We must pass the buffer damage all the way to `GPUSurfaceMetalSkia/GPUSurfaceMetalImpeller` so that they know that the other two surfaces are lagging behind front surface and need to be repainted.

This is currently not being done with platform view present, that's why we miss full frame repaint when removing platform view.

With this merged in, it should be safe to reland https://github.com/flutter/engine/pull/54537 without any changes.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
