### PR TITLE
Add `crossOrigin` property to <img> tag used for decoding

### DIFF
--- a/lib/web_ui/lib/src/engine/html_image_element_codec.dart
+++ b/lib/web_ui/lib/src/engine/html_image_element_codec.dart
@@ -45,6 +45,7 @@ abstract class HtmlImageElementCodec implements ui.Codec {
     imgElement = createDomHTMLImageElement();
     imgElement!.src = src;
     setJsProperty<String>(imgElement!, 'decoding', 'async');
+    setJsProperty<String>(imgElement!, 'crossOrigin', '');
 
     // Ignoring the returned future on purpose because we're communicating
     // through the `completer`.

--- a/lib/web_ui/lib/src/engine/html_image_element_codec.dart
+++ b/lib/web_ui/lib/src/engine/html_image_element_codec.dart
@@ -45,7 +45,7 @@ abstract class HtmlImageElementCodec implements ui.Codec {
     imgElement = createDomHTMLImageElement();
     imgElement!.src = src;
     setJsProperty<String>(imgElement!, 'decoding', 'async');
-    setJsProperty<String>(imgElement!, 'crossOrigin', '');
+    setJsProperty<String>(imgElement!, 'crossOrigin', 'anonymous');
 
     // Ignoring the returned future on purpose because we're communicating
     // through the `completer`.

--- a/lib/web_ui/lib/src/engine/safe_browser_api.dart
+++ b/lib/web_ui/lib/src/engine/safe_browser_api.dart
@@ -40,6 +40,7 @@ T getJsProperty<T>(Object object, String name) {
 }
 
 const Set<String> _safeJsProperties = <String>{
+  'crossOrigin',
   'decoding',
   '__flutter_state',
 };

--- a/lib/web_ui/test/canvaskit/image_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/image_golden_test.dart
@@ -253,6 +253,19 @@ Future<void> testMain() async {
       }
     });
 
+    test('crossOrigin requests cause an error', () async {
+      final String otherOrigin =
+          domWindow.location.origin.replaceAll('localhost', '127.0.0.1');
+      bool gotError = false;
+      try {
+        final ui.Codec _ = await renderer.instantiateImageCodecFromUrl(
+            Uri.parse('$otherOrigin/test_images/1x1.png'));
+      } catch (e) {
+        gotError = true;
+      }
+      expect(gotError, isTrue, reason: 'Should have got CORS error');
+    });
+
     _testCkAnimatedImage();
 
     test('isAvif', () {


### PR DESCRIPTION
Adds the `crossOrigin` property to the `<img>` tag used for decoding. This allows us to use cross-origin images in CanvasKit as if it were loaded from the same origin, as long as the CORS headers are properly set on the server hosting the image.

In the case where the image doesn't have proper CORS headers, this change causes an error to occur while attempting to decode, rather than later on in Skia when the image is converted into a texture. Hitting the cross-origin error later causes Skia to behave in undefined ways.

Progress towards https://github.com/flutter/flutter/issues/149843 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
