### PR TITLE
[Impeller] ensure that srcOver to src conversion takes stroke coverage into account.

### DIFF
--- a/impeller/aiks/aiks_unittests.cc
+++ b/impeller/aiks/aiks_unittests.cc
@@ -313,8 +313,9 @@ TEST_P(AiksTest, OpaqueEntitiesGetCoercedToSource) {
     return true;
   });
 
+  Matrix matrix;
   ASSERT_TRUE(entity.size() >= 1);
-  ASSERT_TRUE(contents->IsOpaque());
+  ASSERT_TRUE(contents->IsOpaque(matrix));
   ASSERT_EQ(entity[0].GetBlendMode(), BlendMode::kSource);
 }
 

--- a/impeller/aiks/experimental_canvas.cc
+++ b/impeller/aiks/experimental_canvas.cc
@@ -662,7 +662,7 @@ void ExperimentalCanvas::AddRenderEntityToCurrentPass(Entity entity,
       entity.GetTransform());
   entity.SetInheritedOpacity(transform_stack_.back().distributed_opacity);
   if (entity.GetBlendMode() == BlendMode::kSourceOver &&
-      entity.GetContents()->IsOpaque()) {
+      entity.GetContents()->IsOpaque(entity.GetTransform())) {
     entity.SetBlendMode(BlendMode::kSource);
   }
 

--- a/impeller/entity/contents/color_source_contents.cc
+++ b/impeller/entity/contents/color_source_contents.cc
@@ -54,4 +54,9 @@ void ColorSourceContents::SetInheritedOpacity(Scalar opacity) {
   inherited_opacity_ = opacity;
 }
 
+bool ColorSourceContents::AppliesAlphaForStrokeCoverage(
+    const Matrix& transform) const {
+  return GetGeometry() && GetGeometry()->ComputeAlphaCoverage(transform) < 1.0;
+}
+
 }  // namespace impeller

--- a/impeller/entity/contents/color_source_contents.h
+++ b/impeller/entity/contents/color_source_contents.h
@@ -126,6 +126,10 @@ class ColorSourceContents : public Contents {
     return geom.GetPositionBuffer(renderer, entity, pass);
   }
 
+  /// @brief Whether the entity should be treated as non-opaque due to stroke
+  ///        geometry requiring alpha for coverage.
+  bool AppliesAlphaForStrokeCoverage(const Matrix& transform) const;
+
   template <typename VertexShaderT>
   bool DrawGeometry(const ContentContext& renderer,
                     const Entity& entity,

--- a/impeller/entity/contents/conical_gradient_contents.cc
+++ b/impeller/entity/contents/conical_gradient_contents.cc
@@ -80,7 +80,8 @@ bool ConicalGradientContents::RenderSSBO(const ContentContext& renderer,
         frag_info.tile_mode = static_cast<Scalar>(tile_mode_);
         frag_info.decal_border_color = decal_border_color_;
         frag_info.alpha =
-            GetOpacityFactor() * GetGeometry()->ComputeAlphaCoverage(entity);
+            GetOpacityFactor() *
+            GetGeometry()->ComputeAlphaCoverage(entity.GetTransform());
         if (focus_) {
           frag_info.focus = focus_.value();
           frag_info.focus_radius = focus_radius_;
@@ -137,7 +138,8 @@ bool ConicalGradientContents::RenderTexture(const ContentContext& renderer,
         frag_info.texture_sampler_y_coord_scale =
             gradient_texture->GetYCoordScale();
         frag_info.alpha =
-            GetOpacityFactor() * GetGeometry()->ComputeAlphaCoverage(entity);
+            GetOpacityFactor() *
+            GetGeometry()->ComputeAlphaCoverage(entity.GetTransform());
         frag_info.half_texel =
             Vector2(0.5 / gradient_texture->GetSize().width,
                     0.5 / gradient_texture->GetSize().height);

--- a/impeller/entity/contents/contents.cc
+++ b/impeller/entity/contents/contents.cc
@@ -49,7 +49,7 @@ Contents::Contents() = default;
 
 Contents::~Contents() = default;
 
-bool Contents::IsOpaque() const {
+bool Contents::IsOpaque(const Matrix& transform) const {
   return false;
 }
 

--- a/impeller/entity/contents/contents.h
+++ b/impeller/entity/contents/contents.h
@@ -91,7 +91,9 @@ class Contents {
   ///        properties (e.g. the blend mode), clips/visibility culling, or
   ///        inherited opacity.
   ///
-  virtual bool IsOpaque() const;
+  /// @param transform The current transform matrix of the entity that will
+  /// render this contents.
+  virtual bool IsOpaque(const Matrix& transform) const;
 
   //----------------------------------------------------------------------------
   /// @brief Given the current pass space bounding rectangle of the clip

--- a/impeller/entity/contents/linear_gradient_contents.cc
+++ b/impeller/entity/contents/linear_gradient_contents.cc
@@ -44,7 +44,7 @@ void LinearGradientContents::SetTileMode(Entity::TileMode tile_mode) {
   tile_mode_ = tile_mode;
 }
 
-bool LinearGradientContents::IsOpaque() const {
+bool LinearGradientContents::IsOpaque(const Matrix& transform) const {
   if (GetOpacityFactor() < 1 || tile_mode_ == Entity::TileMode::kDecal) {
     return false;
   }
@@ -53,7 +53,7 @@ bool LinearGradientContents::IsOpaque() const {
       return false;
     }
   }
-  return true;
+  return !AppliesAlphaForStrokeCoverage(transform);
 }
 
 bool LinearGradientContents::CanApplyFastGradient() const {
@@ -176,7 +176,8 @@ bool LinearGradientContents::FastLinearGradient(const ContentContext& renderer,
 
         FS::FragInfo frag_info;
         frag_info.alpha =
-            GetOpacityFactor() * GetGeometry()->ComputeAlphaCoverage(entity);
+            GetOpacityFactor() *
+            GetGeometry()->ComputeAlphaCoverage(entity.GetTransform());
 
         FS::BindFragInfo(pass, host_buffer.EmplaceUniform(frag_info));
 
@@ -231,7 +232,8 @@ bool LinearGradientContents::RenderTexture(const ContentContext& renderer,
         frag_info.texture_sampler_y_coord_scale =
             gradient_texture->GetYCoordScale();
         frag_info.alpha =
-            GetOpacityFactor() * GetGeometry()->ComputeAlphaCoverage(entity);
+            GetOpacityFactor() *
+            GetGeometry()->ComputeAlphaCoverage(entity.GetTransform());
         ;
         frag_info.half_texel =
             Vector2(0.5 / gradient_texture->GetSize().width,
@@ -284,7 +286,8 @@ bool LinearGradientContents::RenderSSBO(const ContentContext& renderer,
         frag_info.tile_mode = static_cast<Scalar>(tile_mode_);
         frag_info.decal_border_color = decal_border_color_;
         frag_info.alpha =
-            GetOpacityFactor() * GetGeometry()->ComputeAlphaCoverage(entity);
+            GetOpacityFactor() *
+            GetGeometry()->ComputeAlphaCoverage(entity.GetTransform());
         frag_info.start_to_end = end_point_ - start_point_;
         frag_info.inverse_dot_start_to_end =
             CalculateInverseDotStartToEnd(start_point_, end_point_);

--- a/impeller/entity/contents/linear_gradient_contents.h
+++ b/impeller/entity/contents/linear_gradient_contents.h
@@ -21,7 +21,7 @@ class LinearGradientContents final : public ColorSourceContents {
   ~LinearGradientContents() override;
 
   // |Contents|
-  bool IsOpaque() const override;
+  bool IsOpaque(const Matrix& transform) const override;
 
   // |Contents|
   bool Render(const ContentContext& renderer,

--- a/impeller/entity/contents/radial_gradient_contents.cc
+++ b/impeller/entity/contents/radial_gradient_contents.cc
@@ -43,7 +43,7 @@ const std::vector<Scalar>& RadialGradientContents::GetStops() const {
   return stops_;
 }
 
-bool RadialGradientContents::IsOpaque() const {
+bool RadialGradientContents::IsOpaque(const Matrix& transform) const {
   if (GetOpacityFactor() < 1 || tile_mode_ == Entity::TileMode::kDecal) {
     return false;
   }
@@ -52,7 +52,7 @@ bool RadialGradientContents::IsOpaque() const {
       return false;
     }
   }
-  return true;
+  return !AppliesAlphaForStrokeCoverage(transform);
 }
 
 bool RadialGradientContents::Render(const ContentContext& renderer,
@@ -86,7 +86,8 @@ bool RadialGradientContents::RenderSSBO(const ContentContext& renderer,
         frag_info.tile_mode = static_cast<Scalar>(tile_mode_);
         frag_info.decal_border_color = decal_border_color_;
         frag_info.alpha =
-            GetOpacityFactor() * GetGeometry()->ComputeAlphaCoverage(entity);
+            GetOpacityFactor() *
+            GetGeometry()->ComputeAlphaCoverage(entity.GetTransform());
 
         auto& host_buffer = renderer.GetTransientsBuffer();
         auto colors = CreateGradientColors(colors_, stops_);
@@ -136,7 +137,8 @@ bool RadialGradientContents::RenderTexture(const ContentContext& renderer,
         frag_info.texture_sampler_y_coord_scale =
             gradient_texture->GetYCoordScale();
         frag_info.alpha =
-            GetOpacityFactor() * GetGeometry()->ComputeAlphaCoverage(entity);
+            GetOpacityFactor() *
+            GetGeometry()->ComputeAlphaCoverage(entity.GetTransform());
         frag_info.half_texel =
             Vector2(0.5 / gradient_texture->GetSize().width,
                     0.5 / gradient_texture->GetSize().height);

--- a/impeller/entity/contents/radial_gradient_contents.h
+++ b/impeller/entity/contents/radial_gradient_contents.h
@@ -21,7 +21,7 @@ class RadialGradientContents final : public ColorSourceContents {
   ~RadialGradientContents() override;
 
   // |Contents|
-  bool IsOpaque() const override;
+  bool IsOpaque(const Matrix& transform) const override;
 
   // |Contents|
   bool Render(const ContentContext& renderer,

--- a/impeller/entity/contents/solid_color_contents.cc
+++ b/impeller/entity/contents/solid_color_contents.cc
@@ -28,8 +28,8 @@ bool SolidColorContents::IsSolidColor() const {
   return true;
 }
 
-bool SolidColorContents::IsOpaque() const {
-  return GetColor().IsOpaque();
+bool SolidColorContents::IsOpaque(const Matrix& transform) const {
+  return GetColor().IsOpaque() && !AppliesAlphaForStrokeCoverage(transform);
 }
 
 std::optional<Rect> SolidColorContents::GetCoverage(
@@ -54,8 +54,8 @@ bool SolidColorContents::Render(const ContentContext& renderer,
 
   VS::FrameInfo frame_info;
   FS::FragInfo frag_info;
-  frag_info.color =
-      GetColor().Premultiply() * GetGeometry()->ComputeAlphaCoverage(entity);
+  frag_info.color = GetColor().Premultiply() *
+                    GetGeometry()->ComputeAlphaCoverage(entity.GetTransform());
 
   PipelineBuilderCallback pipeline_callback =
       [&renderer](ContentContextOptions options) {

--- a/impeller/entity/contents/solid_color_contents.h
+++ b/impeller/entity/contents/solid_color_contents.h
@@ -31,7 +31,7 @@ class SolidColorContents final : public ColorSourceContents {
   bool IsSolidColor() const override;
 
   // |Contents|
-  bool IsOpaque() const override;
+  bool IsOpaque(const Matrix& transform) const override;
 
   // |Contents|
   std::optional<Rect> GetCoverage(const Entity& entity) const override;

--- a/impeller/entity/contents/sweep_gradient_contents.cc
+++ b/impeller/entity/contents/sweep_gradient_contents.cc
@@ -49,7 +49,7 @@ const std::vector<Scalar>& SweepGradientContents::GetStops() const {
   return stops_;
 }
 
-bool SweepGradientContents::IsOpaque() const {
+bool SweepGradientContents::IsOpaque(const Matrix& transform) const {
   if (GetOpacityFactor() < 1 || tile_mode_ == Entity::TileMode::kDecal) {
     return false;
   }
@@ -58,7 +58,7 @@ bool SweepGradientContents::IsOpaque() const {
       return false;
     }
   }
-  return true;
+  return !AppliesAlphaForStrokeCoverage(transform);
 }
 
 bool SweepGradientContents::Render(const ContentContext& renderer,
@@ -95,7 +95,8 @@ bool SweepGradientContents::RenderSSBO(const ContentContext& renderer,
         frag_info.tile_mode = static_cast<Scalar>(tile_mode_);
         frag_info.decal_border_color = decal_border_color_;
         frag_info.alpha =
-            GetOpacityFactor() * GetGeometry()->ComputeAlphaCoverage(entity);
+            GetOpacityFactor() *
+            GetGeometry()->ComputeAlphaCoverage(entity.GetTransform());
 
         auto& host_buffer = renderer.GetTransientsBuffer();
         auto colors = CreateGradientColors(colors_, stops_);
@@ -147,7 +148,8 @@ bool SweepGradientContents::RenderTexture(const ContentContext& renderer,
         frag_info.tile_mode = static_cast<Scalar>(tile_mode_);
         frag_info.decal_border_color = decal_border_color_;
         frag_info.alpha =
-            GetOpacityFactor() * GetGeometry()->ComputeAlphaCoverage(entity);
+            GetOpacityFactor() *
+            GetGeometry()->ComputeAlphaCoverage(entity.GetTransform());
         frag_info.half_texel =
             Vector2(0.5 / gradient_texture->GetSize().width,
                     0.5 / gradient_texture->GetSize().height);

--- a/impeller/entity/contents/sweep_gradient_contents.h
+++ b/impeller/entity/contents/sweep_gradient_contents.h
@@ -22,7 +22,7 @@ class SweepGradientContents final : public ColorSourceContents {
   ~SweepGradientContents() override;
 
   // |Contents|
-  bool IsOpaque() const override;
+  bool IsOpaque(const Matrix& transform) const override;
 
   // |Contents|
   bool Render(const ContentContext& renderer,

--- a/impeller/entity/contents/tiled_texture_contents.cc
+++ b/impeller/entity/contents/tiled_texture_contents.cc
@@ -96,7 +96,7 @@ bool TiledTextureContents::UsesEmulatedTileMode(
 }
 
 // |Contents|
-bool TiledTextureContents::IsOpaque() const {
+bool TiledTextureContents::IsOpaque(const Matrix& transform) const {
   if (GetOpacityFactor() < 1 || x_tile_mode_ == Entity::TileMode::kDecal ||
       y_tile_mode_ == Entity::TileMode::kDecal) {
     return false;
@@ -104,7 +104,7 @@ bool TiledTextureContents::IsOpaque() const {
   if (color_filter_) {
     return false;
   }
-  return texture_->IsOpaque();
+  return texture_->IsOpaque() && !AppliesAlphaForStrokeCoverage(transform);
 }
 
 bool TiledTextureContents::Render(const ContentContext& renderer,
@@ -160,14 +160,16 @@ bool TiledTextureContents::Render(const ContentContext& renderer,
           frag_info.x_tile_mode = static_cast<Scalar>(x_tile_mode_);
           frag_info.y_tile_mode = static_cast<Scalar>(y_tile_mode_);
           frag_info.alpha =
-              GetOpacityFactor() * GetGeometry()->ComputeAlphaCoverage(entity);
+              GetOpacityFactor() *
+              GetGeometry()->ComputeAlphaCoverage(entity.GetTransform());
           FSExternal::BindFragInfo(pass, host_buffer.EmplaceUniform(frag_info));
         } else {
           FS::FragInfo frag_info;
           frag_info.x_tile_mode = static_cast<Scalar>(x_tile_mode_);
           frag_info.y_tile_mode = static_cast<Scalar>(y_tile_mode_);
           frag_info.alpha =
-              GetOpacityFactor() * GetGeometry()->ComputeAlphaCoverage(entity);
+              GetOpacityFactor() *
+              GetGeometry()->ComputeAlphaCoverage(entity.GetTransform());
           FS::BindFragInfo(pass, host_buffer.EmplaceUniform(frag_info));
         }
 

--- a/impeller/entity/contents/tiled_texture_contents.h
+++ b/impeller/entity/contents/tiled_texture_contents.h
@@ -28,7 +28,7 @@ class TiledTextureContents final : public ColorSourceContents {
       std::function<std::shared_ptr<ColorFilterContents>(FilterInput::Ref)>;
 
   // |Contents|
-  bool IsOpaque() const override;
+  bool IsOpaque(const Matrix& transform) const override;
 
   // |Contents|
   bool Render(const ContentContext& renderer,

--- a/impeller/entity/entity.cc
+++ b/impeller/entity/entity.cc
@@ -126,7 +126,8 @@ bool Entity::CanInheritOpacity() const {
   if (!contents_) {
     return false;
   }
-  if (!((blend_mode_ == BlendMode::kSource && contents_->IsOpaque()) ||
+  if (!((blend_mode_ == BlendMode::kSource &&
+         contents_->IsOpaque(GetTransform())) ||
         blend_mode_ == BlendMode::kSourceOver)) {
     return false;
   }
@@ -137,7 +138,8 @@ bool Entity::SetInheritedOpacity(Scalar alpha) {
   if (!CanInheritOpacity()) {
     return false;
   }
-  if (blend_mode_ == BlendMode::kSource && contents_->IsOpaque()) {
+  if (blend_mode_ == BlendMode::kSource &&
+      contents_->IsOpaque(GetTransform())) {
     blend_mode_ = BlendMode::kSourceOver;
   }
   contents_->SetInheritedOpacity(alpha);

--- a/impeller/entity/entity_pass.cc
+++ b/impeller/entity/entity_pass.cc
@@ -104,7 +104,7 @@ bool EntityPass::GetBoundsLimitIsSnug() const {
 
 void EntityPass::AddEntity(Entity entity) {
   if (entity.GetBlendMode() == BlendMode::kSourceOver &&
-      entity.GetContents()->IsOpaque()) {
+      entity.GetContents()->IsOpaque(entity.GetTransform())) {
     entity.SetBlendMode(BlendMode::kSource);
   }
 

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2275,62 +2275,118 @@ TEST_P(EntityTest, CoverageForStrokePathWithNegativeValuesInTransform) {
 }
 
 TEST_P(EntityTest, SolidColorContentsIsOpaque) {
+  Matrix matrix;
   SolidColorContents contents;
+  contents.SetGeometry(Geometry::MakeRect(Rect::MakeLTRB(0, 0, 10, 10)));
+
   contents.SetColor(Color::CornflowerBlue());
-  ASSERT_TRUE(contents.IsOpaque());
+  EXPECT_TRUE(contents.IsOpaque(matrix));
   contents.SetColor(Color::CornflowerBlue().WithAlpha(0.5));
-  ASSERT_FALSE(contents.IsOpaque());
+  EXPECT_FALSE(contents.IsOpaque(matrix));
+
+  // Create stroked path that required alpha coverage.
+  contents.SetGeometry(Geometry::MakeStrokePath(
+      PathBuilder{}.AddLine({0, 0}, {100, 100}).TakePath(),
+      /*stroke_width=*/0.05));
+  contents.SetColor(Color::CornflowerBlue());
+
+  EXPECT_FALSE(contents.IsOpaque(matrix));
 }
 
 TEST_P(EntityTest, ConicalGradientContentsIsOpaque) {
+  Matrix matrix;
   ConicalGradientContents contents;
+  contents.SetGeometry(Geometry::MakeRect(Rect::MakeLTRB(0, 0, 10, 10)));
+
   contents.SetColors({Color::CornflowerBlue()});
-  ASSERT_FALSE(contents.IsOpaque());
+  EXPECT_FALSE(contents.IsOpaque(matrix));
   contents.SetColors({Color::CornflowerBlue().WithAlpha(0.5)});
-  ASSERT_FALSE(contents.IsOpaque());
+  EXPECT_FALSE(contents.IsOpaque(matrix));
+
+  // Create stroked path that required alpha coverage.
+  contents.SetGeometry(Geometry::MakeStrokePath(
+      PathBuilder{}.AddLine({0, 0}, {100, 100}).TakePath(),
+      /*stroke_width=*/0.05));
+  contents.SetColors({Color::CornflowerBlue()});
+
+  EXPECT_FALSE(contents.IsOpaque(matrix));
 }
 
 TEST_P(EntityTest, LinearGradientContentsIsOpaque) {
+  Matrix matrix;
   LinearGradientContents contents;
+  contents.SetGeometry(Geometry::MakeRect(Rect::MakeLTRB(0, 0, 10, 10)));
+
   contents.SetColors({Color::CornflowerBlue()});
-  ASSERT_TRUE(contents.IsOpaque());
+  EXPECT_TRUE(contents.IsOpaque(matrix));
   contents.SetColors({Color::CornflowerBlue().WithAlpha(0.5)});
-  ASSERT_FALSE(contents.IsOpaque());
+  EXPECT_FALSE(contents.IsOpaque(matrix));
   contents.SetColors({Color::CornflowerBlue()});
   contents.SetTileMode(Entity::TileMode::kDecal);
-  ASSERT_FALSE(contents.IsOpaque());
+  EXPECT_FALSE(contents.IsOpaque(matrix));
+
+  // Create stroked path that required alpha coverage.
+  contents.SetGeometry(Geometry::MakeStrokePath(
+      PathBuilder{}.AddLine({0, 0}, {100, 100}).TakePath(),
+      /*stroke_width=*/0.05));
+  contents.SetColors({Color::CornflowerBlue()});
+
+  EXPECT_FALSE(contents.IsOpaque(matrix));
 }
 
 TEST_P(EntityTest, RadialGradientContentsIsOpaque) {
+  Matrix matrix;
   RadialGradientContents contents;
+  contents.SetGeometry(Geometry::MakeRect(Rect::MakeLTRB(0, 0, 10, 10)));
+
   contents.SetColors({Color::CornflowerBlue()});
-  ASSERT_TRUE(contents.IsOpaque());
+  EXPECT_TRUE(contents.IsOpaque(matrix));
   contents.SetColors({Color::CornflowerBlue().WithAlpha(0.5)});
-  ASSERT_FALSE(contents.IsOpaque());
+  EXPECT_FALSE(contents.IsOpaque(matrix));
   contents.SetColors({Color::CornflowerBlue()});
   contents.SetTileMode(Entity::TileMode::kDecal);
-  ASSERT_FALSE(contents.IsOpaque());
+  EXPECT_FALSE(contents.IsOpaque(matrix));
+
+  // Create stroked path that required alpha coverage.
+  contents.SetGeometry(Geometry::MakeStrokePath(
+      PathBuilder{}.AddLine({0, 0}, {100, 100}).TakePath(),
+      /*stroke_width=*/0.05));
+  contents.SetColors({Color::CornflowerBlue()});
+
+  EXPECT_FALSE(contents.IsOpaque(matrix));
 }
 
 TEST_P(EntityTest, SweepGradientContentsIsOpaque) {
+  Matrix matrix;
   RadialGradientContents contents;
+  contents.SetGeometry(Geometry::MakeRect(Rect::MakeLTRB(0, 0, 10, 10)));
+
   contents.SetColors({Color::CornflowerBlue()});
-  ASSERT_TRUE(contents.IsOpaque());
+  EXPECT_TRUE(contents.IsOpaque(matrix));
   contents.SetColors({Color::CornflowerBlue().WithAlpha(0.5)});
-  ASSERT_FALSE(contents.IsOpaque());
+  EXPECT_FALSE(contents.IsOpaque(matrix));
   contents.SetColors({Color::CornflowerBlue()});
   contents.SetTileMode(Entity::TileMode::kDecal);
-  ASSERT_FALSE(contents.IsOpaque());
+  EXPECT_FALSE(contents.IsOpaque(matrix));
+
+  // Create stroked path that required alpha coverage.
+  contents.SetGeometry(Geometry::MakeStrokePath(
+      PathBuilder{}.AddLine({0, 0}, {100, 100}).TakePath(),
+      /*stroke_width=*/0.05));
+  contents.SetColors({Color::CornflowerBlue()});
+
+  EXPECT_FALSE(contents.IsOpaque(matrix));
 }
 
 TEST_P(EntityTest, TiledTextureContentsIsOpaque) {
+  Matrix matrix;
   auto bay_bridge = CreateTextureForFixture("bay_bridge.jpg");
   TiledTextureContents contents;
   contents.SetTexture(bay_bridge);
   // This is a placeholder test. Images currently never decompress as opaque
   // (whether in Flutter or the playground), and so this should currently always
   // return false in practice.
-  ASSERT_FALSE(contents.IsOpaque());
+  EXPECT_FALSE(contents.IsOpaque(matrix));
 }
 
 TEST_P(EntityTest, PointFieldGeometryCoverage) {

--- a/impeller/entity/geometry/circle_geometry.h
+++ b/impeller/entity/geometry/circle_geometry.h
@@ -27,6 +27,9 @@ class CircleGeometry final : public Geometry {
   // |Geometry|
   bool IsAxisAlignedRect() const override;
 
+  // |Geometry|
+  Scalar ComputeAlphaCoverage(const Matrix& transform) const override;
+
  private:
   // |Geometry|
   GeometryResult GetPositionBuffer(const ContentContext& renderer,

--- a/impeller/entity/geometry/cover_geometry.cc
+++ b/impeller/entity/geometry/cover_geometry.cc
@@ -13,6 +13,7 @@ CoverGeometry::CoverGeometry() = default;
 GeometryResult CoverGeometry::GetPositionBuffer(const ContentContext& renderer,
                                                 const Entity& entity,
                                                 RenderPass& pass) const {
+  FML_LOG(ERROR) << "CoverGeometry::GetPositionBuffer";
   auto rect = Rect::MakeSize(pass.GetRenderTargetSize());
   constexpr uint16_t kRectIndicies[4] = {0, 1, 2, 3};
   auto& host_buffer = renderer.GetTransientsBuffer();

--- a/impeller/entity/geometry/ellipse_geometry.cc
+++ b/impeller/entity/geometry/ellipse_geometry.cc
@@ -16,7 +16,6 @@ GeometryResult EllipseGeometry::GetPositionBuffer(
     const ContentContext& renderer,
     const Entity& entity,
     RenderPass& pass) const {
-  FML_LOG(ERROR) << "EllipseGeometry::GetPositionBuffer";
   return ComputePositionGeometry(
       renderer,
       renderer.GetTessellator()->FilledEllipse(entity.GetTransform(), bounds_),

--- a/impeller/entity/geometry/ellipse_geometry.cc
+++ b/impeller/entity/geometry/ellipse_geometry.cc
@@ -16,6 +16,7 @@ GeometryResult EllipseGeometry::GetPositionBuffer(
     const ContentContext& renderer,
     const Entity& entity,
     RenderPass& pass) const {
+  FML_LOG(ERROR) << "EllipseGeometry::GetPositionBuffer";
   return ComputePositionGeometry(
       renderer,
       renderer.GetTessellator()->FilledEllipse(entity.GetTransform(), bounds_),

--- a/impeller/entity/geometry/fill_path_geometry.cc
+++ b/impeller/entity/geometry/fill_path_geometry.cc
@@ -20,6 +20,7 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
     const ContentContext& renderer,
     const Entity& entity,
     RenderPass& pass) const {
+  FML_LOG(ERROR) << "FillPathGeometry::GetPositionBuffer";
   auto& host_buffer = renderer.GetTransientsBuffer();
 
   const auto& bounding_box = path_.GetBoundingBox();

--- a/impeller/entity/geometry/fill_path_geometry.cc
+++ b/impeller/entity/geometry/fill_path_geometry.cc
@@ -20,7 +20,6 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
     const ContentContext& renderer,
     const Entity& entity,
     RenderPass& pass) const {
-  FML_LOG(ERROR) << "FillPathGeometry::GetPositionBuffer";
   auto& host_buffer = renderer.GetTransientsBuffer();
 
   const auto& bounding_box = path_.GetBoundingBox();

--- a/impeller/entity/geometry/geometry.cc
+++ b/impeller/entity/geometry/geometry.cc
@@ -129,4 +129,17 @@ bool Geometry::CanApplyMaskFilter() const {
   return true;
 }
 
+// static
+Scalar Geometry::ComputeStrokeAlphaCoverage(const Matrix& transform,
+                                            Scalar stroke_width) {
+  Scalar scaled_stroke_width = transform.GetMaxBasisLengthXY() * stroke_width;
+  // If the stroke width is 0 or greater than kMinStrokeSizeMSAA, don't apply
+  // any additional alpha. This is intended to match Skia behavior.
+  if (scaled_stroke_width == 0.0 || scaled_stroke_width >= kMinStrokeSizeMSAA) {
+    return 1.0;
+  }
+  // This scalling is eyeballed from Skia.
+  return std::clamp(scaled_stroke_width * 2.0f, 0.f, 1.f);
+}
+
 }  // namespace impeller

--- a/impeller/entity/geometry/geometry.h
+++ b/impeller/entity/geometry/geometry.h
@@ -16,6 +16,13 @@ namespace impeller {
 
 class Tessellator;
 
+/// @brief The minimum stroke size can be less than one physical pixel because
+///        of MSAA, but no less that half a physical pixel otherwise we might
+///        not hit one of the sample positions.
+static constexpr Scalar kMinStrokeSizeMSAA = 0.5f;
+
+static constexpr Scalar kMinStrokeSize = 1.0f;
+
 struct GeometryResult {
   enum class Mode {
     /// The geometry has no overlapping triangles.
@@ -91,6 +98,11 @@ class Geometry {
 
   virtual std::optional<Rect> GetCoverage(const Matrix& transform) const = 0;
 
+  /// @brief Compute an alpha value to simulate lower coverage of fractional
+  ///        pixel strokes.
+  static Scalar ComputeStrokeAlphaCoverage(const Matrix& entity,
+                                           Scalar stroke_width);
+
   /// @brief    Determines if this geometry, transformed by the given
   ///           `transform`, will completely cover all surface area of the given
   ///           `rect`.
@@ -107,7 +119,7 @@ class Geometry {
 
   virtual bool CanApplyMaskFilter() const;
 
-  virtual Scalar ComputeAlphaCoverage(const Entity& entitys) const {
+  virtual Scalar ComputeAlphaCoverage(const Matrix& transform) const {
     return 1.0;
   }
 

--- a/impeller/entity/geometry/geometry_unittests.cc
+++ b/impeller/entity/geometry/geometry_unittests.cc
@@ -137,19 +137,18 @@ TEST(EntityGeometryTest, GeometryResultHasReasonableDefaults) {
 }
 
 TEST(EntityGeometryTest, AlphaCoverageStrokePaths) {
-  Entity entity;
-  entity.SetTransform(Matrix::MakeScale(Vector2{3.0, 3.0}));
-  EXPECT_EQ(Geometry::MakeStrokePath({}, 0.5)->ComputeAlphaCoverage(entity), 1);
-  EXPECT_EQ(Geometry::MakeStrokePath({}, 0.1)->ComputeAlphaCoverage(entity), 1);
-  EXPECT_EQ(Geometry::MakeStrokePath({}, 0.05)->ComputeAlphaCoverage(entity),
+  auto matrix = Matrix::MakeScale(Vector2{3.0, 3.0});
+  EXPECT_EQ(Geometry::MakeStrokePath({}, 0.5)->ComputeAlphaCoverage(matrix), 1);
+  EXPECT_EQ(Geometry::MakeStrokePath({}, 0.1)->ComputeAlphaCoverage(matrix), 1);
+  EXPECT_EQ(Geometry::MakeStrokePath({}, 0.05)->ComputeAlphaCoverage(matrix),
             1);
-  EXPECT_NEAR(Geometry::MakeStrokePath({}, 0.01)->ComputeAlphaCoverage(entity),
+  EXPECT_NEAR(Geometry::MakeStrokePath({}, 0.01)->ComputeAlphaCoverage(matrix),
               0.6, 0.1);
   EXPECT_NEAR(
-      Geometry::MakeStrokePath({}, 0.0000005)->ComputeAlphaCoverage(entity),
+      Geometry::MakeStrokePath({}, 0.0000005)->ComputeAlphaCoverage(matrix),
       1e-05, 0.001);
-  EXPECT_EQ(Geometry::MakeStrokePath({}, 0)->ComputeAlphaCoverage(entity), 1);
-  EXPECT_EQ(Geometry::MakeStrokePath({}, 40)->ComputeAlphaCoverage(entity), 1);
+  EXPECT_EQ(Geometry::MakeStrokePath({}, 0)->ComputeAlphaCoverage(matrix), 1);
+  EXPECT_EQ(Geometry::MakeStrokePath({}, 40)->ComputeAlphaCoverage(matrix), 1);
 }
 
 }  // namespace testing

--- a/impeller/entity/geometry/line_geometry.cc
+++ b/impeller/entity/geometry/line_geometry.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "impeller/entity/geometry/line_geometry.h"
+#include "impeller/entity/geometry/geometry.h"
 
 namespace impeller {
 
@@ -12,19 +13,22 @@ LineGeometry::LineGeometry(Point p0, Point p1, Scalar width, Cap cap)
 }
 
 Scalar LineGeometry::ComputePixelHalfWidth(const Matrix& transform,
-                                           Scalar width) {
-  auto determinant = transform.GetDeterminant();
-  if (determinant == 0) {
-    return 0.0f;
+                                           Scalar width,
+                                           bool msaa) {
+  Scalar max_basis = transform.GetMaxBasisLengthXY();
+  if (max_basis == 0) {
+    return {};
   }
 
-  Scalar min_size = 1.0f / sqrt(std::abs(determinant));
-  return std::max(width, min_size) * 0.5f;
+  Scalar min_size = 1.0f / max_basis;
+  return std::max(width, min_size) * 0.5f *
+         (msaa ? kMinStrokeSize : kMinStrokeSizeMSAA);
 }
 
 Vector2 LineGeometry::ComputeAlongVector(const Matrix& transform,
-                                         bool allow_zero_length) const {
-  Scalar stroke_half_width = ComputePixelHalfWidth(transform, width_);
+                                         bool allow_zero_length,
+                                         bool msaa) const {
+  Scalar stroke_half_width = ComputePixelHalfWidth(transform, width_, msaa);
   if (stroke_half_width < kEhCloseEnough) {
     return {};
   }
@@ -44,8 +48,9 @@ Vector2 LineGeometry::ComputeAlongVector(const Matrix& transform,
 
 bool LineGeometry::ComputeCorners(Point corners[4],
                                   const Matrix& transform,
-                                  bool extend_endpoints) const {
-  auto along = ComputeAlongVector(transform, extend_endpoints);
+                                  bool extend_endpoints,
+                                  bool msaa) const {
+  auto along = ComputeAlongVector(transform, extend_endpoints, msaa);
   if (along.IsZero()) {
     return false;
   }
@@ -64,13 +69,18 @@ bool LineGeometry::ComputeCorners(Point corners[4],
   return true;
 }
 
+Scalar LineGeometry::ComputeAlphaCoverage(const Matrix& entity) const {
+  return Geometry::ComputeStrokeAlphaCoverage(entity, width_);
+}
+
 GeometryResult LineGeometry::GetPositionBuffer(const ContentContext& renderer,
                                                const Entity& entity,
                                                RenderPass& pass) const {
   using VT = SolidFillVertexShader::PerVertexData;
 
   auto& transform = entity.GetTransform();
-  auto radius = ComputePixelHalfWidth(transform, width_);
+  auto radius = ComputePixelHalfWidth(
+      transform, width_, pass.GetSampleCount() == SampleCount::kCount4);
 
   if (cap_ == Cap::kRound) {
     std::shared_ptr<Tessellator> tessellator = renderer.GetTessellator();
@@ -79,7 +89,8 @@ GeometryResult LineGeometry::GetPositionBuffer(const ContentContext& renderer,
   }
 
   Point corners[4];
-  if (!ComputeCorners(corners, transform, cap_ == Cap::kSquare)) {
+  if (!ComputeCorners(corners, transform, cap_ == Cap::kSquare,
+                      pass.GetSampleCount() == SampleCount::kCount4)) {
     return kEmptyResult;
   }
 
@@ -110,7 +121,8 @@ GeometryResult LineGeometry::GetPositionBuffer(const ContentContext& renderer,
 
 std::optional<Rect> LineGeometry::GetCoverage(const Matrix& transform) const {
   Point corners[4];
-  if (!ComputeCorners(corners, transform, cap_ != Cap::kButt)) {
+  // Note: MSAA boolean doesn't matter for coverage computation.
+  if (!ComputeCorners(corners, transform, cap_ != Cap::kButt, /*msaa=*/false)) {
     return {};
   }
 

--- a/impeller/entity/geometry/line_geometry.h
+++ b/impeller/entity/geometry/line_geometry.h
@@ -16,13 +16,17 @@ class LineGeometry final : public Geometry {
 
   ~LineGeometry() = default;
 
-  static Scalar ComputePixelHalfWidth(const Matrix& transform, Scalar width);
+  static Scalar ComputePixelHalfWidth(const Matrix& transform,
+                                      Scalar width,
+                                      bool msaa);
 
   // |Geometry|
   bool CoversArea(const Matrix& transform, const Rect& rect) const override;
 
   // |Geometry|
   bool IsAxisAlignedRect() const override;
+
+  Scalar ComputeAlphaCoverage(const Matrix& transform) const override;
 
  private:
   // Computes the 4 corners of a rectangle that defines the line and
@@ -41,10 +45,12 @@ class LineGeometry final : public Geometry {
   // @return true if the transform and width were not degenerate
   bool ComputeCorners(Point corners[4],
                       const Matrix& transform,
-                      bool extend_endpoints) const;
+                      bool extend_endpoints,
+                      bool msaa) const;
 
   Vector2 ComputeAlongVector(const Matrix& transform,
-                             bool allow_zero_length) const;
+                             bool allow_zero_length,
+                             bool msaa) const;
 
   // |Geometry|
   GeometryResult GetPositionBuffer(const ContentContext& renderer,

--- a/impeller/entity/geometry/stroke_path_geometry.cc
+++ b/impeller/entity/geometry/stroke_path_geometry.cc
@@ -17,13 +17,6 @@ using VS = SolidFillVertexShader;
 
 namespace {
 
-/// @brief The minimum stroke size can be less than one physical pixel because
-///        of MSAA, but no less that half a physical pixel otherwise we might
-///        not hit one of the sample positions.
-static constexpr Scalar kMinStrokeSizeMSAA = 0.5f;
-
-static constexpr Scalar kMinStrokeSize = 1.0f;
-
 template <typename VertexWriter>
 using CapProc = std::function<void(VertexWriter& vtx_builder,
                                    const Point& position,
@@ -565,16 +558,8 @@ Join StrokePathGeometry::GetStrokeJoin() const {
   return stroke_join_;
 }
 
-Scalar StrokePathGeometry::ComputeAlphaCoverage(const Entity& entity) const {
-  Scalar scaled_stroke_width =
-      entity.GetTransform().GetMaxBasisLengthXY() * stroke_width_;
-  // If the stroke width is 0 or greater than kMinStrokeSizeMSAA, don't apply
-  // any additional alpha. This is intended to match Skia behavior.
-  if (scaled_stroke_width == 0.0 || scaled_stroke_width >= kMinStrokeSizeMSAA) {
-    return 1.0;
-  }
-  // This scalling is eyeballed from Skia.
-  return std::clamp(scaled_stroke_width * 20.0f, 0.f, 1.f);
+Scalar StrokePathGeometry::ComputeAlphaCoverage(const Matrix& transform) const {
+  return Geometry::ComputeStrokeAlphaCoverage(transform, stroke_width_);
 }
 
 GeometryResult StrokePathGeometry::GetPositionBuffer(
@@ -584,15 +569,15 @@ GeometryResult StrokePathGeometry::GetPositionBuffer(
   if (stroke_width_ < 0.0) {
     return {};
   }
-  auto determinant = entity.GetTransform().GetDeterminant();
-  if (determinant == 0) {
+  Scalar max_basis = entity.GetTransform().GetMaxBasisLengthXY();
+  if (max_basis == 0) {
     return {};
   }
 
   Scalar min_size =
       (pass.GetSampleCount() == SampleCount::kCount4 ? kMinStrokeSizeMSAA
                                                      : kMinStrokeSize) /
-      sqrt(std::abs(determinant));
+      max_basis;
   Scalar stroke_width = std::max(stroke_width_, min_size);
 
   auto& host_buffer = renderer.GetTransientsBuffer();
@@ -641,12 +626,12 @@ std::optional<Rect> StrokePathGeometry::GetCoverage(
   if (stroke_join_ == Join::kMiter) {
     max_radius = std::max(max_radius, miter_limit_ * 0.5f);
   }
-  Scalar determinant = transform.GetDeterminant();
-  if (determinant == 0) {
-    return std::nullopt;
+  Scalar max_basis = transform.GetMaxBasisLengthXY();
+  if (max_basis == 0) {
+    return {};
   }
   // Use the most conervative coverage setting.
-  Scalar min_size = kMinStrokeSize / sqrt(std::abs(determinant));
+  Scalar min_size = kMinStrokeSize / max_basis;
   max_radius *= std::max(stroke_width_, min_size);
   return path_bounds->Expand(max_radius).TransformBounds(transform);
 }

--- a/impeller/entity/geometry/stroke_path_geometry.h
+++ b/impeller/entity/geometry/stroke_path_geometry.h
@@ -6,6 +6,7 @@
 #define FLUTTER_IMPELLER_ENTITY_GEOMETRY_STROKE_PATH_GEOMETRY_H_
 
 #include "impeller/entity/geometry/geometry.h"
+#include "impeller/geometry/matrix.h"
 
 namespace impeller {
 
@@ -28,7 +29,7 @@ class StrokePathGeometry final : public Geometry {
 
   Join GetStrokeJoin() const;
 
-  Scalar ComputeAlphaCoverage(const Entity& entity) const override;
+  Scalar ComputeAlphaCoverage(const Matrix& transform) const override;
 
  private:
   // |Geometry|


### PR DESCRIPTION
When computing whether or not an entity can be cooerced into src blend from srcOver, take into account that stroke geometries may modulate with alpha to emulate stroke widths less than 1.0.

While we're at it, update several computations to use max basis XY (from https://github.com/flutter/flutter/issues/153451 ) since that can lead to incorrect stroke width computations in the presence of canvas scaling.



Fixes https://github.com/flutter/flutter/issues/154178