### PR TITLE
[Impeller] Increase host buffer arena count to 4.

### DIFF
--- a/impeller/core/host_buffer.h
+++ b/impeller/core/host_buffer.h
@@ -19,7 +19,7 @@
 namespace impeller {
 
 /// Approximately the same size as the max frames in flight.
-static const constexpr size_t kHostBufferArenaSize = 3u;
+static const constexpr size_t kHostBufferArenaSize = 4u;
 
 /// The host buffer class manages one more 1024 Kb blocks of device buffer
 /// allocations.

--- a/impeller/entity/contents/host_buffer_unittests.cc
+++ b/impeller/entity/contents/host_buffer_unittests.cc
@@ -94,7 +94,7 @@ TEST_P(HostBufferTest, ResetIncrementsFrameCounter) {
   EXPECT_EQ(buffer->GetStateForTest().current_frame, 3u);
 
   buffer->Reset();
-  EXPECT_EQ(buffer->GetStateForTest().current_frame, 4u);
+  EXPECT_EQ(buffer->GetStateForTest().current_frame, 0u);
 }
 
 TEST_P(HostBufferTest,
@@ -134,7 +134,7 @@ TEST_P(HostBufferTest, UnusedBuffersAreDiscardedWhenResetting) {
   EXPECT_EQ(buffer->GetStateForTest().current_frame, 0u);
 
   // Reset until we get back to this frame.
-  for (auto i = 0; i < 3; i++) {
+  for (auto i = 0; i < 4; i++) {
     buffer->Reset();
   }
 
@@ -144,7 +144,7 @@ TEST_P(HostBufferTest, UnusedBuffersAreDiscardedWhenResetting) {
 
   // Now when we reset, the buffer should get dropped.
   // Reset until we get back to this frame.
-  for (auto i = 0; i < 3; i++) {
+  for (auto i = 0; i < 4; i++) {
     buffer->Reset();
   }
 

--- a/impeller/entity/contents/host_buffer_unittests.cc
+++ b/impeller/entity/contents/host_buffer_unittests.cc
@@ -91,7 +91,10 @@ TEST_P(HostBufferTest, ResetIncrementsFrameCounter) {
   EXPECT_EQ(buffer->GetStateForTest().current_frame, 2u);
 
   buffer->Reset();
-  EXPECT_EQ(buffer->GetStateForTest().current_frame, 0u);
+  EXPECT_EQ(buffer->GetStateForTest().current_frame, 3u);
+
+  buffer->Reset();
+  EXPECT_EQ(buffer->GetStateForTest().current_frame, 4u);
 }
 
 TEST_P(HostBufferTest,

--- a/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain/ahb/ahb_swapchain_impl_vk.cc
@@ -15,6 +15,7 @@
 #include "impeller/renderer/backend/vulkan/swapchain/surface_vk.h"
 #include "impeller/toolkit/android/surface_transaction.h"
 #include "impeller/toolkit/android/surface_transaction_stats.h"
+#include "vulkan/vulkan_to_string.hpp"
 
 namespace impeller {
 
@@ -111,19 +112,20 @@ std::unique_ptr<Surface> AHBSwapchainImplVK::AcquireNextDrawable() {
     return nullptr;
   }
 
-  auto context = transients_->GetContext().lock();
-  if (context) {
-    ContextVK::Cast(*context).GetGPUTracer()->MarkFrameStart();
-  }
-
   // Ask the GPU to wait for the render ready semaphore to be signaled before
   // performing rendering operations.
   if (!SubmitWaitForRenderReady(pool_entry.render_ready_fence,
                                 pool_entry.texture)) {
-    VALIDATION_LOG << "Could not submit a command to the GPU to wait on render "
-                      "readiness.";
+    VALIDATION_LOG << "Could wait on render ready fence.";
     return nullptr;
   }
+
+#if IMPELLER_DEBUG
+  auto context = transients_->GetContext().lock();
+  if (context) {
+    ContextVK::Cast(*context).GetGPUTracer()->MarkFrameStart();
+  }
+#endif  // IMPELLER_DEBUG
 
   auto surface = SurfaceVK::WrapSwapchainImage(
       transients_, pool_entry.texture,
@@ -154,10 +156,12 @@ bool AHBSwapchainImplVK::Present(
     return false;
   }
 
+#if IMPELLER_DEBUG
   auto context = transients_->GetContext().lock();
   if (context) {
     ContextVK::Cast(*context).GetGPUTracer()->MarkFrameEnd();
   }
+#endif  // IMPELLER_DEBUG
 
   if (!texture) {
     return false;
@@ -308,8 +312,8 @@ bool AHBSwapchainImplVK::SubmitWaitForRenderReady(
   );
 
   if (!(result == vk::Result::eSuccess || result == vk::Result::eTimeout)) {
-    VALIDATION_LOG << "Fence waiter encountered an unexpected error. Tearing "
-                      "down the waiter thread.";
+    VALIDATION_LOG << "Encountered error while waiting on swapchain image: "
+                   << vk::to_string(result);
     return false;
   }
 


### PR DESCRIPTION
It seems like on some ANdroid devices we can actually get 4 pending frames even with the 3 frame wait. I thought about this a lot but too hard. Lets bump it up one.

Also minor comment fixes in ahb swapchain.