### PR TITLE
Test running the macOS engine has no stray logging

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -210,6 +210,7 @@ TEST_F(FlutterEngineTest, CanLogToStdout) {
 
   // Replace stdout stream buffer with our own.
   StreamCapture stdout_capture(&std::cout);
+  StreamCapture stderr_capture(&std::cerr);
 
   // Launch the test entrypoint.
   FlutterEngine* engine = GetFlutterEngine();
@@ -219,9 +220,12 @@ TEST_F(FlutterEngineTest, CanLogToStdout) {
   latch.Wait();
 
   stdout_capture.Stop();
+  stderr_capture.Stop();
 
   // Verify hello world was written to stdout.
   EXPECT_TRUE(stdout_capture.GetOutput().find("Hello logging") != std::string::npos);
+  EXPECT_EQ(stdout_capture.GetOutput(), "Hello logging");
+  EXPECT_TRUE(stderr_capture.GetOutput().empty());
 }
 
 TEST_F(FlutterEngineTest, DISABLED_BackgroundIsBlack) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -223,8 +223,8 @@ TEST_F(FlutterEngineTest, CanLogToStdout) {
   stderr_capture.Stop();
 
   // Verify hello world was written to stdout.
-  EXPECT_TRUE(stdout_capture.GetOutput().find("Hello logging") != std::string::npos);
-  EXPECT_EQ(stdout_capture.GetOutput(), "Hello logging");
+  // Check equality to ensure no unexpected stray logging.
+  EXPECT_EQ(stdout_capture.GetOutput(), "flutter: Hello logging\n");
   EXPECT_TRUE(stderr_capture.GetOutput().empty());
 }
 


### PR DESCRIPTION
Assert that running the macOS engine does not log anything unexpected 
See also issue https://github.com/flutter/flutter/issues/111577
Similar Windows check in https://github.com/flutter/engine/pull/47774

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
