### PR TITLE
Ignore generated fixture `.dill.deps` files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ flutter_*.png
 linked_*.ds
 unlinked.ds
 unlinked_spec.ds
+*.dill.deps
 
 # Android related
 **/android/**/gradle-wrapper.jar


### PR DESCRIPTION
After using `testing/run_tests.py`, these artifacts are left in the source tree.

It is probably better _not_ to do that (i.e. use sandboxing), but we don't sandbox across the engine today.

```txt
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        tools/const_finder/test/fixtures/box_web.dill.deps
        tools/const_finder/test/fixtures/consts_and_non_web.dill.deps
        tools/const_finder/test/fixtures/consts_web.dill.deps
        tools/const_finder/test/fixtures/static_icon_provider_web.dill.deps
```