### PR TITLE
macOS: Add @available check at macOS 12 workaround

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -286,38 +286,44 @@ static void OnKeyboardLayoutChanged(CFNotificationCenterRef center,
   return @[ _flutterView ];
 }
 
+// TODO(cbracken): https://github.com/flutter/flutter/issues/154063
+// Remove this whole method override when we drop support for macOS 12 (Monterey).
 - (void)mouseDown:(NSEvent*)event {
-  // Work around an AppKit bug where mouseDown/mouseUp are not called on the view controller if the
-  // view is the content view of an NSPopover AND macOS's Reduced Transparency accessibility setting
-  // is enabled.
-  //
-  // This simply calls mouseDown on the next responder in the responder chain as the default
-  // implementation on NSResponder is documented to do.
-  //
-  // See: https://github.com/flutter/flutter/issues/115015
-  // See: http://www.openradar.me/FB12050037
-  // See: https://developer.apple.com/documentation/appkit/nsresponder/1524634-mousedown
-  //
-  // TODO(cbracken): https://github.com/flutter/flutter/issues/154063
-  // Remove this workaround when we drop support for macOS 12 (Monterey).
-  [self.nextResponder mouseDown:event];
+  if (@available(macOS 13.3.1, *)) {
+    [super mouseDown:event];
+  } else {
+    // Work around an AppKit bug where mouseDown/mouseUp are not called on the view controller if
+    // the view is the content view of an NSPopover AND macOS's Reduced Transparency accessibility
+    // setting is enabled.
+    //
+    // This simply calls mouseDown on the next responder in the responder chain as the default
+    // implementation on NSResponder is documented to do.
+    //
+    // See: https://github.com/flutter/flutter/issues/115015
+    // See: http://www.openradar.me/FB12050037
+    // See: https://developer.apple.com/documentation/appkit/nsresponder/1524634-mousedown
+    [self.nextResponder mouseDown:event];
+  }
 }
 
+// TODO(cbracken): https://github.com/flutter/flutter/issues/154063
+// Remove this workaround when we drop support for macOS 12 (Monterey).
 - (void)mouseUp:(NSEvent*)event {
-  // Work around an AppKit bug where mouseDown/mouseUp are not called on the view controller if the
-  // view is the content view of an NSPopover AND macOS's Reduced Transparency accessibility setting
-  // is enabled.
-  //
-  // This simply calls mouseUp on the next responder in the responder chain as the default
-  // implementation on NSResponder is documented to do.
-  //
-  // See: https://github.com/flutter/flutter/issues/115015
-  // See: http://www.openradar.me/FB12050037
-  // See: https://developer.apple.com/documentation/appkit/nsresponder/1535349-mouseup
-  //
-  // TODO(cbracken): https://github.com/flutter/flutter/issues/154063
-  // Remove this workaround when we drop support for macOS 12 (Monterey).
-  [self.nextResponder mouseUp:event];
+  if (@available(macOS 13.3.1, *)) {
+    [super mouseUp:event];
+  } else {
+    // Work around an AppKit bug where mouseDown/mouseUp are not called on the view controller if
+    // the view is the content view of an NSPopover AND macOS's Reduced Transparency accessibility
+    // setting is enabled.
+    //
+    // This simply calls mouseUp on the next responder in the responder chain as the default
+    // implementation on NSResponder is documented to do.
+    //
+    // See: https://github.com/flutter/flutter/issues/115015
+    // See: http://www.openradar.me/FB12050037
+    // See: https://developer.apple.com/documentation/appkit/nsresponder/1535349-mouseup
+    [self.nextResponder mouseUp:event];
+  }
 }
 
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -1082,7 +1082,16 @@ static void SwizzledNoop(id self, SEL _cmd) {}
 // See: https://github.com/flutter/flutter/issues/115015
 // See: http://www.openradar.me/FB12050037
 // See: https://developer.apple.com/documentation/appkit/nsresponder/1524634-mousedown
+//
+// TODO(cbracken): https://github.com/flutter/flutter/issues/154063
+// Remove this test when we drop support for macOS 12 (Monterey).
 - (bool)testMouseDownUpEventsSentToNextResponder:(id)engineMock {
+  if (@available(macOS 13.3.1, *)) {
+    // This workaround is disabled for macOS 13.3.1 onwards, since the underlying AppKit bug is
+    // fixed.
+    return true;
+  }
+
   // The root cause of the above bug is NSResponder mouseDown/mouseUp methods that don't correctly
   // walk the responder chain calling the appropriate method on the next responder under certain
   // conditions. Simulate this by swizzling out the default implementations and replacing them with


### PR DESCRIPTION
Use default mouse event handling behaviour on macOS 13.3.1 onwards. This has two positive effects:

* Avoids the workaround on newer macOS versions where it's unnecessary, thereby giving us confidence that the underlying AppKit issue is fixed and the whole method can later be removed.
* Will be caught by tooling when we drop support for versions of macOS prior to the fixed version.

Issue: https://github.com/flutter/flutter/issues/154063
Issue: https://github.com/flutter/flutter/issues/115015

No tests modified since there is no semantic change, either on versions of macOS where the issue is fixed (and thus the default event handler is correct) or on versions where it is not (and we still use the workaround).

Re-tested manually with the reduced transparency setting on macOS 14.6.1.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
