### PR TITLE
Flutter 3.25 beta split out fuchsia tests to separate shard to avoid timeouts

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -214,6 +214,20 @@ targets:
     # Scheduler will fail to get the platform
     drone_dimensions:
       - os=Linux
+
+  - name: Linux linux_fuchsia_tests
+    recipe: engine_v2/engine_v2
+    bringup: true
+    timeout: 90
+    properties:
+      # TODO(zanderso): Add this back when this issue is closed:
+      # https://github.com/flutter/flutter/issues/152186
+      # release_build: "true"
+      config_name: linux_fuchsia_tests
+    # Do not remove(https://github.com/flutter/flutter/issues/144644)
+    # Scheduler will fail to get the platform
+    drone_dimensions:
+      - os=Linux
     dimensions:
       kvm: "1"
 

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -206,7 +206,8 @@ targets:
 
   - name: Linux linux_fuchsia
     recipe: engine_v2/engine_v2
-    timeout: 60
+    # Additional workaround for https://github.com/flutter/flutter/issues/152186
+    timeout: 240
     properties:
       release_build: "true"
       config_name: linux_fuchsia

--- a/ci/builders/linux_fuchsia.json
+++ b/ci/builders/linux_fuchsia.json
@@ -30,52 +30,6 @@
             }
         },
         {
-            "cas_archive": false,
-            "drone_dimensions": [
-                "device_type=none",
-                "kvm=1",
-                "os=Linux"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false,
-                "run_fuchsia_emu": true,
-                "use_rbe": true
-            },
-            "gn": [
-                "--target-dir",
-                "ci/fuchsia_profile_arm64_tester",
-                "--fuchsia",
-                "--fuchsia-cpu",
-                "arm64",
-                "--runtime-mode",
-                "profile",
-                "--no-lto",
-                "--rbe",
-                "--no-goma"
-            ],
-            "name": "ci/fuchsia_profile_arm64_tester",
-            "description": "Builds profile mode tests of arm64 Fuchsia.",
-            "ninja": {
-                "config": "ci/fuchsia_profile_arm64_tester",
-                "targets": [
-                    "flutter/shell/platform/fuchsia:fuchsia",
-                    "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
-                    "fuchsia_tests"
-                ]
-            },
-            "tests": [
-                {
-                    "name": "arm64 emulator based profile / aot tests",
-                    "language": "python3",
-                    "script": "flutter/tools/fuchsia/with_envs.py",
-                    "parameters": [
-                        "testing/fuchsia/run_tests.py",
-                        "ci/fuchsia_profile_arm64_tester"
-                    ]
-                }
-            ]
-        },
-        {
             "drone_dimensions": [
                 "device_type=none",
                 "os=Linux"
@@ -103,52 +57,6 @@
                     "flutter/shell/platform/fuchsia:fuchsia"
                 ]
             }
-        },
-        {
-            "cas_archive": false,
-            "drone_dimensions": [
-                "device_type=none",
-                "kvm=1",
-                "os=Linux"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false,
-                "run_fuchsia_emu": true,
-                "use_rbe": true
-            },
-            "gn": [
-                "--target-dir",
-                "ci/fuchsia_release_arm64_tester",
-                "--fuchsia",
-                "--fuchsia-cpu",
-                "arm64",
-                "--runtime-mode",
-                "release",
-                "--no-lto",
-                "--rbe",
-                "--no-goma"
-            ],
-            "name": "ci/fuchsia_release_arm64_tester",
-            "description": "Builds release mode tests of arm64 Fuchsia.",
-            "ninja": {
-                "config": "ci/fuchsia_release_arm64_tester",
-                "targets": [
-                    "flutter/shell/platform/fuchsia:fuchsia",
-                    "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
-                    "fuchsia_tests"
-                ]
-            },
-            "tests": [
-                {
-                    "name": "arm64 emulator based release tests",
-                    "language": "python3",
-                    "script": "flutter/tools/fuchsia/with_envs.py",
-                    "parameters": [
-                        "testing/fuchsia/run_tests.py",
-                        "ci/fuchsia_release_arm64_tester"
-                    ]
-                }
-            ]
         },
         {
             "drone_dimensions": [
@@ -196,52 +104,6 @@
             ]
         },
         {
-            "cas_archive": false,
-            "drone_dimensions": [
-                "device_type=none",
-                "kvm=1",
-                "os=Linux"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false,
-                "run_fuchsia_emu": true,
-                "use_rbe": true
-            },
-            "gn": [
-                "--target-dir",
-                "ci/fuchsia_debug_arm64_tester",
-                "--fuchsia",
-                "--fuchsia-cpu",
-                "arm64",
-                "--runtime-mode",
-                "debug",
-                "--no-lto",
-                "--rbe",
-                "--no-goma"
-            ],
-            "name": "ci/fuchsia_debug_arm64_tester",
-            "description": "Builds debug mode tests of arm64 Fuchsia.",
-            "ninja": {
-                "config": "ci/fuchsia_debug_arm64_tester",
-                "targets": [
-                    "flutter/shell/platform/fuchsia:fuchsia",
-                    "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
-                    "fuchsia_tests"
-                ]
-            },
-            "tests": [
-                {
-                    "name": "arm64 emulator based debug tests",
-                    "language": "python3",
-                    "script": "flutter/tools/fuchsia/with_envs.py",
-                    "parameters": [
-                        "testing/fuchsia/run_tests.py",
-                        "ci/fuchsia_debug_arm64_tester"
-                    ]
-                }
-            ]
-        },
-        {
             "drone_dimensions": [
                 "device_type=none",
                 "os=Linux"
@@ -269,52 +131,6 @@
                     "flutter/shell/platform/fuchsia:fuchsia"
                 ]
             }
-        },
-        {
-            "cas_archive": false,
-            "drone_dimensions": [
-                "device_type=none",
-                "kvm=1",
-                "os=Linux"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false,
-                "run_fuchsia_emu": true,
-                "use_rbe": true
-            },
-            "gn": [
-                "--target-dir",
-                "ci/fuchsia_profile_x64_tester",
-                "--fuchsia",
-                "--fuchsia-cpu",
-                "x64",
-                "--runtime-mode",
-                "profile",
-                "--no-lto",
-                "--rbe",
-                "--no-goma"
-            ],
-            "name": "ci/fuchsia_profile_x64_tester",
-            "description": "Builds profile mode tests of x64 Fuchsia.",
-            "ninja": {
-                "config": "ci/fuchsia_profile_x64_tester",
-                "targets": [
-                    "flutter/shell/platform/fuchsia:fuchsia",
-                    "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
-                    "fuchsia_tests"
-                ]
-            },
-            "tests": [
-                {
-                    "name": "x64 emulator based profile / aot tests",
-                    "language": "python3",
-                    "script": "flutter/tools/fuchsia/with_envs.py",
-                    "parameters": [
-                        "testing/fuchsia/run_tests.py",
-                        "ci/fuchsia_profile_x64_tester"
-                    ]
-                }
-            ]
         },
         {
             "drone_dimensions": [
@@ -345,52 +161,6 @@
                     "flutter/shell/platform/fuchsia:fuchsia"
                 ]
             }
-        },
-        {
-            "cas_archive": false,
-            "drone_dimensions": [
-                "device_type=none",
-                "kvm=1",
-                "os=Linux"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false,
-                "run_fuchsia_emu": true,
-                "use_rbe": true
-            },
-            "gn": [
-                "--target-dir",
-                "ci/fuchsia_release_x64_tester",
-                "--fuchsia",
-                "--fuchsia-cpu",
-                "x64",
-                "--runtime-mode",
-                "release",
-                "--no-lto",
-                "--rbe",
-                "--no-goma"
-            ],
-            "name": "ci/fuchsia_release_x64_tester",
-            "description": "Builds release mode tests of x64 Fuchsia.",
-            "ninja": {
-                "config": "ci/fuchsia_release_x64_tester",
-                "targets": [
-                    "flutter/shell/platform/fuchsia:fuchsia",
-                    "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
-                    "fuchsia_tests"
-                ]
-            },
-            "tests": [
-                {
-                    "name": "x64 emulator based release tests",
-                    "language": "python3",
-                    "script": "flutter/tools/fuchsia/with_envs.py",
-                    "parameters": [
-                        "testing/fuchsia/run_tests.py",
-                        "ci/fuchsia_release_x64_tester"
-                    ]
-                }
-            ]
         },
         {
             "drone_dimensions": [
@@ -434,60 +204,6 @@
                         "--engine-version",
                         "${REVISION}",
                         "--upload"
-                    ]
-                }
-            ]
-        },
-        {
-            "cas_archive": false,
-            "drone_dimensions": [
-                "device_type=none",
-                "kvm=1",
-                "os=Linux"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false,
-                "run_fuchsia_emu": true,
-                "use_rbe": true
-            },
-            "gn": [
-                "--target-dir",
-                "ci/fuchsia_debug_x64_tester",
-                "--fuchsia",
-                "--fuchsia-cpu",
-                "x64",
-                "--runtime-mode",
-                "debug",
-                "--no-lto",
-                "--rbe",
-                "--no-goma"
-            ],
-            "name": "ci/fuchsia_debug_x64_tester",
-            "description": "Builds debug mode tests of x64 Fuchsia.",
-            "ninja": {
-                "config": "ci/fuchsia_debug_x64_tester",
-                "targets": [
-                    "flutter/shell/platform/fuchsia:fuchsia",
-                    "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
-                    "fuchsia_tests"
-                ]
-            },
-            "tests": [
-                {
-                    "name": "run_tests test",
-                    "script": "flutter/testing/fuchsia/run_tests_test.py"
-                },
-                {
-                    "name": "build_fuchsia_artifacts test",
-                    "script": "flutter/tools/fuchsia/build_fuchsia_artifacts_test.py"
-                },
-                {
-                    "name": "x64 emulator based debug tests",
-                    "language": "python3",
-                    "script": "flutter/tools/fuchsia/with_envs.py",
-                    "parameters": [
-                        "testing/fuchsia/run_tests.py",
-                        "ci/fuchsia_debug_x64_tester"
                     ]
                 }
             ]

--- a/ci/builders/linux_fuchsia_tests.json
+++ b/ci/builders/linux_fuchsia_tests.json
@@ -1,0 +1,288 @@
+{
+    "builds": [
+        {
+            "cas_archive": false,
+            "drone_dimensions": [
+                "device_type=none",
+                "kvm=1",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "run_fuchsia_emu": true,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/fuchsia_profile_arm64_tester",
+                "--fuchsia",
+                "--fuchsia-cpu",
+                "arm64",
+                "--runtime-mode",
+                "profile",
+                "--no-lto",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/fuchsia_profile_arm64_tester",
+            "description": "Builds profile mode tests of arm64 Fuchsia.",
+            "ninja": {
+                "config": "ci/fuchsia_profile_arm64_tester",
+                "targets": [
+                    "flutter/shell/platform/fuchsia:fuchsia",
+                    "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
+                    "fuchsia_tests"
+                ]
+            },
+            "tests": [
+                {
+                    "name": "arm64 emulator based profile / aot tests",
+                    "language": "python3",
+                    "script": "flutter/tools/fuchsia/with_envs.py",
+                    "parameters": [
+                        "testing/fuchsia/run_tests.py",
+                        "ci/fuchsia_profile_arm64_tester"
+                    ]
+                }
+            ]
+        },
+        {
+            "cas_archive": false,
+            "drone_dimensions": [
+                "device_type=none",
+                "kvm=1",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "run_fuchsia_emu": true,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/fuchsia_release_arm64_tester",
+                "--fuchsia",
+                "--fuchsia-cpu",
+                "arm64",
+                "--runtime-mode",
+                "release",
+                "--no-lto",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/fuchsia_release_arm64_tester",
+            "description": "Builds release mode tests of arm64 Fuchsia.",
+            "ninja": {
+                "config": "ci/fuchsia_release_arm64_tester",
+                "targets": [
+                    "flutter/shell/platform/fuchsia:fuchsia",
+                    "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
+                    "fuchsia_tests"
+                ]
+            },
+            "tests": [
+                {
+                    "name": "arm64 emulator based release tests",
+                    "language": "python3",
+                    "script": "flutter/tools/fuchsia/with_envs.py",
+                    "parameters": [
+                        "testing/fuchsia/run_tests.py",
+                        "ci/fuchsia_release_arm64_tester"
+                    ]
+                }
+            ]
+        },
+        {
+            "cas_archive": false,
+            "drone_dimensions": [
+                "device_type=none",
+                "kvm=1",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "run_fuchsia_emu": true,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/fuchsia_debug_arm64_tester",
+                "--fuchsia",
+                "--fuchsia-cpu",
+                "arm64",
+                "--runtime-mode",
+                "debug",
+                "--no-lto",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/fuchsia_debug_arm64_tester",
+            "description": "Builds debug mode tests of arm64 Fuchsia.",
+            "ninja": {
+                "config": "ci/fuchsia_debug_arm64_tester",
+                "targets": [
+                    "flutter/shell/platform/fuchsia:fuchsia",
+                    "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
+                    "fuchsia_tests"
+                ]
+            },
+            "tests": [
+                {
+                    "name": "arm64 emulator based debug tests",
+                    "language": "python3",
+                    "script": "flutter/tools/fuchsia/with_envs.py",
+                    "parameters": [
+                        "testing/fuchsia/run_tests.py",
+                        "ci/fuchsia_debug_arm64_tester"
+                    ]
+                }
+            ]
+        },
+        {
+            "cas_archive": false,
+            "drone_dimensions": [
+                "device_type=none",
+                "kvm=1",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "run_fuchsia_emu": true,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/fuchsia_profile_x64_tester",
+                "--fuchsia",
+                "--fuchsia-cpu",
+                "x64",
+                "--runtime-mode",
+                "profile",
+                "--no-lto",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/fuchsia_profile_x64_tester",
+            "description": "Builds profile mode tests of x64 Fuchsia.",
+            "ninja": {
+                "config": "ci/fuchsia_profile_x64_tester",
+                "targets": [
+                    "flutter/shell/platform/fuchsia:fuchsia",
+                    "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
+                    "fuchsia_tests"
+                ]
+            },
+            "tests": [
+                {
+                    "name": "x64 emulator based profile / aot tests",
+                    "language": "python3",
+                    "script": "flutter/tools/fuchsia/with_envs.py",
+                    "parameters": [
+                        "testing/fuchsia/run_tests.py",
+                        "ci/fuchsia_profile_x64_tester"
+                    ]
+                }
+            ]
+        },
+        {
+            "cas_archive": false,
+            "drone_dimensions": [
+                "device_type=none",
+                "kvm=1",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "run_fuchsia_emu": true,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/fuchsia_release_x64_tester",
+                "--fuchsia",
+                "--fuchsia-cpu",
+                "x64",
+                "--runtime-mode",
+                "release",
+                "--no-lto",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/fuchsia_release_x64_tester",
+            "description": "Builds release mode tests of x64 Fuchsia.",
+            "ninja": {
+                "config": "ci/fuchsia_release_x64_tester",
+                "targets": [
+                    "flutter/shell/platform/fuchsia:fuchsia",
+                    "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
+                    "fuchsia_tests"
+                ]
+            },
+            "tests": [
+                {
+                    "name": "x64 emulator based release tests",
+                    "language": "python3",
+                    "script": "flutter/tools/fuchsia/with_envs.py",
+                    "parameters": [
+                        "testing/fuchsia/run_tests.py",
+                        "ci/fuchsia_release_x64_tester"
+                    ]
+                }
+            ]
+        },
+        {
+            "cas_archive": false,
+            "drone_dimensions": [
+                "device_type=none",
+                "kvm=1",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "run_fuchsia_emu": true,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/fuchsia_debug_x64_tester",
+                "--fuchsia",
+                "--fuchsia-cpu",
+                "x64",
+                "--runtime-mode",
+                "debug",
+                "--no-lto",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/fuchsia_debug_x64_tester",
+            "description": "Builds debug mode tests of x64 Fuchsia.",
+            "ninja": {
+                "config": "ci/fuchsia_debug_x64_tester",
+                "targets": [
+                    "flutter/shell/platform/fuchsia:fuchsia",
+                    "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
+                    "fuchsia_tests"
+                ]
+            },
+            "tests": [
+                {
+                    "name": "run_tests test",
+                    "script": "flutter/testing/fuchsia/run_tests_test.py"
+                },
+                {
+                    "name": "build_fuchsia_artifacts test",
+                    "script": "flutter/tools/fuchsia/build_fuchsia_artifacts_test.py"
+                },
+                {
+                    "name": "x64 emulator based debug tests",
+                    "language": "python3",
+                    "script": "flutter/tools/fuchsia/with_envs.py",
+                    "parameters": [
+                        "testing/fuchsia/run_tests.py",
+                        "ci/fuchsia_debug_x64_tester"
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
CP of https://github.com/flutter/engine/pull/54591