### PR TITLE
iOS: don't bundle simulator dSYMs in xcframework

### DIFF
--- a/sky/tools/create_ios_framework.py
+++ b/sky/tools/create_ios_framework.py
@@ -131,10 +131,8 @@ def create_framework(  # pylint: disable=too-many-arguments
 
   # Compute dsym output paths, if enabled.
   framework_dsym = None
-  simulator_dsym = None
   if args.dsym:
     framework_dsym = framework + '.dSYM'
-    simulator_dsym = simulator_framework + '.dSYM'
 
   # Emit the framework for physical devices.
   sky_utils.copy_tree(arm64_framework, framework)
@@ -146,7 +144,7 @@ def create_framework(  # pylint: disable=too-many-arguments
     sky_utils.copy_tree(simulator_arm64_framework, simulator_framework)
     simulator_framework_binary = os.path.join(simulator_framework, 'Flutter')
     sky_utils.lipo([simulator_x64_dylib, simulator_arm64_dylib], simulator_framework_binary)
-    process_framework(args, dst, simulator_framework_binary, simulator_dsym)
+    process_framework(args, dst, simulator_framework_binary, dsym=None)
   else:
     simulator_framework = simulator_x64_framework
 
@@ -154,7 +152,7 @@ def create_framework(  # pylint: disable=too-many-arguments
   # simulator frameworks, or just the x64 simulator framework if only that one
   # exists.
   xcframeworks = [simulator_framework, framework]
-  dsyms = [simulator_dsym, framework_dsym] if args.dsym else None
+  dsyms = {framework: framework_dsym} if args.dsym else None
   create_xcframework(location=dst, name='Flutter', frameworks=xcframeworks, dsyms=dsyms)
 
   sky_utils.lipo([arm64_dylib, simulator_x64_dylib], framework_binary)
@@ -183,9 +181,7 @@ def zip_archive(dst, args):
   if args.dsym:
     without_entitlements.extend([
         'Flutter.xcframework/ios-arm64/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
-        'Flutter.xcframework/ios-arm64_x86_64-simulator/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
         'extension_safe/Flutter.xcframework/ios-arm64/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
-        'extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
     ])
 
   without_entitlements_file = os.path.join(dst, 'without_entitlements.txt')

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -64,7 +64,7 @@ def main():
 
   # Create XCFramework from the arm64 and x64 fat framework.
   xcframeworks = [fat_framework]
-  dsyms = [fat_framework + '.dSYM'] if args.dsym else None
+  dsyms = {fat_framework: fat_framework + '.dSYM'} if args.dsym else None
   create_xcframework(location=dst, name='FlutterMacOS', frameworks=xcframeworks, dsyms=dsyms)
 
   if args.zip:

--- a/sky/tools/create_xcframework.py
+++ b/sky/tools/create_xcframework.py
@@ -22,22 +22,15 @@ def main():
       help='The framework paths used to create the XCFramework.',
       required=True
   )
-  parser.add_argument(
-      '--dsyms', nargs='+', help='The dSYM paths to be bundled in the XCFramework.', required=False
-  )
   parser.add_argument('--name', help='Name of the XCFramework', type=str, required=True)
   parser.add_argument('--location', help='Output directory', type=str, required=True)
 
   args = parser.parse_args()
 
-  create_xcframework(args.location, args.name, args.frameworks, args.dsyms)
+  create_xcframework(args.location, args.name, args.frameworks)
 
 
 def create_xcframework(location, name, frameworks, dsyms=None):
-  if dsyms and len(frameworks) != len(dsyms):
-    print('Number of --dsyms must match number of --frameworks exactly.', file=sys.stderr)
-    sys.exit(1)
-
   output_dir = os.path.abspath(location)
   output_xcframework = os.path.join(output_dir, '%s.xcframework' % name)
 
@@ -54,10 +47,10 @@ def create_xcframework(location, name, frameworks, dsyms=None):
 
   command.extend(['-output', output_xcframework])
 
-  for i in range(len(frameworks)):  # pylint: disable=consider-using-enumerate
-    command.extend(['-framework', os.path.abspath(frameworks[i])])
-    if dsyms:
-      command.extend(['-debug-symbols', os.path.abspath(dsyms[i])])
+  for framework in frameworks:
+    command.extend(['-framework', os.path.abspath(framework)])
+    if dsyms and framework in dsyms:
+      command.extend(['-debug-symbols', os.path.abspath(dsyms[framework])])
 
   subprocess.check_call(command, stdout=open(os.devnull, 'w'))
 


### PR DESCRIPTION
While we do produce a simulator slice in our iOS release framework binaries, this is actually an unsupported runtime mode, therefore there is no need to bundle dSYMs for this mode.

This saves roughly 1GB of cached debug info.

Issue: https://github.com/flutter/flutter/issues/116493
Fixes: https://github.com/flutter/flutter/issues/154019
Related issue: https://github.com/flutter/flutter/issues/11754

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
