### PR TITLE
Use GNI group instead of hardcoding PNG codecs source files.

### DIFF
--- a/skia/BUILD.gn
+++ b/skia/BUILD.gn
@@ -528,10 +528,8 @@ optional("png_decode") {
   ]
 
   deps = [ "//flutter/third_party/libpng" ]
-  sources = [
-    "$_skia_root/src/codec/SkIcoCodec.cpp",
-    "$_skia_root/src/codec/SkPngCodec.cpp",
-  ]
+  sources = [ "$_skia_root/src/codec/SkIcoCodec.cpp" ]
+  sources += skia_codec_png
 }
 
 optional("png_encode") {


### PR DESCRIPTION
Fixes https://issues.skia.org/issues/362267329.  The indirection introduced by this PR insulates Flutter from source-file-list changes in Skia.  See the linked bug for more details.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
