### PR TITLE
Remove spammy warning message on `FlutterView`

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -777,8 +777,6 @@ public class FlutterView extends FrameLayout
     // existing Insets-based method calls above.
     if (Build.VERSION.SDK_INT >= API_LEVELS.API_35) {
       delegate.growViewportMetricsToCaptionBar(getContext(), viewportMetrics);
-    } else {
-      Log.w(TAG, "API level " + Build.VERSION.SDK_INT + " is too low to query bounding rects.");
     }
 
     Log.v(


### PR DESCRIPTION
@matanlurey:

> As of https://github.com/flutter/engine/commit/d6bc4dc6e59d2d97d0326350c351bff99f845078, we are now printing a `W/FlutterView( 7775): API level 34 is too low to query bounding rects.` message which is not user actionable. Was this intended to stay in the merged PR? What value is it supposed to have?

@yaakovschectman:

> You might be right about that
