### PR TITLE
Set cores in 'dimensions' instead of 'properties'

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -211,11 +211,12 @@ targets:
     properties:
       release_build: "true"
       config_name: linux_fuchsia
-      cores: "8"
     # Do not remove(https://github.com/flutter/flutter/issues/144644)
     # Scheduler will fail to get the platform
     drone_dimensions:
       - os=Linux
+    dimensions:
+      cores: "8"
 
   - name: Linux linux_fuchsia_tests
     recipe: engine_v2/engine_v2


### PR DESCRIPTION
`properties` gets routed to the build properties json that gets handed to the recipe. `dimensions` gets routed to the common_pb2.RequestedDimension buildbucket protobuf field. See:

https://flutter.googlesource.com/recipes/+/refs/heads/main/recipe_modules/shard_util/api.py#368

