### PR TITLE
Fix `build/dart/rules.gni` which contains erroneous code after my refactor.

### DIFF
--- a/build/dart/rules.gni
+++ b/build/dart/rules.gni
@@ -120,7 +120,7 @@ template("flutter_frontend_server") {
       inputs = [ invoker.main_dart ]
       outputs = [ invoker.kernel_output ]
       depfile = snapshot_depfile
-      vm_args = (args = common_args)
+      args = common_args
     }
   }
 }


### PR DESCRIPTION
In https://github.com/flutter/engine/pull/54845, I removed `common_vm_args = ['--disable-dart-dev']`, but the resulting change created invalid code `vm_args = (args = common_args)`. We don't seem to run this configuration on our own CI, so it wasn't noticed, but it broke the Dart monorepo build, which does use it:

https://ci.chromium.org/p/dart/g/monorepo/console

https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8738311211510911329/+/u/gn_--runtime-mode_debug_--full-dart-sdk_--rbe_--no-goma_--unoptimized_--no-prebuilt-dart-sdk_--gn-args_engine_version__5295ec1b816af727165015d84d4a1091520122ae__--rbe-server-address_unix:___b_s_w_ir_x_w_recipe_cleanup_rbe4v23ir8o_reproxy.sock/stdout

I am open to reverting instead, but this seems straight-forward enough for something that isn't tested on either pre or post-submit.