### PR TITLE
[macOS] Add TODOs to remove AppKit bug workaround

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -297,6 +297,9 @@ static void OnKeyboardLayoutChanged(CFNotificationCenterRef center,
   // See: https://github.com/flutter/flutter/issues/115015
   // See: http://www.openradar.me/FB12050037
   // See: https://developer.apple.com/documentation/appkit/nsresponder/1524634-mousedown
+  //
+  // TODO(cbracken): https://github.com/flutter/flutter/issues/154063
+  // Remove this workaround when we drop support for macOS 12 (Monterey).
   [self.nextResponder mouseDown:event];
 }
 
@@ -311,6 +314,9 @@ static void OnKeyboardLayoutChanged(CFNotificationCenterRef center,
   // See: https://github.com/flutter/flutter/issues/115015
   // See: http://www.openradar.me/FB12050037
   // See: https://developer.apple.com/documentation/appkit/nsresponder/1535349-mouseup
+  //
+  // TODO(cbracken): https://github.com/flutter/flutter/issues/154063
+  // Remove this workaround when we drop support for macOS 12 (Monterey).
   [self.nextResponder mouseUp:event];
 }
 


### PR DESCRIPTION
In https://github.com/flutter/engine/pull/40241, I added a workaround for an AppKit bug wherein mouseDown/Up events were ignored when the *Reduced Transparency* accessibility setting was enabled, and the view was hosted in an `NSPopover`.

I filed a Radar and Apple reported the bug fixed in macOS 13.3.1.

When we drop support for macOS 12 in Flutter, we should remove the workaround.

So long as nothing else has been added to these methods at that time, the method overrides themselves should be removed, so that we fall back to the default behaviour.

See: http://www.openradar.me/FB12050037
See: https://developer.apple.com/documentation/appkit/nsresponder/1535349-mouseup

Issue: https://github.com/flutter/flutter/issues/154063
Issue: https://github.com/flutter/flutter/issues/115015

No tests modified since this only adds a comment.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
