### PR TITLE
Export GPU symbols for embedder

### DIFF
--- a/examples/glfw/main.dart
+++ b/examples/glfw/main.dart
@@ -2,11 +2,22 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter_gpu/gpu.dart' as gpu;
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart'
     show debugDefaultTargetPlatformOverride;
 
 void main() {
+  // Ensure Flutter GPU symbols are available by forcing the GPU context to instantiate.
+  try {
+    // ignore: unnecessary_statements
+    gpu.gpuContext; // Force the context to instantiate.
+  } catch (e) {
+    // If impeller is not enabled, make sure the exception isn't about symbols missing.
+    assert(e.toString().contains(
+        'Flutter GPU requires the Impeller rendering backend to be enabled.'));
+  }
+
   // This is a hack to make Flutter think you are running on Google Fuchsia,
   // otherwise you will get an error about running from an unsupported platform.
   debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia;

--- a/examples/glfw/run.sh
+++ b/examples/glfw/run.sh
@@ -25,6 +25,7 @@ if [ ! -d myapp ]; then
 fi
 
 cd myapp
+flutter pub add flutter_gpu --sdk=flutter
 cp ../../main.dart lib/main.dart
 flutter build bundle \
         --local-engine-src-path ../../../../../ \

--- a/shell/platform/embedder/embedder_exports.lst
+++ b/shell/platform/embedder/embedder_exports.lst
@@ -13,6 +13,8 @@
     kDartIsolateSnapshotInstructions;
     kDartVmSnapshotData;
     kDartVmSnapshotInstructions;
+    InternalFlutterGpu*;
+    kInternalFlutterGpu*;
   local:
     *;
 };


### PR DESCRIPTION
This PR exports GPU symbols for the embedder library.

*List which issues are fixed by this PR. You must list at least one issue.*
https://github.com/flutter/flutter/issues/153196

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
