### PR TITLE
[Impeller] Make extensions required for AHB swapchains optional on Android.

### DIFF
--- a/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -288,12 +288,10 @@ CapabilitiesVK::GetEnabledDeviceExtensions(
 
   auto for_each_optional_android_extension =
       [&](OptionalAndroidDeviceExtensionVK ext) {
-#ifdef FML_OS_ANDROID
         auto name = GetExtensionName(ext);
         if (exts->find(name) != exts->end()) {
           enabled.push_back(name);
         }
-#endif  //  FML_OS_ANDROID
         return true;
       };
 

--- a/impeller/renderer/backend/vulkan/capabilities_vk.h
+++ b/impeller/renderer/backend/vulkan/capabilities_vk.h
@@ -80,33 +80,6 @@ enum class RequiredAndroidDeviceExtensionVK : uint32_t {
   ///
   kKHRDedicatedAllocation,
 
-  //----------------------------------------------------------------------------
-  /// For exporting file descriptors from fences to interact with platform APIs.
-  ///
-  /// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_external_fence_fd.html
-  ///
-  kKHRExternalFenceFd,
-
-  //----------------------------------------------------------------------------
-  /// Dependency of kKHRExternalFenceFd.
-  ///
-  /// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_external_fence.html
-  ///
-  kKHRExternalFence,
-
-  //----------------------------------------------------------------------------
-  /// For importing sync file descriptors as semaphores so the GPU can wait for
-  /// semaphore to be signaled.
-  ///
-  /// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_external_semaphore_fd.html
-  kKHRExternalSemaphoreFd,
-
-  //----------------------------------------------------------------------------
-  /// Dependency of kKHRExternalSemaphoreFd
-  ///
-  /// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_external_semaphore.html
-  kKHRExternalSemaphore,
-
   kLast,
 };
 
@@ -139,6 +112,46 @@ enum class OptionalDeviceExtensionVK : uint32_t {
   /// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_image_compression_control.html
   ///
   kEXTImageCompressionControl,
+
+  kLast,
+};
+
+//------------------------------------------------------------------------------
+/// @brief      A device extensions that may be available on Android platforms.
+///             Without the presence of these extensions on Android, certain
+///             features cannot be used, like AHB swapchains.
+///
+///             Platform agnostic code can still check if these Android
+///             extensions are present.
+///
+enum class OptionalAndroidDeviceExtensionVK : uint32_t {
+
+  //----------------------------------------------------------------------------
+  /// For exporting file descriptors from fences to interact with platform APIs.
+  ///
+  /// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_external_fence_fd.html
+  ///
+  kKHRExternalFenceFd,
+
+  //----------------------------------------------------------------------------
+  /// Dependency of kKHRExternalFenceFd.
+  ///
+  /// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_external_fence.html
+  ///
+  kKHRExternalFence,
+
+  //----------------------------------------------------------------------------
+  /// For importing sync file descriptors as semaphores so the GPU can wait for
+  /// semaphore to be signaled.
+  ///
+  /// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_external_semaphore_fd.html
+  kKHRExternalSemaphoreFd,
+
+  //----------------------------------------------------------------------------
+  /// Dependency of kKHRExternalSemaphoreFd
+  ///
+  /// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_external_semaphore.html
+  kKHRExternalSemaphore,
 
   kLast,
 };
@@ -181,6 +194,8 @@ class CapabilitiesVK final : public Capabilities,
   bool HasExtension(RequiredCommonDeviceExtensionVK ext) const;
 
   bool HasExtension(RequiredAndroidDeviceExtensionVK ext) const;
+
+  bool HasExtension(OptionalAndroidDeviceExtensionVK ext) const;
 
   bool HasExtension(OptionalDeviceExtensionVK ext) const;
 
@@ -276,6 +291,8 @@ class CapabilitiesVK final : public Capabilities,
   std::set<RequiredAndroidDeviceExtensionVK>
       required_android_device_extensions_;
   std::set<OptionalDeviceExtensionVK> optional_device_extensions_;
+  std::set<OptionalAndroidDeviceExtensionVK>
+      optional_android_device_extensions_;
   mutable PixelFormat default_color_format_ = PixelFormat::kUnknown;
   PixelFormat default_stencil_format_ = PixelFormat::kUnknown;
   PixelFormat default_depth_stencil_format_ = PixelFormat::kUnknown;

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -626,4 +626,16 @@ const std::unique_ptr<DriverInfoVK>& ContextVK::GetDriverInfo() const {
   return driver_info_;
 }
 
+bool ContextVK::SupportsAHBSwapchain() const {
+  const CapabilitiesVK& caps = CapabilitiesVK::Cast(*device_capabilities_);
+  return caps.HasExtension(
+             OptionalAndroidDeviceExtensionVK::kKHRExternalFence) &&
+         caps.HasExtension(
+             OptionalAndroidDeviceExtensionVK::kKHRExternalFenceFd) &&
+         caps.HasExtension(
+             OptionalAndroidDeviceExtensionVK::kKHRExternalSemaphore) &&
+         caps.HasExtension(
+             OptionalAndroidDeviceExtensionVK::kKHRExternalSemaphoreFd);
+}
+
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/context_vk.h
+++ b/impeller/renderer/backend/vulkan/context_vk.h
@@ -102,6 +102,10 @@ class ContextVK final : public Context,
   // |Context|
   void Shutdown() override;
 
+  /// @brief Whether the Vulkan context has sufficient capabilities to support
+  ///        Android Hardware Buffer swapchains.
+  bool SupportsAHBSwapchain() const;
+
   void SetOffscreenFormat(PixelFormat pixel_format);
 
   template <typename T>

--- a/impeller/renderer/backend/vulkan/context_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/context_vk_unittests.cc
@@ -241,5 +241,24 @@ TEST(ContextVKTest, HasDefaultColorFormat) {
   ASSERT_NE(capabilites_vk->GetDefaultColorFormat(), PixelFormat::kUnknown);
 }
 
+TEST(ContextVKTest, ChecksOptionalDeviceExtensionsForAndroid) {
+  auto context = MockVulkanContextBuilder().Build();
+  ASSERT_NE(context, nullptr);
+
+  EXPECT_FALSE(context->SupportsAHBSwapchain());
+
+  context = MockVulkanContextBuilder()
+                .SetDeviceExtensions({
+                    VK_KHR_EXTERNAL_FENCE_FD_EXTENSION_NAME,      //
+                    VK_KHR_EXTERNAL_FENCE_EXTENSION_NAME,         //
+                    VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME,  //
+                    VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME      //
+                })
+                .Build();
+  ASSERT_NE(context, nullptr);
+
+  EXPECT_TRUE(context->SupportsAHBSwapchain());
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_impl_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_impl_vk.cc
@@ -20,11 +20,6 @@ namespace impeller {
 
 static constexpr size_t kMaxFramesInFlight = 3u;
 
-// Number of frames to poll for orientation changes. For example `1u` means
-// that the orientation will be polled every frame, while `2u` means that the
-// orientation will be polled every other frame.
-static constexpr size_t kPollFramesForOrientation = 1u;
-
 struct KHRFrameSynchronizerVK {
   vk::UniqueFence acquire;
   vk::UniqueSemaphore render_ready;
@@ -335,10 +330,10 @@ KHRSwapchainImplVK::AcquireResult KHRSwapchainImplVK::AcquireNextDrawable() {
   /// Get the next image index.
   ///
   auto [acq_result, index] = context.GetDevice().acquireNextImageKHR(
-      *swapchain_,          // swapchain
-      1'000'000'000,        // timeout (ns) 1000ms
-      *sync->render_ready,  // signal semaphore
-      nullptr               // fence
+      *swapchain_,                           // swapchain
+      std::numeric_limits<uint64_t>::max(),  // timeout (ns)
+      *sync->render_ready,                   // signal semaphore
+      nullptr                                // fence
   );
 
   switch (acq_result) {

--- a/impeller/renderer/backend/vulkan/swapchain/swapchain_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain/swapchain_vk.cc
@@ -55,8 +55,11 @@ std::shared_ptr<SwapchainVK> SwapchainVK::Create(
     return nullptr;
   }
 
+  // TODO(147533): AHB swapchains on emulators are not functional.
+  const auto emulator = ContextVK::Cast(*context).GetDriverInfo()->IsEmulator();
+
   // Try AHB swapchains first.
-  if (ContextVK::Cast(*context).SupportsAHBSwapchain() &&
+  if (!emulator && ContextVK::Cast(*context).SupportsAHBSwapchain() &&
       AHBSwapchainVK::IsAvailableOnPlatform()) {
     auto ahb_swapchain = std::shared_ptr<AHBSwapchainVK>(new AHBSwapchainVK(
         context,             //

--- a/impeller/renderer/backend/vulkan/swapchain/swapchain_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain/swapchain_vk.cc
@@ -55,11 +55,9 @@ std::shared_ptr<SwapchainVK> SwapchainVK::Create(
     return nullptr;
   }
 
-  // TODO(147533): AHB swapchains on emulators are not functional.
-  const auto emulator = ContextVK::Cast(*context).GetDriverInfo()->IsEmulator();
-
   // Try AHB swapchains first.
-  if (!emulator && AHBSwapchainVK::IsAvailableOnPlatform()) {
+  if (ContextVK::Cast(*context).SupportsAHBSwapchain() &&
+      AHBSwapchainVK::IsAvailableOnPlatform()) {
     auto ahb_swapchain = std::shared_ptr<AHBSwapchainVK>(new AHBSwapchainVK(
         context,             //
         window.GetHandle(),  //

--- a/impeller/renderer/backend/vulkan/test/mock_vulkan.h
+++ b/impeller/renderer/backend/vulkan/test/mock_vulkan.h
@@ -83,6 +83,13 @@ class MockVulkanContextBuilder {
     return *this;
   }
 
+  MockVulkanContextBuilder& SetDeviceExtensions(
+      const std::vector<std::string>& device_extensions) {
+    device_extensions_ = device_extensions;
+    device_extensions_.push_back("VK_KHR_swapchain");
+    return *this;
+  }
+
   MockVulkanContextBuilder& SetInstanceLayers(
       const std::vector<std::string>& instance_layers) {
     instance_layers_ = instance_layers;
@@ -103,6 +110,7 @@ class MockVulkanContextBuilder {
  private:
   std::function<void(ContextVK::Settings&)> settings_callback_;
   std::vector<std::string> instance_extensions_;
+  std::vector<std::string> device_extensions_;
   std::vector<std::string> instance_layers_;
   std::function<void(VkPhysicalDevice physicalDevice,
                      VkFormat format,


### PR DESCRIPTION
From https://github.com/flutter/flutter/issues/153762

AHB required extensions are not present on some devices. These devices can still use KHR, right now we're kciking them off vulkan entirely.

Minor fixes:
Some devices don't support non-infinite timeouts
Some devices don't seem to work with the AHB swapchain/SurfaceControl.

Make some adjustments so we can prepare to fallback to KHR if needed.
