### PR TITLE
Update web_ui and web_sdk min Dart SDK versions to 3.6

### DIFF
--- a/lib/web_ui/pubspec.yaml
+++ b/lib/web_ui/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 # Keep the SDK version range in sync with pubspecs under web_sdk
 environment:
-  sdk: '>=3.2.0-0 <4.0.0'
+  sdk: '>=3.6.0-0 <4.0.0'
 
 dependencies:
   js: 0.6.4

--- a/web_sdk/pubspec.yaml
+++ b/web_sdk/pubspec.yaml
@@ -2,7 +2,7 @@ name: web_sdk_tests
 
 # Keep the SDK version range in sync with lib/web_ui/pubspec.yaml
 environment:
-  sdk: '>=3.2.0-0 <4.0.0'
+  sdk: '>=3.6.0-0 <4.0.0'
 
 dependencies:
   args: 2.3.1


### PR DESCRIPTION
Some dart:js_interop APIs that are available since 3.6 have been annotated with `@Since('3.6')`. Since web_ui uses these APIs, analysis fails since the minimum SDK version is not >= 3.6.

Dart SDK change: https://dart-review.googlesource.com/c/sdk/+/380900