### PR TITLE
Do not move focus when the semantics text strategy is deactivated.

### DIFF
--- a/lib/web_ui/lib/src/engine/pointer_binding.dart
+++ b/lib/web_ui/lib/src/engine/pointer_binding.dart
@@ -992,7 +992,7 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
       _convertEventsToPointerData(data: pointerData, event: event, details: down);
       _callback(event, pointerData);
 
-      if (event.target == _viewTarget) {
+      if (event.target == _viewTarget && !EngineSemantics.instance.semanticsEnabled) {
         // Ensure smooth focus transitions between text fields within the Flutter view.
         // Without preventing the default and this delay, the engine may not have fully
         // rendered the next input element, leading to the focus incorrectly returning to

--- a/lib/web_ui/lib/src/engine/semantics/text_field.dart
+++ b/lib/web_ui/lib/src/engine/semantics/text_field.dart
@@ -114,16 +114,6 @@ class SemanticsTextEditingStrategy extends DefaultTextEditingStrategy {
     }
     subscriptions.clear();
     lastEditingState = null;
-
-    // If the text element still has focus, remove focus from the editable
-    // element to cause the on-screen keyboard, if any, to hide (e.g. on iOS,
-    // Android).
-    // Otherwise, the keyboard stays on screen even when the user navigates to
-    // a different screen (e.g. by hitting the "back" button).
-    // Keep this consistent with how DefaultTextEditingStrategy does it. As of
-    // right now, the only difference is that semantic text fields do not
-    // participate in form autofill.
-    DefaultTextEditingStrategy.scheduleFocusFlutterView(activeDomElement, activeDomElementView);
     domElement = null;
     activeTextField = null;
     _queuedStyle = null;

--- a/lib/web_ui/test/engine/semantics/text_field_test.dart
+++ b/lib/web_ui/test/engine/semantics/text_field_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:test/bootstrap/browser.dart';
@@ -159,7 +158,7 @@ void testMain() {
       // TODO(yjbanov): https://github.com/flutter/flutter/issues/46638
     }, skip: ui_web.browser.browserEngine == ui_web.BrowserEngine.firefox);
 
-    test('Syncs semantic state from framework', () async {
+    test('Syncs semantic state from framework', () {
       expect(
           owner().semanticsHost.ownerDocument?.activeElement, domDocument.body);
 
@@ -223,10 +222,12 @@ void testMain() {
         owner().semanticsHost.ownerDocument?.activeElement,
         textField.editableElement,
       );
-      await Future<void>.delayed(Duration.zero);
+
+      // When semantics are enabled, deactivation shouldn't move focus or blur the
+      // editable element. Instead the engine/browser should move it accordingly.
       expect(
         owner().semanticsHost.ownerDocument?.activeElement,
-        EnginePlatformDispatcher.instance.implicitView!.dom.rootElement,
+        textField.editableElement,
       );
 
       // There was no user interaction with the <input> element,
@@ -336,8 +337,7 @@ void testMain() {
       strategy.disable();
     });
 
-    test('Does not dispose and recreate dom elements in persistent mode',
-        () async {
+    test('Does not dispose and recreate dom elements in persistent mode', () {
       strategy.enable(
         singlelineConfig,
         onChange: (_, __) {},
@@ -362,12 +362,15 @@ void testMain() {
       // It doesn't remove the DOM element.
       final textField = textFieldSemantics.semanticRole! as SemanticTextField;
       expect(owner().semanticsHost.contains(textField.editableElement), isTrue);
+
       // Editing element is not enabled.
       expect(strategy.isEnabled, isFalse);
-      await Future<void>.delayed(Duration.zero);
+
+      // When semantics are enabled, deactivation shouldn't move focus or blur the
+      // editable element. Instead the engine/browser should move it accordingly.
       expect(
         owner().semanticsHost.ownerDocument?.activeElement,
-        EnginePlatformDispatcher.instance.implicitView!.dom.rootElement,
+        textField.editableElement,
       );
     });
 


### PR DESCRIPTION
When the text field is deactivated, the non-semantics text strategy refocuses on the Flutter view. This is necessary because there's no assurance that the next interactive widget will be supported by a DOM node. If not, focus will shift outside the Flutter view. With semantics enabled, the app ensures every interactive widget has a corresponding DOM node, eliminating the need to refocus on the Flutter view. In fact, the view shouldn't be focusable with semantics enabled to avoid disrupting the interaction sequence.

This PR should be the last step before landing https://github.com/flutter/engine/pull/54966

I compiled https://github.com/flutter/flutter/tree/master/dev/a11y_assessments with these changes. App can be found at https://tugorez.com/flutter_focus_web/

https://github.com/flutter/flutter/issues/153022

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
