### PR TITLE
Clean up macOS framework creation scripts

### DIFF
--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -47,12 +47,12 @@ def main():
     print('Cannot find macOS x64 Framework at %s' % x64_framework)
     return 1
 
-  arm64_dylib = os.path.join(arm64_framework, 'FlutterMacOS')
+  arm64_dylib = sky_utils.get_framework_dylib_path(arm64_framework)
   if not os.path.isfile(arm64_dylib):
     print('Cannot find macOS arm64 dylib at %s' % arm64_dylib)
     return 1
 
-  x64_dylib = os.path.join(x64_framework, 'FlutterMacOS')
+  x64_dylib = sky_utils.get_framework_dylib_path(x64_framework)
   if not os.path.isfile(x64_dylib):
     print('Cannot find macOS x64 dylib at %s' % x64_dylib)
     return 1
@@ -71,10 +71,10 @@ def main():
   return 0
 
 
-def process_framework(dst, args, fat_framework):
-  fat_framework_binary = os.path.join(fat_framework, 'Versions', 'A', 'FlutterMacOS')
+def process_framework(dst, args, framework_path):
+  fat_framework_binary = os.path.join(framework_path, 'Versions', 'A', 'FlutterMacOS')
   if args.dsym:
-    dsym_out = os.path.splitext(fat_framework)[0] + '.dSYM'
+    dsym_out = os.path.splitext(framework_path)[0] + '.dSYM'
     sky_utils.extract_dsym(fat_framework_binary, dsym_out)
     if args.zip:
       dsym_dst = os.path.join(dst, 'FlutterMacOS.dSYM')

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -47,12 +47,12 @@ def main():
     print('Cannot find macOS x64 Framework at %s' % x64_framework)
     return 1
 
-  arm64_dylib = sky_utils.get_framework_dylib_path(arm64_framework)
+  arm64_dylib = sky_utils.get_mac_framework_dylib_path(arm64_framework)
   if not os.path.isfile(arm64_dylib):
     print('Cannot find macOS arm64 dylib at %s' % arm64_dylib)
     return 1
 
-  x64_dylib = sky_utils.get_framework_dylib_path(x64_framework)
+  x64_dylib = sky_utils.get_mac_framework_dylib_path(x64_framework)
   if not os.path.isfile(x64_dylib):
     print('Cannot find macOS x64 dylib at %s' % x64_dylib)
     return 1
@@ -72,7 +72,7 @@ def main():
 
 
 def process_framework(dst, args, framework_path):
-  framework_binary = sky_utils.get_framework_dylib_path(framework_path)
+  framework_binary = sky_utils.get_mac_framework_dylib_path(framework_path)
 
   if args.dsym:
     dsym_out = os.path.join(dst, 'FlutterMacOS.dSYM')

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -72,9 +72,10 @@ def main():
 
 
 def process_framework(dst, args, framework_path):
-  framework_binary = os.path.join(framework_path, 'Versions', 'A', 'FlutterMacOS')
+  framework_binary = sky_utils.get_framework_dylib_path(framework_path)
+
   if args.dsym:
-    dsym_out = os.path.splitext(framework_path)[0] + '.dSYM'
+    dsym_out = os.path.join(dst, 'FlutterMacOS.dSYM')
     sky_utils.extract_dsym(framework_binary, dsym_out)
     if args.zip:
       dsym_dst = os.path.join(dst, 'FlutterMacOS.dSYM')

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -72,14 +72,14 @@ def main():
 
 
 def process_framework(dst, args, framework_path):
-  fat_framework_binary = os.path.join(framework_path, 'Versions', 'A', 'FlutterMacOS')
+  framework_binary = os.path.join(framework_path, 'Versions', 'A', 'FlutterMacOS')
   if args.dsym:
     dsym_out = os.path.splitext(framework_path)[0] + '.dSYM'
-    sky_utils.extract_dsym(fat_framework_binary, dsym_out)
+    sky_utils.extract_dsym(framework_binary, dsym_out)
     if args.zip:
       dsym_dst = os.path.join(dst, 'FlutterMacOS.dSYM')
       sky_utils.create_zip(dsym_dst, 'FlutterMacOS.dSYM.zip', ['.'])
-      # Double zip to make it consistent with legacy artifacts.
+      # Create a zip of just the contents of the dSYM, then create a zip of that zip.
       # TODO(fujino): remove this once https://github.com/flutter/flutter/issues/125067 is resolved
       sky_utils.create_zip(dsym_dst, 'FlutterMacOS.dSYM_.zip', ['FlutterMacOS.dSYM.zip'])
 
@@ -90,7 +90,7 @@ def process_framework(dst, args, framework_path):
 
   if args.strip:
     unstripped_out = os.path.join(dst, 'FlutterMacOS.unstripped')
-    sky_utils.strip_binary(fat_framework_binary, unstripped_out)
+    sky_utils.strip_binary(framework_binary, unstripped_out)
 
 
 def zip_framework(dst):

--- a/sky/tools/sky_utils.py
+++ b/sky/tools/sky_utils.py
@@ -123,8 +123,8 @@ def create_fat_macos_framework(fat_framework, arm64_framework, x64_framework):
   # Clone the arm64 framework bundle as a starting point.
   copy_tree(arm64_framework, fat_framework, symlinks=True)
   _regenerate_symlinks(fat_framework)
-  lipo([get_framework_dylib_path(arm64_framework),
-        get_framework_dylib_path(x64_framework)], get_framework_dylib_path(fat_framework))
+  lipo([get_mac_framework_dylib_path(arm64_framework),
+        get_mac_framework_dylib_path(x64_framework)], get_mac_framework_dylib_path(fat_framework))
   _set_framework_permissions(fat_framework)
 
 
@@ -203,7 +203,7 @@ def get_framework_name(framework_dir):
   return os.path.splitext(os.path.basename(framework_dir))[0]
 
 
-def get_framework_dylib_path(framework_dir):
+def get_mac_framework_dylib_path(framework_dir):
   """Returns /path/to/Foo.framework/Versions/A/Foo given /path/to/Foo.framework."""
   return os.path.join(framework_dir, 'Versions', 'A', get_framework_name(framework_dir))
 

--- a/sky/tools/sky_utils.py
+++ b/sky/tools/sky_utils.py
@@ -191,6 +191,16 @@ def _dsymutil_path():
   return buildroot_relative_path(dsymutil_path)
 
 
+def get_framework_name(framework_dir):
+  """Returns Foo given /path/to/Foo.framework."""
+  return os.path.splitext(os.path.basename(framework_dir))[0]
+
+
+def get_framework_dylib_path(framework_dir):
+  """Returns /path/to/Foo.framework/Versions/A/Foo given /path/to/Foo.framework."""
+  return os.path.join(framework_dir, 'Versions', 'A', get_framework_name(framework_dir))
+
+
 def extract_dsym(binary_path, dsym_out_path):
   """Extracts a dSYM bundle from the specified Mach-O binary."""
   arch_dir = 'mac-arm64' if platform.processor() == 'arm' else 'mac-x64'

--- a/sky/tools/sky_utils.py
+++ b/sky/tools/sky_utils.py
@@ -158,6 +158,7 @@ def _regenerate_symlinks(framework_dir):
 
 
 def _set_framework_permissions(framework_dir):
+  """Sets framework contents to be world readable, and world executable if user-executable."""
   # Make the framework readable and executable: u=rwx,go=rx.
   subprocess.check_call(['chmod', '755', framework_dir])
 

--- a/sky/tools/sky_utils.py
+++ b/sky/tools/sky_utils.py
@@ -123,13 +123,8 @@ def create_fat_macos_framework(fat_framework, arm64_framework, x64_framework):
   # Clone the arm64 framework bundle as a starting point.
   copy_tree(arm64_framework, fat_framework, symlinks=True)
   _regenerate_symlinks(fat_framework)
-
-  fat_dylib = get_framework_dylib_path(fat_framework)
-
-  # Create the arm64/x64 fat framework.
-  arm64_dylib = os.path.join(arm64_framework, 'FlutterMacOS')
-  x64_dylib = os.path.join(x64_framework, 'FlutterMacOS')
-  lipo([arm64_dylib, x64_dylib], fat_dylib)
+  lipo([get_framework_dylib_path(arm64_framework),
+        get_framework_dylib_path(x64_framework)], get_framework_dylib_path(fat_framework))
   _set_framework_permissions(fat_framework)
 
 

--- a/sky/tools/sky_utils.py
+++ b/sky/tools/sky_utils.py
@@ -119,15 +119,17 @@ def copy_tree(source_path, destination_path, symlinks=False):
 
 
 def create_fat_macos_framework(fat_framework, arm64_framework, x64_framework):
+  """Creates a fat framework from two arm64 and x64 frameworks."""
+  # Clone the arm64 framework bundle as a starting point.
   copy_tree(arm64_framework, fat_framework, symlinks=True)
   _regenerate_symlinks(fat_framework)
 
-  fat_framework_binary = os.path.join(fat_framework, 'Versions', 'A', 'FlutterMacOS')
+  fat_dylib = get_framework_dylib_path(fat_framework)
 
   # Create the arm64/x64 fat framework.
   arm64_dylib = os.path.join(arm64_framework, 'FlutterMacOS')
   x64_dylib = os.path.join(x64_framework, 'FlutterMacOS')
-  lipo([arm64_dylib, x64_dylib], fat_framework_binary)
+  lipo([arm64_dylib, x64_dylib], fat_dylib)
   _set_framework_permissions(fat_framework)
 
 


### PR DESCRIPTION
This refactors `create_fat_macos_framework`, `_regenerate_symlinks` and
`_set_framework_permissions` to be more generic and not hardcode "FlutterMacOS"
as a framework name. Further, it reuses several utility functions from the iOS
code in `sky_utils` to improve readability and eliminate duplication.

This is refactoring prior to embedding dSYMs in FlutterMacOS.xcframework in a
followup patch.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
