### PR TITLE
[WIP][display_list] eagerly convert to impeller geometry.

### DIFF
--- a/display_list/benchmarking/dl_builder_benchmarks.cc
+++ b/display_list/benchmarking/dl_builder_benchmarks.cc
@@ -92,7 +92,7 @@ static void BM_DisplayListBuilderDefault(benchmark::State& state,
                                          DisplayListBuilderBenchmarkType type) {
   bool prepare_rtree = NeedPrepareRTree(type);
   while (state.KeepRunning()) {
-    DisplayListBuilder builder(prepare_rtree);
+    DisplayListBuilder builder(/*impeller=*/true, prepare_rtree);
     InvokeAllRenderingOps(builder);
     Complete(builder, type);
   }
@@ -103,7 +103,7 @@ static void BM_DisplayListBuilderWithScaleAndTranslate(
     DisplayListBuilderBenchmarkType type) {
   bool prepare_rtree = NeedPrepareRTree(type);
   while (state.KeepRunning()) {
-    DisplayListBuilder builder(prepare_rtree);
+    DisplayListBuilder builder(/*impeller=*/true, prepare_rtree);
     builder.Scale(3.5, 3.5);
     builder.Translate(10.3, 6.9);
     InvokeAllRenderingOps(builder);
@@ -116,7 +116,7 @@ static void BM_DisplayListBuilderWithPerspective(
     DisplayListBuilderBenchmarkType type) {
   bool prepare_rtree = NeedPrepareRTree(type);
   while (state.KeepRunning()) {
-    DisplayListBuilder builder(prepare_rtree);
+    DisplayListBuilder builder(/*impeller=*/true, prepare_rtree);
     builder.TransformFullPerspective(0, 1, 0, 12, 1, 0, 0, 33, 3, 2, 5, 29, 0,
                                      0, 0, 12);
     InvokeAllRenderingOps(builder);
@@ -130,7 +130,7 @@ static void BM_DisplayListBuilderWithClipRect(
   SkRect clip_bounds = SkRect::MakeLTRB(6.5, 7.3, 90.2, 85.7);
   bool prepare_rtree = NeedPrepareRTree(type);
   while (state.KeepRunning()) {
-    DisplayListBuilder builder(prepare_rtree);
+    DisplayListBuilder builder(/*impeller=*/true, prepare_rtree);
     builder.ClipRect(clip_bounds, DlCanvas::ClipOp::kIntersect, true);
     InvokeAllRenderingOps(builder);
     Complete(builder, type);
@@ -142,7 +142,7 @@ static void BM_DisplayListBuilderWithGlobalSaveLayer(
     DisplayListBuilderBenchmarkType type) {
   bool prepare_rtree = NeedPrepareRTree(type);
   while (state.KeepRunning()) {
-    DisplayListBuilder builder(prepare_rtree);
+    DisplayListBuilder builder(/*impeller=*/true, prepare_rtree);
     builder.Scale(3.5, 3.5);
     builder.Translate(10.3, 6.9);
     builder.SaveLayer(nullptr, nullptr);
@@ -164,7 +164,7 @@ static void BM_DisplayListBuilderWithSaveLayer(
     DisplayListBuilderBenchmarkType type) {
   bool prepare_rtree = NeedPrepareRTree(type);
   while (state.KeepRunning()) {
-    DisplayListBuilder builder(prepare_rtree);
+    DisplayListBuilder builder(/*impeller=*/true, prepare_rtree);
     DlOpReceiver& receiver = DisplayListBuilderBenchmarkAccessor(builder);
     for (auto& group : allRenderingOps) {
       for (size_t i = 0; i < group.variants.size(); i++) {
@@ -186,7 +186,7 @@ static void BM_DisplayListBuilderWithSaveLayerAndImageFilter(
   SkRect layer_bounds = SkRect::MakeLTRB(6.5, 7.3, 35.2, 42.7);
   bool prepare_rtree = NeedPrepareRTree(type);
   while (state.KeepRunning()) {
-    DisplayListBuilder builder(prepare_rtree);
+    DisplayListBuilder builder(/*impeller=*/true, prepare_rtree);
     DlOpReceiver& receiver = DisplayListBuilderBenchmarkAccessor(builder);
     for (auto& group : allRenderingOps) {
       for (size_t i = 0; i < group.variants.size(); i++) {
@@ -209,7 +209,7 @@ static void BM_DisplayListDispatchDefault(
     benchmark::State& state,
     DisplayListDispatchBenchmarkType type) {
   bool prepare_rtree = NeedPrepareRTree(type);
-  DisplayListBuilder builder(prepare_rtree);
+  DisplayListBuilder builder(/*impeller=*/true, prepare_rtree);
   for (int i = 0; i < 5; i++) {
     InvokeAllOps(builder);
   }
@@ -224,7 +224,7 @@ static void BM_DisplayListDispatchByIndexDefault(
     benchmark::State& state,
     DisplayListDispatchBenchmarkType type) {
   bool prepare_rtree = NeedPrepareRTree(type);
-  DisplayListBuilder builder(prepare_rtree);
+  DisplayListBuilder builder(/*impeller=*/true, prepare_rtree);
   for (int i = 0; i < 5; i++) {
     InvokeAllOps(builder);
   }
@@ -242,7 +242,7 @@ static void BM_DisplayListDispatchByIteratorDefault(
     benchmark::State& state,
     DisplayListDispatchBenchmarkType type) {
   bool prepare_rtree = NeedPrepareRTree(type);
-  DisplayListBuilder builder(prepare_rtree);
+  DisplayListBuilder builder(/*impeller=*/true, prepare_rtree);
   for (int i = 0; i < 5; i++) {
     InvokeAllOps(builder);
   }
@@ -259,7 +259,7 @@ static void BM_DisplayListDispatchByVectorDefault(
     benchmark::State& state,
     DisplayListDispatchBenchmarkType type) {
   bool prepare_rtree = NeedPrepareRTree(type);
-  DisplayListBuilder builder(prepare_rtree);
+  DisplayListBuilder builder(/*impeller=*/true, prepare_rtree);
   for (int i = 0; i < 5; i++) {
     InvokeAllOps(builder);
   }
@@ -277,7 +277,7 @@ static void BM_DisplayListDispatchByVectorDefault(
 static void BM_DisplayListDispatchCull(benchmark::State& state,
                                        DisplayListDispatchBenchmarkType type) {
   bool prepare_rtree = NeedPrepareRTree(type);
-  DisplayListBuilder builder(prepare_rtree);
+  DisplayListBuilder builder(/*impeller=*/true, prepare_rtree);
   for (int i = 0; i < 5; i++) {
     InvokeAllOps(builder);
   }
@@ -294,7 +294,7 @@ static void BM_DisplayListDispatchByVectorCull(
     benchmark::State& state,
     DisplayListDispatchBenchmarkType type) {
   bool prepare_rtree = NeedPrepareRTree(type);
-  DisplayListBuilder builder(prepare_rtree);
+  DisplayListBuilder builder(/*impeller=*/true, prepare_rtree);
   for (int i = 0; i < 5; i++) {
     InvokeAllOps(builder);
   }

--- a/display_list/display_list.cc
+++ b/display_list/display_list.cc
@@ -327,6 +327,8 @@ DisplayListOpCategory DisplayList::GetOpCategory(DisplayListOpType type) {
     case DisplayListOpType::kClipDifferenceOval:
     case DisplayListOpType::kClipDifferenceRRect:
     case DisplayListOpType::kClipDifferencePath:
+    case DisplayListOpType::kClipDifferenceImpellerPath:
+    case DisplayListOpType::kClipIntersectImpellerPath:
       return DisplayListOpCategory::kClip;
 
     case DisplayListOpType::kDrawPaint:
@@ -355,6 +357,9 @@ DisplayListOpCategory DisplayList::GetOpCategory(DisplayListOpType type) {
     case DisplayListOpType::kDrawTextFrame:
     case DisplayListOpType::kDrawShadow:
     case DisplayListOpType::kDrawShadowTransparentOccluder:
+    case DisplayListOpType::kDrawImpellerShadow:
+    case DisplayListOpType::kDrawImpellerShadowTransparentOccluder:
+    case DisplayListOpType::kDrawImpellerPath:
       return DisplayListOpCategory::kRendering;
 
     case DisplayListOpType::kDrawDisplayList:
@@ -362,6 +367,7 @@ DisplayListOpCategory DisplayList::GetOpCategory(DisplayListOpType type) {
 
     case DisplayListOpType::kInvalidOp:
       return DisplayListOpCategory::kInvalidCategory;
+      break;
   }
 }
 

--- a/display_list/display_list.h
+++ b/display_list/display_list.h
@@ -55,89 +55,97 @@
 
 namespace flutter {
 
-#define FOR_EACH_DISPLAY_LIST_OP(V) \
-  V(SetAntiAlias)                   \
-  V(SetInvertColors)                \
-                                    \
-  V(SetStrokeCap)                   \
-  V(SetStrokeJoin)                  \
-                                    \
-  V(SetStyle)                       \
-  V(SetStrokeWidth)                 \
-  V(SetStrokeMiter)                 \
-                                    \
-  V(SetColor)                       \
-  V(SetBlendMode)                   \
-                                    \
-  V(ClearColorFilter)               \
-  V(SetPodColorFilter)              \
-                                    \
-  V(ClearColorSource)               \
-  V(SetPodColorSource)              \
-  V(SetImageColorSource)            \
-  V(SetRuntimeEffectColorSource)    \
-                                    \
-  V(ClearImageFilter)               \
-  V(SetPodImageFilter)              \
-  V(SetSharedImageFilter)           \
-                                    \
-  V(ClearMaskFilter)                \
-  V(SetPodMaskFilter)               \
-                                    \
-  V(Save)                           \
-  V(SaveLayer)                      \
-  V(SaveLayerBackdrop)              \
-  V(Restore)                        \
-                                    \
-  V(Translate)                      \
-  V(Scale)                          \
-  V(Rotate)                         \
-  V(Skew)                           \
-  V(Transform2DAffine)              \
-  V(TransformFullPerspective)       \
-  V(TransformReset)                 \
-                                    \
-  V(ClipIntersectRect)              \
-  V(ClipIntersectOval)              \
-  V(ClipIntersectRRect)             \
-  V(ClipIntersectPath)              \
-  V(ClipDifferenceRect)             \
-  V(ClipDifferenceOval)             \
-  V(ClipDifferenceRRect)            \
-  V(ClipDifferencePath)             \
-                                    \
-  V(DrawPaint)                      \
-  V(DrawColor)                      \
-                                    \
-  V(DrawLine)                       \
-  V(DrawDashedLine)                 \
-  V(DrawRect)                       \
-  V(DrawOval)                       \
-  V(DrawCircle)                     \
-  V(DrawRRect)                      \
-  V(DrawDRRect)                     \
-  V(DrawArc)                        \
-  V(DrawPath)                       \
-                                    \
-  V(DrawPoints)                     \
-  V(DrawLines)                      \
-  V(DrawPolygon)                    \
-  V(DrawVertices)                   \
-                                    \
-  V(DrawImage)                      \
-  V(DrawImageWithAttr)              \
-  V(DrawImageRect)                  \
-  V(DrawImageNine)                  \
-  V(DrawImageNineWithAttr)          \
-  V(DrawAtlas)                      \
-  V(DrawAtlasCulled)                \
-                                    \
-  V(DrawDisplayList)                \
-  V(DrawTextBlob)                   \
-  V(DrawTextFrame)                  \
-                                    \
-  V(DrawShadow)                     \
-  V(DrawShadowTransparentOccluder)
+#define FOR_EACH_DISPLAY_LIST_OP(V)        \
+  V(SetAntiAlias)                          \
+  V(SetInvertColors)                       \
+                                           \
+  V(SetStrokeCap)                          \
+  V(SetStrokeJoin)                         \
+                                           \
+  V(SetStyle)                              \
+  V(SetStrokeWidth)                        \
+  V(SetStrokeMiter)                        \
+                                           \
+  V(SetColor)                              \
+  V(SetBlendMode)                          \
+                                           \
+  V(ClearColorFilter)                      \
+  V(SetPodColorFilter)                     \
+                                           \
+  V(ClearColorSource)                      \
+  V(SetPodColorSource)                     \
+  V(SetImageColorSource)                   \
+  V(SetRuntimeEffectColorSource)           \
+                                           \
+  V(ClearImageFilter)                      \
+  V(SetPodImageFilter)                     \
+  V(SetSharedImageFilter)                  \
+                                           \
+  V(ClearMaskFilter)                       \
+  V(SetPodMaskFilter)                      \
+                                           \
+  V(Save)                                  \
+  V(SaveLayer)                             \
+  V(SaveLayerBackdrop)                     \
+  V(Restore)                               \
+                                           \
+  V(Translate)                             \
+  V(Scale)                                 \
+  V(Rotate)                                \
+  V(Skew)                                  \
+  V(Transform2DAffine)                     \
+  V(TransformFullPerspective)              \
+  V(TransformReset)                        \
+                                           \
+  V(ClipIntersectRect)                     \
+  V(ClipIntersectOval)                     \
+  V(ClipIntersectRRect)                    \
+  V(ClipIntersectPath)                     \
+  V(ClipDifferenceRect)                    \
+  V(ClipDifferenceOval)                    \
+  V(ClipDifferenceRRect)                   \
+  V(ClipDifferencePath)                    \
+                                           \
+  V(ClipDifferenceImpellerPath)            \
+  V(ClipIntersectImpellerPath)             \
+                                           \
+  V(DrawPaint)                             \
+  V(DrawColor)                             \
+                                           \
+  V(DrawLine)                              \
+  V(DrawDashedLine)                        \
+  V(DrawRect)                              \
+  V(DrawOval)                              \
+  V(DrawCircle)                            \
+  V(DrawRRect)                             \
+  V(DrawDRRect)                            \
+  V(DrawArc)                               \
+  V(DrawPath)                              \
+                                           \
+  V(DrawPoints)                            \
+  V(DrawLines)                             \
+  V(DrawPolygon)                           \
+  V(DrawVertices)                          \
+                                           \
+  V(DrawImage)                             \
+  V(DrawImageWithAttr)                     \
+  V(DrawImageRect)                         \
+  V(DrawImageNine)                         \
+  V(DrawImageNineWithAttr)                 \
+  V(DrawAtlas)                             \
+  V(DrawAtlasCulled)                       \
+                                           \
+  V(DrawDisplayList)                       \
+  V(DrawTextBlob)                          \
+  V(DrawTextFrame)                         \
+                                           \
+  V(DrawShadow)                            \
+  V(DrawShadowTransparentOccluder)         \
+                                           \
+  V(DrawImpellerShadow)                    \
+  V(DrawImpellerShadowTransparentOccluder) \
+                                           \
+  V(DrawImpellerPath)
 
 #define DL_OP_TO_ENUM_VALUE(name) k##name,
 enum class DisplayListOpType {

--- a/display_list/dl_builder.h
+++ b/display_list/dl_builder.h
@@ -32,10 +32,11 @@ class DisplayListBuilder final : public virtual DlCanvas,
   static constexpr SkRect kMaxCullRect =
       SkRect::MakeLTRB(-1E9F, -1E9F, 1E9F, 1E9F);
 
-  explicit DisplayListBuilder(bool prepare_rtree)
-      : DisplayListBuilder(kMaxCullRect, prepare_rtree) {}
+  explicit DisplayListBuilder(bool impeller, bool prepare_rtree)
+      : DisplayListBuilder(kMaxCullRect, impeller, prepare_rtree) {}
 
   explicit DisplayListBuilder(const SkRect& cull_rect = kMaxCullRect,
+                              bool impeller = false,
                               bool prepare_rtree = false);
 
   ~DisplayListBuilder();
@@ -517,6 +518,7 @@ class DisplayListBuilder final : public virtual DlCanvas,
   uint32_t nested_op_count_ = 0;
 
   bool is_ui_thread_safe_ = true;
+  bool impeller_ = false;
 
   template <typename T, typename... Args>
   void* Push(size_t extra, Args&&... args);
@@ -841,6 +843,8 @@ class DisplayListBuilder final : public virtual DlCanvas,
   bool AccumulateBounds(const SkRect& bounds) {
     return AccumulateBounds(bounds, current_info(), op_index_);
   }
+
+  void SimplifyOrPushPath(const SkPath& path);
 };
 
 }  // namespace flutter

--- a/display_list/dl_op_receiver.h
+++ b/display_list/dl_op_receiver.h
@@ -96,38 +96,11 @@ class DlOpReceiver {
   // MaxDrawPointsCount * sizeof(SkPoint) must be less than 1 << 32
   static constexpr int kMaxDrawPointsCount = ((1 << 29) - 1);
 
-  // ---------------------------------------------------------------------
-  // The CacheablePath forms of the drawPath, clipPath, and drawShadow
-  // methods are only called if the DlOpReceiver indicates that it prefers
-  // impeller paths by returning true from |PrefersImpellerPaths|.
-  // Note that we pass in both the SkPath and (a place to cache the)
-  // impeller::Path forms of the path since the SkPath version can contain
-  // information about the type of path that lets the receiver optimize
-  // the operation (and potentially avoid the need to cache it).
-  // It is up to the receiver to convert the path to Impeller form and
-  // cache it to avoid needing to do a lot of Impeller-specific processing
-  // inside the DisplayList code.
-
-  virtual bool PrefersImpellerPaths() const { return false; }
-
-  struct CacheablePath {
-    explicit CacheablePath(const SkPath& path) : sk_path(path) {}
-
-    const SkPath sk_path;
-    mutable impeller::Path cached_impeller_path;
-
-    bool operator==(const CacheablePath& other) const {
-      return sk_path == other.sk_path;
-    }
-  };
-
-  virtual void clipPath(const CacheablePath& cache,
-                        ClipOp clip_op,
-                        bool is_aa) {
+  virtual void clipPath(const impeller::Path& path, ClipOp clip_op) {
     FML_UNREACHABLE();
   }
-  virtual void drawPath(const CacheablePath& cache) { FML_UNREACHABLE(); }
-  virtual void drawShadow(const CacheablePath& cache,
+  virtual void drawPath(const impeller::Path& path) { FML_UNREACHABLE(); }
+  virtual void drawShadow(const impeller::Path& path,
                           const DlColor color,
                           const SkScalar elevation,
                           bool transparent_occluder,

--- a/flow/embedded_views.cc
+++ b/flow/embedded_views.cc
@@ -6,9 +6,11 @@
 
 namespace flutter {
 
-DisplayListEmbedderViewSlice::DisplayListEmbedderViewSlice(SkRect view_bounds) {
+DisplayListEmbedderViewSlice::DisplayListEmbedderViewSlice(bool impeller,
+                                                           SkRect view_bounds) {
   builder_ = std::make_unique<DisplayListBuilder>(
       /*bounds=*/view_bounds,
+      /*impeller=*/impeller,
       /*prepare_rtree=*/true);
 }
 

--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -348,7 +348,7 @@ class EmbedderViewSlice {
 
 class DisplayListEmbedderViewSlice : public EmbedderViewSlice {
  public:
-  explicit DisplayListEmbedderViewSlice(SkRect view_bounds);
+  explicit DisplayListEmbedderViewSlice(bool impeller, SkRect view_bounds);
   ~DisplayListEmbedderViewSlice() override = default;
 
   DlCanvas* canvas() override;

--- a/flow/layers/display_list_layer_unittests.cc
+++ b/flow/layers/display_list_layer_unittests.cc
@@ -297,7 +297,7 @@ TEST_F(DisplayListLayerTest, CachedIncompatibleDisplayListOpacityInheritance) {
 TEST_F(DisplayListLayerTest, RasterCachePreservesRTree) {
   const SkRect picture1_bounds = SkRect::MakeXYWH(10, 10, 10, 10);
   const SkRect picture2_bounds = SkRect::MakeXYWH(15, 15, 10, 10);
-  DisplayListBuilder builder(true);
+  DisplayListBuilder builder(/*impeller=*/true, true);
   builder.DrawRect(picture1_bounds, DlPaint());
   builder.DrawRect(picture2_bounds, DlPaint());
   auto display_list = builder.Build();
@@ -321,7 +321,7 @@ TEST_F(DisplayListLayerTest, RasterCachePreservesRTree) {
                                 &paint_context(), false);
   }
 
-  DisplayListBuilder expected_root_canvas(true);
+  DisplayListBuilder expected_root_canvas(/*impeller=*/true, true);
   expected_root_canvas.Scale(2.0, 2.0);
   ASSERT_TRUE(context->raster_cache->Draw(display_list_layer->caching_key_id(),
                                           expected_root_canvas, nullptr,
@@ -334,7 +334,7 @@ TEST_F(DisplayListLayerTest, RasterCachePreservesRTree) {
   };
   EXPECT_EQ(root_canvas_rects_expected, root_canvas_rects);
 
-  DisplayListBuilder expected_overlay_canvas(true);
+  DisplayListBuilder expected_overlay_canvas(/*impeller=*/true, true);
   expected_overlay_canvas.Scale(2.0, 2.0);
   ASSERT_TRUE(context->raster_cache->Draw(display_list_layer->caching_key_id(),
                                           expected_overlay_canvas, nullptr,
@@ -545,7 +545,7 @@ TEST_F(DisplayListLayerTest, OverflowCachedDisplayListOpacityInheritance) {
   auto opacity_layer = std::make_shared<OpacityLayer>(0.5f, opacity_offset);
   std::vector<std::shared_ptr<DisplayListLayer>> layers;
   for (int i = 0; i < layer_count; i++) {
-    DisplayListBuilder builder(false);
+    DisplayListBuilder builder(/*impeller=*/true, false);
     builder.DrawRect({0, 0, 100, 100}, DlPaint());
     builder.DrawRect({50, 50, 100, 100}, DlPaint());
     auto display_list = builder.Build();

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -146,11 +146,12 @@ void LayerTree::Paint(CompositorContext::ScopedFrame& frame,
 
 sk_sp<DisplayList> LayerTree::Flatten(
     const SkRect& bounds,
+    bool impeller,
     const std::shared_ptr<TextureRegistry>& texture_registry,
     GrDirectContext* gr_context) {
   TRACE_EVENT0("flutter", "LayerTree::Flatten");
 
-  DisplayListBuilder builder(bounds);
+  DisplayListBuilder builder(bounds, /*impeller=*/impeller);
 
   const FixedRefreshRateStopwatch unused_stopwatch;
 

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -47,6 +47,7 @@ class LayerTree {
 
   sk_sp<DisplayList> Flatten(
       const SkRect& bounds,
+      bool impeller,
       const std::shared_ptr<TextureRegistry>& texture_registry = nullptr,
       GrDirectContext* gr_context = nullptr);
 

--- a/flow/surface_frame.cc
+++ b/flow/surface_frame.cc
@@ -21,7 +21,8 @@ SurfaceFrame::SurfaceFrame(sk_sp<SkSurface> surface,
                            const SubmitCallback& submit_callback,
                            SkISize frame_size,
                            std::unique_ptr<GLContextResult> context_result,
-                           bool display_list_fallback)
+                           bool display_list_fallback,
+                           bool impeller)
     : surface_(std::move(surface)),
       framebuffer_info_(framebuffer_info),
       encode_callback_(encode_callback),
@@ -44,6 +45,7 @@ SurfaceFrame::SurfaceFrame(sk_sp<SkSurface> surface,
     // will live underneath any platform views so we do not need to compute
     // exact coverage to describe "pixel ownership" to the platform.
     dl_builder_ = sk_make_sp<DisplayListBuilder>(SkRect::Make(frame_size),
+                                                 /*impeller=*/impeller,
                                                  /*prepare_rtree=*/false);
     canvas_ = dl_builder_.get();
   }

--- a/flow/surface_frame.h
+++ b/flow/surface_frame.h
@@ -67,7 +67,8 @@ class SurfaceFrame {
                const SubmitCallback& submit_callback,
                SkISize frame_size,
                std::unique_ptr<GLContextResult> context_result = nullptr,
-               bool display_list_fallback = false);
+               bool display_list_fallback = false,
+               bool impeller = false);
 
   struct SubmitInfo {
     // The frame damage for frame n is the difference between frame n and

--- a/impeller/display_list/aiks_dl_unittests.cc
+++ b/impeller/display_list/aiks_dl_unittests.cc
@@ -862,7 +862,7 @@ TEST_P(AiksTest, TransparentShadowProducesCorrectColor) {
 
 // Regression test for https://github.com/flutter/flutter/issues/130613
 TEST_P(AiksTest, DispatcherDoesNotCullPerspectiveTransformedChildDisplayLists) {
-  flutter::DisplayListBuilder sub_builder(true);
+  flutter::DisplayListBuilder sub_builder(/*enable_impeller=*/true, true);
   sub_builder.DrawRect(SkRect::MakeXYWH(0, 0, 50, 50),
                        flutter::DlPaint(flutter::DlColor::kRed()));
   auto display_list = sub_builder.Build();

--- a/impeller/display_list/dl_dispatcher.h
+++ b/impeller/display_list/dl_dispatcher.h
@@ -25,9 +25,6 @@ class DlDispatcherBase : public flutter::DlOpReceiver {
   Picture EndRecordingAsPicture();
 
   // |flutter::DlOpReceiver|
-  bool PrefersImpellerPaths() const override { return true; }
-
-  // |flutter::DlOpReceiver|
   void setAntiAlias(bool aa) override;
 
   // |flutter::DlOpReceiver|
@@ -133,9 +130,7 @@ class DlDispatcherBase : public flutter::DlOpReceiver {
   void clipPath(const SkPath& path, ClipOp clip_op, bool is_aa) override;
 
   // |flutter::DlOpReceiver|
-  void clipPath(const CacheablePath& cache,
-                ClipOp clip_op,
-                bool is_aa) override;
+  void clipPath(const Path& path, ClipOp clip_op) override;
 
   // |flutter::DlOpReceiver|
   void drawColor(flutter::DlColor color, flutter::DlBlendMode mode) override;
@@ -171,7 +166,7 @@ class DlDispatcherBase : public flutter::DlOpReceiver {
   void drawPath(const SkPath& path) override;
 
   // |flutter::DlOpReceiver|
-  void drawPath(const CacheablePath& cache) override;
+  void drawPath(const Path& cache) override;
 
   // |flutter::DlOpReceiver|
   void drawArc(const SkRect& oval_bounds,
@@ -242,7 +237,7 @@ class DlDispatcherBase : public flutter::DlOpReceiver {
                   SkScalar dpr) override;
 
   // |flutter::DlOpReceiver|
-  void drawShadow(const CacheablePath& cache,
+  void drawShadow(const Path& cache,
                   const flutter::DlColor color,
                   const SkScalar elevation,
                   bool transparent_occluder,
@@ -254,11 +249,11 @@ class DlDispatcherBase : public flutter::DlOpReceiver {
   Paint paint_;
   Matrix initial_matrix_;
 
-  static const Path& GetOrCachePath(const CacheablePath& cache);
+  // static const Path& GetOrCachePath(const CacheablePath& cache);
 
-  static void SimplifyOrDrawPath(Canvas& canvas,
-                                 const CacheablePath& cache,
-                                 const Paint& paint);
+  // static void SimplifyOrDrawPath(Canvas& canvas,
+  //                                const Path& path,
+  //                                const Paint& paint);
 };
 
 #if !EXPERIMENTAL_CANVAS

--- a/lib/ui/painting/canvas.cc
+++ b/lib/ui/painting/canvas.cc
@@ -36,6 +36,7 @@ void Canvas::Create(Dart_Handle wrapper,
 
   fml::RefPtr<Canvas> canvas =
       fml::MakeRefCounted<Canvas>(recorder->BeginRecording(
+          UIDartState::Current()->IsImpellerEnabled(),
           SkRect::MakeLTRB(SafeNarrow(left), SafeNarrow(top), SafeNarrow(right),
                            SafeNarrow(bottom))));
   recorder->set_canvas(canvas);

--- a/lib/ui/painting/display_list_deferred_image_gpu_impeller.cc
+++ b/lib/ui/painting/display_list_deferred_image_gpu_impeller.cc
@@ -173,7 +173,7 @@ void DlDeferredImageGPUImpeller::ImageWrapper::SnapshotDisplayList(
         if (layer_tree) {
           wrapper->display_list_ = layer_tree->Flatten(
               SkRect::MakeWH(wrapper->size_.width(), wrapper->size_.height()),
-              wrapper->texture_registry_);
+              /*impeller=*/true, wrapper->texture_registry_);
         }
         auto snapshot = snapshot_delegate->MakeRasterSnapshotSync(
             wrapper->display_list_, wrapper->size_);

--- a/lib/ui/painting/display_list_deferred_image_gpu_skia.cc
+++ b/lib/ui/painting/display_list_deferred_image_gpu_skia.cc
@@ -181,11 +181,11 @@ void DlDeferredImageGPUSkia::ImageWrapper::SnapshotDisplayList(
           return;
         }
         if (layer_tree) {
-          auto display_list =
-              layer_tree->Flatten(SkRect::MakeWH(wrapper->image_info_.width(),
-                                                 wrapper->image_info_.height()),
-                                  snapshot_delegate->GetTextureRegistry(),
-                                  snapshot_delegate->GetGrContext());
+          auto display_list = layer_tree->Flatten(
+              SkRect::MakeWH(wrapper->image_info_.width(),
+                             wrapper->image_info_.height()),
+              /*impeller=*/false, snapshot_delegate->GetTextureRegistry(),
+              snapshot_delegate->GetGrContext());
           wrapper->display_list_ = std::move(display_list);
         }
         auto result = snapshot_delegate->MakeSkiaGpuImage(

--- a/lib/ui/painting/picture_recorder.cc
+++ b/lib/ui/painting/picture_recorder.cc
@@ -25,9 +25,10 @@ PictureRecorder::PictureRecorder() {}
 
 PictureRecorder::~PictureRecorder() {}
 
-sk_sp<DisplayListBuilder> PictureRecorder::BeginRecording(SkRect bounds) {
-  display_list_builder_ =
-      sk_make_sp<DisplayListBuilder>(bounds, /*prepare_rtree=*/true);
+sk_sp<DisplayListBuilder> PictureRecorder::BeginRecording(bool impeller,
+                                                          SkRect bounds) {
+  display_list_builder_ = sk_make_sp<DisplayListBuilder>(
+      bounds, /*impeller=*/impeller, /*prepare_rtree=*/true);
   return display_list_builder_;
 }
 

--- a/lib/ui/painting/picture_recorder.h
+++ b/lib/ui/painting/picture_recorder.h
@@ -21,7 +21,7 @@ class PictureRecorder : public RefCountedDartWrappable<PictureRecorder> {
 
   ~PictureRecorder() override;
 
-  sk_sp<DisplayListBuilder> BeginRecording(SkRect bounds);
+  sk_sp<DisplayListBuilder> BeginRecording(bool impeller, SkRect bounds);
   void endRecording(Dart_Handle dart_picture);
 
   void set_canvas(fml::RefPtr<Canvas> canvas) { canvas_ = std::move(canvas); }

--- a/shell/platform/android/external_view_embedder/external_view_embedder.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.cc
@@ -20,7 +20,8 @@ AndroidExternalViewEmbedder::AndroidExternalViewEmbedder(
       jni_facade_(std::move(jni_facade)),
       surface_factory_(std::move(surface_factory)),
       surface_pool_(std::make_unique<SurfacePool>()),
-      task_runners_(task_runners) {}
+      task_runners_(task_runners),
+      impeller_(!!android_context.GetImpellerContext()) {}
 
 // |ExternalViewEmbedder|
 void AndroidExternalViewEmbedder::PrerollCompositeEmbeddedView(
@@ -31,7 +32,7 @@ void AndroidExternalViewEmbedder::PrerollCompositeEmbeddedView(
 
   SkRect view_bounds = SkRect::Make(frame_size_);
   std::unique_ptr<EmbedderViewSlice> view;
-  view = std::make_unique<DisplayListEmbedderViewSlice>(view_bounds);
+  view = std::make_unique<DisplayListEmbedderViewSlice>(impeller_, view_bounds);
   slices_.insert_or_assign(view_id, std::move(view));
 
   composition_order_.push_back(view_id);

--- a/shell/platform/android/external_view_embedder/external_view_embedder.h
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.h
@@ -128,6 +128,9 @@ class AndroidExternalViewEmbedder final : public ExternalViewEmbedder {
   // The number of platform views in the previous frame.
   int64_t previous_frame_view_count_;
 
+  // If Impeller rendering engine is enabled.
+  const bool impeller_;
+
   // Destroys the surfaces created from the surface factory.
   // This method schedules a task on the platform thread, and waits for
   // the task until it completes.

--- a/shell/platform/embedder/embedder_external_view.cc
+++ b/shell/platform/embedder/embedder_external_view.cc
@@ -124,7 +124,8 @@ bool EmbedderExternalView::Render(const EmbedderRenderTarget& render_target,
   if (impeller_target) {
     auto aiks_context = render_target.GetAiksContext();
 
-    auto dl_builder = DisplayListBuilder();
+    auto dl_builder =
+        DisplayListBuilder(DisplayListBuilder::kMaxCullRect, /*impeller=*/true);
     dl_builder.SetTransform(&surface_transformation_);
     slice_->render_into(&dl_builder);
     auto display_list = dl_builder.Build();

--- a/shell/testing/tester_main.cc
+++ b/shell/testing/tester_main.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "display_list/dl_builder.h"
 #define FML_USED_ON_EMBEDDER
 
 #include <cstdlib>
@@ -147,6 +148,9 @@ static void ConfigureShell(Shell* shell) {
 }
 
 class TesterExternalViewEmbedder : public ExternalViewEmbedder {
+  explicit TesterExternalViewEmbedder(bool impeller)
+      : builder_(DisplayListBuilder::kMaxCullRect, /*impeller=*/true);
+
   // |ExternalViewEmbedder|
   DlCanvas* GetRootCanvas() override { return nullptr; }
 


### PR DESCRIPTION
Experimentation with more eager Impeller type conversions.

If the DisplayListBuilder knows the targeted backend, then we can perform conversions while recording. This would eventually let us lift most of the dl_dispatcher logic into the builder, which is advantageous as display lists are generally rendered more times than they are built (as the framework repaint boundary mechanism stabilizes display lists).

The only conversions we couldn't do are those that depend on the final flattened display list, such as tessellation (we need to know the total scale).