### PR TITLE
[impeller] fake image for fake tests.

### DIFF
--- a/display_list/image/dl_image.h
+++ b/display_list/image/dl_image.h
@@ -9,7 +9,7 @@
 #include <optional>
 #include <string>
 
-#include "flutter/fml/macros.h"
+#include "flutter/fml/build_config.h"
 #include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkRefCnt.h"
 
@@ -117,6 +117,10 @@ class DlImage : public SkRefCnt {
   /// @return     An error, if any, that occurred when trying to create the
   ///             image.
   virtual std::optional<std::string> get_error() const;
+
+#if FML_OS_IOS_SIMULATOR
+  virtual bool IsFakeImage() const { return false; }
+#endif  // FML_OS_IOS_SIMULATOR
 
   bool Equals(const DlImage* other) const {
     if (!other) {

--- a/impeller/display_list/dl_image_impeller.cc
+++ b/impeller/display_list/dl_image_impeller.cc
@@ -9,6 +9,17 @@
 
 namespace impeller {
 
+#if FML_OS_IOS_SIMULATOR
+sk_sp<DlImageImpeller> DlImageImpeller::Make(std::shared_ptr<Texture> texture,
+                                             OwningContext owning_context,
+                                             bool is_fake_image) {
+  if (!texture && !is_fake_image) {
+    return nullptr;
+  }
+  return sk_sp<DlImageImpeller>(
+      new DlImageImpeller(std::move(texture), owning_context, is_fake_image));
+}
+#else
 sk_sp<DlImageImpeller> DlImageImpeller::Make(std::shared_ptr<Texture> texture,
                                              OwningContext owning_context) {
   if (!texture) {
@@ -17,6 +28,7 @@ sk_sp<DlImageImpeller> DlImageImpeller::Make(std::shared_ptr<Texture> texture,
   return sk_sp<DlImageImpeller>(
       new DlImageImpeller(std::move(texture), owning_context));
 }
+#endif  // FML_OS_IOS_SIMULATOR
 
 sk_sp<DlImageImpeller> DlImageImpeller::MakeFromYUVTextures(
     AiksContext* aiks_context,
@@ -45,8 +57,20 @@ sk_sp<DlImageImpeller> DlImageImpeller::MakeFromYUVTextures(
 }
 
 DlImageImpeller::DlImageImpeller(std::shared_ptr<Texture> texture,
-                                 OwningContext owning_context)
-    : texture_(std::move(texture)), owning_context_(owning_context) {}
+                                 OwningContext owning_context
+#ifdef FML_OS_IOS_SIMULATOR
+                                 ,
+                                 bool is_fake_image
+#endif  // FML_OS_IOS_SIMULATOR
+                                 )
+    : texture_(std::move(texture)),
+      owning_context_(owning_context)
+#ifdef FML_OS_IOS_SIMULATOR
+      ,
+      is_fake_image_(is_fake_image)
+#endif  // #ifdef FML_OS_IOS_SIMULATOR
+{
+}
 
 // |DlImage|
 DlImageImpeller::~DlImageImpeller() = default;

--- a/impeller/display_list/dl_image_impeller.h
+++ b/impeller/display_list/dl_image_impeller.h
@@ -16,7 +16,12 @@ class DlImageImpeller final : public flutter::DlImage {
  public:
   static sk_sp<DlImageImpeller> Make(
       std::shared_ptr<Texture> texture,
-      OwningContext owning_context = OwningContext::kIO);
+      OwningContext owning_context = OwningContext::kIO
+#if FML_OS_IOS_SIMULATOR
+      ,
+      bool is_fake_image = false
+#endif  // FML_OS_IOS_SIMULATOR
+  );
 
   static sk_sp<DlImageImpeller> MakeFromYUVTextures(
       AiksContext* aiks_context,
@@ -51,12 +56,25 @@ class DlImageImpeller final : public flutter::DlImage {
   // |DlImage|
   OwningContext owning_context() const override { return owning_context_; }
 
+#if FML_OS_IOS_SIMULATOR
+  // |DlImage|
+  bool IsFakeImage() const override { return is_fake_image_; }
+#endif  // FML_OS_IOS_SIMULATOR
+
  private:
   std::shared_ptr<Texture> texture_;
   OwningContext owning_context_;
+#if FML_OS_IOS_SIMULATOR
+  bool is_fake_image_ = false;
+#endif  // FML_OS_IOS_SIMULATOR
 
   explicit DlImageImpeller(std::shared_ptr<Texture> texture,
-                           OwningContext owning_context = OwningContext::kIO);
+                           OwningContext owning_context = OwningContext::kIO
+#if FML_OS_IOS_SIMULATOR
+                           ,
+                           bool is_fake_image = false
+#endif  // FML_OS_IOS_SIMULATOR
+  );
 
   DlImageImpeller(const DlImageImpeller&) = delete;
 

--- a/lib/ui/painting/image.cc
+++ b/lib/ui/painting/image.cc
@@ -52,8 +52,7 @@ int CanvasImage::colorSpace() {
     return ImageEncodingImpeller::GetColorSpace(image_->impeller_texture());
 #endif  // IMPELLER_SUPPORTS_RENDERING
   }
-
-  return -1;
+  return ColorSpace::kSRGB;
 }
 
 }  // namespace flutter

--- a/lib/ui/painting/image_encoding.cc
+++ b/lib/ui/painting/image_encoding.cc
@@ -178,6 +178,14 @@ Dart_Handle EncodeImage(CanvasImage* canvas_image,
   auto callback = std::make_unique<DartPersistentValue>(
       tonic::DartState::Current(), callback_handle);
 
+#if IMPELLER_SUPPORTS_RENDERING && FML_OS_IOS_SIMULATOR
+  if (canvas_image->image()->IsFakeImage()) {
+    sk_sp<SkData> data = SkData::MakeEmpty();
+    InvokeDataCallback(std::move(callback), data);
+    return Dart_Null();
+  }
+#endif  // IMPELLER_SUPPORTS_RENDERING && FML_OS_IOS_SIMULATOR
+
   const auto& task_runners = UIDartState::Current()->GetTaskRunners();
 
   // The static leak checker gets confused by the use of fml::MakeCopyable.

--- a/lib/ui/painting/picture.cc
+++ b/lib/ui/painting/picture.cc
@@ -207,7 +207,6 @@ Dart_Handle Picture::DoRasterizeToImage(const sk_sp<DisplayList>& display_list,
                          height, ui_task,
                          layer_tree = std::move(layer_tree)]() mutable {
         auto picture_bounds = SkISize::Make(width, height);
-        sk_sp<DlImage> image;
         sk_sp<DisplayList> snapshot_display_list = display_list;
         if (layer_tree) {
           FML_DCHECK(picture_bounds == layer_tree->frame_size());

--- a/shell/platform/darwin/ios/rendering_api_selection.mm
+++ b/shell/platform/darwin/ios/rendering_api_selection.mm
@@ -20,12 +20,7 @@ FLUTTER_ASSERT_ARC
 namespace flutter {
 
 bool ShouldUseMetalRenderer() {
-  bool ios_version_supports_metal = false;
-  if (@available(iOS METAL_IOS_VERSION_BASELINE, *)) {
-    id<MTLDevice> device = MTLCreateSystemDefaultDevice();
-    ios_version_supports_metal = [device supportsFeatureSet:MTLFeatureSet_iOS_GPUFamily1_v3];
-  }
-  return ios_version_supports_metal;
+  return false;
 }
 
 IOSRenderingAPI GetRenderingAPIForProcess(bool force_software) {

--- a/shell/platform/darwin/ios/rendering_api_selection.mm
+++ b/shell/platform/darwin/ios/rendering_api_selection.mm
@@ -20,7 +20,12 @@ FLUTTER_ASSERT_ARC
 namespace flutter {
 
 bool ShouldUseMetalRenderer() {
-  return false;
+  bool ios_version_supports_metal = false;
+  if (@available(iOS METAL_IOS_VERSION_BASELINE, *)) {
+    id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+    ios_version_supports_metal = [device supportsFeatureSet:MTLFeatureSet_iOS_GPUFamily1_v3];
+  }
+  return ios_version_supports_metal;
 }
 
 IOSRenderingAPI GetRenderingAPIForProcess(bool force_software) {


### PR DESCRIPTION
Simulator only change to allow toImage and toByteData to not fail when there is no metal context w/ impeller.