### PR TITLE
[iOS] Tweak note about OpenGL support on mac in a user facing log.

### DIFF
--- a/shell/platform/darwin/ios/ios_context_software.mm
+++ b/shell/platform/darwin/ios/ios_context_software.mm
@@ -38,7 +38,7 @@ std::unique_ptr<Texture> IOSContextSoftware::CreateExternalTexture(
   // message.
   NSLog(@"Flutter: Attempted to composite external texture sources using the software backend. "
         @"This backend is only used on simulators. This feature is only available on actual "
-        @"devices where OpenGL or Metal is used for rendering.");
+        @"devices where Metal is used for rendering.");
 
   // Not supported in this backend.
   return nullptr;


### PR DESCRIPTION
We don't have an OpenGL backend on iOS.
