### PR TITLE
Pin mac host and iOS builds to arm64 builders

### DIFF
--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -14,7 +14,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -79,7 +80,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -133,7 +135,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -197,7 +200,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -247,7 +251,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -297,7 +302,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -359,7 +365,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -412,7 +419,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -464,7 +472,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -528,7 +537,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -583,7 +593,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -638,7 +649,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -703,7 +715,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -757,7 +770,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -811,7 +825,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -877,7 +892,8 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -934,7 +950,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -990,7 +1007,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,

--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -3,7 +3,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -49,7 +50,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -97,7 +99,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -143,7 +146,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -189,7 +193,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -235,7 +240,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -283,7 +289,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -333,7 +340,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -381,7 +389,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,
@@ -429,7 +438,8 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-13|Mac-14"
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
             ],
             "gclient_variables": {
                 "download_android_deps": false,


### PR DESCRIPTION
For https://github.com/flutter/flutter/issues/153925.

This limits these builds to using a little under 60% of mac capacity. If the queue times go up, we can trade intel and arm machines between the prod and try pool.