### PR TITLE
docs: use test: all rather than editing .ci.yaml

### DIFF
--- a/docs/Testing-presubmit-Engine-PRs-with-the-Flutter-framework.md
+++ b/docs/Testing-presubmit-Engine-PRs-with-the-Flutter-framework.md
@@ -4,16 +4,26 @@ This documentation describes how to run flutter/flutter presubmit checks on flut
 
 ## Overview
 
-1. Enable the web SDK presubmits.
+1. Create your engine pull request with the `test: all` label.
 2. Wait for all presubmit checks on your flutter/engine PR to be green.
 3. Determine the commit hash for your flutter/engine PR.
 4. Create and upload a flutter/flutter PR, (OR run tests locally).
 5. Wait for flutter/flutter presubmits/tests to run ☕.
-6. Edit `.ci.yaml` to uncomment the `runIf` block you commented out above.
 
-## 1. Edit .ci.yaml
+## 1. Create your engine pull request with the `test: all` label.
 
-Edit [`.ci.yaml`](https://github.com/flutter/engine/blob/main/.ci.yaml) to comment out the `runIf:` block in `linux_web_engine`. This will ensure Flutter Web artifacts build, otherwise most framework tests will fail during precache.
+When creating your PR, add the `test: all` label *before* submitting the PR to
+presubmit. This will ensure that all builds required for framework testing are
+triggered.
+
+If you sent out your PR without adding the `test: all` label, add it, then
+re-push your branch to re-trigger presubmits.
+
+By default, not all builds and tests are run in engine presubmits. When our CI
+is able to determine that certain shards are unaffected by a change, via a
+`runIf` clause in our `.ci.yaml`, for example, it will be skipped. Many
+framework tests, however, assume all build products are present and will trigger
+a `flutter precache`, which will fail with a 404 on missing build artifacts.
 
 ## 2. Wait
 

--- a/docs/Testing-presubmit-Engine-PRs-with-the-Flutter-framework.md
+++ b/docs/Testing-presubmit-Engine-PRs-with-the-Flutter-framework.md
@@ -13,17 +13,20 @@ This documentation describes how to run flutter/flutter presubmit checks on flut
 ## 1. Create your engine pull request with the `test: all` label.
 
 When creating your PR, add the `test: all` label *before* submitting the PR to
-presubmit. This will ensure that all builds required for framework testing are
+CI. This will ensure that all builds required for framework testing are
 triggered.
 
-If you sent out your PR without adding the `test: all` label, add it, then
-re-push your branch to re-trigger presubmits.
+If you sent out your PR without adding the `test: all` label, you can add it,
+then re-push your branch to re-trigger presubmits.
 
-By default, not all builds and tests are run in engine presubmits. When our CI
-is able to determine that certain shards are unaffected by a change, via a
-`runIf` clause in our `.ci.yaml`, for example, it will be skipped. Many
-framework tests, however, assume all build products are present and will trigger
-a `flutter precache`, which will fail with a 404 on missing build artifacts.
+By default, [not all builds and tests are run][engine_presubmits] in engine
+presubmits. When our CI is able to determine that certain shards are unaffected
+by a change, via a `runIf` clause in our `.ci.yaml`, for example, it will be
+skipped. Many framework tests, however, assume all build products are present
+and will trigger a `flutter precache`, which will fail with a 404 on missing
+build artifacts.
+
+[engine_presubmits]: ci/Engine-pre-submits-and-post-submits.md#running-post-submits-eagerly
 
 ## 2. Wait
 


### PR DESCRIPTION
Rather than editing `.ci.yaml` to enable the `linux_web_engine` shard, instead suggest tagging with the `test: all` label, which avoids the risk of accidentally committing an unwanted change to `.ci.yaml` and having to revert the change before landing.

This is also more future-proof against further `runIf` additions to `.ci.yaml`.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
