### PR TITLE
macOS: Do not archive/upload FlutterMacOS.dSYM to cloud

### DIFF
--- a/ci/builders/mac_host_engine.json
+++ b/ci/builders/mac_host_engine.json
@@ -1175,11 +1175,6 @@
             "realm": "production"
         },
         {
-            "source": "out/release/framework/FlutterMacOS.dSYM.zip",
-            "destination": "darwin-x64-release/FlutterMacOS.dSYM.zip",
-            "realm": "production"
-        },
-        {
             "source": "out/debug/framework/FlutterMacOS.framework.zip",
             "destination": "darwin-x64/FlutterMacOS.framework.zip",
             "realm": "production"

--- a/docs/Crashes.md
+++ b/docs/Crashes.md
@@ -110,6 +110,27 @@ schema:
 `https://storage.googleapis.com/flutter_infra_release/flutter/c11fe483947c95553610ab59210af643f031f5f4/ios-release/artifacts.zip`
 (replace the engine hash with your hash).
 
+### macOS
+
+Since Flutter 3.27, symbols can be found in the Flutter framework's artifact
+cache, within the xcframework bundle at
+`bin/cache/artifacts/engine/darwin-x64-release/Flutter.xcframework`.
+
+  * Symbols for device builds are in the `macos-arm64_x86_64/dSYMs/FlutterMacOS.framework.dSYM` bundle.
+
+For versions prior to Flutter 3.27, the dSYM bundle can downloaded from Google
+Cloud Storage. Follow the steps from the Android section in this guide, but in
+the last step use a download url following this schema:
+`https://storage.cloud.google.com/flutter_infra_release/flutter/cf4507ae1008c11c6155d31e852999d75670afcf/darwin-x64-release/FlutterMacOS.dSYM.zip`
+(replace the engine hash with your hash).
+
+For release since Flutter 3.27, these symbols are no longer uploaded as a
+separate archive and should be obtained from the artifact cache as described
+above. The artifact cache can be downloaded direcly using a URL following this
+schema:
+`https://storage.googleapis.com/flutter_infra_release/flutter/cf4507ae1008c11c6155d31e852999d75670afcf/darwin-x64-release/framework.zip`
+(replace the engine hash with your hash).
+
 #### Symbolicating local builds
 
 If you built your local engine in debug or profile Dart modes, the framework's dylib's symbols aren't stripped and are available by default.

--- a/sky/tools/create_macos_framework.py
+++ b/sky/tools/create_macos_framework.py
@@ -112,29 +112,6 @@ def zip_framework(dst, args):
 
   zip_xcframework_archive(dst, args)
 
-  # Generate Flutter.dSYM.zip for manual symbolification.
-  #
-  # Historically, the framework dSYM was named FlutterMacOS.dSYM, so in order
-  # to remain backward-compatible with existing instructions in docs/Crashes.md
-  # and existing tooling such as dart-lang/dart_ci, we rename back to that name
-  #
-  # TODO(cbracken): remove these archives and the upload steps once we bundle
-  # dSYMs in app archives. https://github.com/flutter/flutter/issues/153879
-  framework_dsym = framework_dst + '.dSYM'
-  if os.path.exists(framework_dsym):
-    renamed_dsym = framework_dsym.replace('FlutterMacOS.framework.dSYM', 'FlutterMacOS.dSYM')
-    os.rename(framework_dsym, renamed_dsym)
-
-    # Create a zip of just the contents of the dSYM, then create a zip of that zip.
-    # TODO(cbracken): remove this once https://github.com/flutter/flutter/issues/125067 is resolved
-    sky_utils.create_zip(renamed_dsym, 'FlutterMacOS.dSYM.zip', ['.'])
-    sky_utils.create_zip(renamed_dsym, 'FlutterMacOS.dSYM_.zip', ['FlutterMacOS.dSYM.zip'])
-
-    # Move the double-zipped FlutterMacOS.dSYM.zip to dst.
-    dsym_final_src_path = os.path.join(renamed_dsym, 'FlutterMacOS.dSYM_.zip')
-    dsym_final_dst_path = os.path.join(dst, 'FlutterMacOS.dSYM.zip')
-    shutil.move(dsym_final_src_path, dsym_final_dst_path)
-
 
 def zip_xcframework_archive(dst, args):
   # pylint: disable=line-too-long


### PR DESCRIPTION
As of the following patches, we now bundle FlutterMacOS.framework.dSYM as part of FlutterMacOS.xcframework. The dSYM is automatically copied into the release build products directory, and bundled in the .xcarchive produced by Xcode's *Product > Archive* feature which produces bundles for upload to the App Store.

* https://github.com/flutter/engine/pull/54696
* https://github.com/flutter/flutter/pull/153975

The .dSYM bundle is now available both in the uploaded .xcarchive and in the xcframework in Flutter's internal artifact cache. For developers with CI toolchains that do additional manual handling or local archiving of .dSYMs, the dSYMs no longer need to be downloaded from cloud storage as previously detailed in `docs/Crashes.md`, but can instead be copied up from the appropriate dSYM subdirectory in the framework cache:

* `flutter/bin/cache/artifacts/engine/darwin-x64-release/FlutterMacOS.xcframework`

Also adds documentation for crash symbolication on macOS.

Issue: https://github.com/flutter/flutter/issues/153879

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
