### PR TITLE
iOS,macOS: Don't archive extra framework metadata

### DIFF
--- a/sky/tools/sky_utils.py
+++ b/sky/tools/sky_utils.py
@@ -186,9 +186,10 @@ def create_zip(cwd, zip_filename, paths):
   """Creates a zip archive in cwd, containing a set of cwd-relative files.
 
   In order to preserve the correct internal structure of macOS frameworks,
-  symlinks are preserved.
+  symlinks are preserved (-y). In order to generate reproducible builds,
+  owner/group and unix file timestamps are not included in the archive (-X).
   """
-  subprocess.check_call(['zip', '-r', '-y', zip_filename] + paths, cwd=cwd)
+  subprocess.check_call(['zip', '-r', '-X', '-y', zip_filename] + paths, cwd=cwd)
 
 
 def _dsymutil_path():


### PR DESCRIPTION
By default, zip archives don't just archive the files themselves, but also bundle extra metadata such as unix owner/group and unix timestamps. None of these is particularly important in the case of Flutter: owner/group information is likely to differ across machines and thus be overridden on the unarchiver's end. The tool checks for file presence and occasionally content hashes.

This change results in more reproducible zip archives across runs/machines.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
