### PR TITLE
[Impeller] account for negative scale in max basis xy.

### DIFF
--- a/impeller/geometry/matrix.h
+++ b/impeller/geometry/matrix.h
@@ -303,7 +303,7 @@ struct Matrix {
     // precision for small and large scales. Instead, check for the common cases
     // and directly return the max scaling factor.
     if (e[0][1] == 0 && e[1][0] == 0) {
-      return std::max(e[0][0], e[1][1]);
+      return std::max(std::abs(e[0][0]), std::abs(e[1][1]));
     }
     return std::sqrt(std::max(e[0][0] * e[0][0] + e[0][1] * e[0][1],
                               e[1][0] * e[1][0] + e[1][1] * e[1][1]));

--- a/impeller/geometry/matrix_unittests.cc
+++ b/impeller/geometry/matrix_unittests.cc
@@ -161,6 +161,16 @@ TEST(MatrixTest, TransformHomogenous) {
             Vector3(32.0f, 33.0f, 41.0f));
 }
 
+TEST(MatrixTest, GetMaxBasisXYNegativeScale) {
+  Matrix m = Matrix::MakeScale({-2, 1, 1});
+
+  EXPECT_EQ(m.GetMaxBasisLengthXY(), 2);
+
+  m = Matrix::MakeScale({1, -3, 1});
+
+  EXPECT_EQ(m.GetMaxBasisLengthXY(), 3);
+}
+
 // Verifies a translate scale matrix doesn't need to compute sqrt(pow(scale, 2))
 TEST(MatrixTest, GetMaxBasisXYWithLargeAndSmallScalingFactor) {
   Matrix m = Matrix::MakeScale({2.625e+20, 2.625e+20, 1});


### PR DESCRIPTION
Otherwise we get funky negative scales that break tessellation.
