### PR TITLE
Revert "Test running the macOS engine has no stray logging"

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -210,7 +210,6 @@ TEST_F(FlutterEngineTest, CanLogToStdout) {
 
   // Replace stdout stream buffer with our own.
   StreamCapture stdout_capture(&std::cout);
-  StreamCapture stderr_capture(&std::cerr);
 
   // Launch the test entrypoint.
   FlutterEngine* engine = GetFlutterEngine();
@@ -220,12 +219,9 @@ TEST_F(FlutterEngineTest, CanLogToStdout) {
   latch.Wait();
 
   stdout_capture.Stop();
-  stderr_capture.Stop();
 
   // Verify hello world was written to stdout.
-  // Check equality to ensure no unexpected stray logging.
-  EXPECT_EQ(stdout_capture.GetOutput(), "flutter: Hello logging\n");
-  EXPECT_TRUE(stderr_capture.GetOutput().empty());
+  EXPECT_TRUE(stdout_capture.GetOutput().find("Hello logging") != std::string::npos);
 }
 
 TEST_F(FlutterEngineTest, DISABLED_BackgroundIsBlack) {


### PR DESCRIPTION
This reverts commit 5aed693f87b5a77bc7b3aa7e6e411f12f7deb921.

Revert https://github.com/flutter/engine/pull/54716. This new check is flaking and isn't very high-value.
https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8738562907128595441/+/u/test:_Host_Tests_for_host_profile/stdout


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
