### PR TITLE
[CP] Ensure orchestrators aren't assigned to 32 core machines

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -176,6 +176,20 @@ targets:
     # Scheduler will fail to get the platform
     drone_dimensions:
       - os=Linux
+
+  - name: Linux linux_fuchsia_tests
+    recipe: engine_v2/engine_v2
+    bringup: true
+    timeout: 90
+    properties:
+      # TODO(zanderso): Add this back when this issue is closed:
+      # https://github.com/flutter/flutter/issues/152186
+      # release_build: "true"
+      config_name: linux_fuchsia_tests
+    # Do not remove(https://github.com/flutter/flutter/issues/144644)
+    # Scheduler will fail to get the platform
+    drone_dimensions:
+      - os=Linux
     dimensions:
       kvm: "1"
 

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -176,15 +176,18 @@ targets:
     # Scheduler will fail to get the platform
     drone_dimensions:
       - os=Linux
+    dimensions:
+      # This is needed so that orchestrators that only spawn subbuilds are not
+      # assigned to the large 32 core workers when doing release builds.
+      # For more details see the issue
+      # at https://github.com/flutter/flutter/issues/152186.
+      cores: "8"
 
   - name: Linux linux_fuchsia_tests
     recipe: engine_v2/engine_v2
     bringup: true
     timeout: 90
     properties:
-      # TODO(zanderso): Add this back when this issue is closed:
-      # https://github.com/flutter/flutter/issues/152186
-      # release_build: "true"
       config_name: linux_fuchsia_tests
     # Do not remove(https://github.com/flutter/flutter/issues/144644)
     # Scheduler will fail to get the platform
@@ -218,8 +221,16 @@ targets:
       add_recipes_cq: "true"
       release_build: "true"
       config_name: linux_arm_host_engine
+    # Do not remove(https://github.com/flutter/flutter/issues/144644)
+    # Scheduler will fail to get the platform
     drone_dimensions:
       - os=Linux
+    dimensions:
+      # This is needed so that orchestrators that only spawn subbuilds are not
+      # assigned to the large 32 core workers when doing release builds.
+      # For more details see the issue
+      # at https://github.com/flutter/flutter/issues/152186.
+      cores: "8"
 
   - name: Linux linux_host_engine
     recipe: engine_v2/engine_v2
@@ -232,8 +243,16 @@ targets:
         [
           {"dependency": "goldctl", "version": "git_revision:720a542f6fe4f92922c3b8f0fdcc4d2ac6bb83cd"}
         ]
+    # Do not remove(https://github.com/flutter/flutter/issues/144644)
+    # Scheduler will fail to get the platform
     drone_dimensions:
       - os=Linux
+    dimensions:
+      # This is needed so that orchestrators that only spawn subbuilds are not
+      # assigned to the large 32 core workers when doing release builds.
+      # For more details see the issue
+      # at https://github.com/flutter/flutter/issues/152186.
+      cores: "8"
 
   - name: Linux linux_host_desktop_engine
     recipe: engine_v2/engine_v2
@@ -242,8 +261,16 @@ targets:
       add_recipes_cq: "true"
       release_build: "true"
       config_name: linux_host_desktop_engine
+    # Do not remove(https://github.com/flutter/flutter/issues/144644)
+    # Scheduler will fail to get the platform
     drone_dimensions:
       - os=Linux
+    dimensions:
+      # This is needed so that orchestrators that only spawn subbuilds are not
+      # assigned to the large 32 core workers when doing release builds.
+      # For more details see the issue
+      # at https://github.com/flutter/flutter/issues/152186.
+      cores: "8"
 
   - name: Linux linux_android_aot_engine
     recipe: engine_v2/engine_v2
@@ -252,8 +279,16 @@ targets:
       add_recipes_cq: "true"
       release_build: "true"
       config_name: linux_android_aot_engine
+    # Do not remove(https://github.com/flutter/flutter/issues/144644)
+    # Scheduler will fail to get the platform
     drone_dimensions:
       - os=Linux
+    dimensions:
+      # This is needed so that orchestrators that only spawn subbuilds are not
+      # assigned to the large 32 core workers when doing release builds.
+      # For more details see the issue
+      # at https://github.com/flutter/flutter/issues/152186.
+      cores: "8"
 
   - name: Linux linux_android_debug_engine
     recipe: engine_v2/engine_v2
@@ -262,8 +297,16 @@ targets:
       add_recipes_cq: "true"
       release_build: "true"
       config_name: linux_android_debug_engine
+    # Do not remove(https://github.com/flutter/flutter/issues/144644)
+    # Scheduler will fail to get the platform
     drone_dimensions:
       - os=Linux
+    dimensions:
+      # This is needed so that orchestrators that only spawn subbuilds are not
+      # assigned to the large 32 core workers when doing release builds.
+      # For more details see the issue
+      # at https://github.com/flutter/flutter/issues/152186.
+      cores: "8"
 
   - name: Linux linux_license
     recipe: engine_v2/builder
@@ -279,8 +322,16 @@ targets:
     properties:
       release_build: "true"
       config_name: linux_web_engine
+    # Do not remove(https://github.com/flutter/flutter/issues/144644)
+    # Scheduler will fail to get the platform
     drone_dimensions:
       - os=Linux
+    dimensions:
+      # This is needed so that orchestrators that only spawn subbuilds are not
+      # assigned to the large 32 core workers when doing release builds.
+      # For more details see the issue
+      # at https://github.com/flutter/flutter/issues/152186.
+      cores: "8"
     runIf:
       - DEPS
       - .ci.yaml
@@ -339,8 +390,16 @@ targets:
       add_recipes_cq: "true"
       release_build: "true"
       config_name: mac_android_aot_engine
+    # Do not remove(https://github.com/flutter/flutter/issues/144644)
+    # Scheduler will fail to get the platform
     drone_dimensions:
       - os=Linux
+    dimensions:
+      # This is needed so that orchestrators that only spawn subbuilds are not
+      # assigned to the large 32 core workers when doing release builds.
+      # For more details see the issue
+      # at https://github.com/flutter/flutter/issues/152186.
+      cores: "8"
 
   - name: Mac mac_clang_tidy
     recipe: engine_v2/engine_v2
@@ -378,13 +437,17 @@ targets:
         {
           "sdk_version": "15a240d"
         }
+    # Do not remove(https://github.com/flutter/flutter/issues/144644)
+    # Scheduler will fail to get the platform
     drone_dimensions:
       - os=Mac-13|Mac-14
 
+  # Avoid using a Mac orchestrator to save ~5 minutes of Mac host time.
   - name: Linux mac_clangd
     recipe: engine_v2/engine_v2
     timeout: 240
-    # Avoid using a Mac orchestrator to save ~5 minutes of Mac host time.
+    # Do not remove(https://github.com/flutter/flutter/issues/144644)
+    # Scheduler will fail to get the platform
     drone_dimensions:
       - os=Linux
     properties:
@@ -408,6 +471,8 @@ targets:
         {
           "sdk_version": "15a240d"
         }
+    # Do not remove(https://github.com/flutter/flutter/issues/144644)
+    # Scheduler will fail to get the platform
     drone_dimensions:
       - os=Mac-13|Mac-14
       - cpu=x86
@@ -427,6 +492,8 @@ targets:
       add_recipes_cq: "true"
       release_build: "true"
       config_name: windows_android_aot_engine
+    # Do not remove(https://github.com/flutter/flutter/issues/144644)
+    # Scheduler will fail to get the platform
     drone_dimensions:
       - os=Windows
 
@@ -437,6 +504,8 @@ targets:
       add_recipes_cq: "true"
       release_build: "true"
       config_name: windows_host_engine
+    # Do not remove(https://github.com/flutter/flutter/issues/144644)
+    # Scheduler will fail to get the platform
     drone_dimensions:
       - os=Windows
 

--- a/ci/builders/linux_fuchsia.json
+++ b/ci/builders/linux_fuchsia.json
@@ -30,52 +30,6 @@
             }
         },
         {
-            "cas_archive": false,
-            "drone_dimensions": [
-                "device_type=none",
-                "kvm=1",
-                "os=Linux"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false,
-                "run_fuchsia_emu": true,
-                "use_rbe": true
-            },
-            "gn": [
-                "--target-dir",
-                "ci/fuchsia_profile_arm64_tester",
-                "--fuchsia",
-                "--fuchsia-cpu",
-                "arm64",
-                "--runtime-mode",
-                "profile",
-                "--no-lto",
-                "--rbe",
-                "--no-goma"
-            ],
-            "name": "ci/fuchsia_profile_arm64_tester",
-            "description": "Builds profile mode tests of arm64 Fuchsia.",
-            "ninja": {
-                "config": "ci/fuchsia_profile_arm64_tester",
-                "targets": [
-                    "flutter/shell/platform/fuchsia:fuchsia",
-                    "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
-                    "fuchsia_tests"
-                ]
-            },
-            "tests": [
-                {
-                    "name": "arm64 emulator based profile / aot tests",
-                    "language": "python3",
-                    "script": "flutter/tools/fuchsia/with_envs.py",
-                    "parameters": [
-                        "testing/fuchsia/run_tests.py",
-                        "ci/fuchsia_profile_arm64_tester"
-                    ]
-                }
-            ]
-        },
-        {
             "drone_dimensions": [
                 "device_type=none",
                 "os=Linux"
@@ -103,52 +57,6 @@
                     "flutter/shell/platform/fuchsia:fuchsia"
                 ]
             }
-        },
-        {
-            "cas_archive": false,
-            "drone_dimensions": [
-                "device_type=none",
-                "kvm=1",
-                "os=Linux"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false,
-                "run_fuchsia_emu": true,
-                "use_rbe": true
-            },
-            "gn": [
-                "--target-dir",
-                "ci/fuchsia_release_arm64_tester",
-                "--fuchsia",
-                "--fuchsia-cpu",
-                "arm64",
-                "--runtime-mode",
-                "release",
-                "--no-lto",
-                "--rbe",
-                "--no-goma"
-            ],
-            "name": "ci/fuchsia_release_arm64_tester",
-            "description": "Builds release mode tests of arm64 Fuchsia.",
-            "ninja": {
-                "config": "ci/fuchsia_release_arm64_tester",
-                "targets": [
-                    "flutter/shell/platform/fuchsia:fuchsia",
-                    "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
-                    "fuchsia_tests"
-                ]
-            },
-            "tests": [
-                {
-                    "name": "arm64 emulator based release tests",
-                    "language": "python3",
-                    "script": "flutter/tools/fuchsia/with_envs.py",
-                    "parameters": [
-                        "testing/fuchsia/run_tests.py",
-                        "ci/fuchsia_release_arm64_tester"
-                    ]
-                }
-            ]
         },
         {
             "drone_dimensions": [
@@ -196,52 +104,6 @@
             ]
         },
         {
-            "cas_archive": false,
-            "drone_dimensions": [
-                "device_type=none",
-                "kvm=1",
-                "os=Linux"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false,
-                "run_fuchsia_emu": true,
-                "use_rbe": true
-            },
-            "gn": [
-                "--target-dir",
-                "ci/fuchsia_debug_arm64_tester",
-                "--fuchsia",
-                "--fuchsia-cpu",
-                "arm64",
-                "--runtime-mode",
-                "debug",
-                "--no-lto",
-                "--rbe",
-                "--no-goma"
-            ],
-            "name": "ci/fuchsia_debug_arm64_tester",
-            "description": "Builds debug mode tests of arm64 Fuchsia.",
-            "ninja": {
-                "config": "ci/fuchsia_debug_arm64_tester",
-                "targets": [
-                    "flutter/shell/platform/fuchsia:fuchsia",
-                    "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
-                    "fuchsia_tests"
-                ]
-            },
-            "tests": [
-                {
-                    "name": "arm64 emulator based debug tests",
-                    "language": "python3",
-                    "script": "flutter/tools/fuchsia/with_envs.py",
-                    "parameters": [
-                        "testing/fuchsia/run_tests.py",
-                        "ci/fuchsia_debug_arm64_tester"
-                    ]
-                }
-            ]
-        },
-        {
             "drone_dimensions": [
                 "device_type=none",
                 "os=Linux"
@@ -269,52 +131,6 @@
                     "flutter/shell/platform/fuchsia:fuchsia"
                 ]
             }
-        },
-        {
-            "cas_archive": false,
-            "drone_dimensions": [
-                "device_type=none",
-                "kvm=1",
-                "os=Linux"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false,
-                "run_fuchsia_emu": true,
-                "use_rbe": true
-            },
-            "gn": [
-                "--target-dir",
-                "ci/fuchsia_profile_x64_tester",
-                "--fuchsia",
-                "--fuchsia-cpu",
-                "x64",
-                "--runtime-mode",
-                "profile",
-                "--no-lto",
-                "--rbe",
-                "--no-goma"
-            ],
-            "name": "ci/fuchsia_profile_x64_tester",
-            "description": "Builds profile mode tests of x64 Fuchsia.",
-            "ninja": {
-                "config": "ci/fuchsia_profile_x64_tester",
-                "targets": [
-                    "flutter/shell/platform/fuchsia:fuchsia",
-                    "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
-                    "fuchsia_tests"
-                ]
-            },
-            "tests": [
-                {
-                    "name": "x64 emulator based profile / aot tests",
-                    "language": "python3",
-                    "script": "flutter/tools/fuchsia/with_envs.py",
-                    "parameters": [
-                        "testing/fuchsia/run_tests.py",
-                        "ci/fuchsia_profile_x64_tester"
-                    ]
-                }
-            ]
         },
         {
             "drone_dimensions": [
@@ -345,52 +161,6 @@
                     "flutter/shell/platform/fuchsia:fuchsia"
                 ]
             }
-        },
-        {
-            "cas_archive": false,
-            "drone_dimensions": [
-                "device_type=none",
-                "kvm=1",
-                "os=Linux"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false,
-                "run_fuchsia_emu": true,
-                "use_rbe": true
-            },
-            "gn": [
-                "--target-dir",
-                "ci/fuchsia_release_x64_tester",
-                "--fuchsia",
-                "--fuchsia-cpu",
-                "x64",
-                "--runtime-mode",
-                "release",
-                "--no-lto",
-                "--rbe",
-                "--no-goma"
-            ],
-            "name": "ci/fuchsia_release_x64_tester",
-            "description": "Builds release mode tests of x64 Fuchsia.",
-            "ninja": {
-                "config": "ci/fuchsia_release_x64_tester",
-                "targets": [
-                    "flutter/shell/platform/fuchsia:fuchsia",
-                    "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
-                    "fuchsia_tests"
-                ]
-            },
-            "tests": [
-                {
-                    "name": "x64 emulator based release tests",
-                    "language": "python3",
-                    "script": "flutter/tools/fuchsia/with_envs.py",
-                    "parameters": [
-                        "testing/fuchsia/run_tests.py",
-                        "ci/fuchsia_release_x64_tester"
-                    ]
-                }
-            ]
         },
         {
             "drone_dimensions": [
@@ -434,60 +204,6 @@
                         "--engine-version",
                         "${REVISION}",
                         "--upload"
-                    ]
-                }
-            ]
-        },
-        {
-            "cas_archive": false,
-            "drone_dimensions": [
-                "device_type=none",
-                "kvm=1",
-                "os=Linux"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false,
-                "run_fuchsia_emu": true,
-                "use_rbe": true
-            },
-            "gn": [
-                "--target-dir",
-                "ci/fuchsia_debug_x64_tester",
-                "--fuchsia",
-                "--fuchsia-cpu",
-                "x64",
-                "--runtime-mode",
-                "debug",
-                "--no-lto",
-                "--rbe",
-                "--no-goma"
-            ],
-            "name": "ci/fuchsia_debug_x64_tester",
-            "description": "Builds debug mode tests of x64 Fuchsia.",
-            "ninja": {
-                "config": "ci/fuchsia_debug_x64_tester",
-                "targets": [
-                    "flutter/shell/platform/fuchsia:fuchsia",
-                    "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
-                    "fuchsia_tests"
-                ]
-            },
-            "tests": [
-                {
-                    "name": "run_tests test",
-                    "script": "flutter/testing/fuchsia/run_tests_test.py"
-                },
-                {
-                    "name": "build_fuchsia_artifacts test",
-                    "script": "flutter/tools/fuchsia/build_fuchsia_artifacts_test.py"
-                },
-                {
-                    "name": "x64 emulator based debug tests",
-                    "language": "python3",
-                    "script": "flutter/tools/fuchsia/with_envs.py",
-                    "parameters": [
-                        "testing/fuchsia/run_tests.py",
-                        "ci/fuchsia_debug_x64_tester"
                     ]
                 }
             ]

--- a/ci/builders/linux_fuchsia_tests.json
+++ b/ci/builders/linux_fuchsia_tests.json
@@ -1,0 +1,288 @@
+{
+    "builds": [
+        {
+            "cas_archive": false,
+            "drone_dimensions": [
+                "device_type=none",
+                "kvm=1",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "run_fuchsia_emu": true,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/fuchsia_profile_arm64_tester",
+                "--fuchsia",
+                "--fuchsia-cpu",
+                "arm64",
+                "--runtime-mode",
+                "profile",
+                "--no-lto",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/fuchsia_profile_arm64_tester",
+            "description": "Builds profile mode tests of arm64 Fuchsia.",
+            "ninja": {
+                "config": "ci/fuchsia_profile_arm64_tester",
+                "targets": [
+                    "flutter/shell/platform/fuchsia:fuchsia",
+                    "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
+                    "fuchsia_tests"
+                ]
+            },
+            "tests": [
+                {
+                    "name": "arm64 emulator based profile / aot tests",
+                    "language": "python3",
+                    "script": "flutter/tools/fuchsia/with_envs.py",
+                    "parameters": [
+                        "testing/fuchsia/run_tests.py",
+                        "ci/fuchsia_profile_arm64_tester"
+                    ]
+                }
+            ]
+        },
+        {
+            "cas_archive": false,
+            "drone_dimensions": [
+                "device_type=none",
+                "kvm=1",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "run_fuchsia_emu": true,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/fuchsia_release_arm64_tester",
+                "--fuchsia",
+                "--fuchsia-cpu",
+                "arm64",
+                "--runtime-mode",
+                "release",
+                "--no-lto",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/fuchsia_release_arm64_tester",
+            "description": "Builds release mode tests of arm64 Fuchsia.",
+            "ninja": {
+                "config": "ci/fuchsia_release_arm64_tester",
+                "targets": [
+                    "flutter/shell/platform/fuchsia:fuchsia",
+                    "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
+                    "fuchsia_tests"
+                ]
+            },
+            "tests": [
+                {
+                    "name": "arm64 emulator based release tests",
+                    "language": "python3",
+                    "script": "flutter/tools/fuchsia/with_envs.py",
+                    "parameters": [
+                        "testing/fuchsia/run_tests.py",
+                        "ci/fuchsia_release_arm64_tester"
+                    ]
+                }
+            ]
+        },
+        {
+            "cas_archive": false,
+            "drone_dimensions": [
+                "device_type=none",
+                "kvm=1",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "run_fuchsia_emu": true,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/fuchsia_debug_arm64_tester",
+                "--fuchsia",
+                "--fuchsia-cpu",
+                "arm64",
+                "--runtime-mode",
+                "debug",
+                "--no-lto",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/fuchsia_debug_arm64_tester",
+            "description": "Builds debug mode tests of arm64 Fuchsia.",
+            "ninja": {
+                "config": "ci/fuchsia_debug_arm64_tester",
+                "targets": [
+                    "flutter/shell/platform/fuchsia:fuchsia",
+                    "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
+                    "fuchsia_tests"
+                ]
+            },
+            "tests": [
+                {
+                    "name": "arm64 emulator based debug tests",
+                    "language": "python3",
+                    "script": "flutter/tools/fuchsia/with_envs.py",
+                    "parameters": [
+                        "testing/fuchsia/run_tests.py",
+                        "ci/fuchsia_debug_arm64_tester"
+                    ]
+                }
+            ]
+        },
+        {
+            "cas_archive": false,
+            "drone_dimensions": [
+                "device_type=none",
+                "kvm=1",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "run_fuchsia_emu": true,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/fuchsia_profile_x64_tester",
+                "--fuchsia",
+                "--fuchsia-cpu",
+                "x64",
+                "--runtime-mode",
+                "profile",
+                "--no-lto",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/fuchsia_profile_x64_tester",
+            "description": "Builds profile mode tests of x64 Fuchsia.",
+            "ninja": {
+                "config": "ci/fuchsia_profile_x64_tester",
+                "targets": [
+                    "flutter/shell/platform/fuchsia:fuchsia",
+                    "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
+                    "fuchsia_tests"
+                ]
+            },
+            "tests": [
+                {
+                    "name": "x64 emulator based profile / aot tests",
+                    "language": "python3",
+                    "script": "flutter/tools/fuchsia/with_envs.py",
+                    "parameters": [
+                        "testing/fuchsia/run_tests.py",
+                        "ci/fuchsia_profile_x64_tester"
+                    ]
+                }
+            ]
+        },
+        {
+            "cas_archive": false,
+            "drone_dimensions": [
+                "device_type=none",
+                "kvm=1",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "run_fuchsia_emu": true,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/fuchsia_release_x64_tester",
+                "--fuchsia",
+                "--fuchsia-cpu",
+                "x64",
+                "--runtime-mode",
+                "release",
+                "--no-lto",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/fuchsia_release_x64_tester",
+            "description": "Builds release mode tests of x64 Fuchsia.",
+            "ninja": {
+                "config": "ci/fuchsia_release_x64_tester",
+                "targets": [
+                    "flutter/shell/platform/fuchsia:fuchsia",
+                    "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
+                    "fuchsia_tests"
+                ]
+            },
+            "tests": [
+                {
+                    "name": "x64 emulator based release tests",
+                    "language": "python3",
+                    "script": "flutter/tools/fuchsia/with_envs.py",
+                    "parameters": [
+                        "testing/fuchsia/run_tests.py",
+                        "ci/fuchsia_release_x64_tester"
+                    ]
+                }
+            ]
+        },
+        {
+            "cas_archive": false,
+            "drone_dimensions": [
+                "device_type=none",
+                "kvm=1",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "run_fuchsia_emu": true,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/fuchsia_debug_x64_tester",
+                "--fuchsia",
+                "--fuchsia-cpu",
+                "x64",
+                "--runtime-mode",
+                "debug",
+                "--no-lto",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/fuchsia_debug_x64_tester",
+            "description": "Builds debug mode tests of x64 Fuchsia.",
+            "ninja": {
+                "config": "ci/fuchsia_debug_x64_tester",
+                "targets": [
+                    "flutter/shell/platform/fuchsia:fuchsia",
+                    "flutter/shell/platform/fuchsia/dart_runner:dart_runner_tests",
+                    "fuchsia_tests"
+                ]
+            },
+            "tests": [
+                {
+                    "name": "run_tests test",
+                    "script": "flutter/testing/fuchsia/run_tests_test.py"
+                },
+                {
+                    "name": "build_fuchsia_artifacts test",
+                    "script": "flutter/tools/fuchsia/build_fuchsia_artifacts_test.py"
+                },
+                {
+                    "name": "x64 emulator based debug tests",
+                    "language": "python3",
+                    "script": "flutter/tools/fuchsia/with_envs.py",
+                    "parameters": [
+                        "testing/fuchsia/run_tests.py",
+                        "ci/fuchsia_debug_x64_tester"
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This PR contains CPs of two changes:
1. https://github.com/flutter/engine/pull/54591 to avoid running Fuchsia tests on dart-internal, which was needed in order to avoid conflicts in
2. https://github.com/flutter/engine/pull/54754, which avoids using 32 core machines as orchestrators. (Instead they'll use the 8 core machines that are no longer used for the Fuchsia tests.)