### PR TITLE
[web] set the "dialog" ARIA role unconditionally

### DIFF
--- a/lib/web_ui/lib/src/engine/semantics/route.dart
+++ b/lib/web_ui/lib/src/engine/semantics/route.dart
@@ -41,6 +41,13 @@ class SemanticRoute extends SemanticRole {
       // Case 2: nothing requested explicit focus. Focus on the first descendant.
       _setDefaultFocus();
     });
+
+    // Lacking any more specific information, ARIA role "dialog" is the
+    // closest thing to Flutter's route. This can be revisited if better
+    // options become available, especially if the framework volunteers more
+    // specific information about the route. Other attributes in the vicinity
+    // of routes include: "alertdialog", `aria-modal`, "menu", "tooltip".
+    setAriaRole('dialog');
   }
 
   void _setDefaultFocus() {
@@ -79,7 +86,6 @@ class SemanticRoute extends SemanticRole {
       }());
 
       setAttribute('aria-label', label ?? '');
-      _assignRole();
     }
   }
 
@@ -91,20 +97,10 @@ class SemanticRoute extends SemanticRole {
       return;
     }
 
-    _assignRole();
     setAttribute(
       'aria-describedby',
       routeName.semanticsObject.element.id,
     );
-  }
-
-  void _assignRole() {
-    // Lacking any more specific information, ARIA role "dialog" is the
-    // closest thing to Flutter's route. This can be revisited if better
-    // options become available, especially if the framework volunteers more
-    // specific information about the route. Other attributes in the vicinity
-    // of routes include: "alertdialog", `aria-modal`, "menu", "tooltip".
-    setAriaRole('dialog');
   }
 
   @override

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -3110,10 +3110,7 @@ void _testRoute() {
     semantics().semanticsEnabled = false;
   });
 
-  test('scopesRoute alone sets the SemanticRoute role with no label', () {
-    final List<String> warnings = <String>[];
-    printWarning = warnings.add;
-
+  test('scopesRoute alone sets the SemanticRoute role and "dialog" ARIA role with no label', () {
     semantics()
       ..debugOverrideTimestampFunction(() => _testTime)
       ..semanticsEnabled = true;
@@ -3127,7 +3124,7 @@ void _testRoute() {
     tester.apply();
 
     expectSemanticsTree(owner(), '''
-      <sem></sem>
+      <sem role="dialog"></sem>
     ''');
 
     expect(


### PR DESCRIPTION
Previously the "dialog" ARIA role was only set if the route or any of its descendants had the `namesRoute` flag. This PR sets the ARIA role unconditionally. Although it's always a good idea to have a label on the route, a missing label doesn't change the fact that the route is a route, so the ARIA role should still be set.

Fixes https://github.com/flutter/flutter/issues/153791
