### PR TITLE
web_ui: bump min Dart SDK to 3.6.0-0

### DIFF
--- a/lib/web_ui/pubspec.yaml
+++ b/lib/web_ui/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 # Keep the SDK version range in sync with pubspecs under web_sdk
 environment:
-  sdk: '>=3.2.0-0 <4.0.0'
+  sdk: '>=3.6.0-0 <4.0.0'
 
 dependencies:
   js: 0.6.4
@@ -27,7 +27,6 @@ dev_dependencies:
   http: 1.1.0
   http_multi_server: any
   image: 3.0.1
-  matcher: 0.12.16
   package_config: any
   path: 1.8.0
   pool: any
@@ -42,7 +41,6 @@ dev_dependencies:
   test_api: any
   test_core: any
   typed_data: any
-  uuid: 4.1.0
   watcher: 1.1.0
   web_socket_channel: any
   webdriver: 3.0.3

--- a/web_sdk/pubspec.yaml
+++ b/web_sdk/pubspec.yaml
@@ -2,7 +2,7 @@ name: web_sdk_tests
 
 # Keep the SDK version range in sync with lib/web_ui/pubspec.yaml
 environment:
-  sdk: '>=3.2.0-0 <4.0.0'
+  sdk: '>=3.6.0-0 <4.0.0'
 
 dependencies:
   args: 2.3.1


### PR DESCRIPTION
Also removed two unused dev dependencies

Enables usage of `Since` in dart:js_interop
