### PR TITLE
macOS: Make framework creation consistent with iOS

### DIFF
--- a/sky/tools/create_ios_framework.py
+++ b/sky/tools/create_ios_framework.py
@@ -34,7 +34,6 @@ def main():
   args = parser.parse_args()
 
   dst = (args.dst if os.path.isabs(args.dst) else sky_utils.buildroot_relative_path(args.dst))
-
   arm64_out_dir = (
       args.arm64_out_dir if os.path.isabs(args.arm64_out_dir) else
       sky_utils.buildroot_relative_path(args.arm64_out_dir)

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -61,7 +61,8 @@ def main():
 
   fat_framework = os.path.join(dst, 'FlutterMacOS.framework')
   sky_utils.create_fat_macos_framework(fat_framework, arm64_framework, x64_framework)
-  process_framework(args, dst, fat_framework)
+  framework_binary = sky_utils.get_mac_framework_dylib_path(fat_framework)
+  process_framework(args, dst, framework_binary)
 
   # Create XCFramework from the arm64 and x64 fat framework.
   xcframeworks = [fat_framework]
@@ -73,9 +74,7 @@ def main():
   return 0
 
 
-def process_framework(args, dst, framework_path):
-  framework_binary = sky_utils.get_mac_framework_dylib_path(framework_path)
-
+def process_framework(args, dst, framework_binary):
   if args.dsym:
     dsym_out = os.path.join(dst, 'FlutterMacOS.dSYM')
     sky_utils.extract_dsym(framework_binary, dsym_out)

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -78,17 +78,6 @@ def process_framework(args, dst, framework_binary):
   if args.dsym:
     dsym_out = os.path.join(dst, 'FlutterMacOS.dSYM')
     sky_utils.extract_dsym(framework_binary, dsym_out)
-    if args.zip:
-      dsym_dst = os.path.join(dst, 'FlutterMacOS.dSYM')
-      sky_utils.create_zip(dsym_dst, 'FlutterMacOS.dSYM.zip', ['.'])
-      # Create a zip of just the contents of the dSYM, then create a zip of that zip.
-      # TODO(fujino): remove this once https://github.com/flutter/flutter/issues/125067 is resolved
-      sky_utils.create_zip(dsym_dst, 'FlutterMacOS.dSYM_.zip', ['FlutterMacOS.dSYM.zip'])
-
-      # Overwrite the FlutterMacOS.dSYM.zip with the double-zipped archive.
-      dsym_final_src_path = os.path.join(dsym_dst, 'FlutterMacOS.dSYM_.zip')
-      dsym_final_dst_path = os.path.join(dst, 'FlutterMacOS.dSYM.zip')
-      shutil.move(dsym_final_src_path, dsym_final_dst_path)
 
   if args.strip:
     unstripped_out = os.path.join(dst, 'FlutterMacOS.unstripped')
@@ -126,6 +115,18 @@ def zip_framework(dst):
   shutil.move(final_src_path, final_dst_path)
 
   zip_xcframework_archive(dst)
+
+  dsym_dst = os.path.join(dst, 'FlutterMacOS.dSYM')
+  if os.path.exists(dsym_dst):
+    # Create a zip of just the contents of the dSYM, then create a zip of that zip.
+    # TODO(cbracken): remove this once https://github.com/flutter/flutter/issues/125067 is resolved
+    sky_utils.create_zip(dsym_dst, 'FlutterMacOS.dSYM.zip', ['.'])
+    sky_utils.create_zip(dsym_dst, 'FlutterMacOS.dSYM_.zip', ['FlutterMacOS.dSYM.zip'])
+
+    # Move the double-zipped FlutterMacOS.dSYM.zip to dst.
+    dsym_final_src_path = os.path.join(dsym_dst, 'FlutterMacOS.dSYM_.zip')
+    dsym_final_dst_path = os.path.join(dst, 'FlutterMacOS.dSYM.zip')
+    shutil.move(dsym_final_src_path, dsym_final_dst_path)
 
 
 def zip_xcframework_archive(dst):

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -28,10 +28,12 @@ def main():
   args = parser.parse_args()
 
   dst = args.dst if os.path.isabs(args.dst) else sky_utils.buildroot_relative_path(args.dst)
+
   arm64_out_dir = (
       args.arm64_out_dir if os.path.isabs(args.arm64_out_dir) else
       sky_utils.buildroot_relative_path(args.arm64_out_dir)
   )
+
   x64_out_dir = (
       args.x64_out_dir
       if os.path.isabs(args.x64_out_dir) else sky_utils.buildroot_relative_path(args.x64_out_dir)
@@ -59,7 +61,7 @@ def main():
 
   fat_framework = os.path.join(dst, 'FlutterMacOS.framework')
   sky_utils.create_fat_macos_framework(fat_framework, arm64_framework, x64_framework)
-  process_framework(dst, args, fat_framework)
+  process_framework(args, dst, fat_framework)
 
   # Create XCFramework from the arm64 and x64 fat framework.
   xcframeworks = [fat_framework]
@@ -71,7 +73,7 @@ def main():
   return 0
 
 
-def process_framework(dst, args, framework_path):
+def process_framework(args, dst, framework_path):
   framework_binary = sky_utils.get_mac_framework_dylib_path(framework_path)
 
   if args.dsym:

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -60,9 +60,7 @@ def main():
     return 1
 
   fat_framework = os.path.join(dst, 'FlutterMacOS.framework')
-  sky_utils.create_fat_macos_framework(fat_framework, arm64_framework, x64_framework)
-  framework_binary = sky_utils.get_mac_framework_dylib_path(fat_framework)
-  process_framework(args, dst, framework_binary)
+  sky_utils.create_fat_macos_framework(args, dst, fat_framework, arm64_framework, x64_framework)
 
   # Create XCFramework from the arm64 and x64 fat framework.
   xcframeworks = [fat_framework]
@@ -72,16 +70,6 @@ def main():
     zip_framework(dst)
 
   return 0
-
-
-def process_framework(args, dst, framework_binary):
-  if args.dsym:
-    dsym_out = os.path.join(dst, 'FlutterMacOS.dSYM')
-    sky_utils.extract_dsym(framework_binary, dsym_out)
-
-  if args.strip:
-    unstripped_out = os.path.join(dst, 'FlutterMacOS.unstripped')
-    sky_utils.strip_binary(framework_binary, unstripped_out)
 
 
 def zip_framework(dst):

--- a/sky/tools/sky_utils.py
+++ b/sky/tools/sky_utils.py
@@ -118,14 +118,17 @@ def copy_tree(source_path, destination_path, symlinks=False):
   shutil.copytree(source_path, destination_path, symlinks=symlinks)
 
 
-def create_fat_macos_framework(fat_framework, arm64_framework, x64_framework):
+def create_fat_macos_framework(args, dst, fat_framework, arm64_framework, x64_framework):
   """Creates a fat framework from two arm64 and x64 frameworks."""
   # Clone the arm64 framework bundle as a starting point.
   copy_tree(arm64_framework, fat_framework, symlinks=True)
   _regenerate_symlinks(fat_framework)
+  framework_dylib = get_mac_framework_dylib_path(fat_framework)
   lipo([get_mac_framework_dylib_path(arm64_framework),
-        get_mac_framework_dylib_path(x64_framework)], get_mac_framework_dylib_path(fat_framework))
+        get_mac_framework_dylib_path(x64_framework)], framework_dylib)
   _set_framework_permissions(fat_framework)
+  framework_dsym = os.path.join(dst, get_framework_name(fat_framework) + '.dSYM')
+  _process_macos_framework(args, dst, framework_dylib, framework_dsym)
 
 
 def _regenerate_symlinks(framework_dir):
@@ -180,6 +183,15 @@ def _set_framework_permissions(framework_dir):
                                       stdin=find_subprocess.stdout)
   find_subprocess.wait()
   xargs_subprocess.wait()
+
+
+def _process_macos_framework(args, dst, framework_dylib, dsym):
+  if dsym:
+    extract_dsym(framework_dylib, dsym)
+
+  if args.strip:
+    unstripped_out = os.path.join(dst, 'FlutterMacOS.unstripped')
+    strip_binary(framework_dylib, unstripped_out)
 
 
 def create_zip(cwd, zip_filename, paths):

--- a/sky/tools/sky_utils.py
+++ b/sky/tools/sky_utils.py
@@ -127,7 +127,12 @@ def create_fat_macos_framework(args, dst, fat_framework, arm64_framework, x64_fr
   lipo([get_mac_framework_dylib_path(arm64_framework),
         get_mac_framework_dylib_path(x64_framework)], framework_dylib)
   _set_framework_permissions(fat_framework)
-  framework_dsym = os.path.join(dst, get_framework_name(fat_framework) + '.dSYM')
+
+  # Compute dsym output path, if enabled.
+  framework_dsym = None
+  if args.dsym:
+    framework_dsym = os.path.join(dst, get_framework_name(fat_framework) + '.dSYM')
+
   _process_macos_framework(args, dst, framework_dylib, framework_dsym)
 
 


### PR DESCRIPTION
Separates dSYM creation from archiving, consistent with iOS tooling. This
introduces no semantic changes, but simply adjusts `create_fat_macos_framework`
and `process_framework` for consistency with the equivalent iOS tooling in
`create_ios_framework.py`.

Related issue: https://github.com/flutter/flutter/issues/153879

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
