### PR TITLE
[canvaskit] Makes access to CkSurface null-safer

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/surface.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/surface.dart
@@ -182,7 +182,6 @@ class Surface extends DisplayCanvas {
   }
 
   BitmapSize? _currentCanvasPhysicalSize;
-  BitmapSize? _currentSurfaceSize;
 
   /// Sets the CSS size of the canvas so that canvas pixels are 1:1 with device
   /// pixels.
@@ -250,7 +249,7 @@ class Surface extends DisplayCanvas {
     if (!_forceNewContext) {
       // Check if the window is the same size as before, and if so, don't allocate
       // a new canvas as the previous canvas is big enough to fit everything.
-      final BitmapSize? previousSurfaceSize = _currentSurfaceSize;
+      final BitmapSize? previousSurfaceSize = _surface?._size;
       if (previousSurfaceSize != null &&
           size.width == previousSurfaceSize.width &&
           size.height == previousSurfaceSize.height) {
@@ -299,10 +298,8 @@ class Surface extends DisplayCanvas {
       _currentCanvasPhysicalSize = size;
     }
 
-    _currentSurfaceSize = size;
     _surface?.dispose();
-    _surface = _createNewSurface(size);
-    return _surface!;
+    return _surface = _createNewSurface(size);
   }
 
   JSVoid _contextRestoredListener(DomEvent event) {
@@ -462,11 +459,17 @@ class Surface extends DisplayCanvas {
   CkSurface _createNewSurface(BitmapSize size) {
     assert(_offscreenCanvas != null || _canvasElement != null);
     if (webGLVersion == -1) {
-      return _makeSoftwareCanvasSurface('WebGL support not detected');
+      return _makeSoftwareCanvasSurface('WebGL support not detected', size);
     } else if (configuration.canvasKitForceCpuOnly) {
-      return _makeSoftwareCanvasSurface('CPU rendering forced by application');
+      return _makeSoftwareCanvasSurface(
+        'CPU rendering forced by application',
+        size,
+      );
     } else if (_glContext == 0) {
-      return _makeSoftwareCanvasSurface('Failed to initialize WebGL context');
+      return _makeSoftwareCanvasSurface(
+        'Failed to initialize WebGL context',
+        size,
+      );
     } else {
       final SkSurface? skSurface = canvasKit.MakeOnScreenGLSurface(
           _grContext!,
@@ -477,16 +480,19 @@ class Surface extends DisplayCanvas {
           _stencilBits);
 
       if (skSurface == null) {
-        return _makeSoftwareCanvasSurface('Failed to initialize WebGL surface');
+        return _makeSoftwareCanvasSurface(
+          'Failed to initialize WebGL surface',
+          size,
+        );
       }
 
-      return CkSurface(skSurface, _glContext);
+      return CkSurface(skSurface, _glContext, size);
     }
   }
 
   static bool _didWarnAboutWebGlInitializationFailure = false;
 
-  CkSurface _makeSoftwareCanvasSurface(String reason) {
+  CkSurface _makeSoftwareCanvasSurface(String reason, BitmapSize size) {
     if (!_didWarnAboutWebGlInitializationFailure) {
       printWarning('WARNING: Falling back to CPU-only rendering. $reason.');
       _didWarnAboutWebGlInitializationFailure = true;
@@ -498,10 +504,7 @@ class Surface extends DisplayCanvas {
     } else {
       surface = canvasKit.MakeSWCanvasSurface(_canvasElement!);
     }
-    return CkSurface(
-      surface,
-      null,
-    );
+    return CkSurface(surface, null, size);
   }
 
   bool _presentSurface() {
@@ -534,9 +537,9 @@ class Surface extends DisplayCanvas {
       browserSupportsOffscreenCanvas && !isSafari;
 }
 
-/// A Dart wrapper around Skia's CkSurface.
+/// A Dart wrapper around Skia's SkSurface.
 class CkSurface {
-  CkSurface(this.surface, this._glContext);
+  CkSurface(this.surface, this._glContext, this._size);
 
   CkCanvas getCanvas() {
     assert(!_isDisposed, 'Attempting to use the canvas of a disposed surface');
@@ -548,6 +551,8 @@ class CkSurface {
   /// Only borrow this value temporarily. Do not store it as it may be deleted
   /// at any moment. Storing it may lead to dangling pointer bugs.
   final SkSurface surface;
+
+  final BitmapSize _size;
 
   final int? _glContext;
 

--- a/lib/web_ui/lib/src/engine/canvaskit/surface.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/surface.dart
@@ -498,13 +498,17 @@ class Surface extends DisplayCanvas {
       _didWarnAboutWebGlInitializationFailure = true;
     }
 
-    SkSurface surface;
-    if (useOffscreenCanvas) {
-      surface = canvasKit.MakeOffscreenSWCanvasSurface(_offscreenCanvas!);
-    } else {
-      surface = canvasKit.MakeSWCanvasSurface(_canvasElement!);
+    try {
+      SkSurface surface;
+      if (useOffscreenCanvas) {
+        surface = canvasKit.MakeOffscreenSWCanvasSurface(_offscreenCanvas!);
+      } else {
+        surface = canvasKit.MakeSWCanvasSurface(_canvasElement!);
+      }
+      return CkSurface(surface, null, size);
+    } catch (error) {
+      throw CanvasKitError('Failed to create CPU-based surface: $error.');
     }
-    return CkSurface(surface, null, size);
   }
 
   bool _presentSurface() {

--- a/lib/web_ui/lib/src/engine/canvaskit/surface.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/surface.dart
@@ -71,6 +71,10 @@ class Surface extends DisplayCanvas {
   bool _contextLost = false;
   bool get debugContextLost => _contextLost;
 
+  /// Forces AssertionError when attempting to create a CPU-based surface.
+  /// Only for tests.
+  bool debugThrowOnSoftwareSurfaceCreation = false;
+
   /// A cached copy of the most recently created `webglcontextlost` listener.
   ///
   /// We must cache this function because each time we access the tear-off it
@@ -499,6 +503,8 @@ class Surface extends DisplayCanvas {
     }
 
     try {
+      assert(!debugThrowOnSoftwareSurfaceCreation);
+
       SkSurface surface;
       if (useOffscreenCanvas) {
         surface = canvasKit.MakeOffscreenSWCanvasSurface(_offscreenCanvas!);

--- a/lib/web_ui/test/canvaskit/surface_test.dart
+++ b/lib/web_ui/test/canvaskit/surface_test.dart
@@ -311,11 +311,10 @@ void testMain() {
       expect(surface.debugForceNewContext, isFalse);
 
       surface.debugThrowOnSoftwareSurfaceCreation = false;
-      surface.createOrUpdateSurface(const BitmapSize(12, 34));
+      final ckSurface = surface.createOrUpdateSurface(const BitmapSize(12, 34));
 
-      final DomOffscreenCanvas canvas = surface.debugOffscreenCanvas!;
-      expect(canvas.width, 12);
-      expect(canvas.height, 34);
+      expect(ckSurface.surface.width(), 12);
+      expect(ckSurface.surface.height(), 34);
     });
   });
 }

--- a/lib/web_ui/test/canvaskit/surface_test.dart
+++ b/lib/web_ui/test/canvaskit/surface_test.dart
@@ -10,7 +10,6 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
 
-import '../common/matchers.dart';
 import 'common.dart';
 
 void main() {


### PR DESCRIPTION
Handles exceptions coming from `MakeSWCanvasSurface` and `MakeOffscreenSWCanvasSurface`.

Also makes surface size a member of `CkSurface` to make sure that it's always in sync with `surface`.

Fixes https://github.com/flutter/flutter/issues/154402

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
