### PR TITLE
iOS: Add dSYM binaries to without_entitlements.txt

### DIFF
--- a/sky/tools/create_ios_framework.py
+++ b/sky/tools/create_ios_framework.py
@@ -164,26 +164,35 @@ def create_framework(  # pylint: disable=too-many-arguments
 
 
 def zip_archive(dst):
-  sky_utils.write_codesign_config(os.path.join(dst, 'entitlements.txt'), ['gen_snapshot_arm64'])
+  # pylint: disable=line-too-long
+  with_entitlements = ['gen_snapshot_arm64']
+  with_entitlements_file = os.path.join(dst, 'entitlements.txt')
+  sky_utils.write_codesign_config(with_entitlements_file, with_entitlements)
 
-  sky_utils.write_codesign_config(
-      os.path.join(dst, 'without_entitlements.txt'), [
-          'Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
-          'Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
-          'extension_safe/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
-          'extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter'
-      ]
-  )
+  without_entitlements = [
+      'Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
+      'Flutter.xcframework/ios-arm64/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
+      'Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
+      'Flutter.xcframework/ios-arm64_x86_64-simulator/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
+      'extension_safe/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
+      'extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
+      'extension_safe/Flutter.xcframework/ios-arm64/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
+      'extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
+      'extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
+  ]
+  without_entitlements_file = os.path.join(dst, 'without_entitlements.txt')
+  sky_utils.write_codesign_config(without_entitlements_file, without_entitlements)
+  # pylint: enable=line-too-long
 
-  sky_utils.create_zip(
-      dst, 'artifacts.zip', [
-          'gen_snapshot_arm64',
-          'Flutter.xcframework',
-          'entitlements.txt',
-          'without_entitlements.txt',
-          'extension_safe/Flutter.xcframework',
-      ]
-  )
+  zip_contents = [
+      'gen_snapshot_arm64',
+      'Flutter.xcframework',
+      'entitlements.txt',
+      'without_entitlements.txt',
+      'extension_safe/Flutter.xcframework',
+  ]
+  sky_utils.assert_valid_codesign_config(dst, zip_contents, with_entitlements, without_entitlements)
+  sky_utils.create_zip(dst, 'artifacts.zip', zip_contents)
 
 
 def process_framework(args, dst, framework_binary, dsym):

--- a/sky/tools/create_ios_framework.py
+++ b/sky/tools/create_ios_framework.py
@@ -91,7 +91,7 @@ def main():
     gen_snapshot = os.path.join(x64_out_dir, 'gen_snapshot_x64')
     sky_utils.copy_binary(gen_snapshot, os.path.join(dst, 'gen_snapshot_x64'))
 
-  zip_archive(dst)
+  zip_archive(dst, args)
   return 0
 
 
@@ -163,7 +163,7 @@ def create_framework(  # pylint: disable=too-many-arguments
   return 0
 
 
-def zip_archive(dst):
+def zip_archive(dst, args):
   # pylint: disable=line-too-long
   with_entitlements = ['gen_snapshot_arm64']
   with_entitlements_file = os.path.join(dst, 'entitlements.txt')
@@ -171,14 +171,18 @@ def zip_archive(dst):
 
   without_entitlements = [
       'Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
-      'Flutter.xcframework/ios-arm64/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
       'Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
-      'Flutter.xcframework/ios-arm64_x86_64-simulator/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
       'extension_safe/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
-      'extension_safe/Flutter.xcframework/ios-arm64/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
       'extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
-      'extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
   ]
+  if args.dsym:
+    without_entitlements.extend([
+        'Flutter.xcframework/ios-arm64/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
+        'Flutter.xcframework/ios-arm64_x86_64-simulator/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
+        'extension_safe/Flutter.xcframework/ios-arm64/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
+        'extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
+    ])
+
   without_entitlements_file = os.path.join(dst, 'without_entitlements.txt')
   sky_utils.write_codesign_config(without_entitlements_file, without_entitlements)
   # pylint: enable=line-too-long

--- a/sky/tools/create_ios_framework.py
+++ b/sky/tools/create_ios_framework.py
@@ -175,7 +175,6 @@ def zip_archive(dst):
       'Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
       'Flutter.xcframework/ios-arm64_x86_64-simulator/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
       'extension_safe/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
-      'extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
       'extension_safe/Flutter.xcframework/ios-arm64/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
       'extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
       'extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',

--- a/sky/tools/sky_utils.py
+++ b/sky/tools/sky_utils.py
@@ -31,15 +31,15 @@ def assert_valid_codesign_config(framework_dir, zip_contents, entitlements, with
   either entitlements or without_entitlements."""
   if _contains_duplicates(entitlements):
     log_error('ERROR: duplicate value(s) found in entitlements.txt')
-    sys.exit(1)
+    sys.exit(os.EX_DATAERR)
 
   if _contains_duplicates(without_entitlements):
     log_error('ERROR: duplicate value(s) found in without_entitlements.txt')
-    sys.exit(1)
+    sys.exit(os.EX_DATAERR)
 
   if _contains_duplicates(entitlements + without_entitlements):
     log_error('ERROR: value(s) found in both entitlements and without_entitlements.txt')
-    sys.exit(1)
+    sys.exit(os.EX_DATAERR)
 
   binaries = set()
   for zip_content_path in zip_contents:
@@ -74,7 +74,7 @@ def assert_valid_codesign_config(framework_dir, zip_contents, entitlements, with
       log_error('Binaries listed in entitlements.txt/without_entitlements.txt but NOT FOUND:')
       for file in not_found:
         log_error('    ' + file)
-    sys.exit(1)
+    sys.exit(os.EX_NOINPUT)
 
 
 def _contains_duplicates(strings):

--- a/sky/tools/sky_utils.py
+++ b/sky/tools/sky_utils.py
@@ -89,12 +89,12 @@ def _is_macho_binary(filename):
 
   with open(filename, 'rb') as file:
     chunk = file.read(4)
-    return (
-        chunk == b'\xca\xfe\xba\xbe' or  # Mach-O Universal Big Endian
-        chunk == b'\xce\xfa\xed\xfe' or  # Mach-O Little Endian (32-bit)
-        chunk == b'\xcf\xfa\xed\xfe' or  # Mach-O Little Endian (64-bit)
-        chunk == b'\xfe\xed\xfa\xce' or  # Mach-O Big Endian (32-bit)
-        chunk == b'\xfe\xed\xfa\xcf'  # Mach-O Big Endian (64-bit)
+    return chunk in (
+        b'\xca\xfe\xba\xbe',  # Mach-O Universal Big Endian
+        b'\xce\xfa\xed\xfe',  # Mach-O Little Endian (32-bit)
+        b'\xcf\xfa\xed\xfe',  # Mach-O Little Endian (64-bit)
+        b'\xfe\xed\xfa\xce',  # Mach-O Big Endian (32-bit)
+        b'\xfe\xed\xfa\xcf',  # Mach-O Big Endian (64-bit)
     )
 
 

--- a/sky/tools/sky_utils.py
+++ b/sky/tools/sky_utils.py
@@ -29,6 +29,18 @@ def assert_valid_codesign_config(framework_dir, zip_contents, entitlements, with
   """Exits with exit code 1 if the codesign configuration contents are incorrect.
   All Mach-O binaries found within zip_contents exactly must be listed in
   either entitlements or without_entitlements."""
+  if _contains_duplicates(entitlements):
+    log_error('ERROR: duplicate value(s) found in entitlements.txt')
+    sys.exit(1)
+
+  if _contains_duplicates(without_entitlements):
+    log_error('ERROR: duplicate value(s) found in without_entitlements.txt')
+    sys.exit(1)
+
+  if _contains_duplicates(entitlements + without_entitlements):
+    log_error('ERROR: value(s) found in both entitlements and without_entitlements.txt')
+    sys.exit(1)
+
   binaries = set()
   for zip_content_path in zip_contents:
     # If file, check if Mach-O binary.
@@ -63,6 +75,11 @@ def assert_valid_codesign_config(framework_dir, zip_contents, entitlements, with
       for file in not_found:
         log_error('    ' + file)
     sys.exit(1)
+
+
+def _contains_duplicates(strings):
+  """Returns true if the list of strings contains a duplicate value."""
+  return len(strings) != len(set(strings))
 
 
 def _is_macho_binary(filename):


### PR DESCRIPTION
In flutter/engine#54414, we added dSYM files for physical and simulator binaries in both regular and extension-safe framework builds, but did not add the dSYMs to the without_entitlements.txt list.

This passed all engine pre/post-submit tests, as well as framework tests, but failed during release code signing in Cocoon in a test here:
https://github.com/flutter/cocoon/blob/d849b14bab90e0f90e2f7667e37c9f9a5696b918/cipd_packages/codesign/lib/src/file_codesign_visitor.dart#L305-L313

This adds the missing files to `without_entitlements.txt`, which fixes a code-signing error as seen in this build log:
https://ci.chromium.org/ui/p/dart-internal/builders/flutter/Mac%20Production%20Engine%20Drone/13590/overview

A corresponding change was landed on the [flutter-3.24-candidate.1](https://github.com/flutter/engine/tree/flutter-3.24-candidate.1) branch:
https://github.com/flutter/engine/pull/54573

The build associated with that patch correctly completed code signing in this build:
https://ci.chromium.org/ui/p/dart-internal/builders/flutter/Mac%20engine_release_builder/688/overview

And more specifically, this sub-build:
https://ci.chromium.org/ui/p/dart-internal/builders/flutter/Mac%20Production%20Engine%20Drone/13650/overview

And even more specifically, this build step:
https://logs.chromium.org/logs/dart-internal/buildbucket/cr-buildbucket/8739493904842446705/+/u/Global_generators/Codesign__Volumes_Work_s_w_ir_cache_builder_src_out_release_unsigned_artifacts.zip/codesign_Apple_engine_binaries/stdout

Additionally, this patch adds `sky_utils.assert_valid_codesign_config()` which fails the script (and thus the build) with an error message if any file in scope for code signing (i.e. Mach-O binaries) is not listed in the code-signing config (`entitlements.txt`, `without_entitlements.txt`), or any listed file is not found on disk.

Issue: https://github.com/flutter/flutter/issues/116493
Issue: https://github.com/flutter/flutter/issues/153532

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
