### PR TITLE
[Impeller] Use infinite swapchain present timeouts to avoid logspam.

### DIFF
--- a/impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_impl_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain/khr/khr_swapchain_impl_vk.cc
@@ -20,11 +20,6 @@ namespace impeller {
 
 static constexpr size_t kMaxFramesInFlight = 3u;
 
-// Number of frames to poll for orientation changes. For example `1u` means
-// that the orientation will be polled every frame, while `2u` means that the
-// orientation will be polled every other frame.
-static constexpr size_t kPollFramesForOrientation = 1u;
-
 struct KHRFrameSynchronizerVK {
   vk::UniqueFence acquire;
   vk::UniqueSemaphore render_ready;
@@ -334,11 +329,15 @@ KHRSwapchainImplVK::AcquireResult KHRSwapchainImplVK::AcquireNextDrawable() {
   //----------------------------------------------------------------------------
   /// Get the next image index.
   ///
+  /// @bug  Non-infinite timeouts are not supported on some older Android
+  ///       devices and the only indication we get is log spam which serves to
+  ///       add confusion. Just use an infinite timeout instead of being
+  ///       defensive.
   auto [acq_result, index] = context.GetDevice().acquireNextImageKHR(
-      *swapchain_,          // swapchain
-      1'000'000'000,        // timeout (ns) 1000ms
-      *sync->render_ready,  // signal semaphore
-      nullptr               // fence
+      *swapchain_,                           // swapchain
+      std::numeric_limits<uint64_t>::max(),  // timeout (ns)
+      *sync->render_ready,                   // signal semaphore
+      nullptr                                // fence
   );
 
   switch (acq_result) {


### PR DESCRIPTION
The initial timeout of 1 second was chosen to model the Metal backend where the [default drawable timeout is the same](https://developer.apple.com/documentation/quartzcore/cametallayer/2887086-allowsnextdrawabletimeout?language=objc).