### PR TITLE
[Impeller] fall back to path rendering on thick paths.

### DIFF
--- a/third_party/txt/src/skia/paragraph_skia.cc
+++ b/third_party/txt/src/skia/paragraph_skia.cc
@@ -87,8 +87,7 @@ class DisplayListParagraphPainter : public skt::ParagraphPainter {
 #ifdef IMPELLER_SUPPORTS_RENDERING
     if (impeller_enabled_) {
       SkTextBlobRunIterator run(blob.get());
-      if (ShouldRenderAsPath(dl_paints_[paint_id]) ||
-          ShouldForcePathRendering(run.font(), /*dpr_guess=*/3.0)) {
+      if (ShouldRenderAsPath(dl_paints_[paint_id])) {
         auto path = skia::textlayout::Paragraph::GetPath(blob.get());
         // If there is no path, this is an emoji and should be drawn as is,
         // ignoring the color source.
@@ -189,9 +188,12 @@ class DisplayListParagraphPainter : public skt::ParagraphPainter {
     // samples.
     // If the text is stroked and the stroke width is large enough, use path
     // rendering anyway, as the fidelity problems won't be as noticable and
-    // rendering will be faster as it avoids software rasterization.
+    // rendering will be faster as it avoids software rasterization. A stroke
+    // width of four was chosen by eyeballing the point at which the path
+    // text looks good enough, with some room for error.
     return (paint.getColorSource() && !paint.getColorSource()->asColor()) ||
-      (paint.getDrawStyle() == DlDrawStyle::kStroke && paint.getStrokeWidth() > 16);
+           (paint.getDrawStyle() == DlDrawStyle::kStroke &&
+            paint.getStrokeWidth() > 4);
   }
 
   DlPaint toDlPaint(const DecorationStyle& decor_style,

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -265,7 +265,7 @@ TEST_F(PainterTest, DrawStrokedTextWithLargeWidthImpeller) {
   auto style = makeStyle();
   DlPaint foreground;
   foreground.setDrawStyle(DlDrawStyle::kStroke);
-  foreground.setStrokeWidth(100);
+  foreground.setStrokeWidth(10);
   style.foreground = foreground;
 
   auto recorder = DlOpRecorder();

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -259,6 +259,23 @@ TEST_F(PainterTest, DrawStrokedTextImpeller) {
   EXPECT_EQ(recorder.pathCount(), 0);
 }
 
+TEST_F(PainterTest, DrawStrokedTextWithLargeWidthImpeller) {
+  PretendImpellerIsEnabled(true);
+
+  auto style = makeStyle();
+  DlPaint foreground;
+  foreground.setDrawStyle(DlDrawStyle::kStroke);
+  foreground.setStrokeWidth(100);
+  style.foreground = foreground;
+
+  auto recorder = DlOpRecorder();
+  draw(style)->Dispatch(recorder);
+
+  EXPECT_EQ(recorder.textFrameCount(), 0);
+  EXPECT_EQ(recorder.blobCount(), 0);
+  EXPECT_EQ(recorder.pathCount(), 1);
+}
+
 TEST_F(PainterTest, DrawTextWithGradientImpeller) {
   PretendImpellerIsEnabled(true);
 


### PR DESCRIPTION
For very thin stroked text we switch to skia font rasterization for higher fidelity. However and very large stroke widths, the fidelity loss doesn't matter and may be much slower due to software rasterization.

As several users have noticed, there is a maximum size limit of skia stroked text that we hit as well. This only seems to happen on large stroke widths.

Fixes https://github.com/flutter/flutter/issues/153784
