### PR TITLE
Chain FlView plugin registrar call to engine implementation.

### DIFF
--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -283,10 +283,8 @@ static FlPluginRegistrar* fl_view_get_registrar_for_plugin(
     FlPluginRegistry* registry,
     const gchar* name) {
   FlView* self = FL_VIEW(registry);
-
-  return fl_plugin_registrar_new(self,
-                                 fl_engine_get_binary_messenger(self->engine),
-                                 fl_engine_get_texture_registrar(self->engine));
+  return fl_plugin_registry_get_registrar_for_plugin(
+      FL_PLUGIN_REGISTRY(self->engine), name);
 }
 
 static void fl_view_plugin_registry_iface_init(


### PR DESCRIPTION
The engine became a plugin registrar when headless was supported (01e06ed3d99). Call this version from the FlView instead of duplicating the code. As we go to multi-view the use of FlView as a plugin registrar should be deprecated.
