### PR TITLE
Split tests out of Linux Android artifact creation builds

### DIFF
--- a/ci/builders/linux_android_debug_engine.json
+++ b/ci/builders/linux_android_debug_engine.json
@@ -36,26 +36,9 @@
                 "targets": [
                     "flutter",
                     "flutter/shell/platform/android:embedding_jars",
-                    "flutter/shell/platform/android:abi_jars",
-                    "flutter/shell/platform/android:robolectric_tests"
+                    "flutter/shell/platform/android:abi_jars"
                 ]
-            },
-            "tests": [
-                {
-                    "language": "python3",
-                    "name": "Host Tests for android_jit_release_x86",
-                    "script": "flutter/testing/run_tests.py",
-                    "parameters": [
-                        "--variant",
-                        "ci/android_jit_release_x86",
-                        "--type",
-                        "java",
-                        "--engine-capture-core-dump",
-                        "--android-variant",
-                        "ci/android_jit_release_x86"
-                    ]
-                }
-            ]
+            }
         },
         {
             "archives": [
@@ -99,26 +82,9 @@
                     "flutter/sky/dist:zip_old_location",
                     "flutter/lib/gpu/dist:zip_old_location",
                     "flutter/shell/platform/android:embedding_jars",
-                    "flutter/shell/platform/android:abi_jars",
-                    "flutter/shell/platform/android:robolectric_tests"
+                    "flutter/shell/platform/android:abi_jars"
                 ]
-            },
-            "tests": [
-                {
-                    "language": "python3",
-                    "name": "Host Tests for android_debug",
-                    "script": "flutter/testing/run_tests.py",
-                    "parameters": [
-                        "--variant",
-                        "ci/android_debug",
-                        "--type",
-                        "java",
-                        "--engine-capture-core-dump",
-                        "--android-variant",
-                        "ci/android_debug"
-                    ]
-                }
-            ]
+            }
         },
         {
             "archives": [

--- a/ci/builders/linux_unopt.json
+++ b/ci/builders/linux_unopt.json
@@ -269,6 +269,100 @@
                     ]
                 }
             ]
+        },
+        {
+            "cas_archive": false,
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/android_jit_release_x86_test",
+                "--android",
+                "--android-cpu=x86",
+                "--runtime-mode=jit_release",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/android_jit_release_x86_test",
+            "description": "Produces jit-release mode artifacts to target x86 Android from a Linux host.",
+            "ninja": {
+                "config": "ci/android_jit_release_x86_test",
+                "targets": [
+                    "flutter",
+                    "flutter/shell/platform/android:embedding_jars",
+                    "flutter/shell/platform/android:abi_jars",
+                    "flutter/shell/platform/android:robolectric_tests"
+                ]
+            },
+            "tests": [
+                {
+                    "language": "python3",
+                    "name": "Host Tests for android_jit_release_x86_test",
+                    "script": "flutter/testing/run_tests.py",
+                    "parameters": [
+                        "--variant",
+                        "ci/android_jit_release_x86_test",
+                        "--type",
+                        "java",
+                        "--engine-capture-core-dump",
+                        "--android-variant",
+                        "ci/android_jit_release_x86_test"
+                    ]
+                }
+            ]
+        },
+        {
+            "cas_archive": false,
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/android_debug_test",
+                "--android",
+                "--android-cpu=arm",
+                "--no-lto",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/android_debug_test",
+            "description": "Produces debug mode artifacts to target 32-bit arm Android from a Linux host.",
+            "ninja": {
+                "config": "ci/android_debug_test",
+                "targets": [
+                    "flutter",
+                    "flutter/sky/dist:zip_old_location",
+                    "flutter/lib/gpu/dist:zip_old_location",
+                    "flutter/shell/platform/android:embedding_jars",
+                    "flutter/shell/platform/android:abi_jars",
+                    "flutter/shell/platform/android:robolectric_tests"
+                ]
+            },
+            "tests": [
+                {
+                    "language": "python3",
+                    "name": "Host Tests for android_debug_test",
+                    "script": "flutter/testing/run_tests.py",
+                    "parameters": [
+                        "--variant",
+                        "ci/android_debug_test",
+                        "--type",
+                        "java",
+                        "--engine-capture-core-dump",
+                        "--android-variant",
+                        "ci/android_debug_test"
+                    ]
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/145842.

Mostly a note to self: I'll need to write a lint at some point that this does not regress. Possibly part of https://github.com/flutter/engine/blob/main/tools/pkg/engine_build_configs/bin/check.dart, but it will also need to query the ci.yaml to ask whether a build config json is part of a `release_build: "true"` build.