### PR TITLE
[engine] add an ios noop context.

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -125,6 +125,8 @@ source_set("flutter_framework_source_arc") {
     "ios_context_metal_impeller.mm",
     "ios_context_metal_skia.h",
     "ios_context_metal_skia.mm",
+    "ios_context_noop.h",
+    "ios_context_noop.mm",
     "ios_context_software.h",
     "ios_context_software.mm",
     "ios_external_texture_metal.h",
@@ -286,6 +288,7 @@ shared_library("ios_test_flutter") {
     "framework/Source/accessibility_bridge_test.mm",
     "framework/Source/availability_version_check_test.mm",
     "framework/Source/connection_collection_test.mm",
+    "ios_context_noop_unittests.mm",
     "ios_surface_noop_unittests.mm",
     "platform_message_handler_ios_test.mm",
   ]

--- a/shell/platform/darwin/ios/ios_context_noop.h
+++ b/shell/platform/darwin/ios/ios_context_noop.h
@@ -1,0 +1,44 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_IOS_CONTEXT_NOOP_H_
+#define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_IOS_CONTEXT_NOOP_H_
+
+#import "flutter/shell/platform/darwin/ios/ios_context.h"
+
+namespace flutter {
+
+/// @brief A noop rendering context for usage on simulators without metal support.
+class IOSContextNoop final : public IOSContext {
+ public:
+  IOSContextNoop();
+
+  // |IOSContext|
+  ~IOSContextNoop();
+
+  // |IOSContext|
+  sk_sp<GrDirectContext> CreateResourceContext() override;
+
+  // |IOSContext|
+  sk_sp<GrDirectContext> GetMainContext() const override;
+
+  // |IOSContext|
+  std::unique_ptr<GLContextResult> MakeCurrent() override;
+
+  // |IOSContext|
+  std::unique_ptr<Texture> CreateExternalTexture(
+      int64_t texture_id,
+      fml::scoped_nsobject<NSObject<FlutterTexture>> texture) override;
+
+  IOSRenderingBackend GetBackend() const override;
+
+ private:
+  IOSContextNoop(const IOSContextNoop&) = delete;
+
+  IOSContextNoop& operator=(const IOSContextNoop&) = delete;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_IOS_CONTEXT_NOOP_H_

--- a/shell/platform/darwin/ios/ios_context_noop.mm
+++ b/shell/platform/darwin/ios/ios_context_noop.mm
@@ -1,0 +1,53 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "flutter/shell/platform/darwin/ios/ios_context_noop.h"
+#include "ios_context.h"
+#include "shell/platform/darwin/ios/rendering_api_selection.h"
+
+FLUTTER_ASSERT_ARC
+
+namespace flutter {
+
+IOSContextNoop::IOSContextNoop() = default;
+
+// |IOSContext|
+IOSContextNoop::~IOSContextNoop() = default;
+
+// |IOSContext|
+sk_sp<GrDirectContext> IOSContextNoop::CreateResourceContext() {
+  return nullptr;
+}
+
+// |IOSContext|
+sk_sp<GrDirectContext> IOSContextNoop::GetMainContext() const {
+  return nullptr;
+}
+
+// |IOSContext|
+IOSRenderingBackend IOSContextNoop::GetBackend() const {
+  return IOSRenderingBackend::kImpeller;
+}
+
+// |IOSContext|
+std::unique_ptr<GLContextResult> IOSContextNoop::MakeCurrent() {
+  // This only makes sense for context that need to be bound to a specific thread.
+  return std::make_unique<GLContextDefaultResult>(false);
+}
+
+// |IOSContext|
+std::unique_ptr<Texture> IOSContextNoop::CreateExternalTexture(
+    int64_t texture_id,
+    fml::scoped_nsobject<NSObject<FlutterTexture>> texture) {
+  // Don't use FML for logging as it will contain engine specific details. This is a user facing
+  // message.
+  NSLog(@"Flutter: Attempted to composite external texture sources using the noop backend. "
+        @"This backend is only used on simulators. This feature is only available on actual "
+        @"devices where Metal is used for rendering.");
+
+  // Not supported in this backend.
+  return nullptr;
+}
+
+}  // namespace flutter

--- a/shell/platform/darwin/ios/ios_context_noop_unittests.mm
+++ b/shell/platform/darwin/ios/ios_context_noop_unittests.mm
@@ -1,0 +1,24 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <QuartzCore/QuartzCore.h>
+#import <XCTest/XCTest.h>
+
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
+#include "shell/platform/darwin/ios/ios_context_noop.h"
+#include "shell/platform/darwin/ios/rendering_api_selection.h"
+
+FLUTTER_ASSERT_ARC
+
+@interface IOSContextNoopTest : XCTestCase
+@end
+
+@implementation IOSContextNoopTest
+- (void)testCreateNoop {
+  flutter::IOSContextNoop noop;
+
+  XCTAssertTrue(noop.GetBackend() == flutter::IOSRenderingBackend::kImpeller);
+}
+
+@end


### PR DESCRIPTION
This is required to allow simulators to run without exiting when impeller is enabled and there is no available metal contxt.