### PR TITLE
macOS: Extract framework creation to sky_utils

### DIFF
--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -38,31 +38,28 @@ def main():
       if os.path.isabs(args.x64_out_dir) else sky_utils.buildroot_relative_path(args.x64_out_dir)
   )
 
-  fat_framework_bundle = os.path.join(dst, 'FlutterMacOS.framework')
   arm64_framework = os.path.join(arm64_out_dir, 'FlutterMacOS.framework')
-  x64_framework = os.path.join(x64_out_dir, 'FlutterMacOS.framework')
-
-  arm64_dylib = os.path.join(arm64_framework, 'FlutterMacOS')
-  x64_dylib = os.path.join(x64_framework, 'FlutterMacOS')
-
   if not os.path.isdir(arm64_framework):
     print('Cannot find macOS arm64 Framework at %s' % arm64_framework)
     return 1
 
+  x64_framework = os.path.join(x64_out_dir, 'FlutterMacOS.framework')
   if not os.path.isdir(x64_framework):
     print('Cannot find macOS x64 Framework at %s' % x64_framework)
     return 1
 
+  arm64_dylib = os.path.join(arm64_framework, 'FlutterMacOS')
   if not os.path.isfile(arm64_dylib):
     print('Cannot find macOS arm64 dylib at %s' % arm64_dylib)
     return 1
 
+  x64_dylib = os.path.join(x64_framework, 'FlutterMacOS')
   if not os.path.isfile(x64_dylib):
     print('Cannot find macOS x64 dylib at %s' % x64_dylib)
     return 1
 
+  fat_framework_bundle = os.path.join(dst, 'FlutterMacOS.framework')
   sky_utils.copy_tree(arm64_framework, fat_framework_bundle, symlinks=True)
-
   regenerate_symlinks(fat_framework_bundle)
 
   fat_framework_binary = os.path.join(fat_framework_bundle, 'Versions', 'A', 'FlutterMacOS')

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -59,7 +59,7 @@ def main():
     return 1
 
   fat_framework = os.path.join(dst, 'FlutterMacOS.framework')
-  create_fat_macos_framework(fat_framework, arm64_framework, x64_framework)
+  sky_utils.create_fat_macos_framework(fat_framework, arm64_framework, x64_framework)
   process_framework(dst, args, fat_framework)
 
   # Create XCFramework from the arm64 and x64 fat framework.
@@ -70,67 +70,6 @@ def main():
     zip_framework(dst)
 
   return 0
-
-
-def create_fat_macos_framework(fat_framework, arm64_framework, x64_framework):
-  sky_utils.copy_tree(arm64_framework, fat_framework, symlinks=True)
-  regenerate_symlinks(fat_framework)
-
-  fat_framework_binary = os.path.join(fat_framework, 'Versions', 'A', 'FlutterMacOS')
-
-  # Create the arm64/x64 fat framework.
-  arm64_dylib = os.path.join(arm64_framework, 'FlutterMacOS')
-  x64_dylib = os.path.join(x64_framework, 'FlutterMacOS')
-  sky_utils.lipo([arm64_dylib, x64_dylib], fat_framework_binary)
-  set_framework_permissions(fat_framework)
-
-
-def set_framework_permissions(framework_dir):
-  # Make the framework readable and executable: u=rwx,go=rx.
-  subprocess.check_call(['chmod', '755', framework_dir])
-
-  # Add group and other readability to all files.
-  versions_path = os.path.join(framework_dir, 'Versions')
-  subprocess.check_call(['chmod', '-R', 'og+r', versions_path])
-  # Find all the files below the target dir with owner execute permission
-  find_subprocess = subprocess.Popen(['find', versions_path, '-perm', '-100', '-print0'],
-                                     stdout=subprocess.PIPE)
-  # Add execute permission for other and group for all files that had it for owner.
-  xargs_subprocess = subprocess.Popen(['xargs', '-0', 'chmod', 'og+x'],
-                                      stdin=find_subprocess.stdout)
-  find_subprocess.wait()
-  xargs_subprocess.wait()
-
-
-def regenerate_symlinks(framework_dir):
-  """Regenerates the symlinks structure.
-
-  Recipes V2 upload artifacts in CAS before integration and CAS follows symlinks.
-  This logic regenerates the symlinks in the expected structure.
-  """
-  if os.path.islink(os.path.join(framework_dir, 'FlutterMacOS')):
-    return
-  os.remove(os.path.join(framework_dir, 'FlutterMacOS'))
-  shutil.rmtree(os.path.join(framework_dir, 'Headers'), True)
-  shutil.rmtree(os.path.join(framework_dir, 'Modules'), True)
-  shutil.rmtree(os.path.join(framework_dir, 'Resources'), True)
-  current_version_path = os.path.join(framework_dir, 'Versions', 'Current')
-  shutil.rmtree(current_version_path, True)
-  os.symlink('A', current_version_path)
-  os.symlink(
-      os.path.join('Versions', 'Current', 'FlutterMacOS'),
-      os.path.join(framework_dir, 'FlutterMacOS')
-  )
-  os.symlink(
-      os.path.join('Versions', 'Current', 'Headers'), os.path.join(framework_dir, 'Headers')
-  )
-  os.symlink(
-      os.path.join('Versions', 'Current', 'Modules'), os.path.join(framework_dir, 'Modules')
-  )
-  os.symlink(
-      os.path.join('Versions', 'Current', 'Resources'),
-      os.path.join(framework_dir, 'Resources')
-  )
 
 
 def process_framework(dst, args, fat_framework):

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -5,7 +5,6 @@
 # found in the LICENSE file.
 
 import argparse
-import subprocess
 import shutil
 import sys
 import os

--- a/sky/tools/sky_utils.py
+++ b/sky/tools/sky_utils.py
@@ -150,15 +150,10 @@ def _regenerate_symlinks(framework_dir):
       os.path.join('Versions', 'Current', 'FlutterMacOS'),
       os.path.join(framework_dir, 'FlutterMacOS')
   )
+  os.symlink(os.path.join('Versions', 'Current', 'Headers'), os.path.join(framework_dir, 'Headers'))
+  os.symlink(os.path.join('Versions', 'Current', 'Modules'), os.path.join(framework_dir, 'Modules'))
   os.symlink(
-      os.path.join('Versions', 'Current', 'Headers'), os.path.join(framework_dir, 'Headers')
-  )
-  os.symlink(
-      os.path.join('Versions', 'Current', 'Modules'), os.path.join(framework_dir, 'Modules')
-  )
-  os.symlink(
-      os.path.join('Versions', 'Current', 'Resources'),
-      os.path.join(framework_dir, 'Resources')
+      os.path.join('Versions', 'Current', 'Resources'), os.path.join(framework_dir, 'Resources')
   )
 
 

--- a/sky/tools/sky_utils.py
+++ b/sky/tools/sky_utils.py
@@ -118,6 +118,67 @@ def copy_tree(source_path, destination_path, symlinks=False):
   shutil.copytree(source_path, destination_path, symlinks=symlinks)
 
 
+def create_fat_macos_framework(fat_framework, arm64_framework, x64_framework):
+  copy_tree(arm64_framework, fat_framework, symlinks=True)
+  _regenerate_symlinks(fat_framework)
+
+  fat_framework_binary = os.path.join(fat_framework, 'Versions', 'A', 'FlutterMacOS')
+
+  # Create the arm64/x64 fat framework.
+  arm64_dylib = os.path.join(arm64_framework, 'FlutterMacOS')
+  x64_dylib = os.path.join(x64_framework, 'FlutterMacOS')
+  lipo([arm64_dylib, x64_dylib], fat_framework_binary)
+  _set_framework_permissions(fat_framework)
+
+
+def _regenerate_symlinks(framework_dir):
+  """Regenerates the symlinks structure.
+
+  Recipes V2 upload artifacts in CAS before integration and CAS follows symlinks.
+  This logic regenerates the symlinks in the expected structure.
+  """
+  if os.path.islink(os.path.join(framework_dir, 'FlutterMacOS')):
+    return
+  os.remove(os.path.join(framework_dir, 'FlutterMacOS'))
+  shutil.rmtree(os.path.join(framework_dir, 'Headers'), True)
+  shutil.rmtree(os.path.join(framework_dir, 'Modules'), True)
+  shutil.rmtree(os.path.join(framework_dir, 'Resources'), True)
+  current_version_path = os.path.join(framework_dir, 'Versions', 'Current')
+  shutil.rmtree(current_version_path, True)
+  os.symlink('A', current_version_path)
+  os.symlink(
+      os.path.join('Versions', 'Current', 'FlutterMacOS'),
+      os.path.join(framework_dir, 'FlutterMacOS')
+  )
+  os.symlink(
+      os.path.join('Versions', 'Current', 'Headers'), os.path.join(framework_dir, 'Headers')
+  )
+  os.symlink(
+      os.path.join('Versions', 'Current', 'Modules'), os.path.join(framework_dir, 'Modules')
+  )
+  os.symlink(
+      os.path.join('Versions', 'Current', 'Resources'),
+      os.path.join(framework_dir, 'Resources')
+  )
+
+
+def _set_framework_permissions(framework_dir):
+  # Make the framework readable and executable: u=rwx,go=rx.
+  subprocess.check_call(['chmod', '755', framework_dir])
+
+  # Add group and other readability to all files.
+  versions_path = os.path.join(framework_dir, 'Versions')
+  subprocess.check_call(['chmod', '-R', 'og+r', versions_path])
+  # Find all the files below the target dir with owner execute permission
+  find_subprocess = subprocess.Popen(['find', versions_path, '-perm', '-100', '-print0'],
+                                     stdout=subprocess.PIPE)
+  # Add execute permission for other and group for all files that had it for owner.
+  xargs_subprocess = subprocess.Popen(['xargs', '-0', 'chmod', 'og+x'],
+                                      stdin=find_subprocess.stdout)
+  find_subprocess.wait()
+  xargs_subprocess.wait()
+
+
 def create_zip(cwd, zip_filename, paths):
   """Creates a zip archive in cwd, containing a set of cwd-relative files.
 


### PR DESCRIPTION
This refactors `create_mac_framework.py` to extract framework creation to `sky_utils.py`. The only other changes are minor variable renaming and extraction of functions to make the code more readable/easier to work with.

The resulting zip archives have been verified to be identical before and after.

This is refactoring to support embedding dSYM debug information in a follow-up patch.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
