### PR TITLE
Remove C++ style from keyboard code

### DIFF
--- a/shell/platform/linux/fl_key_event.cc
+++ b/shell/platform/linux/fl_key_event.cc
@@ -35,9 +35,3 @@ void fl_key_event_dispose(FlKeyEvent* event) {
   }
   g_free(event);
 }
-
-FlKeyEvent* fl_key_event_clone(const FlKeyEvent* event) {
-  FlKeyEvent* new_event = g_new(FlKeyEvent, 1);
-  *new_event = *event;
-  return new_event;
-}

--- a/shell/platform/linux/fl_key_event.h
+++ b/shell/platform/linux/fl_key_event.h
@@ -55,6 +55,4 @@ FlKeyEvent* fl_key_event_new_from_gdk_event(GdkEvent* event);
  */
 void fl_key_event_dispose(FlKeyEvent* event);
 
-FlKeyEvent* fl_key_event_clone(const FlKeyEvent* source);
-
 #endif  // FLUTTER_SHELL_PLATFORM_LINUX_FL_KEY_EVENT_H_

--- a/shell/platform/linux/fl_keyboard_handler_test.cc
+++ b/shell/platform/linux/fl_keyboard_handler_test.cc
@@ -88,19 +88,6 @@ typedef struct {
   std::unique_ptr<char[]> event_character;
 } CallRecord;
 
-// Clone a C-string.
-//
-// Must be deleted by delete[].
-char* cloneString(const char* source) {
-  if (source == nullptr) {
-    return nullptr;
-  }
-  size_t charLen = strlen(source);
-  char* target = new char[charLen + 1];
-  strncpy(target, source, charLen + 1);
-  return target;
-}
-
 constexpr guint16 kKeyCodeKeyA = 0x26u;
 constexpr guint16 kKeyCodeKeyB = 0x38u;
 constexpr guint16 kKeyCodeKeyM = 0x3au;
@@ -508,7 +495,7 @@ class KeyboardTester {
                                 AsyncKeyCallback callback) {
           EXPECT_FALSE(during_redispatch_);
           auto new_event = std::make_unique<FlutterKeyEvent>(*event);
-          char* new_event_character = cloneString(event->character);
+          char* new_event_character = g_strdup(event->character);
           new_event->character = new_event_character;
           storage.push_back(CallRecord{
               .type = CallRecord::kKeyCallEmbedder,
@@ -527,7 +514,7 @@ class KeyboardTester {
                                           const AsyncKeyCallback& callback) {
           EXPECT_FALSE(during_redispatch_);
           auto new_event = std::make_unique<FlutterKeyEvent>(*event);
-          char* new_event_character = cloneString(event->character);
+          char* new_event_character = g_strdup(event->character);
           new_event->character = new_event_character;
           storage.push_back(CallRecord{
               .type = CallRecord::kKeyCallEmbedder,


### PR DESCRIPTION
It doesn't match the other GObject code and makes it harder to debug.