### PR TITLE
Clean up the view focus enabler flag

### DIFF
--- a/lib/web_ui/lib/src/engine/platform_dispatcher/view_focus_binding.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher/view_focus_binding.dart
@@ -3,20 +3,12 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'package:meta/meta.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
 
 /// Tracks the [FlutterView]s focus changes.
 final class ViewFocusBinding {
   ViewFocusBinding(this._viewManager, this._onViewFocusChange);
-
-
-  /// Wether [FlutterView] focus changes will be reported and performed.
-  ///
-  /// DO NOT rely on this bit as it will go away soon. You're warned :)!
-  @visibleForTesting
-  static bool isEnabled = false;
 
   final FlutterViewManager _viewManager;
   final ui.ViewFocusChangeCallback _onViewFocusChange;
@@ -43,9 +35,6 @@ final class ViewFocusBinding {
   }
 
   void changeViewFocus(int viewId, ui.ViewFocusState state) {
-    if (!isEnabled) {
-      return;
-    }
     final DomElement? viewElement = _viewManager[viewId]?.dom.rootElement;
 
     if (state == ui.ViewFocusState.focused) {
@@ -82,10 +71,6 @@ final class ViewFocusBinding {
   });
 
   void _handleFocusChange(DomElement? focusedElement) {
-    if (!isEnabled) {
-      return;
-    }
-
     final int? viewId = _viewId(focusedElement);
     if (viewId == _lastViewId) {
       return;

--- a/lib/web_ui/test/engine/platform_dispatcher/view_focus_binding_test.dart
+++ b/lib/web_ui/test/engine/platform_dispatcher/view_focus_binding_test.dart
@@ -17,15 +17,12 @@ void testMain() {
     late EnginePlatformDispatcher dispatcher;
 
     setUp(() {
-      ViewFocusBinding.isEnabled = true;
-
       dispatcher = EnginePlatformDispatcher.instance;
       dispatchedViewFocusEvents = <ui.ViewFocusEvent>[];
       dispatcher.onViewFocusChange = dispatchedViewFocusEvents.add;
     });
 
     tearDown(() {
-      ViewFocusBinding.isEnabled = false;
       EngineSemantics.instance.semanticsEnabled = false;
     });
 


### PR DESCRIPTION
This PR reverts https://github.com/flutter/engine/pull/52527 now that the view focus functionality was fully launched.

This PR should be merged at least 1 week after https://github.com/flutter/engine/pull/54966 is checked in.

Fixes https://github.com/flutter/flutter/issues/153022.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
