### PR TITLE
[ui] fix missing color conversion in drawAtlas.

### DIFF
--- a/lib/ui/painting/canvas.cc
+++ b/lib/ui/painting/canvas.cc
@@ -596,12 +596,16 @@ Dart_Handle Canvas::drawAtlas(Dart_Handle paint_objects,
     tonic::Int32List colors(colors_handle);
     tonic::Float32List cull_rect(cull_rect_handle);
 
+    std::vector<DlColor> dl_color(colors.num_elements());
+    for (auto i = 0u; i < colors.num_elements(); i++) {
+      dl_color[i] = DlColor(colors[i]);
+    }
+
     DlPaint dl_paint;
     const DlPaint* opt_paint = paint.paint(dl_paint, kDrawAtlasWithPaintFlags);
     builder()->DrawAtlas(
         dl_image, reinterpret_cast<const SkRSXform*>(transforms.data()),
-        reinterpret_cast<const SkRect*>(rects.data()),
-        reinterpret_cast<const DlColor*>(colors.data()),
+        reinterpret_cast<const SkRect*>(rects.data()), dl_color.data(),
         rects.num_elements() / 4,  // SkRect have four floats.
         blend_mode, sampling, reinterpret_cast<const SkRect*>(cull_rect.data()),
         opt_paint);

--- a/lib/ui/painting/canvas.cc
+++ b/lib/ui/painting/canvas.cc
@@ -597,7 +597,8 @@ Dart_Handle Canvas::drawAtlas(Dart_Handle paint_objects,
     tonic::Float32List cull_rect(cull_rect_handle);
 
     std::vector<DlColor> dl_color(colors.num_elements());
-    for (auto i = 0u; i < colors.num_elements(); i++) {
+    size_t count = colors.num_elements();
+    for (size_t i = 0; i < count; i++) {
       dl_color[i] = DlColor(colors[i]);
     }
 

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -1302,7 +1302,7 @@ void main() async {
       fail('Expected non-null byte data');
       return;
     }
-    final int rgba = data.buffer.asInt32List()[0];
+    final int rgba = data.buffer.asUint32List()[0];
     expect(rgba, 0xFF0000FF);
   });
 }

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -1267,6 +1267,52 @@ void main() async {
     expect(paintCopy.colorFilter, equals(const ColorFilter.mode(Color(0xFF00FF00), BlendMode.color)));
     expect(paintCopy.imageFilter, equals(ImageFilter.blur(sigmaX: 10.0, sigmaY: 10.0)));
   });
+
+  test('DrawAtlas correctly copies color values into display list format', () async {
+    final Image testImage = await createTestImage();
+    final PictureRecorder recorder = PictureRecorder();
+    final Canvas canvas = Canvas(recorder);
+    // Make a drawAtlas call that should be solid red.
+    canvas.drawAtlas(
+      testImage,
+      [
+        RSTransform.fromComponents(
+          rotation: 0,
+          scale: 10,
+          anchorX: 0,
+          anchorY: 0,
+          translateX: 0,
+          translateY: 0,
+        ),
+      ],
+      [
+        const Rect.fromLTWH(0, 0, 1, 1)
+      ],
+      [
+        const Color.fromARGB(255, 255, 0, 0)
+      ],
+      BlendMode.dst,
+      null,
+      Paint(),
+    );
+
+    final Image resultImage = await recorder.endRecording().toImage(1, 1);
+    final ByteData? data = await resultImage.toByteData();
+    if (data == null) {
+      fail('Expected non-null byte data');
+      return;
+    }
+    final Color resultColor = Color(data.buffer.asInt32List()[0]);
+    expect(resultColor, const Color.fromARGB(255, 255, 0 0));
+  });
+}
+
+Future<Image> createTestImage() async {
+  final PictureRecorder recorder = PictureRecorder();
+  final Canvas recorderCanvas = Canvas(recorder);
+  recorderCanvas.scale(1.0, 1.0);
+  final Picture picture = recorder.endRecording();
+  return picture.toImage(1, 1);
 }
 
 Matcher listEquals(ByteData expected) => (dynamic v) {

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -1303,7 +1303,7 @@ void main() async {
       return;
     }
     final Color resultColor = Color(data.buffer.asInt32List()[0]);
-    expect(resultColor, const Color.fromARGB(255, 255, 0 0));
+    expect(resultColor, const Color.fromARGB(255, 255, 0, 0));
   });
 }
 

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -1302,8 +1302,8 @@ void main() async {
       fail('Expected non-null byte data');
       return;
     }
-    final Color resultColor = Color(data.buffer.asInt32List()[0]);
-    expect(resultColor, const Color.fromARGB(255, 255, 0, 0));
+    final int rgba = data.buffer.asInt32List()[0];
+    expect(rgba, 0xFF0000FF);
   });
 }
 


### PR DESCRIPTION
Ensure that int32 ui colors are correctly converted to Dl Colors (convert instead of reinterpret cast).