### PR TITLE
Reland: Framework wide color (#54415)

### DIFF
--- a/lib/gpu/lib/src/render_pass.dart
+++ b/lib/gpu/lib/src/render_pass.dart
@@ -95,6 +95,15 @@ base class RenderTarget {
   final DepthStencilAttachment? depthStencilAttachment;
 }
 
+// TODO(gaaclarke): Refactor this to support wide gamut colors.
+int _colorToInt(ui.Color color) {
+  assert(color.colorSpace == ui.ColorSpace.sRGB);
+  return ((color.a * 255.0).round() << 24) |
+      ((color.r * 255.0).round() << 16) |
+      ((color.g * 255.0).round() << 8) |
+      ((color.b * 255.0).round() << 0);
+}
+
 base class RenderPass extends NativeFieldWrapperClass1 {
   /// Creates a new RenderPass.
   RenderPass._(CommandBuffer commandBuffer, RenderTarget renderTarget) {
@@ -105,7 +114,7 @@ base class RenderPass extends NativeFieldWrapperClass1 {
           index,
           color.loadAction.index,
           color.storeAction.index,
-          color.clearValue.value,
+          _colorToInt(color.clearValue),
           color.texture,
           color.resolveTexture);
       if (error != null) {

--- a/lib/ui/lerp.dart
+++ b/lib/ui/lerp.dart
@@ -26,7 +26,7 @@ double? lerpDouble(num? a, num? b, double t) {
 ///
 /// Same as [lerpDouble] but specialized for non-null `double` type.
 double _lerpDouble(double a, double b, double t) {
-  return a * (1.0 - t) + b * t;
+  return a + (b - a) * t;
 }
 
 /// Linearly interpolate between two integers.

--- a/lib/ui/painting/paint.cc
+++ b/lib/ui/painting/paint.cc
@@ -21,20 +21,25 @@
 namespace flutter {
 
 // Indices for 32bit values.
+// Must match //lib/ui/painting.dart.
 constexpr int kIsAntiAliasIndex = 0;
-constexpr int kColorIndex = 1;
-constexpr int kBlendModeIndex = 2;
-constexpr int kStyleIndex = 3;
-constexpr int kStrokeWidthIndex = 4;
-constexpr int kStrokeCapIndex = 5;
-constexpr int kStrokeJoinIndex = 6;
-constexpr int kStrokeMiterLimitIndex = 7;
-constexpr int kFilterQualityIndex = 8;
-constexpr int kMaskFilterIndex = 9;
-constexpr int kMaskFilterBlurStyleIndex = 10;
-constexpr int kMaskFilterSigmaIndex = 11;
-constexpr int kInvertColorIndex = 12;
-constexpr size_t kDataByteCount = 52;  // 4 * (last index + 1)
+constexpr int kColorRedIndex = 1;
+constexpr int kColorGreenIndex = 2;
+constexpr int kColorBlueIndex = 3;
+constexpr int kColorAlphaIndex = 4;
+constexpr int kColorSpaceIndex = 5;
+constexpr int kBlendModeIndex = 6;
+constexpr int kStyleIndex = 7;
+constexpr int kStrokeWidthIndex = 8;
+constexpr int kStrokeCapIndex = 9;
+constexpr int kStrokeJoinIndex = 10;
+constexpr int kStrokeMiterLimitIndex = 11;
+constexpr int kFilterQualityIndex = 12;
+constexpr int kMaskFilterIndex = 13;
+constexpr int kMaskFilterBlurStyleIndex = 14;
+constexpr int kMaskFilterSigmaIndex = 15;
+constexpr int kInvertColorIndex = 16;
+constexpr size_t kDataByteCount = 68;  // 4 * (last index + 1)
 static_assert(kDataByteCount == sizeof(uint32_t) * (kInvertColorIndex + 1),
               "kDataByteCount must match the size of the data array.");
 
@@ -43,9 +48,6 @@ constexpr int kShaderIndex = 0;
 constexpr int kColorFilterIndex = 1;
 constexpr int kImageFilterIndex = 2;
 constexpr int kObjectCount = 3;  // One larger than largest object index.
-
-// Must be kept in sync with the default in painting.dart.
-constexpr uint32_t kColorDefault = 0xFF000000;
 
 // Must be kept in sync with the default in painting.dart.
 constexpr uint32_t kBlendModeDefault =
@@ -57,6 +59,28 @@ constexpr float kStrokeMiterLimitDefault = 4.0f;
 
 // Must be kept in sync with the MaskFilter private constants in painting.dart.
 enum MaskFilterType { kNull, kBlur };
+
+namespace {
+DlColor ReadColor(const tonic::DartByteData& byte_data) {
+  const uint32_t* uint_data = static_cast<const uint32_t*>(byte_data.data());
+  const float* float_data = static_cast<const float*>(byte_data.data());
+
+  float red = float_data[kColorRedIndex];
+  float green = float_data[kColorGreenIndex];
+  float blue = float_data[kColorBlueIndex];
+  // Invert alpha so 0 initialized buffer has default value;
+  float alpha = 1.f - float_data[kColorAlphaIndex];
+  uint32_t colorspace = uint_data[kColorSpaceIndex];
+  (void)colorspace;
+  uint32_t encoded_color =
+      static_cast<uint8_t>(std::round(alpha * 255.f)) << 24 |  //
+      static_cast<uint8_t>(std::round(red * 255.f)) << 16 |    //
+      static_cast<uint8_t>(std::round(green * 255.f)) << 8 |   //
+      static_cast<uint8_t>(std::round(blue * 255.f)) << 0;
+  // TODO(gaaclarke): Pass down color info to DlColor.
+  return DlColor(encoded_color);
+}
+}  // namespace
 
 Paint::Paint(Dart_Handle paint_objects, Dart_Handle paint_data)
     : paint_objects_(paint_objects), paint_data_(paint_data) {}
@@ -137,8 +161,7 @@ const DlPaint* Paint::paint(DlPaint& paint,
   }
 
   if (flags.applies_alpha_or_color()) {
-    uint32_t encoded_color = uint_data[kColorIndex];
-    paint.setColor(DlColor(encoded_color ^ kColorDefault));
+    paint.setColor(ReadColor(byte_data));
   }
 
   if (flags.applies_blend()) {
@@ -238,8 +261,7 @@ void Paint::toDlPaint(DlPaint& paint) const {
 
   paint.setAntiAlias(uint_data[kIsAntiAliasIndex] == 0);
 
-  uint32_t encoded_color = uint_data[kColorIndex];
-  paint.setColor(DlColor(encoded_color ^ kColorDefault));
+  paint.setColor(ReadColor(byte_data));
 
   uint32_t encoded_blend_mode = uint_data[kBlendModeIndex];
   uint32_t blend_mode = encoded_blend_mode ^ kBlendModeDefault;

--- a/lib/web_ui/lib/painting.dart
+++ b/lib/web_ui/lib/painting.dart
@@ -22,25 +22,126 @@ Color _scaleAlpha(Color a, double factor) {
 }
 
 class Color {
-  const Color(int value) : value = value & 0xFFFFFFFF;
+  const Color(int value)
+      : _value = value & 0xFFFFFFFF,
+        colorSpace = ColorSpace.sRGB,
+        _a = null,
+        _r = null,
+        _g = null,
+        _b = null;
+
+  const Color.from(
+      {required double alpha,
+      required double red,
+      required double green,
+      required double blue,
+      this.colorSpace = ColorSpace.sRGB})
+      : _value = 0,
+        _a = alpha,
+        _r = red,
+        _g = green,
+        _b = blue;
+
   const Color.fromARGB(int a, int r, int g, int b)
-      : value = (((a & 0xff) << 24) |
+      : _value = (((a & 0xff) << 24) |
                 ((r & 0xff) << 16) |
                 ((g & 0xff) << 8) |
                 ((b & 0xff) << 0)) &
-            0xFFFFFFFF;
+            0xFFFFFFFF,
+        colorSpace = ColorSpace.sRGB,
+        _a = null,
+        _r = null,
+        _g = null,
+        _b = null;
+
+  const Color._fromARGBC(
+      int alpha, int red, int green, int blue, this.colorSpace)
+      : _value = (((alpha & 0xff) << 24) |
+                ((red & 0xff) << 16) |
+                ((green & 0xff) << 8) |
+                ((blue & 0xff) << 0)) &
+            0xFFFFFFFF,
+        _a = null,
+        _r = null,
+        _g = null,
+        _b = null;
+
   const Color.fromRGBO(int r, int g, int b, double opacity)
-      : value = ((((opacity * 0xff ~/ 1) & 0xff) << 24) |
+      : _value = ((((opacity * 0xff ~/ 1) & 0xff) << 24) |
                 ((r & 0xff) << 16) |
                 ((g & 0xff) << 8) |
                 ((b & 0xff) << 0)) &
-            0xFFFFFFFF;
-  final int value;
+            0xFFFFFFFF,
+        colorSpace = ColorSpace.sRGB,
+        _a = null,
+        _r = null,
+        _g = null,
+        _b = null;
+
+  double get a => _a ?? (alpha / 255);
+  final double? _a;
+
+  double get r => _r ?? (red / 255);
+  final double? _r;
+
+  double get g => _g ?? (green / 255);
+  final double? _g;
+
+  double get b => _b ?? (blue / 255);
+  final double? _b;
+
+  final ColorSpace colorSpace;
+
+  static int _floatToInt8(double x) {
+    return ((x * 255.0).round()) & 0xff;
+  }
+
+  int get value {
+    if (_a != null && _r != null && _g != null && _b != null) {
+      return _floatToInt8(_a) << 24 |
+          _floatToInt8(_r) << 16 |
+          _floatToInt8(_g) << 8 |
+          _floatToInt8(_b) << 0;
+    } else {
+      return _value;
+    }
+  }
+  final int _value;
+
   int get alpha => (0xff000000 & value) >> 24;
+
   double get opacity => alpha / 0xFF;
+
   int get red => (0x00ff0000 & value) >> 16;
+
   int get green => (0x0000ff00 & value) >> 8;
+
   int get blue => (0x000000ff & value) >> 0;
+
+  Color withValues(
+      {double? alpha,
+      double? red,
+      double? green,
+      double? blue,
+      ColorSpace? colorSpace}) {
+    Color? updatedComponents;
+    if (alpha != null || red != null || green != null || blue != null) {
+      updatedComponents = Color.from(
+          alpha: alpha ?? a,
+          red: red ?? r,
+          green: green ?? g,
+          blue: blue ?? b,
+          colorSpace: this.colorSpace);
+    }
+    if (colorSpace != null && colorSpace != this.colorSpace) {
+      final _ColorTransform transform =
+          _getColorTransform(this.colorSpace, colorSpace);
+      return transform.transform(updatedComponents ?? this, colorSpace);
+    } else {
+      return updatedComponents ?? this;
+    }
+  }
+
   Color withAlpha(int a) {
     return Color.fromARGB(a, red, green, blue);
   }
@@ -79,6 +180,8 @@ class Color {
   }
 
   static Color? lerp(Color? a, Color? b, double t) {
+    assert(a?.colorSpace != ColorSpace.extendedSRGB);
+    assert(b?.colorSpace != ColorSpace.extendedSRGB);
     if (b == null) {
       if (a == null) {
         return null;
@@ -89,42 +192,45 @@ class Color {
       if (a == null) {
         return _scaleAlpha(b, t);
       } else {
-        return Color.fromARGB(
+        assert(a.colorSpace == b.colorSpace);
+        return Color._fromARGBC(
           engine.clampInt(_lerpInt(a.alpha, b.alpha, t).toInt(), 0, 255),
           engine.clampInt(_lerpInt(a.red, b.red, t).toInt(), 0, 255),
           engine.clampInt(_lerpInt(a.green, b.green, t).toInt(), 0, 255),
           engine.clampInt(_lerpInt(a.blue, b.blue, t).toInt(), 0, 255),
+          a.colorSpace,
         );
       }
     }
   }
 
   static Color alphaBlend(Color foreground, Color background) {
+    assert(foreground.colorSpace == background.colorSpace);
+    assert(foreground.colorSpace != ColorSpace.extendedSRGB);
     final int alpha = foreground.alpha;
     if (alpha == 0x00) {
-      // Foreground completely transparent.
       return background;
     }
     final int invAlpha = 0xff - alpha;
     int backAlpha = background.alpha;
     if (backAlpha == 0xff) {
-      // Opaque background case
-      return Color.fromARGB(
+      return Color._fromARGBC(
         0xff,
         (alpha * foreground.red + invAlpha * background.red) ~/ 0xff,
         (alpha * foreground.green + invAlpha * background.green) ~/ 0xff,
         (alpha * foreground.blue + invAlpha * background.blue) ~/ 0xff,
+        foreground.colorSpace,
       );
     } else {
-      // General case
       backAlpha = (backAlpha * invAlpha) ~/ 0xff;
       final int outAlpha = alpha + backAlpha;
       assert(outAlpha != 0x00);
-      return Color.fromARGB(
+      return Color._fromARGBC(
         outAlpha,
         (foreground.red * alpha + background.red * backAlpha) ~/ outAlpha,
         (foreground.green * alpha + background.green * backAlpha) ~/ outAlpha,
         (foreground.blue * alpha + background.blue * backAlpha) ~/ outAlpha,
+        foreground.colorSpace,
       );
     }
   }
@@ -141,16 +247,16 @@ class Color {
     if (other.runtimeType != runtimeType) {
       return false;
     }
-    return other is Color && other.value == value;
+    return other is Color &&
+        other.value == value &&
+        other.colorSpace == colorSpace;
   }
 
   @override
-  int get hashCode => value.hashCode;
+  int get hashCode => Object.hash(value, colorSpace);
 
   @override
-  String toString() {
-    return 'Color(0x${value.toRadixString(16).padLeft(8, '0')})';
-  }
+  String toString() => 'Color(0x${value.toRadixString(16).padLeft(8, '0')})';
 }
 
 enum StrokeCap {
@@ -414,6 +520,101 @@ class MaskFilter {
   String toString() => 'MaskFilter.blur($_style, ${_sigma.toStringAsFixed(1)})';
 }
 
+abstract class _ColorTransform {
+  Color transform(Color color, ColorSpace resultColorSpace);
+}
+
+class _IdentityColorTransform implements _ColorTransform {
+  const _IdentityColorTransform();
+  @override
+  Color transform(Color color, ColorSpace resultColorSpace) => color;
+}
+
+class _ClampTransform implements _ColorTransform {
+  const _ClampTransform(this.child);
+  final _ColorTransform child;
+  @override
+  Color transform(Color color, ColorSpace resultColorSpace) {
+    return Color.from(
+      alpha: clampDouble(color.a, 0, 1),
+      red: clampDouble(color.r, 0, 1),
+      green: clampDouble(color.g, 0, 1),
+      blue: clampDouble(color.b, 0, 1),
+      colorSpace: resultColorSpace);
+  }
+}
+
+class _MatrixColorTransform implements _ColorTransform {
+  const _MatrixColorTransform(this.values);
+
+  final List<double> values;
+
+  @override
+  Color transform(Color color, ColorSpace resultColorSpace) {
+    return Color.from(
+        alpha: color.a,
+        red: values[0] * color.r +
+            values[1] * color.g +
+            values[2] * color.b +
+            values[3],
+        green: values[4] * color.r +
+            values[5] * color.g +
+            values[6] * color.b +
+            values[7],
+        blue: values[8] * color.r +
+            values[9] * color.g +
+            values[10] * color.b +
+            values[11],
+        colorSpace: resultColorSpace);
+  }
+}
+
+_ColorTransform _getColorTransform(ColorSpace source, ColorSpace destination) {
+  const _MatrixColorTransform srgbToP3 = _MatrixColorTransform(<double>[
+    0.808052267214446, 0.220292047628890, -0.139648846160100,
+    0.145738111193222, //
+    0.096480880462996, 0.916386732581291, -0.086093928394828,
+    0.089490172325882, //
+    -0.127099563510240, -0.068983484963878, 0.735426667591299, 0.233655661600230
+  ]);
+  const _ColorTransform p3ToSrgb = _MatrixColorTransform(<double>[
+    1.306671048092539, -0.298061942172353, 0.213228303487995,
+    -0.213580156254466, //
+    -0.117390025596251, 1.127722006101976, 0.109727644608938,
+    -0.109450321455370, //
+    0.214813187718391, 0.054268702864647, 1.406898424029350, -0.364892765879631
+  ]);
+  switch (source) {
+    case ColorSpace.sRGB:
+      switch (destination) {
+        case ColorSpace.sRGB:
+          return const _IdentityColorTransform();
+        case ColorSpace.extendedSRGB:
+          return const _IdentityColorTransform();
+        case ColorSpace.displayP3:
+          return srgbToP3;
+      }
+    case ColorSpace.extendedSRGB:
+      switch (destination) {
+        case ColorSpace.sRGB:
+          return const _ClampTransform(_IdentityColorTransform());
+        case ColorSpace.extendedSRGB:
+          return const _IdentityColorTransform();
+        case ColorSpace.displayP3:
+          return const _ClampTransform(srgbToP3);
+      }
+    case ColorSpace.displayP3:
+      switch (destination) {
+        case ColorSpace.sRGB:
+          return const _ClampTransform(p3ToSrgb);
+        case ColorSpace.extendedSRGB:
+          return p3ToSrgb;
+        case ColorSpace.displayP3:
+          return const _IdentityColorTransform();
+      }
+  }
+}
+
 // This needs to be kept in sync with the "_FilterQuality" enum in skwasm's canvas.cpp
 enum FilterQuality {
   none,
@@ -453,6 +654,7 @@ class ImageFilter {
 enum ColorSpace {
   sRGB,
   extendedSRGB,
+  displayP3,
 }
 
 // This must be kept in sync with the `ImageByteFormat` enum in Skwasm's surface.cpp.


### PR DESCRIPTION
[This PR](https://github.com/flutter/engine/pull/54415) was reverted because it requires a manual roll into the framework.

issue: https://github.com/flutter/flutter/issues/127855
integration test: https://github.com/flutter/engine/pull/54415

This does the preliminary work for implementing wide gamut colors in the Flutter framework. Here are the following changes: 1) colors now specify a colorspace with which they are to be interpreted 1) colors now store their components as floats to accommodate bit depths more than 8

The storage of this Color class is weird with float/int storage but that is a temporary solution to support a smooth transition. Here is the plan for landing this:
1) Land this PR
1) Wait for it to roll into the Framework
1) Land https://github.com/flutter/flutter/pull/153938 which will make CupertinoDynamicColor implement Color
1) Land another engine PR that rips out the int storage: https://github.com/flutter/engine/pull/54714

Here are follow up PRs:
1) https://github.com/flutter/engine/pull/54473 - changes DlColor so the wide gamut colors are rendered
1) https://github.com/flutter/engine/pull/54567 - Hooks up these changes to take advantage of wide DlColor
1) https://github.com/flutter/flutter/pull/153319 - the integration test for the framework repo

There are some things that have been left as follow up PRs since they are technically breaking:
1) The math on `lerp` hasn't been updated to take advantage of the higher bit depth
1) `operator==` hasn't been updated to take advantage of the higher bit depth
1) `hashCode` hasn't been updated to take advantage of the higher bit depth
1) `alphaBlend` hasn't been updated to take advantage of the higher bit depth
1) `toString` hasn't been updated to take advantage of the higher bit depth

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
