### PR TITLE
[DisplayList] use DlScalar, DlPoint, DlRect exclusively in DlOpReceiver methods

### DIFF
--- a/display_list/benchmarking/dl_complexity_gl.h
+++ b/display_list/benchmarking/dl_complexity_gl.h
@@ -35,52 +35,52 @@ class DisplayListGLComplexityCalculator
     explicit GLHelper(unsigned int ceiling)
         : ComplexityCalculatorHelper(ceiling) {}
 
-    void saveLayer(const SkRect& bounds,
+    void saveLayer(const DlRect& bounds,
                    const SaveLayerOptions options,
                    const DlImageFilter* backdrop) override;
 
-    void drawLine(const SkPoint& p0, const SkPoint& p1) override;
+    void drawLine(const DlPoint& p0, const DlPoint& p1) override;
     void drawDashedLine(const DlPoint& p0,
                         const DlPoint& p1,
                         DlScalar on_length,
                         DlScalar off_length) override;
-    void drawRect(const SkRect& rect) override;
-    void drawOval(const SkRect& bounds) override;
-    void drawCircle(const SkPoint& center, SkScalar radius) override;
+    void drawRect(const DlRect& rect) override;
+    void drawOval(const DlRect& bounds) override;
+    void drawCircle(const DlPoint& center, DlScalar radius) override;
     void drawRRect(const SkRRect& rrect) override;
     void drawDRRect(const SkRRect& outer, const SkRRect& inner) override;
     void drawPath(const SkPath& path) override;
-    void drawArc(const SkRect& oval_bounds,
-                 SkScalar start_degrees,
-                 SkScalar sweep_degrees,
+    void drawArc(const DlRect& oval_bounds,
+                 DlScalar start_degrees,
+                 DlScalar sweep_degrees,
                  bool use_center) override;
     void drawPoints(DlCanvas::PointMode mode,
                     uint32_t count,
-                    const SkPoint points[]) override;
+                    const DlPoint points[]) override;
     void drawVertices(const std::shared_ptr<DlVertices>& vertices,
                       DlBlendMode mode) override;
     void drawImage(const sk_sp<DlImage> image,
-                   const SkPoint point,
+                   const DlPoint& point,
                    DlImageSampling sampling,
                    bool render_with_attributes) override;
     void drawImageNine(const sk_sp<DlImage> image,
-                       const SkIRect& center,
-                       const SkRect& dst,
+                       const DlIRect& center,
+                       const DlRect& dst,
                        DlFilterMode filter,
                        bool render_with_attributes) override;
     void drawDisplayList(const sk_sp<DisplayList> display_list,
-                         SkScalar opacity) override;
+                         DlScalar opacity) override;
     void drawTextBlob(const sk_sp<SkTextBlob> blob,
-                      SkScalar x,
-                      SkScalar y) override;
+                      DlScalar x,
+                      DlScalar y) override;
     void drawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                       SkScalar x,
-                       SkScalar y) override;
+                       DlScalar x,
+                       DlScalar y) override;
     void drawShadow(const SkPath& path,
                     const DlColor color,
-                    const SkScalar elevation,
+                    const DlScalar elevation,
                     bool transparent_occluder,
-                    SkScalar dpr) override;
+                    DlScalar dpr) override;
 
    protected:
     void ImageRect(const SkISize& size,

--- a/display_list/benchmarking/dl_complexity_helper.h
+++ b/display_list/benchmarking/dl_complexity_helper.h
@@ -145,8 +145,8 @@ class ComplexityCalculatorHelper
 
   void drawImageRect(
       const sk_sp<DlImage> image,
-      const SkRect& src,
-      const SkRect& dst,
+      const DlRect& src,
+      const DlRect& dst,
       DlImageSampling sampling,
       bool render_with_attributes,
       SrcRectConstraint constraint = SrcRectConstraint::kFast) override {
@@ -159,12 +159,12 @@ class ComplexityCalculatorHelper
 
   void drawAtlas(const sk_sp<DlImage> atlas,
                  const SkRSXform xform[],
-                 const SkRect tex[],
+                 const DlRect tex[],
                  const DlColor colors[],
                  int count,
                  DlBlendMode mode,
                  DlImageSampling sampling,
-                 const SkRect* cull_rect,
+                 const DlRect* cull_rect,
                  bool render_with_attributes) override {
     if (IsComplex()) {
       return;
@@ -172,7 +172,7 @@ class ComplexityCalculatorHelper
     // This API just does a series of drawImage calls from the atlas
     // This is equivalent to calling drawImageRect lots of times
     for (int i = 0; i < count; i++) {
-      ImageRect(SkISize::Make(tex[i].width(), tex[i].height()), true,
+      ImageRect(SkISize::Make(tex[i].GetWidth(), tex[i].GetHeight()), true,
                 render_with_attributes, true);
     }
   }

--- a/display_list/benchmarking/dl_complexity_metal.cc
+++ b/display_list/benchmarking/dl_complexity_metal.cc
@@ -63,7 +63,7 @@ DisplayListMetalComplexityCalculator::MetalHelper::BatchedComplexity() {
 }
 
 void DisplayListMetalComplexityCalculator::MetalHelper::saveLayer(
-    const SkRect& bounds,
+    const DlRect& bounds,
     const SaveLayerOptions options,
     const DlImageFilter* backdrop) {
   if (IsComplex()) {
@@ -79,8 +79,8 @@ void DisplayListMetalComplexityCalculator::MetalHelper::saveLayer(
 }
 
 void DisplayListMetalComplexityCalculator::MetalHelper::drawLine(
-    const SkPoint& p0,
-    const SkPoint& p1) {
+    const DlPoint& p0,
+    const DlPoint& p1) {
   if (IsComplex()) {
     return;
   }
@@ -100,7 +100,7 @@ void DisplayListMetalComplexityCalculator::MetalHelper::drawLine(
 
   // Use an approximation for the distance to avoid floating point or
   // sqrt() calls.
-  SkScalar distance = abs(p0.x() - p1.x()) + abs(p0.y() - p1.y());
+  DlScalar distance = abs(p0.x - p1.x) + abs(p0.y - p1.y);
 
   // The baseline complexity is for a hairline stroke with no AA.
   // m = 1/45
@@ -118,11 +118,11 @@ void DisplayListMetalComplexityCalculator::MetalHelper::drawDashedLine(
     DlScalar off_length) {
   // Dashing is slightly more complex than a regular drawLine, but this
   // op is so rare it is not worth measuring the difference.
-  drawLine(ToSkPoint(p0), ToSkPoint(p1));
+  drawLine(p0, p1);
 }
 
 void DisplayListMetalComplexityCalculator::MetalHelper::drawRect(
-    const SkRect& rect) {
+    const DlRect& rect) {
   if (IsComplex()) {
     return;
   }
@@ -140,14 +140,14 @@ void DisplayListMetalComplexityCalculator::MetalHelper::drawRect(
   // currently use it anywhere in Flutter.
   if (DrawStyle() == DlDrawStyle::kFill) {
     // No real difference for AA with filled styles.
-    unsigned int area = rect.width() * rect.height();
+    unsigned int area = rect.GetWidth() * rect.GetHeight();
 
     // m = 1/9000
     // c = 0
     complexity = area / 225;
   } else {
     // Take the average of the width and height.
-    unsigned int length = (rect.width() + rect.height()) / 2;
+    unsigned int length = (rect.GetWidth() + rect.GetHeight()) / 2;
 
     // There is a penalty for AA being *disabled*.
     if (IsAntiAliased()) {
@@ -165,7 +165,7 @@ void DisplayListMetalComplexityCalculator::MetalHelper::drawRect(
 }
 
 void DisplayListMetalComplexityCalculator::MetalHelper::drawOval(
-    const SkRect& bounds) {
+    const DlRect& bounds) {
   if (IsComplex()) {
     return;
   }
@@ -174,7 +174,7 @@ void DisplayListMetalComplexityCalculator::MetalHelper::drawOval(
   //
   // Filled styles and stroked styles with AA scale linearly with the bounding
   // box area.
-  unsigned int area = bounds.width() * bounds.height();
+  unsigned int area = bounds.GetWidth() * bounds.GetHeight();
 
   unsigned int complexity;
 
@@ -192,7 +192,7 @@ void DisplayListMetalComplexityCalculator::MetalHelper::drawOval(
       complexity = area * 2 / 75;
     } else {
       // Take the average of the width and height.
-      unsigned int length = (bounds.width() + bounds.height()) / 2;
+      unsigned int length = (bounds.GetWidth() + bounds.GetHeight()) / 2;
 
       // m = 1/80
       // c = 0
@@ -204,8 +204,8 @@ void DisplayListMetalComplexityCalculator::MetalHelper::drawOval(
 }
 
 void DisplayListMetalComplexityCalculator::MetalHelper::drawCircle(
-    const SkPoint& center,
-    SkScalar radius) {
+    const DlPoint& center,
+    DlScalar radius) {
   if (IsComplex()) {
     return;
   }
@@ -362,9 +362,9 @@ void DisplayListMetalComplexityCalculator::MetalHelper::drawPath(
 }
 
 void DisplayListMetalComplexityCalculator::MetalHelper::drawArc(
-    const SkRect& oval_bounds,
-    SkScalar start_degrees,
-    SkScalar sweep_degrees,
+    const DlRect& oval_bounds,
+    DlScalar start_degrees,
+    DlScalar sweep_degrees,
     bool use_center) {
   if (IsComplex()) {
     return;
@@ -373,8 +373,9 @@ void DisplayListMetalComplexityCalculator::MetalHelper::drawArc(
   // Stroked styles without AA scale linearly with the diameter.
   // Stroked styles with AA scale linearly with the area except for small
   // values. Filled styles scale linearly with the area.
-  unsigned int diameter = (oval_bounds.width() + oval_bounds.height()) / 2;
-  unsigned int area = oval_bounds.width() * oval_bounds.height();
+  unsigned int diameter =
+      (oval_bounds.GetWidth() + oval_bounds.GetHeight()) / 2;
+  unsigned int area = oval_bounds.GetWidth() * oval_bounds.GetHeight();
 
   unsigned int complexity;
 
@@ -412,7 +413,7 @@ void DisplayListMetalComplexityCalculator::MetalHelper::drawArc(
 void DisplayListMetalComplexityCalculator::MetalHelper::drawPoints(
     DlCanvas::PointMode mode,
     uint32_t count,
-    const SkPoint points[]) {
+    const DlPoint points[]) {
   if (IsComplex()) {
     return;
   }
@@ -466,7 +467,7 @@ void DisplayListMetalComplexityCalculator::MetalHelper::drawVertices(
 
 void DisplayListMetalComplexityCalculator::MetalHelper::drawImage(
     const sk_sp<DlImage> image,
-    const SkPoint point,
+    const DlPoint& point,
     DlImageSampling sampling,
     bool render_with_attributes) {
   if (IsComplex()) {
@@ -543,8 +544,8 @@ void DisplayListMetalComplexityCalculator::MetalHelper::ImageRect(
 
 void DisplayListMetalComplexityCalculator::MetalHelper::drawImageNine(
     const sk_sp<DlImage> image,
-    const SkIRect& center,
-    const SkRect& dst,
+    const DlIRect& center,
+    const DlRect& dst,
     DlFilterMode filter,
     bool render_with_attributes) {
   if (IsComplex()) {
@@ -563,13 +564,13 @@ void DisplayListMetalComplexityCalculator::MetalHelper::drawImageNine(
 
 void DisplayListMetalComplexityCalculator::MetalHelper::drawDisplayList(
     const sk_sp<DisplayList> display_list,
-    SkScalar opacity) {
+    DlScalar opacity) {
   if (IsComplex()) {
     return;
   }
   MetalHelper helper(Ceiling() - CurrentComplexityScore());
   if (opacity < SK_Scalar1 && !display_list->can_apply_group_opacity()) {
-    auto bounds = display_list->bounds();
+    auto bounds = display_list->GetBounds();
     helper.saveLayer(bounds, SaveLayerOptions::kWithAttributes, nullptr);
   }
   display_list->Dispatch(helper);
@@ -578,8 +579,8 @@ void DisplayListMetalComplexityCalculator::MetalHelper::drawDisplayList(
 
 void DisplayListMetalComplexityCalculator::MetalHelper::drawTextBlob(
     const sk_sp<SkTextBlob> blob,
-    SkScalar x,
-    SkScalar y) {
+    DlScalar x,
+    DlScalar y) {
   if (IsComplex()) {
     return;
   }
@@ -594,15 +595,15 @@ void DisplayListMetalComplexityCalculator::MetalHelper::drawTextBlob(
 
 void DisplayListMetalComplexityCalculator::MetalHelper::drawTextFrame(
     const std::shared_ptr<impeller::TextFrame>& text_frame,
-    SkScalar x,
-    SkScalar y) {}
+    DlScalar x,
+    DlScalar y) {}
 
 void DisplayListMetalComplexityCalculator::MetalHelper::drawShadow(
     const SkPath& path,
     const DlColor color,
-    const SkScalar elevation,
+    const DlScalar elevation,
     bool transparent_occluder,
-    SkScalar dpr) {
+    DlScalar dpr) {
   if (IsComplex()) {
     return;
   }

--- a/display_list/benchmarking/dl_complexity_metal.h
+++ b/display_list/benchmarking/dl_complexity_metal.h
@@ -35,52 +35,52 @@ class DisplayListMetalComplexityCalculator
     explicit MetalHelper(unsigned int ceiling)
         : ComplexityCalculatorHelper(ceiling) {}
 
-    void saveLayer(const SkRect& bounds,
+    void saveLayer(const DlRect& bounds,
                    const SaveLayerOptions options,
                    const DlImageFilter* backdrop) override;
 
-    void drawLine(const SkPoint& p0, const SkPoint& p1) override;
+    void drawLine(const DlPoint& p0, const DlPoint& p1) override;
     void drawDashedLine(const DlPoint& p0,
                         const DlPoint& p1,
                         DlScalar on_length,
                         DlScalar off_length) override;
-    void drawRect(const SkRect& rect) override;
-    void drawOval(const SkRect& bounds) override;
-    void drawCircle(const SkPoint& center, SkScalar radius) override;
+    void drawRect(const DlRect& rect) override;
+    void drawOval(const DlRect& bounds) override;
+    void drawCircle(const DlPoint& center, DlScalar radius) override;
     void drawRRect(const SkRRect& rrect) override;
     void drawDRRect(const SkRRect& outer, const SkRRect& inner) override;
     void drawPath(const SkPath& path) override;
-    void drawArc(const SkRect& oval_bounds,
-                 SkScalar start_degrees,
-                 SkScalar sweep_degrees,
+    void drawArc(const DlRect& oval_bounds,
+                 DlScalar start_degrees,
+                 DlScalar sweep_degrees,
                  bool use_center) override;
     void drawPoints(DlCanvas::PointMode mode,
                     uint32_t count,
-                    const SkPoint points[]) override;
+                    const DlPoint points[]) override;
     void drawVertices(const std::shared_ptr<DlVertices>& vertices,
                       DlBlendMode mode) override;
     void drawImage(const sk_sp<DlImage> image,
-                   const SkPoint point,
+                   const DlPoint& point,
                    DlImageSampling sampling,
                    bool render_with_attributes) override;
     void drawImageNine(const sk_sp<DlImage> image,
-                       const SkIRect& center,
-                       const SkRect& dst,
+                       const DlIRect& center,
+                       const DlRect& dst,
                        DlFilterMode filter,
                        bool render_with_attributes) override;
     void drawDisplayList(const sk_sp<DisplayList> display_list,
-                         SkScalar opacity) override;
+                         DlScalar opacity) override;
     void drawTextBlob(const sk_sp<SkTextBlob> blob,
-                      SkScalar x,
-                      SkScalar y) override;
+                      DlScalar x,
+                      DlScalar y) override;
     void drawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                       SkScalar x,
-                       SkScalar y) override;
+                       DlScalar x,
+                       DlScalar y) override;
     void drawShadow(const SkPath& path,
                     const DlColor color,
-                    const SkScalar elevation,
+                    const DlScalar elevation,
                     bool transparent_occluder,
-                    SkScalar dpr) override;
+                    DlScalar dpr) override;
 
    protected:
     void ImageRect(const SkISize& size,

--- a/display_list/display_list.h
+++ b/display_list/display_list.h
@@ -10,6 +10,7 @@
 
 #include "flutter/display_list/dl_blend_mode.h"
 #include "flutter/display_list/dl_sampling_options.h"
+#include "flutter/display_list/geometry/dl_geometry_types.h"
 #include "flutter/display_list/geometry/dl_rtree.h"
 #include "flutter/fml/logging.h"
 
@@ -320,6 +321,7 @@ class DisplayList : public SkRefCnt {
   uint32_t unique_id() const { return unique_id_; }
 
   const SkRect& bounds() const { return bounds_; }
+  const DlRect& GetBounds() const { return ToDlRect(bounds_); }
 
   bool has_rtree() const { return rtree_ != nullptr; }
   sk_sp<const DlRTree> rtree() const { return rtree_; }

--- a/display_list/dl_builder.cc
+++ b/display_list/dl_builder.cc
@@ -415,7 +415,7 @@ void DisplayListBuilder::Save() {
   FML_DCHECK(current_info().has_deferred_save_op);
 }
 
-void DisplayListBuilder::saveLayer(const SkRect& bounds,
+void DisplayListBuilder::saveLayer(const DlRect& bounds,
                                    const SaveLayerOptions in_options,
                                    const DlImageFilter* backdrop) {
   SaveLayerOptions options = in_options.without_optimizations();
@@ -523,12 +523,12 @@ void DisplayListBuilder::saveLayer(const SkRect& bounds,
 
   // Accumulate options to store in the SaveLayer op record.
   {
-    SkRect record_bounds;
+    DlRect record_bounds;
     if (in_options.bounds_from_caller()) {
       options = options.with_bounds_from_caller();
       record_bounds = bounds;
     } else {
-      FML_DCHECK(record_bounds.isEmpty());
+      FML_DCHECK(record_bounds.IsEmpty());
     }
 
     if (backdrop) {
@@ -552,12 +552,12 @@ void DisplayListBuilder::SaveLayer(const SkRect* bounds,
                                    const DlPaint* paint,
                                    const DlImageFilter* backdrop) {
   SaveLayerOptions options;
-  SkRect temp_bounds;
+  DlRect temp_bounds;
   if (bounds) {
     options = options.with_bounds_from_caller();
-    temp_bounds = *bounds;
+    temp_bounds = ToDlRect(*bounds);
   } else {
-    temp_bounds.setEmpty();
+    FML_DCHECK(temp_bounds.IsEmpty());
   }
   if (paint != nullptr) {
     options = options.with_renders_with_attributes();
@@ -615,9 +615,10 @@ void DisplayListBuilder::RestoreLayer() {
             layer_op->type == DisplayListOpType::kSaveLayerBackdrop);
 
   if (layer_op->options.bounds_from_caller()) {
-    if (!content_bounds.isEmpty() && !layer_op->rect.contains(content_bounds)) {
+    SkRect user_bounds = ToSkRect(layer_op->rect);
+    if (!content_bounds.isEmpty() && !user_bounds.contains(content_bounds)) {
       layer_op->options = layer_op->options.with_content_is_clipped();
-      if (!content_bounds.intersect(layer_op->rect)) {
+      if (!content_bounds.intersect(user_bounds)) {
         // Should never happen because we prune ops that don't intersect the
         // supplied bounds so content_bounds would already be empty and we
         // wouldn't come into this control block due to the empty test above.
@@ -625,7 +626,7 @@ void DisplayListBuilder::RestoreLayer() {
       }
     }
   }
-  layer_op->rect = content_bounds;
+  layer_op->rect = ToDlRect(content_bounds);
   layer_op->max_blend_mode = current_layer().max_blend_mode;
 
   if (current_layer().contains_backdrop_filter) {
@@ -807,7 +808,7 @@ void DisplayListBuilder::RestoreToCount(int restore_count) {
   }
 }
 
-void DisplayListBuilder::Translate(SkScalar tx, SkScalar ty) {
+void DisplayListBuilder::Translate(DlScalar tx, DlScalar ty) {
   if (std::isfinite(tx) && std::isfinite(ty) && (tx != 0.0 || ty != 0.0)) {
     checkForDeferredSave();
     Push<TranslateOp>(0, tx, ty);
@@ -815,7 +816,7 @@ void DisplayListBuilder::Translate(SkScalar tx, SkScalar ty) {
     layer_local_state().translate(tx, ty);
   }
 }
-void DisplayListBuilder::Scale(SkScalar sx, SkScalar sy) {
+void DisplayListBuilder::Scale(DlScalar sx, DlScalar sy) {
   if (std::isfinite(sx) && std::isfinite(sy) && (sx != 1.0 || sy != 1.0)) {
     checkForDeferredSave();
     Push<ScaleOp>(0, sx, sy);
@@ -823,7 +824,7 @@ void DisplayListBuilder::Scale(SkScalar sx, SkScalar sy) {
     layer_local_state().scale(sx, sy);
   }
 }
-void DisplayListBuilder::Rotate(SkScalar degrees) {
+void DisplayListBuilder::Rotate(DlScalar degrees) {
   if (SkScalarMod(degrees, 360.0) != 0.0) {
     checkForDeferredSave();
     Push<RotateOp>(0, degrees);
@@ -831,7 +832,7 @@ void DisplayListBuilder::Rotate(SkScalar degrees) {
     layer_local_state().rotate(degrees);
   }
 }
-void DisplayListBuilder::Skew(SkScalar sx, SkScalar sy) {
+void DisplayListBuilder::Skew(DlScalar sx, DlScalar sy) {
   if (std::isfinite(sx) && std::isfinite(sy) && (sx != 0.0 || sy != 0.0)) {
     checkForDeferredSave();
     Push<SkewOp>(0, sx, sy);
@@ -844,8 +845,8 @@ void DisplayListBuilder::Skew(SkScalar sx, SkScalar sy) {
 
 // 2x3 2D affine subset of a 4x4 transform in row major order
 void DisplayListBuilder::Transform2DAffine(
-    SkScalar mxx, SkScalar mxy, SkScalar mxt,
-    SkScalar myx, SkScalar myy, SkScalar myt) {
+    DlScalar mxx, DlScalar mxy, DlScalar mxt,
+    DlScalar myx, DlScalar myy, DlScalar myt) {
   if (std::isfinite(mxx) && std::isfinite(myx) &&
       std::isfinite(mxy) && std::isfinite(myy) &&
       std::isfinite(mxt) && std::isfinite(myt)) {
@@ -866,10 +867,10 @@ void DisplayListBuilder::Transform2DAffine(
 }
 // full 4x4 transform in row major order
 void DisplayListBuilder::TransformFullPerspective(
-    SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
-    SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
-    SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
-    SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) {
+    DlScalar mxx, DlScalar mxy, DlScalar mxz, DlScalar mxt,
+    DlScalar myx, DlScalar myy, DlScalar myz, DlScalar myt,
+    DlScalar mzx, DlScalar mzy, DlScalar mzz, DlScalar mzt,
+    DlScalar mwx, DlScalar mwy, DlScalar mwz, DlScalar mwt) {
   if (                        mxz == 0 &&
                               myz == 0 &&
       mzx == 0 && mzy == 0 && mzz == 1 && mzt == 0 &&
@@ -967,10 +968,10 @@ void DisplayListBuilder::ClipRect(const SkRect& rect,
   checkForDeferredSave();
   switch (clip_op) {
     case ClipOp::kIntersect:
-      Push<ClipIntersectRectOp>(0, rect, is_aa);
+      Push<ClipIntersectRectOp>(0, ToDlRect(rect), is_aa);
       break;
     case ClipOp::kDifference:
-      Push<ClipDifferenceRectOp>(0, rect, is_aa);
+      Push<ClipDifferenceRectOp>(0, ToDlRect(rect), is_aa);
       break;
   }
 }
@@ -999,10 +1000,10 @@ void DisplayListBuilder::ClipOval(const SkRect& bounds,
   checkForDeferredSave();
   switch (clip_op) {
     case ClipOp::kIntersect:
-      Push<ClipIntersectOvalOp>(0, bounds, is_aa);
+      Push<ClipIntersectOvalOp>(0, ToDlRect(bounds), is_aa);
       break;
     case ClipOp::kDifference:
-      Push<ClipDifferenceOvalOp>(0, bounds, is_aa);
+      Push<ClipDifferenceOvalOp>(0, ToDlRect(bounds), is_aa);
       break;
   }
 }
@@ -1108,8 +1109,8 @@ void DisplayListBuilder::DrawColor(DlColor color, DlBlendMode mode) {
     UpdateLayerResult(result, mode);
   }
 }
-void DisplayListBuilder::drawLine(const SkPoint& p0, const SkPoint& p1) {
-  SkRect bounds = SkRect::MakeLTRB(p0.fX, p0.fY, p1.fX, p1.fY).makeSorted();
+void DisplayListBuilder::drawLine(const DlPoint& p0, const DlPoint& p1) {
+  SkRect bounds = SkRect::MakeLTRB(p0.x, p0.y, p1.x, p1.y).makeSorted();
   DisplayListAttributeFlags flags =
       (bounds.width() > 0.0f && bounds.height() > 0.0f) ? kDrawLineFlags
                                                         : kDrawHVLineFlags;
@@ -1124,7 +1125,7 @@ void DisplayListBuilder::DrawLine(const SkPoint& p0,
                                   const SkPoint& p1,
                                   const DlPaint& paint) {
   SetAttributesFromPaint(paint, DisplayListOpFlags::kDrawLineFlags);
-  drawLine(p0, p1);
+  drawLine(ToDlPoint(p0), ToDlPoint(p1));
 }
 void DisplayListBuilder::drawDashedLine(const DlPoint& p0,
                                         const DlPoint& p1,
@@ -1149,11 +1150,11 @@ void DisplayListBuilder::DrawDashedLine(const DlPoint& p0,
   SetAttributesFromPaint(paint, DisplayListOpFlags::kDrawLineFlags);
   drawDashedLine(p0, p1, on_length, off_length);
 }
-void DisplayListBuilder::drawRect(const SkRect& rect) {
+void DisplayListBuilder::drawRect(const DlRect& rect) {
   DisplayListAttributeFlags flags = kDrawRectFlags;
   OpResult result = PaintResult(current_, flags);
   if (result != OpResult::kNoEffect &&
-      AccumulateOpBounds(rect.makeSorted(), flags)) {
+      AccumulateOpBounds(ToSkRect(rect.GetPositive()), flags)) {
     Push<DrawRectOp>(0, rect);
     CheckLayerOpacityCompatibility();
     UpdateLayerResult(result);
@@ -1161,13 +1162,13 @@ void DisplayListBuilder::drawRect(const SkRect& rect) {
 }
 void DisplayListBuilder::DrawRect(const SkRect& rect, const DlPaint& paint) {
   SetAttributesFromPaint(paint, DisplayListOpFlags::kDrawRectFlags);
-  drawRect(rect);
+  drawRect(ToDlRect(rect));
 }
-void DisplayListBuilder::drawOval(const SkRect& bounds) {
+void DisplayListBuilder::drawOval(const DlRect& bounds) {
   DisplayListAttributeFlags flags = kDrawOvalFlags;
   OpResult result = PaintResult(current_, flags);
   if (result != OpResult::kNoEffect &&
-      AccumulateOpBounds(bounds.makeSorted(), flags)) {
+      AccumulateOpBounds(ToSkRect(bounds.GetPositive()), flags)) {
     Push<DrawOvalOp>(0, bounds);
     CheckLayerOpacityCompatibility();
     UpdateLayerResult(result);
@@ -1175,14 +1176,14 @@ void DisplayListBuilder::drawOval(const SkRect& bounds) {
 }
 void DisplayListBuilder::DrawOval(const SkRect& bounds, const DlPaint& paint) {
   SetAttributesFromPaint(paint, DisplayListOpFlags::kDrawOvalFlags);
-  drawOval(bounds);
+  drawOval(ToDlRect(bounds));
 }
-void DisplayListBuilder::drawCircle(const SkPoint& center, SkScalar radius) {
+void DisplayListBuilder::drawCircle(const DlPoint& center, DlScalar radius) {
   DisplayListAttributeFlags flags = kDrawCircleFlags;
   OpResult result = PaintResult(current_, flags);
   if (result != OpResult::kNoEffect) {
-    SkRect bounds = SkRect::MakeLTRB(center.fX - radius, center.fY - radius,
-                                     center.fX + radius, center.fY + radius);
+    SkRect bounds = SkRect::MakeLTRB(center.x - radius, center.y - radius,
+                                     center.x + radius, center.y + radius);
     if (AccumulateOpBounds(bounds, flags)) {
       Push<DrawCircleOp>(0, center, radius);
       CheckLayerOpacityCompatibility();
@@ -1191,16 +1192,16 @@ void DisplayListBuilder::drawCircle(const SkPoint& center, SkScalar radius) {
   }
 }
 void DisplayListBuilder::DrawCircle(const SkPoint& center,
-                                    SkScalar radius,
+                                    DlScalar radius,
                                     const DlPaint& paint) {
   SetAttributesFromPaint(paint, DisplayListOpFlags::kDrawCircleFlags);
-  drawCircle(center, radius);
+  drawCircle(ToDlPoint(center), radius);
 }
 void DisplayListBuilder::drawRRect(const SkRRect& rrect) {
   if (rrect.isRect()) {
-    drawRect(rrect.rect());
+    drawRect(ToDlRect(rrect.rect()));
   } else if (rrect.isOval()) {
-    drawOval(rrect.rect());
+    drawOval(ToDlRect(rrect.rect()));
   } else {
     DisplayListAttributeFlags flags = kDrawRRectFlags;
     OpResult result = PaintResult(current_, flags);
@@ -1252,9 +1253,9 @@ void DisplayListBuilder::DrawPath(const SkPath& path, const DlPaint& paint) {
   drawPath(path);
 }
 
-void DisplayListBuilder::drawArc(const SkRect& bounds,
-                                 SkScalar start,
-                                 SkScalar sweep,
+void DisplayListBuilder::drawArc(const DlRect& bounds,
+                                 DlScalar start,
+                                 DlScalar sweep,
                                  bool useCenter) {
   DisplayListAttributeFlags flags =  //
       useCenter                      //
@@ -1264,7 +1265,8 @@ void DisplayListBuilder::drawArc(const SkRect& bounds,
   // This could be tighter if we compute where the start and end
   // angles are and then also consider the quadrants swept and
   // the center if specified.
-  if (result != OpResult::kNoEffect && AccumulateOpBounds(bounds, flags)) {
+  if (result != OpResult::kNoEffect &&
+      AccumulateOpBounds(ToSkRect(bounds), flags)) {
     Push<DrawArcOp>(0, bounds, start, sweep, useCenter);
     if (useCenter) {
       CheckLayerOpacityHairlineCompatibility();
@@ -1275,13 +1277,13 @@ void DisplayListBuilder::drawArc(const SkRect& bounds,
   }
 }
 void DisplayListBuilder::DrawArc(const SkRect& bounds,
-                                 SkScalar start,
-                                 SkScalar sweep,
+                                 DlScalar start,
+                                 DlScalar sweep,
                                  bool useCenter,
                                  const DlPaint& paint) {
   SetAttributesFromPaint(
       paint, useCenter ? kDrawArcWithCenterFlags : kDrawArcNoCenterFlags);
-  drawArc(bounds, start, sweep, useCenter);
+  drawArc(ToDlRect(bounds), start, sweep, useCenter);
 }
 
 DisplayListAttributeFlags DisplayListBuilder::FlagsForPointMode(
@@ -1298,7 +1300,7 @@ DisplayListAttributeFlags DisplayListBuilder::FlagsForPointMode(
 }
 void DisplayListBuilder::drawPoints(PointMode mode,
                                     uint32_t count,
-                                    const SkPoint pts[]) {
+                                    const DlPoint pts[]) {
   if (count == 0) {
     return;
   }
@@ -1353,7 +1355,7 @@ void DisplayListBuilder::DrawPoints(PointMode mode,
                                     const SkPoint pts[],
                                     const DlPaint& paint) {
   SetAttributesFromPaint(paint, FlagsForPointMode(mode));
-  drawPoints(mode, count, pts);
+  drawPoints(mode, count, ToDlPoints(pts));
 }
 void DisplayListBuilder::drawVertices(
     const std::shared_ptr<DlVertices>& vertices,
@@ -1389,7 +1391,7 @@ void DisplayListBuilder::DrawVertices(
 }
 
 void DisplayListBuilder::drawImage(const sk_sp<DlImage> image,
-                                   const SkPoint point,
+                                   const DlPoint& point,
                                    DlImageSampling sampling,
                                    bool render_with_attributes) {
   DisplayListAttributeFlags flags = render_with_attributes  //
@@ -1399,7 +1401,7 @@ void DisplayListBuilder::drawImage(const sk_sp<DlImage> image,
   if (result == OpResult::kNoEffect) {
     return;
   }
-  SkRect bounds = SkRect::MakeXYWH(point.fX, point.fY,  //
+  SkRect bounds = SkRect::MakeXYWH(point.x, point.y,  //
                                    image->width(), image->height());
   if (AccumulateOpBounds(bounds, flags)) {
     render_with_attributes
@@ -1411,20 +1413,20 @@ void DisplayListBuilder::drawImage(const sk_sp<DlImage> image,
   }
 }
 void DisplayListBuilder::DrawImage(const sk_sp<DlImage>& image,
-                                   const SkPoint point,
+                                   const SkPoint& point,
                                    DlImageSampling sampling,
                                    const DlPaint* paint) {
   if (paint != nullptr) {
     SetAttributesFromPaint(*paint,
                            DisplayListOpFlags::kDrawImageWithPaintFlags);
-    drawImage(image, point, sampling, true);
+    drawImage(image, ToDlPoint(point), sampling, true);
   } else {
-    drawImage(image, point, sampling, false);
+    drawImage(image, ToDlPoint(point), sampling, false);
   }
 }
 void DisplayListBuilder::drawImageRect(const sk_sp<DlImage> image,
-                                       const SkRect& src,
-                                       const SkRect& dst,
+                                       const DlRect& src,
+                                       const DlRect& dst,
                                        DlImageSampling sampling,
                                        bool render_with_attributes,
                                        SrcRectConstraint constraint) {
@@ -1432,7 +1434,8 @@ void DisplayListBuilder::drawImageRect(const sk_sp<DlImage> image,
                                         ? kDrawImageRectWithPaintFlags
                                         : kDrawImageRectFlags;
   OpResult result = PaintResult(current_, flags);
-  if (result != OpResult::kNoEffect && AccumulateOpBounds(dst, flags)) {
+  if (result != OpResult::kNoEffect &&
+      AccumulateOpBounds(ToSkRect(dst), flags)) {
     Push<DrawImageRectOp>(0, image, src, dst, sampling, render_with_attributes,
                           constraint);
     CheckLayerOpacityCompatibility(render_with_attributes);
@@ -1449,21 +1452,24 @@ void DisplayListBuilder::DrawImageRect(const sk_sp<DlImage>& image,
   if (paint != nullptr) {
     SetAttributesFromPaint(*paint,
                            DisplayListOpFlags::kDrawImageRectWithPaintFlags);
-    drawImageRect(image, src, dst, sampling, true, constraint);
+    drawImageRect(image, ToDlRect(src), ToDlRect(dst), sampling, true,
+                  constraint);
   } else {
-    drawImageRect(image, src, dst, sampling, false, constraint);
+    drawImageRect(image, ToDlRect(src), ToDlRect(dst), sampling, false,
+                  constraint);
   }
 }
 void DisplayListBuilder::drawImageNine(const sk_sp<DlImage> image,
-                                       const SkIRect& center,
-                                       const SkRect& dst,
+                                       const DlIRect& center,
+                                       const DlRect& dst,
                                        DlFilterMode filter,
                                        bool render_with_attributes) {
   DisplayListAttributeFlags flags = render_with_attributes
                                         ? kDrawImageNineWithPaintFlags
                                         : kDrawImageNineFlags;
   OpResult result = PaintResult(current_, flags);
-  if (result != OpResult::kNoEffect && AccumulateOpBounds(dst, flags)) {
+  if (result != OpResult::kNoEffect &&
+      AccumulateOpBounds(ToSkRect(dst), flags)) {
     render_with_attributes
         ? Push<DrawImageNineWithAttrOp>(0, image, center, dst, filter)
         : Push<DrawImageNineOp>(0, image, center, dst, filter);
@@ -1480,19 +1486,19 @@ void DisplayListBuilder::DrawImageNine(const sk_sp<DlImage>& image,
   if (paint != nullptr) {
     SetAttributesFromPaint(*paint,
                            DisplayListOpFlags::kDrawImageNineWithPaintFlags);
-    drawImageNine(image, center, dst, filter, true);
+    drawImageNine(image, ToDlIRect(center), ToDlRect(dst), filter, true);
   } else {
-    drawImageNine(image, center, dst, filter, false);
+    drawImageNine(image, ToDlIRect(center), ToDlRect(dst), filter, false);
   }
 }
 void DisplayListBuilder::drawAtlas(const sk_sp<DlImage> atlas,
                                    const SkRSXform xform[],
-                                   const SkRect tex[],
+                                   const DlRect tex[],
                                    const DlColor colors[],
                                    int count,
                                    DlBlendMode mode,
                                    DlImageSampling sampling,
-                                   const SkRect* cull_rect,
+                                   const DlRect* cull_rect,
                                    bool render_with_attributes) {
   DisplayListAttributeFlags flags = render_with_attributes  //
                                         ? kDrawAtlasWithPaintFlags
@@ -1504,7 +1510,7 @@ void DisplayListBuilder::drawAtlas(const sk_sp<DlImage> atlas,
   SkPoint quad[4];
   AccumulationRect accumulator;
   for (int i = 0; i < count; i++) {
-    const SkRect& src = tex[i];
+    const SkRect& src = ToSkRect(tex[i]);
     xform[i].toQuad(src.width(), src.height(), quad);
     for (int j = 0; j < 4; j++) {
       accumulator.accumulate(quad[j]);
@@ -1571,16 +1577,16 @@ void DisplayListBuilder::DrawAtlas(const sk_sp<DlImage>& atlas,
   if (paint != nullptr) {
     SetAttributesFromPaint(*paint,
                            DisplayListOpFlags::kDrawAtlasWithPaintFlags);
-    drawAtlas(atlas, xform, tex, colors, count, mode, sampling, cull_rect,
-              true);
+    drawAtlas(atlas, xform, ToDlRects(tex), colors, count, mode, sampling,
+              ToDlRect(cull_rect), true);
   } else {
-    drawAtlas(atlas, xform, tex, colors, count, mode, sampling, cull_rect,
-              false);
+    drawAtlas(atlas, xform, ToDlRects(tex), colors, count, mode, sampling,
+              ToDlRect(cull_rect), false);
   }
 }
 
 void DisplayListBuilder::DrawDisplayList(const sk_sp<DisplayList> display_list,
-                                         SkScalar opacity) {
+                                         DlScalar opacity) {
   if (!std::isfinite(opacity) || opacity <= SK_ScalarNearlyZero ||
       display_list->op_count() == 0 || display_list->bounds().isEmpty() ||
       current_info().is_nop) {
@@ -1650,8 +1656,8 @@ void DisplayListBuilder::DrawDisplayList(const sk_sp<DisplayList> display_list,
   }
 }
 void DisplayListBuilder::drawTextBlob(const sk_sp<SkTextBlob> blob,
-                                      SkScalar x,
-                                      SkScalar y) {
+                                      DlScalar x,
+                                      DlScalar y) {
   DisplayListAttributeFlags flags = kDrawTextBlobFlags;
   OpResult result = PaintResult(current_, flags);
   if (result == OpResult::kNoEffect) {
@@ -1677,8 +1683,8 @@ void DisplayListBuilder::drawTextBlob(const sk_sp<SkTextBlob> blob,
   }
 }
 void DisplayListBuilder::DrawTextBlob(const sk_sp<SkTextBlob>& blob,
-                                      SkScalar x,
-                                      SkScalar y,
+                                      DlScalar x,
+                                      DlScalar y,
                                       const DlPaint& paint) {
   SetAttributesFromPaint(paint, DisplayListOpFlags::kDrawTextBlobFlags);
   drawTextBlob(blob, x, y);
@@ -1686,8 +1692,8 @@ void DisplayListBuilder::DrawTextBlob(const sk_sp<SkTextBlob>& blob,
 
 void DisplayListBuilder::drawTextFrame(
     const std::shared_ptr<impeller::TextFrame>& text_frame,
-    SkScalar x,
-    SkScalar y) {
+    DlScalar x,
+    DlScalar y) {
   DisplayListAttributeFlags flags = kDrawTextBlobFlags;
   OpResult result = PaintResult(current_, flags);
   if (result == OpResult::kNoEffect) {
@@ -1718,8 +1724,8 @@ void DisplayListBuilder::drawTextFrame(
 
 void DisplayListBuilder::DrawTextFrame(
     const std::shared_ptr<impeller::TextFrame>& text_frame,
-    SkScalar x,
-    SkScalar y,
+    DlScalar x,
+    DlScalar y,
     const DlPaint& paint) {
   SetAttributesFromPaint(paint, DisplayListOpFlags::kDrawTextBlobFlags);
   drawTextFrame(text_frame, x, y);
@@ -1727,9 +1733,9 @@ void DisplayListBuilder::DrawTextFrame(
 
 void DisplayListBuilder::DrawShadow(const SkPath& path,
                                     const DlColor color,
-                                    const SkScalar elevation,
+                                    const DlScalar elevation,
                                     bool transparent_occluder,
-                                    SkScalar dpr) {
+                                    DlScalar dpr) {
   OpResult result = PaintResult(DlPaint(color));
   if (result != OpResult::kNoEffect) {
     SkRect shadow_bounds =
@@ -1760,7 +1766,7 @@ bool DisplayListBuilder::AdjustBoundsForPaint(SkRect& bounds,
 
     if (is_stroked) {
       // Determine the max multiplier to the stroke width first.
-      SkScalar pad = 1.0f;
+      DlScalar pad = 1.0f;
       if (current_.getStrokeJoin() == DlStrokeJoin::kMiter &&
           special_flags.may_have_acute_joins()) {
         pad = std::max(pad, current_.getStrokeMiter());
@@ -1769,7 +1775,7 @@ bool DisplayListBuilder::AdjustBoundsForPaint(SkRect& bounds,
           special_flags.may_have_diagonal_caps()) {
         pad = std::max(pad, SK_ScalarSqrt2);
       }
-      SkScalar min_stroke_width = 0.01;
+      DlScalar min_stroke_width = 0.01;
       pad *= std::max(current_.getStrokeWidth() * 0.5f, min_stroke_width);
       bounds.outset(pad, pad);
     }
@@ -1781,7 +1787,7 @@ bool DisplayListBuilder::AdjustBoundsForPaint(SkRect& bounds,
       switch (filter->type()) {
         case DlMaskFilterType::kBlur: {
           FML_DCHECK(filter->asBlur());
-          SkScalar mask_sigma_pad = filter->asBlur()->sigma() * 3.0;
+          DlScalar mask_sigma_pad = filter->asBlur()->sigma() * 3.0;
           bounds.outset(mask_sigma_pad, mask_sigma_pad);
         }
       }

--- a/display_list/dl_builder.h
+++ b/display_list/dl_builder.h
@@ -60,26 +60,26 @@ class DisplayListBuilder final : public virtual DlCanvas,
   void RestoreToCount(int restore_count) override;
 
   // |DlCanvas|
-  void Translate(SkScalar tx, SkScalar ty) override;
+  void Translate(DlScalar tx, DlScalar ty) override;
   // |DlCanvas|
-  void Scale(SkScalar sx, SkScalar sy) override;
+  void Scale(DlScalar sx, DlScalar sy) override;
   // |DlCanvas|
-  void Rotate(SkScalar degrees) override;
+  void Rotate(DlScalar degrees) override;
   // |DlCanvas|
-  void Skew(SkScalar sx, SkScalar sy) override;
+  void Skew(DlScalar sx, DlScalar sy) override;
 
   // clang-format off
   // 2x3 2D affine subset of a 4x4 transform in row major order
   // |DlCanvas|
-  void Transform2DAffine(SkScalar mxx, SkScalar mxy, SkScalar mxt,
-                         SkScalar myx, SkScalar myy, SkScalar myt) override;
+  void Transform2DAffine(DlScalar mxx, DlScalar mxy, DlScalar mxt,
+                         DlScalar myx, DlScalar myy, DlScalar myt) override;
   // full 4x4 transform in row major order
   // |DlCanvas|
   void TransformFullPerspective(
-      SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
-      SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
-      SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
-      SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) override;
+      DlScalar mxx, DlScalar mxy, DlScalar mxz, DlScalar mxt,
+      DlScalar myx, DlScalar myy, DlScalar myz, DlScalar myt,
+      DlScalar mzx, DlScalar mzy, DlScalar mzz, DlScalar mzt,
+      DlScalar mwx, DlScalar mwy, DlScalar mwz, DlScalar mwt) override;
   // clang-format on
   // |DlCanvas|
   void TransformReset() override;
@@ -170,7 +170,7 @@ class DisplayListBuilder final : public virtual DlCanvas,
   void DrawOval(const SkRect& bounds, const DlPaint& paint) override;
   // |DlCanvas|
   void DrawCircle(const SkPoint& center,
-                  SkScalar radius,
+                  DlScalar radius,
                   const DlPaint& paint) override;
   // |DlCanvas|
   void DrawRRect(const SkRRect& rrect, const DlPaint& paint) override;
@@ -182,8 +182,8 @@ class DisplayListBuilder final : public virtual DlCanvas,
   void DrawPath(const SkPath& path, const DlPaint& paint) override;
   // |DlCanvas|
   void DrawArc(const SkRect& bounds,
-               SkScalar start,
-               SkScalar sweep,
+               DlScalar start,
+               DlScalar sweep,
                bool useCenter,
                const DlPaint& paint) override;
   // |DlCanvas|
@@ -197,7 +197,7 @@ class DisplayListBuilder final : public virtual DlCanvas,
                     const DlPaint& paint) override;
   // |DlCanvas|
   void DrawImage(const sk_sp<DlImage>& image,
-                 const SkPoint point,
+                 const SkPoint& point,
                  DlImageSampling sampling,
                  const DlPaint* paint = nullptr) override;
   // |DlCanvas|
@@ -227,28 +227,28 @@ class DisplayListBuilder final : public virtual DlCanvas,
                  const DlPaint* paint = nullptr) override;
   // |DlCanvas|
   void DrawDisplayList(const sk_sp<DisplayList> display_list,
-                       SkScalar opacity = SK_Scalar1) override;
+                       DlScalar opacity = SK_Scalar1) override;
   // |DlCanvas|
   void DrawTextBlob(const sk_sp<SkTextBlob>& blob,
-                    SkScalar x,
-                    SkScalar y,
+                    DlScalar x,
+                    DlScalar y,
                     const DlPaint& paint) override;
 
   void drawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                     SkScalar x,
-                     SkScalar y) override;
+                     DlScalar x,
+                     DlScalar y) override;
 
   void DrawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                     SkScalar x,
-                     SkScalar y,
+                     DlScalar x,
+                     DlScalar y,
                      const DlPaint& paint) override;
 
   // |DlCanvas|
   void DrawShadow(const SkPath& path,
                   const DlColor color,
-                  const SkScalar elevation,
+                  const DlScalar elevation,
                   bool transparent_occluder,
-                  SkScalar dpr) override;
+                  DlScalar dpr) override;
 
   // |DlCanvas|
   void Flush() override {}
@@ -361,35 +361,35 @@ class DisplayListBuilder final : public virtual DlCanvas,
   void save() override { Save(); }
   // Only the |renders_with_attributes()| option will be accepted here. Any
   // other flags will be ignored and calculated anew as the DisplayList is
-  // built. Alternatively, use the |saveLayer(SkRect, bool)| method.
+  // built. Alternatively, use the |saveLayer(DlRect, bool)| method.
   // |DlOpReceiver|
-  void saveLayer(const SkRect& bounds,
+  void saveLayer(const DlRect& bounds,
                  const SaveLayerOptions options,
                  const DlImageFilter* backdrop) override;
   // |DlOpReceiver|
   void restore() override { Restore(); }
 
   // |DlOpReceiver|
-  void translate(SkScalar tx, SkScalar ty) override { Translate(tx, ty); }
+  void translate(DlScalar tx, DlScalar ty) override { Translate(tx, ty); }
   // |DlOpReceiver|
-  void scale(SkScalar sx, SkScalar sy) override { Scale(sx, sy); }
+  void scale(DlScalar sx, DlScalar sy) override { Scale(sx, sy); }
   // |DlOpReceiver|
-  void rotate(SkScalar degrees) override { Rotate(degrees); }
+  void rotate(DlScalar degrees) override { Rotate(degrees); }
   // |DlOpReceiver|
-  void skew(SkScalar sx, SkScalar sy) override { Skew(sx, sy); }
+  void skew(DlScalar sx, DlScalar sy) override { Skew(sx, sy); }
 
   // clang-format off
   // |DlOpReceiver|
-  void transform2DAffine(SkScalar mxx, SkScalar mxy, SkScalar mxt,
-                         SkScalar myx, SkScalar myy, SkScalar myt) override {
+  void transform2DAffine(DlScalar mxx, DlScalar mxy, DlScalar mxt,
+                         DlScalar myx, DlScalar myy, DlScalar myt) override {
     Transform2DAffine(mxx, mxy, mxt, myx, myy, myt);
   }
   // |DlOpReceiver|
   void transformFullPerspective(
-      SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
-      SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
-      SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
-      SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) override {
+      DlScalar mxx, DlScalar mxy, DlScalar mxz, DlScalar mxt,
+      DlScalar myx, DlScalar myy, DlScalar myz, DlScalar myt,
+      DlScalar mzx, DlScalar mzy, DlScalar mzz, DlScalar mzt,
+      DlScalar mwx, DlScalar mwy, DlScalar mwz, DlScalar mwt) override {
     TransformFullPerspective(mxx, mxy, mxz, mxt,
                              myx, myy, myz, myt,
                              mzx, mzy, mzz, mzt,
@@ -400,12 +400,12 @@ class DisplayListBuilder final : public virtual DlCanvas,
   void transformReset() override { TransformReset(); }
 
   // |DlOpReceiver|
-  void clipRect(const SkRect& rect, ClipOp clip_op, bool is_aa) override {
-    ClipRect(rect, clip_op, is_aa);
+  void clipRect(const DlRect& rect, ClipOp clip_op, bool is_aa) override {
+    ClipRect(ToSkRect(rect), clip_op, is_aa);
   }
   // |DlOpReceiver|
-  void clipOval(const SkRect& bounds, ClipOp clip_op, bool is_aa) override {
-    ClipOval(bounds, clip_op, is_aa);
+  void clipOval(const DlRect& bounds, ClipOp clip_op, bool is_aa) override {
+    ClipOval(ToSkRect(bounds), clip_op, is_aa);
   }
   // |DlOpReceiver|
   void clipRRect(const SkRRect& rrect, ClipOp clip_op, bool is_aa) override {
@@ -423,18 +423,18 @@ class DisplayListBuilder final : public virtual DlCanvas,
     DrawColor(color, mode);
   }
   // |DlOpReceiver|
-  void drawLine(const SkPoint& p0, const SkPoint& p1) override;
+  void drawLine(const DlPoint& p0, const DlPoint& p1) override;
   // |DlOpReceiver|
   void drawDashedLine(const DlPoint& p0,
                       const DlPoint& p1,
                       DlScalar on_length,
                       DlScalar off_length) override;
   // |DlOpReceiver|
-  void drawRect(const SkRect& rect) override;
+  void drawRect(const DlRect& rect) override;
   // |DlOpReceiver|
-  void drawOval(const SkRect& bounds) override;
+  void drawOval(const DlRect& bounds) override;
   // |DlOpReceiver|
-  void drawCircle(const SkPoint& center, SkScalar radius) override;
+  void drawCircle(const DlPoint& center, DlScalar radius) override;
   // |DlOpReceiver|
   void drawRRect(const SkRRect& rrect) override;
   // |DlOpReceiver|
@@ -442,61 +442,61 @@ class DisplayListBuilder final : public virtual DlCanvas,
   // |DlOpReceiver|
   void drawPath(const SkPath& path) override;
   // |DlOpReceiver|
-  void drawArc(const SkRect& bounds,
-               SkScalar start,
-               SkScalar sweep,
+  void drawArc(const DlRect& bounds,
+               DlScalar start,
+               DlScalar sweep,
                bool useCenter) override;
   // |DlOpReceiver|
-  void drawPoints(PointMode mode, uint32_t count, const SkPoint pts[]) override;
+  void drawPoints(PointMode mode, uint32_t count, const DlPoint pts[]) override;
   // |DlOpReceiver|
   void drawVertices(const std::shared_ptr<DlVertices>& vertices,
                     DlBlendMode mode) override;
 
   // |DlOpReceiver|
   void drawImage(const sk_sp<DlImage> image,
-                 const SkPoint point,
+                 const DlPoint& point,
                  DlImageSampling sampling,
                  bool render_with_attributes) override;
   // |DlOpReceiver|
   void drawImageRect(
       const sk_sp<DlImage> image,
-      const SkRect& src,
-      const SkRect& dst,
+      const DlRect& src,
+      const DlRect& dst,
       DlImageSampling sampling,
       bool render_with_attributes,
       SrcRectConstraint constraint = SrcRectConstraint::kFast) override;
   // |DlOpReceiver|
   void drawImageNine(const sk_sp<DlImage> image,
-                     const SkIRect& center,
-                     const SkRect& dst,
+                     const DlIRect& center,
+                     const DlRect& dst,
                      DlFilterMode filter,
                      bool render_with_attributes) override;
   // |DlOpReceiver|
   void drawAtlas(const sk_sp<DlImage> atlas,
                  const SkRSXform xform[],
-                 const SkRect tex[],
+                 const DlRect tex[],
                  const DlColor colors[],
                  int count,
                  DlBlendMode mode,
                  DlImageSampling sampling,
-                 const SkRect* cullRect,
+                 const DlRect* cullRect,
                  bool render_with_attributes) override;
 
   // |DlOpReceiver|
   void drawDisplayList(const sk_sp<DisplayList> display_list,
-                       SkScalar opacity) override {
+                       DlScalar opacity) override {
     DrawDisplayList(display_list, opacity);
   }
   // |DlOpReceiver|
   void drawTextBlob(const sk_sp<SkTextBlob> blob,
-                    SkScalar x,
-                    SkScalar y) override;
+                    DlScalar x,
+                    DlScalar y) override;
   // |DlOpReceiver|
   void drawShadow(const SkPath& path,
                   const DlColor color,
-                  const SkScalar elevation,
+                  const DlScalar elevation,
                   bool transparent_occluder,
-                  SkScalar dpr) override {
+                  DlScalar dpr) override {
     DrawShadow(path, color, elevation, transparent_occluder, dpr);
   }
 
@@ -766,8 +766,8 @@ class DisplayListBuilder final : public virtual DlCanvas,
   void onSetStrokeCap(DlStrokeCap cap);
   void onSetStrokeJoin(DlStrokeJoin join);
   void onSetDrawStyle(DlDrawStyle style);
-  void onSetStrokeWidth(SkScalar width);
-  void onSetStrokeMiter(SkScalar limit);
+  void onSetStrokeWidth(DlScalar width);
+  void onSetStrokeMiter(DlScalar limit);
   void onSetColor(DlColor color);
   void onSetBlendMode(DlBlendMode mode);
   void onSetColorSource(const DlColorSource* source);

--- a/display_list/dl_canvas.h
+++ b/display_list/dl_canvas.h
@@ -66,22 +66,22 @@ class DlCanvas {
   virtual int GetSaveCount() const = 0;
   virtual void RestoreToCount(int restore_count) = 0;
 
-  virtual void Translate(SkScalar tx, SkScalar ty) = 0;
-  virtual void Scale(SkScalar sx, SkScalar sy) = 0;
-  virtual void Rotate(SkScalar degrees) = 0;
-  virtual void Skew(SkScalar sx, SkScalar sy) = 0;
+  virtual void Translate(DlScalar tx, DlScalar ty) = 0;
+  virtual void Scale(DlScalar sx, DlScalar sy) = 0;
+  virtual void Rotate(DlScalar degrees) = 0;
+  virtual void Skew(DlScalar sx, DlScalar sy) = 0;
 
   // clang-format off
 
   // 2x3 2D affine subset of a 4x4 transform in row major order
-  virtual void Transform2DAffine(SkScalar mxx, SkScalar mxy, SkScalar mxt,
-                                 SkScalar myx, SkScalar myy, SkScalar myt) = 0;
+  virtual void Transform2DAffine(DlScalar mxx, DlScalar mxy, DlScalar mxt,
+                                 DlScalar myx, DlScalar myy, DlScalar myt) = 0;
   // full 4x4 transform in row major order
   virtual void TransformFullPerspective(
-      SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
-      SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
-      SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
-      SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) = 0;
+      DlScalar mxx, DlScalar mxy, DlScalar mxz, DlScalar mxt,
+      DlScalar myx, DlScalar myy, DlScalar myz, DlScalar myt,
+      DlScalar mzx, DlScalar mzy, DlScalar mzz, DlScalar mzt,
+      DlScalar mwx, DlScalar mwy, DlScalar mwz, DlScalar mwt) = 0;
   // clang-format on
   virtual void TransformReset() = 0;
   virtual void Transform(const SkMatrix* matrix) = 0;
@@ -144,7 +144,7 @@ class DlCanvas {
   virtual void DrawRect(const SkRect& rect, const DlPaint& paint) = 0;
   virtual void DrawOval(const SkRect& bounds, const DlPaint& paint) = 0;
   virtual void DrawCircle(const SkPoint& center,
-                          SkScalar radius,
+                          DlScalar radius,
                           const DlPaint& paint) = 0;
   virtual void DrawRRect(const SkRRect& rrect, const DlPaint& paint) = 0;
   virtual void DrawDRRect(const SkRRect& outer,
@@ -152,8 +152,8 @@ class DlCanvas {
                           const DlPaint& paint) = 0;
   virtual void DrawPath(const SkPath& path, const DlPaint& paint) = 0;
   virtual void DrawArc(const SkRect& bounds,
-                       SkScalar start,
-                       SkScalar sweep,
+                       DlScalar start,
+                       DlScalar sweep,
                        bool useCenter,
                        const DlPaint& paint) = 0;
   virtual void DrawPoints(PointMode mode,
@@ -164,7 +164,7 @@ class DlCanvas {
                             DlBlendMode mode,
                             const DlPaint& paint) = 0;
   virtual void DrawImage(const sk_sp<DlImage>& image,
-                         const SkPoint point,
+                         const SkPoint& point,
                          DlImageSampling sampling,
                          const DlPaint* paint = nullptr) = 0;
   virtual void DrawImageRect(
@@ -205,32 +205,32 @@ class DlCanvas {
                          const SkRect* cullRect,
                          const DlPaint* paint = nullptr) = 0;
   virtual void DrawDisplayList(const sk_sp<DisplayList> display_list,
-                               SkScalar opacity = SK_Scalar1) = 0;
+                               DlScalar opacity = SK_Scalar1) = 0;
 
   virtual void DrawTextFrame(
       const std::shared_ptr<impeller::TextFrame>& text_frame,
-      SkScalar x,
-      SkScalar y,
+      DlScalar x,
+      DlScalar y,
       const DlPaint& paint) = 0;
 
   virtual void DrawTextBlob(const sk_sp<SkTextBlob>& blob,
-                            SkScalar x,
-                            SkScalar y,
+                            DlScalar x,
+                            DlScalar y,
                             const DlPaint& paint) = 0;
   virtual void DrawShadow(const SkPath& path,
                           const DlColor color,
-                          const SkScalar elevation,
+                          const DlScalar elevation,
                           bool transparent_occluder,
-                          SkScalar dpr) = 0;
+                          DlScalar dpr) = 0;
 
   virtual void Flush() = 0;
 
-  static constexpr SkScalar kShadowLightHeight = 600;
-  static constexpr SkScalar kShadowLightRadius = 800;
+  static constexpr DlScalar kShadowLightHeight = 600;
+  static constexpr DlScalar kShadowLightRadius = 800;
 
   static SkRect ComputeShadowBounds(const SkPath& path,
                                     float elevation,
-                                    SkScalar dpr,
+                                    DlScalar dpr,
                                     const SkMatrix& ctm);
 };
 

--- a/display_list/dl_op_receiver.h
+++ b/display_list/dl_op_receiver.h
@@ -93,7 +93,7 @@ class DlOpReceiver {
   using SrcRectConstraint = DlCanvas::SrcRectConstraint;
 
  public:
-  // MaxDrawPointsCount * sizeof(SkPoint) must be less than 1 << 32
+  // MaxDrawPointsCount * sizeof(DlPoint) must be less than 1 << 32
   static constexpr int kMaxDrawPointsCount = ((1 << 29) - 1);
 
   // ---------------------------------------------------------------------
@@ -129,9 +129,9 @@ class DlOpReceiver {
   virtual void drawPath(const CacheablePath& cache) { FML_UNREACHABLE(); }
   virtual void drawShadow(const CacheablePath& cache,
                           const DlColor color,
-                          const SkScalar elevation,
+                          const DlScalar elevation,
                           bool transparent_occluder,
-                          SkScalar dpr) {
+                          DlScalar dpr) {
     FML_UNREACHABLE();
   }
   // ---------------------------------------------------------------------
@@ -181,12 +181,12 @@ class DlOpReceiver {
   // specified in calling a |DisplayListBuilder| as they will be ignored.
   // The |backdrop| filter, if not null, is used to initialize the new
   // layer before further rendering happens.
-  virtual void saveLayer(const SkRect& bounds,
+  virtual void saveLayer(const DlRect& bounds,
                          const SaveLayerOptions options,
                          const DlImageFilter* backdrop = nullptr) = 0;
   // Optional variant of saveLayer() that passes the total depth count of
   // all rendering operations that occur until the next restore() call.
-  virtual void saveLayer(const SkRect& bounds,
+  virtual void saveLayer(const DlRect& bounds,
                          const SaveLayerOptions& options,
                          uint32_t total_content_depth,
                          DlBlendMode max_content_blend_mode,
@@ -210,25 +210,25 @@ class DlOpReceiver {
   // public DisplayListBuilder/DlCanvas public interfaces where possible,
   // as tracked in:
   // https://github.com/flutter/flutter/issues/144070
-  virtual void saveLayer(const SkRect* bounds,
+  virtual void saveLayer(const DlRect* bounds,
                          const SaveLayerOptions options,
                          const DlImageFilter* backdrop = nullptr) final {
     if (bounds) {
       saveLayer(*bounds, options.with_bounds_from_caller(), backdrop);
     } else {
-      saveLayer(SkRect(), options.without_bounds_from_caller(), backdrop);
+      saveLayer(DlRect(), options.without_bounds_from_caller(), backdrop);
     }
   }
   // ---------------------------------------------------------------------
 
-  virtual void translate(SkScalar tx, SkScalar ty) = 0;
-  virtual void scale(SkScalar sx, SkScalar sy) = 0;
-  virtual void rotate(SkScalar degrees) = 0;
-  virtual void skew(SkScalar sx, SkScalar sy) = 0;
+  virtual void translate(DlScalar tx, DlScalar ty) = 0;
+  virtual void scale(DlScalar sx, DlScalar sy) = 0;
+  virtual void rotate(DlScalar degrees) = 0;
+  virtual void skew(DlScalar sx, DlScalar sy) = 0;
 
   // The transform methods all assume the following math for transforming
   // an arbitrary 3D homogenous point (x, y, z, w).
-  // All coordinates in the rendering methods (and SkPoint and SkRect objects)
+  // All coordinates in the rendering methods (and DlPoint and DlRect objects)
   // represent a simplified coordinate (x, y, 0, 1).
   //   x' = x * mxx + y * mxy + z * mxz + w * mxt
   //   y' = x * myx + y * myy + z * myz + w * myt
@@ -309,8 +309,8 @@ class DlOpReceiver {
   //   [ myx  myy   0   myt ]
   //   [  0    0    1    0  ]
   //   [  0    0    0    1  ]
-  virtual void transform2DAffine(SkScalar mxx, SkScalar mxy, SkScalar mxt,
-                                 SkScalar myx, SkScalar myy, SkScalar myt) = 0;
+  virtual void transform2DAffine(DlScalar mxx, DlScalar mxy, DlScalar mxt,
+                                 DlScalar myx, DlScalar myy, DlScalar myt) = 0;
   // |transformFullPerspective| is equivalent to concatenating the internal
   // 4x4 transform with the following row major transform matrix:
   //   [ mxx  mxy  mxz  mxt ]
@@ -318,17 +318,17 @@ class DlOpReceiver {
   //   [ mzx  mzy  mzz  mzt ]
   //   [ mwx  mwy  mwz  mwt ]
   virtual void transformFullPerspective(
-      SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
-      SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
-      SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
-      SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) = 0;
+      DlScalar mxx, DlScalar mxy, DlScalar mxz, DlScalar mxt,
+      DlScalar myx, DlScalar myy, DlScalar myz, DlScalar myt,
+      DlScalar mzx, DlScalar mzy, DlScalar mzz, DlScalar mzt,
+      DlScalar mwx, DlScalar mwy, DlScalar mwz, DlScalar mwt) = 0;
   // clang-format on
 
   // Clears the transformation stack.
   virtual void transformReset() = 0;
 
-  virtual void clipRect(const SkRect& rect, ClipOp clip_op, bool is_aa) = 0;
-  virtual void clipOval(const SkRect& bounds, ClipOp clip_op, bool is_aa) = 0;
+  virtual void clipRect(const DlRect& rect, ClipOp clip_op, bool is_aa) = 0;
+  virtual void clipOval(const DlRect& bounds, ClipOp clip_op, bool is_aa) = 0;
   virtual void clipRRect(const SkRRect& rrect, ClipOp clip_op, bool is_aa) = 0;
   virtual void clipPath(const SkPath& path, ClipOp clip_op, bool is_aa) = 0;
 
@@ -341,65 +341,65 @@ class DlOpReceiver {
   // stream, or assume default attributes.
   virtual void drawColor(DlColor color, DlBlendMode mode) = 0;
   virtual void drawPaint() = 0;
-  virtual void drawLine(const SkPoint& p0, const SkPoint& p1) = 0;
+  virtual void drawLine(const DlPoint& p0, const DlPoint& p1) = 0;
   virtual void drawDashedLine(const DlPoint& p0,
                               const DlPoint& p1,
                               DlScalar on_length,
                               DlScalar off_length) = 0;
-  virtual void drawRect(const SkRect& rect) = 0;
-  virtual void drawOval(const SkRect& bounds) = 0;
-  virtual void drawCircle(const SkPoint& center, SkScalar radius) = 0;
+  virtual void drawRect(const DlRect& rect) = 0;
+  virtual void drawOval(const DlRect& bounds) = 0;
+  virtual void drawCircle(const DlPoint& center, DlScalar radius) = 0;
   virtual void drawRRect(const SkRRect& rrect) = 0;
   virtual void drawDRRect(const SkRRect& outer, const SkRRect& inner) = 0;
   virtual void drawPath(const SkPath& path) = 0;
-  virtual void drawArc(const SkRect& oval_bounds,
-                       SkScalar start_degrees,
-                       SkScalar sweep_degrees,
+  virtual void drawArc(const DlRect& oval_bounds,
+                       DlScalar start_degrees,
+                       DlScalar sweep_degrees,
                        bool use_center) = 0;
   virtual void drawPoints(PointMode mode,
                           uint32_t count,
-                          const SkPoint points[]) = 0;
+                          const DlPoint points[]) = 0;
   virtual void drawVertices(const std::shared_ptr<DlVertices>& vertices,
                             DlBlendMode mode) = 0;
   virtual void drawImage(const sk_sp<DlImage> image,
-                         const SkPoint point,
+                         const DlPoint& point,
                          DlImageSampling sampling,
                          bool render_with_attributes) = 0;
   virtual void drawImageRect(
       const sk_sp<DlImage> image,
-      const SkRect& src,
-      const SkRect& dst,
+      const DlRect& src,
+      const DlRect& dst,
       DlImageSampling sampling,
       bool render_with_attributes,
       SrcRectConstraint constraint = SrcRectConstraint::kFast) = 0;
   virtual void drawImageNine(const sk_sp<DlImage> image,
-                             const SkIRect& center,
-                             const SkRect& dst,
+                             const DlIRect& center,
+                             const DlRect& dst,
                              DlFilterMode filter,
                              bool render_with_attributes) = 0;
   virtual void drawAtlas(const sk_sp<DlImage> atlas,
                          const SkRSXform xform[],
-                         const SkRect tex[],
+                         const DlRect tex[],
                          const DlColor colors[],
                          int count,
                          DlBlendMode mode,
                          DlImageSampling sampling,
-                         const SkRect* cull_rect,
+                         const DlRect* cull_rect,
                          bool render_with_attributes) = 0;
   virtual void drawDisplayList(const sk_sp<DisplayList> display_list,
-                               SkScalar opacity = SK_Scalar1) = 0;
+                               DlScalar opacity = SK_Scalar1) = 0;
   virtual void drawTextBlob(const sk_sp<SkTextBlob> blob,
-                            SkScalar x,
-                            SkScalar y) = 0;
+                            DlScalar x,
+                            DlScalar y) = 0;
   virtual void drawTextFrame(
       const std::shared_ptr<impeller::TextFrame>& text_frame,
-      SkScalar x,
-      SkScalar y) = 0;
+      DlScalar x,
+      DlScalar y) = 0;
   virtual void drawShadow(const SkPath& path,
                           const DlColor color,
-                          const SkScalar elevation,
+                          const DlScalar elevation,
                           bool transparent_occluder,
-                          SkScalar dpr) = 0;
+                          DlScalar dpr) = 0;
 };
 
 }  // namespace flutter

--- a/display_list/dl_op_records.h
+++ b/display_list/dl_op_records.h
@@ -305,10 +305,10 @@ struct SaveOp final : SaveOpBase {
 // The base struct for all saveLayer() ops
 // 16 byte SaveOpBase + 20 byte payload packs into 36 bytes
 struct SaveLayerOpBase : SaveOpBase {
-  SaveLayerOpBase(const SaveLayerOptions& options, const SkRect& rect)
+  SaveLayerOpBase(const SaveLayerOptions& options, const DlRect& rect)
       : SaveOpBase(options), rect(rect) {}
 
-  SkRect rect;
+  DlRect rect;
   DlBlendMode max_blend_mode = DlBlendMode::kClear;
 };
 // 36 byte SaveLayerOpBase with no additional data packs into 40 bytes
@@ -316,7 +316,7 @@ struct SaveLayerOpBase : SaveOpBase {
 struct SaveLayerOp final : SaveLayerOpBase {
   static constexpr auto kType = DisplayListOpType::kSaveLayer;
 
-  SaveLayerOp(const SaveLayerOptions& options, const SkRect& rect)
+  SaveLayerOp(const SaveLayerOptions& options, const DlRect& rect)
       : SaveLayerOpBase(options, rect) {}
 
   void dispatch(DlOpReceiver& receiver) const {
@@ -329,7 +329,7 @@ struct SaveLayerBackdropOp final : SaveLayerOpBase {
   static constexpr auto kType = DisplayListOpType::kSaveLayerBackdrop;
 
   SaveLayerBackdropOp(const SaveLayerOptions& options,
-                      const SkRect& rect,
+                      const DlRect& rect,
                       const DlImageFilter* backdrop)
       : SaveLayerOpBase(options, rect), backdrop(backdrop->shared()) {}
 
@@ -369,10 +369,10 @@ struct TransformClipOpBase : DLOp {
 struct TranslateOp final : TransformClipOpBase {
   static constexpr auto kType = DisplayListOpType::kTranslate;
 
-  TranslateOp(SkScalar tx, SkScalar ty) : tx(tx), ty(ty) {}
+  TranslateOp(DlScalar tx, DlScalar ty) : tx(tx), ty(ty) {}
 
-  const SkScalar tx;
-  const SkScalar ty;
+  const DlScalar tx;
+  const DlScalar ty;
 
   void dispatch(DlOpReceiver& receiver) const {  //
     receiver.translate(tx, ty);
@@ -383,10 +383,10 @@ struct TranslateOp final : TransformClipOpBase {
 struct ScaleOp final : TransformClipOpBase {
   static constexpr auto kType = DisplayListOpType::kScale;
 
-  ScaleOp(SkScalar sx, SkScalar sy) : sx(sx), sy(sy) {}
+  ScaleOp(DlScalar sx, DlScalar sy) : sx(sx), sy(sy) {}
 
-  const SkScalar sx;
-  const SkScalar sy;
+  const DlScalar sx;
+  const DlScalar sy;
 
   void dispatch(DlOpReceiver& receiver) const {  //
     receiver.scale(sx, sy);
@@ -396,9 +396,9 @@ struct ScaleOp final : TransformClipOpBase {
 struct RotateOp final : TransformClipOpBase {
   static constexpr auto kType = DisplayListOpType::kRotate;
 
-  explicit RotateOp(SkScalar degrees) : degrees(degrees) {}
+  explicit RotateOp(DlScalar degrees) : degrees(degrees) {}
 
-  const SkScalar degrees;
+  const DlScalar degrees;
 
   void dispatch(DlOpReceiver& receiver) const {  //
     receiver.rotate(degrees);
@@ -409,10 +409,10 @@ struct RotateOp final : TransformClipOpBase {
 struct SkewOp final : TransformClipOpBase {
   static constexpr auto kType = DisplayListOpType::kSkew;
 
-  SkewOp(SkScalar sx, SkScalar sy) : sx(sx), sy(sy) {}
+  SkewOp(DlScalar sx, DlScalar sy) : sx(sx), sy(sy) {}
 
-  const SkScalar sx;
-  const SkScalar sy;
+  const DlScalar sx;
+  const DlScalar sy;
 
   void dispatch(DlOpReceiver& receiver) const {  //
     receiver.skew(sx, sy);
@@ -424,13 +424,13 @@ struct Transform2DAffineOp final : TransformClipOpBase {
   static constexpr auto kType = DisplayListOpType::kTransform2DAffine;
 
   // clang-format off
-  Transform2DAffineOp(SkScalar mxx, SkScalar mxy, SkScalar mxt,
-                      SkScalar myx, SkScalar myy, SkScalar myt)
+  Transform2DAffineOp(DlScalar mxx, DlScalar mxy, DlScalar mxt,
+                      DlScalar myx, DlScalar myy, DlScalar myt)
       : mxx(mxx), mxy(mxy), mxt(mxt), myx(myx), myy(myy), myt(myt) {}
   // clang-format on
 
-  const SkScalar mxx, mxy, mxt;
-  const SkScalar myx, myy, myt;
+  const DlScalar mxx, mxy, mxt;
+  const DlScalar myx, myy, myt;
 
   void dispatch(DlOpReceiver& receiver) const {
     receiver.transform2DAffine(mxx, mxy, mxt,  //
@@ -444,20 +444,20 @@ struct TransformFullPerspectiveOp final : TransformClipOpBase {
 
   // clang-format off
   TransformFullPerspectiveOp(
-      SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
-      SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
-      SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
-      SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt)
+      DlScalar mxx, DlScalar mxy, DlScalar mxz, DlScalar mxt,
+      DlScalar myx, DlScalar myy, DlScalar myz, DlScalar myt,
+      DlScalar mzx, DlScalar mzy, DlScalar mzz, DlScalar mzt,
+      DlScalar mwx, DlScalar mwy, DlScalar mwz, DlScalar mwt)
       : mxx(mxx), mxy(mxy), mxz(mxz), mxt(mxt),
         myx(myx), myy(myy), myz(myz), myt(myt),
         mzx(mzx), mzy(mzy), mzz(mzz), mzt(mzt),
         mwx(mwx), mwy(mwy), mwz(mwz), mwt(mwt) {}
   // clang-format on
 
-  const SkScalar mxx, mxy, mxz, mxt;
-  const SkScalar myx, myy, myz, myt;
-  const SkScalar mzx, mzy, mzz, mzt;
-  const SkScalar mwx, mwy, mwz, mwt;
+  const DlScalar mxx, mxy, mxz, mxt;
+  const DlScalar myx, myy, myz, myt;
+  const DlScalar mzx, mzy, mzz, mzt;
+  const DlScalar mwx, mwy, mwz, mwt;
 
   void dispatch(DlOpReceiver& receiver) const {
     receiver.transformFullPerspective(mxx, mxy, mxz, mxt,  //
@@ -479,7 +479,7 @@ struct TransformResetOp final : TransformClipOpBase {
 };
 
 // 4 byte header + 4 byte common payload packs into minimum 8 bytes
-// SkRect is 16 more bytes, which packs efficiently into 24 bytes total
+// DlRect is 16 more bytes, which packs efficiently into 24 bytes total
 // SkRRect is 52 more bytes, which rounds up to 56 bytes (4 bytes unused)
 //         which packs into 64 bytes total
 // CacheablePath is 128 more bytes, which packs efficiently into 136 bytes total
@@ -492,22 +492,22 @@ struct TransformResetOp final : TransformClipOpBase {
   struct Clip##clipop##shapename##Op final : TransformClipOpBase {             \
     static constexpr auto kType = DisplayListOpType::kClip##clipop##shapename; \
                                                                                \
-    Clip##clipop##shapename##Op(Sk##shapetype shape, bool is_aa)               \
+    Clip##clipop##shapename##Op(shapetype shape, bool is_aa)                   \
         : is_aa(is_aa), shape(shape) {}                                        \
                                                                                \
     const bool is_aa;                                                          \
-    const Sk##shapetype shape;                                                 \
+    const shapetype shape;                                                     \
                                                                                \
     void dispatch(DlOpReceiver& receiver) const {                              \
       receiver.clip##shapename(shape, DlCanvas::ClipOp::k##clipop, is_aa);     \
     }                                                                          \
   };
-DEFINE_CLIP_SHAPE_OP(Rect, Rect, Intersect)
-DEFINE_CLIP_SHAPE_OP(Oval, Rect, Intersect)
-DEFINE_CLIP_SHAPE_OP(RRect, RRect, Intersect)
-DEFINE_CLIP_SHAPE_OP(Rect, Rect, Difference)
-DEFINE_CLIP_SHAPE_OP(Oval, Rect, Difference)
-DEFINE_CLIP_SHAPE_OP(RRect, RRect, Difference)
+DEFINE_CLIP_SHAPE_OP(Rect, DlRect, Intersect)
+DEFINE_CLIP_SHAPE_OP(Oval, DlRect, Intersect)
+DEFINE_CLIP_SHAPE_OP(RRect, SkRRect, Intersect)
+DEFINE_CLIP_SHAPE_OP(Rect, DlRect, Difference)
+DEFINE_CLIP_SHAPE_OP(Oval, DlRect, Difference)
+DEFINE_CLIP_SHAPE_OP(RRect, SkRRect, Difference)
 #undef DEFINE_CLIP_SHAPE_OP
 
 #define DEFINE_CLIP_PATH_OP(clipop)                                         \
@@ -570,9 +570,9 @@ struct DrawColorOp final : DrawOpBase {
 };
 
 // The common data is a 4 byte header with an unused 4 bytes
-// SkRect is 16 more bytes, using 20 bytes which rounds up to 24 bytes total
+// DlRect is 16 more bytes, using 20 bytes which rounds up to 24 bytes total
 //        (4 bytes unused)
-// SkOval is same as SkRect
+// SkOval is same as DlRect
 // SkRRect is 52 more bytes, which packs efficiently into 56 bytes total
 #define DEFINE_DRAW_1ARG_OP(op_name, arg_type, arg_name)                  \
   struct Draw##op_name##Op final : DrawOpBase {                           \
@@ -586,8 +586,8 @@ struct DrawColorOp final : DrawOpBase {
       receiver.draw##op_name(arg_name);                                   \
     }                                                                     \
   };
-DEFINE_DRAW_1ARG_OP(Rect, SkRect, rect)
-DEFINE_DRAW_1ARG_OP(Oval, SkRect, oval)
+DEFINE_DRAW_1ARG_OP(Rect, DlRect, rect)
+DEFINE_DRAW_1ARG_OP(Oval, DlRect, oval)
 DEFINE_DRAW_1ARG_OP(RRect, SkRRect, rrect)
 #undef DEFINE_DRAW_1ARG_OP
 
@@ -615,9 +615,9 @@ struct DrawPathOp final : DrawOpBase {
 };
 
 // The common data is a 4 byte header with an unused 4 bytes
-// 2 x SkPoint is 16 more bytes, using 20 bytes rounding up to 24 bytes total
+// 2 x DlPoint is 16 more bytes, using 20 bytes rounding up to 24 bytes total
 //             (4 bytes unused)
-// SkPoint + SkScalar is 12 more bytes, packing efficiently into 16 bytes total
+// DlPoint + DlScalar is 12 more bytes, packing efficiently into 16 bytes total
 // 2 x SkRRect is 104 more bytes, using 108 and rounding up to 112 bytes total
 //             (4 bytes unused)
 #define DEFINE_DRAW_2ARG_OP(op_name, type1, name1, type2, name2)     \
@@ -634,8 +634,8 @@ struct DrawPathOp final : DrawOpBase {
       receiver.draw##op_name(name1, name2);                          \
     }                                                                \
   };
-DEFINE_DRAW_2ARG_OP(Line, SkPoint, p0, SkPoint, p1)
-DEFINE_DRAW_2ARG_OP(Circle, SkPoint, center, SkScalar, radius)
+DEFINE_DRAW_2ARG_OP(Line, DlPoint, p0, DlPoint, p1)
+DEFINE_DRAW_2ARG_OP(Circle, DlPoint, center, DlScalar, radius)
 DEFINE_DRAW_2ARG_OP(DRRect, SkRRect, outer, SkRRect, inner)
 #undef DEFINE_DRAW_2ARG_OP
 
@@ -651,8 +651,8 @@ struct DrawDashedLineOp final : DrawOpBase {
 
   const DlPoint p0;
   const DlPoint p1;
-  const SkScalar on_length;
-  const SkScalar off_length;
+  const DlScalar on_length;
+  const DlScalar off_length;
 
   void dispatch(DlOpReceiver& receiver) const {
     receiver.drawDashedLine(p0, p1, on_length, off_length);
@@ -663,12 +663,12 @@ struct DrawDashedLineOp final : DrawOpBase {
 struct DrawArcOp final : DrawOpBase {
   static constexpr auto kType = DisplayListOpType::kDrawArc;
 
-  DrawArcOp(SkRect bounds, SkScalar start, SkScalar sweep, bool center)
+  DrawArcOp(DlRect bounds, DlScalar start, DlScalar sweep, bool center)
       : bounds(bounds), start(start), sweep(sweep), center(center) {}
 
-  const SkRect bounds;
-  const SkScalar start;
-  const SkScalar sweep;
+  const DlRect bounds;
+  const DlScalar start;
+  const DlScalar sweep;
   const bool center;
 
   void dispatch(DlOpReceiver& receiver) const {
@@ -678,7 +678,7 @@ struct DrawArcOp final : DrawOpBase {
 
 // 4 byte header + 4 byte fixed payload packs efficiently into 8 bytes
 // But then there is a list of points following the structure which
-// is guaranteed to be a multiple of 8 bytes (SkPoint is 8 bytes)
+// is guaranteed to be a multiple of 8 bytes (DlPoint is 8 bytes)
 // so this op will always pack efficiently
 // The point type is packed into 3 different OpTypes to avoid expanding
 // the fixed payload beyond the 8 bytes
@@ -691,7 +691,7 @@ struct DrawArcOp final : DrawOpBase {
     const uint32_t count;                                              \
                                                                        \
     void dispatch(DlOpReceiver& receiver) const {                      \
-      const SkPoint* pts = reinterpret_cast<const SkPoint*>(this + 1); \
+      const DlPoint* pts = reinterpret_cast<const DlPoint*>(this + 1); \
       receiver.drawPoints(DlCanvas::PointMode::mode, count, pts);      \
     }                                                                  \
   };
@@ -723,11 +723,11 @@ struct DrawVerticesOp final : DrawOpBase {
     static constexpr auto kType = DisplayListOpType::k##name;          \
                                                                        \
     name##Op(const sk_sp<DlImage>& image,                              \
-             const SkPoint& point,                                     \
+             const DlPoint& point,                                     \
              DlImageSampling sampling)                                 \
         : point(point), sampling(sampling), image(std::move(image)) {} \
                                                                        \
-    const SkPoint point;                                               \
+    const DlPoint point;                                               \
     const DlImageSampling sampling;                                    \
     const sk_sp<DlImage> image;                                        \
                                                                        \
@@ -752,8 +752,8 @@ struct DrawImageRectOp final : DrawOpBase {
   static constexpr auto kType = DisplayListOpType::kDrawImageRect;
 
   DrawImageRectOp(const sk_sp<DlImage>& image,
-                  const SkRect& src,
-                  const SkRect& dst,
+                  const DlRect& src,
+                  const DlRect& dst,
                   DlImageSampling sampling,
                   bool render_with_attributes,
                   DlCanvas::SrcRectConstraint constraint)
@@ -764,8 +764,8 @@ struct DrawImageRectOp final : DrawOpBase {
         constraint(constraint),
         image(image) {}
 
-  const SkRect src;
-  const SkRect dst;
+  const DlRect src;
+  const DlRect dst;
   const DlImageSampling sampling;
   const bool render_with_attributes;
   const DlCanvas::SrcRectConstraint constraint;
@@ -793,13 +793,13 @@ struct DrawImageRectOp final : DrawOpBase {
     static constexpr uint32_t kDepthInc = 9;                               \
                                                                            \
     name##Op(const sk_sp<DlImage>& image,                                  \
-             const SkIRect& center,                                        \
-             const SkRect& dst,                                            \
+             const DlIRect& center,                                        \
+             const DlRect& dst,                                            \
              DlFilterMode mode)                                            \
         : center(center), dst(dst), mode(mode), image(std::move(image)) {} \
                                                                            \
-    const SkIRect center;                                                  \
-    const SkRect dst;                                                      \
+    const DlIRect center;                                                  \
+    const DlRect dst;                                                      \
     const DlFilterMode mode;                                               \
     const sk_sp<DlImage> image;                                            \
                                                                            \
@@ -823,7 +823,7 @@ DEFINE_DRAW_IMAGE_NINE_OP(DrawImageNineWithAttr, true)
 // (4 bytes unused)
 // Each of these is then followed by a number of lists.
 // SkRSXform list is a multiple of 16 bytes so it is always packed well
-// SkRect list is also a multiple of 16 bytes so it also packs well
+// DlRect list is also a multiple of 16 bytes so it also packs well
 // DlColor list only packs well if the count is even, otherwise there
 // can be 4 unusued bytes at the end.
 struct DrawAtlasBaseOp : DrawOpBase {
@@ -855,7 +855,7 @@ struct DrawAtlasBaseOp : DrawOpBase {
                 render_with_attributes == other->render_with_attributes &&
                 sampling == other->sampling && atlas->Equals(other->atlas));
     if (ret) {
-      size_t bytes = count * (sizeof(SkRSXform) + sizeof(SkRect));
+      size_t bytes = count * (sizeof(SkRSXform) + sizeof(DlRect));
       if (has_colors) {
         bytes += count * sizeof(DlColor);
       }
@@ -885,7 +885,7 @@ struct DrawAtlasOp final : DrawAtlasBaseOp {
 
   void dispatch(DlOpReceiver& receiver) const {
     const SkRSXform* xform = reinterpret_cast<const SkRSXform*>(this + 1);
-    const SkRect* tex = reinterpret_cast<const SkRect*>(xform + count);
+    const DlRect* tex = reinterpret_cast<const DlRect*>(xform + count);
     const DlColor* colors =
         has_colors ? reinterpret_cast<const DlColor*>(tex + count) : nullptr;
     const DlBlendMode mode = static_cast<DlBlendMode>(mode_index);
@@ -914,7 +914,7 @@ struct DrawAtlasCulledOp final : DrawAtlasBaseOp {
                     DlBlendMode mode,
                     DlImageSampling sampling,
                     bool has_colors,
-                    const SkRect& cull_rect,
+                    const DlRect& cull_rect,
                     bool render_with_attributes)
       : DrawAtlasBaseOp(atlas,
                         count,
@@ -924,11 +924,11 @@ struct DrawAtlasCulledOp final : DrawAtlasBaseOp {
                         render_with_attributes),
         cull_rect(cull_rect) {}
 
-  const SkRect cull_rect;
+  const DlRect cull_rect;
 
   void dispatch(DlOpReceiver& receiver) const {
     const SkRSXform* xform = reinterpret_cast<const SkRSXform*>(this + 1);
-    const SkRect* tex = reinterpret_cast<const SkRect*>(xform + count);
+    const DlRect* tex = reinterpret_cast<const DlRect*>(xform + count);
     const DlColor* colors =
         has_colors ? reinterpret_cast<const DlColor*>(tex + count) : nullptr;
     const DlBlendMode mode = static_cast<DlBlendMode>(mode_index);
@@ -952,10 +952,10 @@ struct DrawDisplayListOp final : DrawOpBase {
   static constexpr auto kType = DisplayListOpType::kDrawDisplayList;
 
   explicit DrawDisplayListOp(const sk_sp<DisplayList>& display_list,
-                             SkScalar opacity)
+                             DlScalar opacity)
       : opacity(opacity), display_list(display_list) {}
 
-  SkScalar opacity;
+  DlScalar opacity;
   const sk_sp<DisplayList> display_list;
 
   void dispatch(DlOpReceiver& receiver) const {
@@ -975,11 +975,11 @@ struct DrawDisplayListOp final : DrawOpBase {
 struct DrawTextBlobOp final : DrawOpBase {
   static constexpr auto kType = DisplayListOpType::kDrawTextBlob;
 
-  DrawTextBlobOp(const sk_sp<SkTextBlob>& blob, SkScalar x, SkScalar y)
+  DrawTextBlobOp(const sk_sp<SkTextBlob>& blob, DlScalar x, DlScalar y)
       : x(x), y(y), blob(blob) {}
 
-  const SkScalar x;
-  const SkScalar y;
+  const DlScalar x;
+  const DlScalar y;
   const sk_sp<SkTextBlob> blob;
 
   void dispatch(DlOpReceiver& receiver) const {
@@ -991,12 +991,12 @@ struct DrawTextFrameOp final : DrawOpBase {
   static constexpr auto kType = DisplayListOpType::kDrawTextFrame;
 
   DrawTextFrameOp(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                  SkScalar x,
-                  SkScalar y)
+                  DlScalar x,
+                  DlScalar y)
       : x(x), y(y), text_frame(text_frame) {}
 
-  const SkScalar x;
-  const SkScalar y;
+  const DlScalar x;
+  const DlScalar y;
   const std::shared_ptr<impeller::TextFrame> text_frame;
 
   void dispatch(DlOpReceiver& receiver) const {
@@ -1011,13 +1011,13 @@ struct DrawTextFrameOp final : DrawOpBase {
                                                                              \
     Draw##name##Op(const SkPath& path,                                       \
                    DlColor color,                                            \
-                   SkScalar elevation,                                       \
-                   SkScalar dpr)                                             \
+                   DlScalar elevation,                                       \
+                   DlScalar dpr)                                             \
         : color(color), elevation(elevation), dpr(dpr), cached_path(path) {} \
                                                                              \
     const DlColor color;                                                     \
-    const SkScalar elevation;                                                \
-    const SkScalar dpr;                                                      \
+    const DlScalar elevation;                                                \
+    const DlScalar dpr;                                                      \
     const DlOpReceiver::CacheablePath cached_path;                           \
                                                                              \
     void dispatch(DlOpReceiver& receiver) const {                            \

--- a/display_list/dl_paint.h
+++ b/display_list/dl_paint.h
@@ -74,8 +74,8 @@ class DlPaint {
 
   uint8_t getAlpha() const { return color_.argb() >> 24; }
   DlPaint& setAlpha(uint8_t alpha) { return setColor(color_.withAlpha(alpha)); }
-  SkScalar getOpacity() const { return color_.getAlphaF(); }
-  DlPaint& setOpacity(SkScalar opacity) {
+  DlScalar getOpacity() const { return color_.getAlphaF(); }
+  DlPaint& setOpacity(DlScalar opacity) {
     setAlpha(SkScalarRoundToInt(opacity * 0xff));
     return *this;
   }

--- a/display_list/geometry/dl_geometry_types.h
+++ b/display_list/geometry/dl_geometry_types.h
@@ -39,8 +39,24 @@ inline const DlPoint& ToDlPoint(const SkPoint& point) {
   return *reinterpret_cast<const DlPoint*>(&point);
 }
 
+inline const DlPoint* ToDlPoints(const SkPoint* points) {
+  return points == nullptr ? nullptr : reinterpret_cast<const DlPoint*>(points);
+}
+
 inline const DlRect& ToDlRect(const SkRect& rect) {
   return *reinterpret_cast<const DlRect*>(&rect);
+}
+
+inline const DlIRect& ToDlIRect(const SkIRect& rect) {
+  return *reinterpret_cast<const DlIRect*>(&rect);
+}
+
+inline const DlRect* ToDlRect(const SkRect* rect) {
+  return rect == nullptr ? nullptr : reinterpret_cast<const DlRect*>(rect);
+}
+
+inline const DlRect* ToDlRects(const SkRect* rects) {
+  return rects == nullptr ? nullptr : reinterpret_cast<const DlRect*>(rects);
 }
 
 inline const DlISize& ToDlISize(const SkISize& size) {
@@ -68,8 +84,24 @@ inline const SkPoint& ToSkPoint(const DlPoint& point) {
   return *reinterpret_cast<const SkPoint*>(&point);
 }
 
+inline const SkPoint* ToSkPoints(const DlPoint* points) {
+  return points == nullptr ? nullptr : reinterpret_cast<const SkPoint*>(points);
+}
+
 inline const SkRect& ToSkRect(const DlRect& rect) {
   return *reinterpret_cast<const SkRect*>(&rect);
+}
+
+inline const SkIRect& ToSkIRect(const DlIRect& rect) {
+  return *reinterpret_cast<const SkIRect*>(&rect);
+}
+
+inline const SkRect* ToSkRect(const DlRect* rect) {
+  return rect == nullptr ? nullptr : reinterpret_cast<const SkRect*>(rect);
+}
+
+inline const SkRect* ToSkRects(const DlRect* rects) {
+  return rects == nullptr ? nullptr : reinterpret_cast<const SkRect*>(rects);
 }
 
 inline const SkISize& ToSkISize(const DlISize& size) {

--- a/display_list/image/dl_image.h
+++ b/display_list/image/dl_image.h
@@ -9,7 +9,9 @@
 #include <optional>
 #include <string>
 
+#include "flutter/display_list/geometry/dl_geometry_types.h"
 #include "flutter/fml/build_config.h"
+#include "flutter/fml/macros.h"
 #include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkRefCnt.h"
 
@@ -106,6 +108,12 @@ class DlImage : public SkRefCnt {
   ///             convenience method that calls |DlImage::dimensions|.
   ///
   SkIRect bounds() const;
+
+  //----------------------------------------------------------------------------
+  /// @return     The bounds of the pixel grid with 0, 0 as origin. A
+  ///             convenience method that calls |DlImage::dimensions|.
+  ///
+  DlIRect GetBounds() const { return ToDlIRect(bounds()); }
 
   //----------------------------------------------------------------------------
   /// @return     Specifies which context was used to create this image. The

--- a/display_list/skia/dl_sk_canvas.cc
+++ b/display_list/skia/dl_sk_canvas.cc
@@ -268,7 +268,7 @@ void DlSkCanvasAdapter::DrawVertices(
 }
 
 void DlSkCanvasAdapter::DrawImage(const sk_sp<DlImage>& image,
-                                  const SkPoint point,
+                                  const SkPoint& point,
                                   DlImageSampling sampling,
                                   const DlPaint* paint) {
   SkOptionalPaint sk_paint(paint);

--- a/display_list/skia/dl_sk_canvas.h
+++ b/display_list/skia/dl_sk_canvas.h
@@ -123,7 +123,7 @@ class DlSkCanvasAdapter final : public virtual DlCanvas {
                     DlBlendMode mode,
                     const DlPaint& paint) override;
   void DrawImage(const sk_sp<DlImage>& image,
-                 const SkPoint point,
+                 const SkPoint& point,
                  DlImageSampling sampling,
                  const DlPaint* paint = nullptr) override;
   void DrawImageRect(

--- a/display_list/skia/dl_sk_dispatcher.cc
+++ b/display_list/skia/dl_sk_dispatcher.cc
@@ -44,7 +44,7 @@ void DlSkCanvasDispatcher::restore() {
   canvas_->restore();
   restore_opacity();
 }
-void DlSkCanvasDispatcher::saveLayer(const SkRect& bounds,
+void DlSkCanvasDispatcher::saveLayer(const DlRect& bounds,
                                      const SaveLayerOptions options,
                                      const DlImageFilter* backdrop) {
   if (!options.content_is_clipped() && options.can_distribute_opacity() &&
@@ -68,7 +68,8 @@ void DlSkCanvasDispatcher::saveLayer(const SkRect& bounds,
     TRACE_EVENT0("flutter", "Canvas::saveLayer");
     const SkPaint* paint = safe_paint(options.renders_with_attributes());
     const sk_sp<SkImageFilter> sk_backdrop = ToSk(backdrop);
-    const SkRect* sl_bounds = options.bounds_from_caller() ? &bounds : nullptr;
+    const SkRect* sl_bounds =
+        options.bounds_from_caller() ? &ToSkRect(bounds) : nullptr;
     canvas_->saveLayer(
         SkCanvas::SaveLayerRec(sl_bounds, paint, sk_backdrop.get(), 0));
     // saveLayer will apply the current opacity on behalf of the children
@@ -77,23 +78,23 @@ void DlSkCanvasDispatcher::saveLayer(const SkRect& bounds,
   }
 }
 
-void DlSkCanvasDispatcher::translate(SkScalar tx, SkScalar ty) {
+void DlSkCanvasDispatcher::translate(DlScalar tx, DlScalar ty) {
   canvas_->translate(tx, ty);
 }
-void DlSkCanvasDispatcher::scale(SkScalar sx, SkScalar sy) {
+void DlSkCanvasDispatcher::scale(DlScalar sx, DlScalar sy) {
   canvas_->scale(sx, sy);
 }
-void DlSkCanvasDispatcher::rotate(SkScalar degrees) {
+void DlSkCanvasDispatcher::rotate(DlScalar degrees) {
   canvas_->rotate(degrees);
 }
-void DlSkCanvasDispatcher::skew(SkScalar sx, SkScalar sy) {
+void DlSkCanvasDispatcher::skew(DlScalar sx, DlScalar sy) {
   canvas_->skew(sx, sy);
 }
 // clang-format off
 // 2x3 2D affine subset of a 4x4 transform in row major order
 void DlSkCanvasDispatcher::transform2DAffine(
-    SkScalar mxx, SkScalar mxy, SkScalar mxt,
-    SkScalar myx, SkScalar myy, SkScalar myt) {
+    DlScalar mxx, DlScalar mxy, DlScalar mxt,
+    DlScalar myx, DlScalar myy, DlScalar myt) {
   // Internally concat(SkMatrix) gets redirected to concat(SkM44)
   // so we just jump directly to the SkM44 version
   canvas_->concat(SkM44(mxx, mxy, 0, mxt,
@@ -103,10 +104,10 @@ void DlSkCanvasDispatcher::transform2DAffine(
 }
 // full 4x4 transform in row major order
 void DlSkCanvasDispatcher::transformFullPerspective(
-    SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
-    SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
-    SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
-    SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) {
+    DlScalar mxx, DlScalar mxy, DlScalar mxz, DlScalar mxt,
+    DlScalar myx, DlScalar myy, DlScalar myz, DlScalar myt,
+    DlScalar mzx, DlScalar mzy, DlScalar mzz, DlScalar mzt,
+    DlScalar mwx, DlScalar mwy, DlScalar mwz, DlScalar mwt) {
   canvas_->concat(SkM44(mxx, mxy, mxz, mxt,
                         myx, myy, myz, myt,
                         mzx, mzy, mzz, mzt,
@@ -117,15 +118,15 @@ void DlSkCanvasDispatcher::transformReset() {
   canvas_->setMatrix(original_transform_);
 }
 
-void DlSkCanvasDispatcher::clipRect(const SkRect& rect,
+void DlSkCanvasDispatcher::clipRect(const DlRect& rect,
                                     ClipOp clip_op,
                                     bool is_aa) {
-  canvas_->clipRect(rect, ToSk(clip_op), is_aa);
+  canvas_->clipRect(ToSkRect(rect), ToSk(clip_op), is_aa);
 }
-void DlSkCanvasDispatcher::clipOval(const SkRect& bounds,
+void DlSkCanvasDispatcher::clipOval(const DlRect& bounds,
                                     ClipOp clip_op,
                                     bool is_aa) {
-  canvas_->clipRRect(SkRRect::MakeOval(bounds), ToSk(clip_op), is_aa);
+  canvas_->clipRRect(SkRRect::MakeOval(ToSkRect(bounds)), ToSk(clip_op), is_aa);
 }
 void DlSkCanvasDispatcher::clipRRect(const SkRRect& rrect,
                                      ClipOp clip_op,
@@ -155,8 +156,8 @@ void DlSkCanvasDispatcher::drawColor(DlColor color, DlBlendMode mode) {
   color4f.fA *= opacity();
   canvas_->drawColor(color4f, ToSk(mode));
 }
-void DlSkCanvasDispatcher::drawLine(const SkPoint& p0, const SkPoint& p1) {
-  canvas_->drawLine(p0, p1, paint());
+void DlSkCanvasDispatcher::drawLine(const DlPoint& p0, const DlPoint& p1) {
+  canvas_->drawLine(ToSkPoint(p0), ToSkPoint(p1), paint());
 }
 void DlSkCanvasDispatcher::drawDashedLine(const DlPoint& p0,
                                           const DlPoint& p1,
@@ -167,14 +168,14 @@ void DlSkCanvasDispatcher::drawDashedLine(const DlPoint& p0,
   dash_paint.setPathEffect(SkDashPathEffect::Make(intervals, 2, 0.0f));
   canvas_->drawLine(ToSkPoint(p0), ToSkPoint(p1), dash_paint);
 }
-void DlSkCanvasDispatcher::drawRect(const SkRect& rect) {
-  canvas_->drawRect(rect, paint());
+void DlSkCanvasDispatcher::drawRect(const DlRect& rect) {
+  canvas_->drawRect(ToSkRect(rect), paint());
 }
-void DlSkCanvasDispatcher::drawOval(const SkRect& bounds) {
-  canvas_->drawOval(bounds, paint());
+void DlSkCanvasDispatcher::drawOval(const DlRect& bounds) {
+  canvas_->drawOval(ToSkRect(bounds), paint());
 }
-void DlSkCanvasDispatcher::drawCircle(const SkPoint& center, SkScalar radius) {
-  canvas_->drawCircle(center, radius, paint());
+void DlSkCanvasDispatcher::drawCircle(const DlPoint& center, DlScalar radius) {
+  canvas_->drawCircle(ToSkPoint(center), radius, paint());
 }
 void DlSkCanvasDispatcher::drawRRect(const SkRRect& rrect) {
   canvas_->drawRRect(rrect, paint());
@@ -186,16 +187,16 @@ void DlSkCanvasDispatcher::drawDRRect(const SkRRect& outer,
 void DlSkCanvasDispatcher::drawPath(const SkPath& path) {
   canvas_->drawPath(path, paint());
 }
-void DlSkCanvasDispatcher::drawArc(const SkRect& bounds,
-                                   SkScalar start,
-                                   SkScalar sweep,
+void DlSkCanvasDispatcher::drawArc(const DlRect& bounds,
+                                   DlScalar start,
+                                   DlScalar sweep,
                                    bool useCenter) {
-  canvas_->drawArc(bounds, start, sweep, useCenter, paint());
+  canvas_->drawArc(ToSkRect(bounds), start, sweep, useCenter, paint());
 }
 void DlSkCanvasDispatcher::drawPoints(PointMode mode,
                                       uint32_t count,
-                                      const SkPoint pts[]) {
-  canvas_->drawPoints(ToSk(mode), count, pts, paint());
+                                      const DlPoint pts[]) {
+  canvas_->drawPoints(ToSk(mode), count, ToSkPoints(pts), paint());
 }
 void DlSkCanvasDispatcher::drawVertices(
     const std::shared_ptr<DlVertices>& vertices,
@@ -203,25 +204,25 @@ void DlSkCanvasDispatcher::drawVertices(
   canvas_->drawVertices(ToSk(vertices), ToSk(mode), paint());
 }
 void DlSkCanvasDispatcher::drawImage(const sk_sp<DlImage> image,
-                                     const SkPoint point,
+                                     const DlPoint& point,
                                      DlImageSampling sampling,
                                      bool render_with_attributes) {
-  canvas_->drawImage(image ? image->skia_image() : nullptr, point.fX, point.fY,
+  canvas_->drawImage(image ? image->skia_image() : nullptr, point.x, point.y,
                      ToSk(sampling), safe_paint(render_with_attributes));
 }
 void DlSkCanvasDispatcher::drawImageRect(const sk_sp<DlImage> image,
-                                         const SkRect& src,
-                                         const SkRect& dst,
+                                         const DlRect& src,
+                                         const DlRect& dst,
                                          DlImageSampling sampling,
                                          bool render_with_attributes,
                                          SrcRectConstraint constraint) {
-  canvas_->drawImageRect(image ? image->skia_image() : nullptr, src, dst,
-                         ToSk(sampling), safe_paint(render_with_attributes),
-                         ToSk(constraint));
+  canvas_->drawImageRect(image ? image->skia_image() : nullptr, ToSkRect(src),
+                         ToSkRect(dst), ToSk(sampling),
+                         safe_paint(render_with_attributes), ToSk(constraint));
 }
 void DlSkCanvasDispatcher::drawImageNine(const sk_sp<DlImage> image,
-                                         const SkIRect& center,
-                                         const SkRect& dst,
+                                         const DlIRect& center,
+                                         const DlRect& dst,
                                          DlFilterMode filter,
                                          bool render_with_attributes) {
   if (!image) {
@@ -231,17 +232,17 @@ void DlSkCanvasDispatcher::drawImageNine(const sk_sp<DlImage> image,
   if (!skia_image) {
     return;
   }
-  canvas_->drawImageNine(skia_image.get(), center, dst, ToSk(filter),
-                         safe_paint(render_with_attributes));
+  canvas_->drawImageNine(skia_image.get(), ToSkIRect(center), ToSkRect(dst),
+                         ToSk(filter), safe_paint(render_with_attributes));
 }
 void DlSkCanvasDispatcher::drawAtlas(const sk_sp<DlImage> atlas,
                                      const SkRSXform xform[],
-                                     const SkRect tex[],
+                                     const DlRect tex[],
                                      const DlColor colors[],
                                      int count,
                                      DlBlendMode mode,
                                      DlImageSampling sampling,
-                                     const SkRect* cullRect,
+                                     const DlRect* cullRect,
                                      bool render_with_attributes) {
   if (!atlas) {
     return;
@@ -255,13 +256,13 @@ void DlSkCanvasDispatcher::drawAtlas(const sk_sp<DlImage> atlas,
   for (int i = 0; i < count; ++i) {
     sk_colors.push_back(colors[i].argb());
   }
-  canvas_->drawAtlas(skia_atlas.get(), xform, tex, sk_colors.data(), count,
-                     ToSk(mode), ToSk(sampling), cullRect,
+  canvas_->drawAtlas(skia_atlas.get(), xform, ToSkRects(tex), sk_colors.data(),
+                     count, ToSk(mode), ToSk(sampling), ToSkRect(cullRect),
                      safe_paint(render_with_attributes));
 }
 void DlSkCanvasDispatcher::drawDisplayList(
     const sk_sp<DisplayList> display_list,
-    SkScalar opacity) {
+    DlScalar opacity) {
   const int restore_count = canvas_->getSaveCount();
 
   // Compute combined opacity and figure out whether we can apply it
@@ -289,15 +290,15 @@ void DlSkCanvasDispatcher::drawDisplayList(
   canvas_->restoreToCount(restore_count);
 }
 void DlSkCanvasDispatcher::drawTextBlob(const sk_sp<SkTextBlob> blob,
-                                        SkScalar x,
-                                        SkScalar y) {
+                                        DlScalar x,
+                                        DlScalar y) {
   canvas_->drawTextBlob(blob, x, y, paint());
 }
 
 void DlSkCanvasDispatcher::drawTextFrame(
     const std::shared_ptr<impeller::TextFrame>& text_frame,
-    SkScalar x,
-    SkScalar y) {
+    DlScalar x,
+    DlScalar y) {
   FML_CHECK(false);
 }
 
@@ -306,7 +307,7 @@ void DlSkCanvasDispatcher::DrawShadow(SkCanvas* canvas,
                                       DlColor color,
                                       float elevation,
                                       bool transparentOccluder,
-                                      SkScalar dpr) {
+                                      DlScalar dpr) {
   const SkScalar kAmbientAlpha = 0.039f;
   const SkScalar kSpotAlpha = 0.25f;
 
@@ -329,9 +330,9 @@ void DlSkCanvasDispatcher::DrawShadow(SkCanvas* canvas,
 
 void DlSkCanvasDispatcher::drawShadow(const SkPath& path,
                                       const DlColor color,
-                                      const SkScalar elevation,
+                                      const DlScalar elevation,
                                       bool transparent_occluder,
-                                      SkScalar dpr) {
+                                      DlScalar dpr) {
   DrawShadow(canvas_, path, color, elevation, transparent_occluder, dpr);
 }
 

--- a/display_list/skia/dl_sk_dispatcher.h
+++ b/display_list/skia/dl_sk_dispatcher.h
@@ -20,7 +20,7 @@ namespace flutter {
 class DlSkCanvasDispatcher : public virtual DlOpReceiver,
                              public DlSkPaintDispatchHelper {
  public:
-  explicit DlSkCanvasDispatcher(SkCanvas* canvas, SkScalar opacity = SK_Scalar1)
+  explicit DlSkCanvasDispatcher(SkCanvas* canvas, DlScalar opacity = SK_Scalar1)
       : DlSkPaintDispatchHelper(opacity),
         canvas_(canvas),
         original_transform_(canvas->getLocalToDevice()) {}
@@ -29,96 +29,96 @@ class DlSkCanvasDispatcher : public virtual DlOpReceiver,
 
   void save() override;
   void restore() override;
-  void saveLayer(const SkRect& bounds,
+  void saveLayer(const DlRect& bounds,
                  const SaveLayerOptions options,
                  const DlImageFilter* backdrop) override;
 
-  void translate(SkScalar tx, SkScalar ty) override;
-  void scale(SkScalar sx, SkScalar sy) override;
-  void rotate(SkScalar degrees) override;
-  void skew(SkScalar sx, SkScalar sy) override;
+  void translate(DlScalar tx, DlScalar ty) override;
+  void scale(DlScalar sx, DlScalar sy) override;
+  void rotate(DlScalar degrees) override;
+  void skew(DlScalar sx, DlScalar sy) override;
   // clang-format off
   // 2x3 2D affine subset of a 4x4 transform in row major order
-  void transform2DAffine(SkScalar mxx, SkScalar mxy, SkScalar mxt,
-                         SkScalar myx, SkScalar myy, SkScalar myt) override;
+  void transform2DAffine(DlScalar mxx, DlScalar mxy, DlScalar mxt,
+                         DlScalar myx, DlScalar myy, DlScalar myt) override;
   // full 4x4 transform in row major order
   void transformFullPerspective(
-      SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
-      SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
-      SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
-      SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) override;
+      DlScalar mxx, DlScalar mxy, DlScalar mxz, DlScalar mxt,
+      DlScalar myx, DlScalar myy, DlScalar myz, DlScalar myt,
+      DlScalar mzx, DlScalar mzy, DlScalar mzz, DlScalar mzt,
+      DlScalar mwx, DlScalar mwy, DlScalar mwz, DlScalar mwt) override;
   // clang-format on
   void transformReset() override;
 
-  void clipRect(const SkRect& rect, ClipOp clip_op, bool is_aa) override;
-  void clipOval(const SkRect& bounds, ClipOp clip_op, bool is_aa) override;
+  void clipRect(const DlRect& rect, ClipOp clip_op, bool is_aa) override;
+  void clipOval(const DlRect& bounds, ClipOp clip_op, bool is_aa) override;
   void clipRRect(const SkRRect& rrect, ClipOp clip_op, bool is_aa) override;
   void clipPath(const SkPath& path, ClipOp clip_op, bool is_aa) override;
 
   void drawPaint() override;
   void drawColor(DlColor color, DlBlendMode mode) override;
-  void drawLine(const SkPoint& p0, const SkPoint& p1) override;
+  void drawLine(const DlPoint& p0, const DlPoint& p1) override;
   void drawDashedLine(const DlPoint& p0,
                       const DlPoint& p1,
                       DlScalar on_length,
                       DlScalar off_length) override;
-  void drawRect(const SkRect& rect) override;
-  void drawOval(const SkRect& bounds) override;
-  void drawCircle(const SkPoint& center, SkScalar radius) override;
+  void drawRect(const DlRect& rect) override;
+  void drawOval(const DlRect& bounds) override;
+  void drawCircle(const DlPoint& center, DlScalar radius) override;
   void drawRRect(const SkRRect& rrect) override;
   void drawDRRect(const SkRRect& outer, const SkRRect& inner) override;
   void drawPath(const SkPath& path) override;
-  void drawArc(const SkRect& bounds,
-               SkScalar start,
-               SkScalar sweep,
+  void drawArc(const DlRect& bounds,
+               DlScalar start,
+               DlScalar sweep,
                bool useCenter) override;
-  void drawPoints(PointMode mode, uint32_t count, const SkPoint pts[]) override;
+  void drawPoints(PointMode mode, uint32_t count, const DlPoint pts[]) override;
   void drawVertices(const std::shared_ptr<DlVertices>& vertices,
                     DlBlendMode mode) override;
   void drawImage(const sk_sp<DlImage> image,
-                 const SkPoint point,
+                 const DlPoint& point,
                  DlImageSampling sampling,
                  bool render_with_attributes) override;
   void drawImageRect(const sk_sp<DlImage> image,
-                     const SkRect& src,
-                     const SkRect& dst,
+                     const DlRect& src,
+                     const DlRect& dst,
                      DlImageSampling sampling,
                      bool render_with_attributes,
                      SrcRectConstraint constraint) override;
   void drawImageNine(const sk_sp<DlImage> image,
-                     const SkIRect& center,
-                     const SkRect& dst,
+                     const DlIRect& center,
+                     const DlRect& dst,
                      DlFilterMode filter,
                      bool render_with_attributes) override;
   void drawAtlas(const sk_sp<DlImage> atlas,
                  const SkRSXform xform[],
-                 const SkRect tex[],
+                 const DlRect tex[],
                  const DlColor colors[],
                  int count,
                  DlBlendMode mode,
                  DlImageSampling sampling,
-                 const SkRect* cullRect,
+                 const DlRect* cullRect,
                  bool render_with_attributes) override;
   void drawDisplayList(const sk_sp<DisplayList> display_list,
-                       SkScalar opacity) override;
+                       DlScalar opacity) override;
   void drawTextBlob(const sk_sp<SkTextBlob> blob,
-                    SkScalar x,
-                    SkScalar y) override;
+                    DlScalar x,
+                    DlScalar y) override;
   void drawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                     SkScalar x,
-                     SkScalar y) override;
+                     DlScalar x,
+                     DlScalar y) override;
   void drawShadow(const SkPath& path,
                   const DlColor color,
-                  const SkScalar elevation,
+                  const DlScalar elevation,
                   bool transparent_occluder,
-                  SkScalar dpr) override;
+                  DlScalar dpr) override;
 
   static void DrawShadow(SkCanvas* canvas,
                          const SkPath& path,
                          DlColor color,
                          float elevation,
                          bool transparentOccluder,
-                         SkScalar dpr);
+                         DlScalar dpr);
 
  private:
   SkCanvas* canvas_;

--- a/display_list/testing/dl_test_snippets.cc
+++ b/display_list/testing/dl_test_snippets.cc
@@ -282,25 +282,28 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
            {5, 96, 2,
             [](DlOpReceiver& r) {
               r.save();
-              r.clipRect({0, 0, 25, 25}, DlCanvas::ClipOp::kIntersect, true);
-              r.drawRect({5, 5, 15, 15});
-              r.drawRect({10, 10, 20, 20});
+              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25),
+                         DlCanvas::ClipOp::kIntersect, true);
+              r.drawRect(DlRect::MakeLTRB(5, 5, 15, 15));
+              r.drawRect(DlRect::MakeLTRB(10, 10, 20, 20));
               r.restore();
             }},
            {5, 120, 3,
             [](DlOpReceiver& r) {
               r.saveLayer(nullptr, SaveLayerOptions::kNoAttributes);
-              r.clipRect({0, 0, 25, 25}, DlCanvas::ClipOp::kIntersect, true);
-              r.drawRect({5, 5, 15, 15});
-              r.drawRect({10, 10, 20, 20});
+              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25),
+                         DlCanvas::ClipOp::kIntersect, true);
+              r.drawRect(DlRect::MakeLTRB(5, 5, 15, 15));
+              r.drawRect(DlRect::MakeLTRB(10, 10, 20, 20));
               r.restore();
             }},
            {5, 120, 3,
             [](DlOpReceiver& r) {
               r.saveLayer(nullptr, SaveLayerOptions::kWithAttributes);
-              r.clipRect({0, 0, 25, 25}, DlCanvas::ClipOp::kIntersect, true);
-              r.drawRect({5, 5, 15, 15});
-              r.drawRect({10, 10, 20, 20});
+              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25),
+                         DlCanvas::ClipOp::kIntersect, true);
+              r.drawRect(DlRect::MakeLTRB(5, 5, 15, 15));
+              r.drawRect(DlRect::MakeLTRB(10, 10, 20, 20));
               r.restore();
             }},
            // For saveLayer calls with bounds, we need at least one unclipped
@@ -310,34 +313,38 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
             [](DlOpReceiver& r) {
               r.saveLayer(&kTestBounds, SaveLayerOptions::kNoAttributes);
               r.drawRect(kTestBounds);
-              r.clipRect({0, 0, 25, 25}, DlCanvas::ClipOp::kIntersect, true);
-              r.drawRect({10, 10, 20, 20});
+              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25),
+                         DlCanvas::ClipOp::kIntersect, true);
+              r.drawRect(DlRect::MakeLTRB(10, 10, 20, 20));
               r.restore();
             }},
            {5, 120, 3,
             [](DlOpReceiver& r) {
               r.saveLayer(&kTestBounds, SaveLayerOptions::kWithAttributes);
               r.drawRect(kTestBounds);
-              r.clipRect({0, 0, 25, 25}, DlCanvas::ClipOp::kIntersect, true);
-              r.drawRect({10, 10, 20, 20});
+              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25),
+                         DlCanvas::ClipOp::kIntersect, true);
+              r.drawRect(DlRect::MakeLTRB(10, 10, 20, 20));
               r.restore();
             }},
            {5, 136, 3,
             [](DlOpReceiver& r) {
               r.saveLayer(nullptr, SaveLayerOptions::kNoAttributes,
                           &kTestCFImageFilter1);
-              r.clipRect({0, 0, 25, 25}, DlCanvas::ClipOp::kIntersect, true);
-              r.drawRect({5, 5, 15, 15});
-              r.drawRect({10, 10, 20, 20});
+              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25),
+                         DlCanvas::ClipOp::kIntersect, true);
+              r.drawRect(DlRect::MakeLTRB(5, 5, 15, 15));
+              r.drawRect(DlRect::MakeLTRB(10, 10, 20, 20));
               r.restore();
             }},
            {5, 136, 3,
             [](DlOpReceiver& r) {
               r.saveLayer(nullptr, SaveLayerOptions::kWithAttributes,
                           &kTestCFImageFilter1);
-              r.clipRect({0, 0, 25, 25}, DlCanvas::ClipOp::kIntersect, true);
-              r.drawRect({5, 5, 15, 15});
-              r.drawRect({10, 10, 20, 20});
+              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25),
+                         DlCanvas::ClipOp::kIntersect, true);
+              r.drawRect(DlRect::MakeLTRB(5, 5, 15, 15));
+              r.drawRect(DlRect::MakeLTRB(10, 10, 20, 20));
               r.restore();
             }},
            {5, 136, 3,
@@ -345,8 +352,9 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
               r.saveLayer(&kTestBounds, SaveLayerOptions::kNoAttributes,
                           &kTestCFImageFilter1);
               r.drawRect(kTestBounds);
-              r.clipRect({0, 0, 25, 25}, DlCanvas::ClipOp::kIntersect, true);
-              r.drawRect({10, 10, 20, 20});
+              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25),
+                         DlCanvas::ClipOp::kIntersect, true);
+              r.drawRect(DlRect::MakeLTRB(10, 10, 20, 20));
               r.restore();
             }},
            {5, 136, 3,
@@ -354,8 +362,9 @@ std::vector<DisplayListInvocationGroup> CreateAllSaveRestoreOps() {
               r.saveLayer(&kTestBounds, SaveLayerOptions::kWithAttributes,
                           &kTestCFImageFilter1);
               r.drawRect(kTestBounds);
-              r.clipRect({0, 0, 25, 25}, DlCanvas::ClipOp::kIntersect, true);
-              r.drawRect({10, 10, 20, 20});
+              r.clipRect(DlRect::MakeLTRB(0, 0, 25, 25),
+                         DlCanvas::ClipOp::kIntersect, true);
+              r.drawRect(DlRect::MakeLTRB(10, 10, 20, 20));
               r.restore();
             }},
        }},
@@ -433,8 +442,8 @@ std::vector<DisplayListInvocationGroup> CreateAllClipOps() {
             }},
            {1, 24, 0,
             [](DlOpReceiver& r) {
-              r.clipRect(kTestBounds.makeOffset(1, 1),
-                         DlCanvas::ClipOp::kIntersect, true);
+              r.clipRect(kTestBounds.Shift(1, 1), DlCanvas::ClipOp::kIntersect,
+                         true);
             }},
            {1, 24, 0,
             [](DlOpReceiver& r) {
@@ -457,8 +466,8 @@ std::vector<DisplayListInvocationGroup> CreateAllClipOps() {
             }},
            {1, 24, 0,
             [](DlOpReceiver& r) {
-              r.clipOval(kTestBounds.makeOffset(1, 1),
-                         DlCanvas::ClipOp::kIntersect, true);
+              r.clipOval(kTestBounds.Shift(1, 1), DlCanvas::ClipOp::kIntersect,
+                         true);
             }},
            {1, 24, 0,
             [](DlOpReceiver& r) {
@@ -621,38 +630,38 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
        {
            {1, 24, 1,
             [](DlOpReceiver& r) {
-              r.drawRect({0, 0, 10, 10});
+              r.drawRect(DlRect::MakeLTRB(0, 0, 10, 10));
             }},
            {1, 24, 1,
             [](DlOpReceiver& r) {
-              r.drawRect({0, 1, 10, 10});
+              r.drawRect(DlRect::MakeLTRB(0, 1, 10, 10));
             }},
            {1, 24, 1,
             [](DlOpReceiver& r) {
-              r.drawRect({0, 0, 20, 10});
+              r.drawRect(DlRect::MakeLTRB(0, 0, 20, 10));
             }},
            {1, 24, 1,
             [](DlOpReceiver& r) {
-              r.drawRect({0, 0, 10, 20});
+              r.drawRect(DlRect::MakeLTRB(0, 0, 10, 20));
             }},
        }},
       {"DrawOval",
        {
            {1, 24, 1,
             [](DlOpReceiver& r) {
-              r.drawOval({0, 0, 10, 10});
+              r.drawOval(DlRect::MakeLTRB(0, 0, 10, 10));
             }},
            {1, 24, 1,
             [](DlOpReceiver& r) {
-              r.drawOval({0, 1, 10, 10});
+              r.drawOval(DlRect::MakeLTRB(0, 1, 10, 10));
             }},
            {1, 24, 1,
             [](DlOpReceiver& r) {
-              r.drawOval({0, 0, 20, 10});
+              r.drawOval(DlRect::MakeLTRB(0, 0, 20, 10));
             }},
            {1, 24, 1,
             [](DlOpReceiver& r) {
-              r.drawOval({0, 0, 10, 20});
+              r.drawOval(DlRect::MakeLTRB(0, 0, 10, 20));
             }},
        }},
       {"DrawCircle",
@@ -702,7 +711,7 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
             [](DlOpReceiver& r) { r.drawArc(kTestBounds, 45, 270, false); }},
            {1, 32, 1,
             [](DlOpReceiver& r) {
-              r.drawArc(kTestBounds.makeOffset(1, 1), 45, 270, false);
+              r.drawArc(kTestBounds.Shift(1, 1), 45, 270, false);
             }},
            {1, 32, 1,
             [](DlOpReceiver& r) { r.drawArc(kTestBounds, 30, 270, false); }},
@@ -716,22 +725,22 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
            {1, 8 + TestPointCount * 8, 1,
             [](DlOpReceiver& r) {
               r.drawPoints(DlCanvas::PointMode::kPoints, TestPointCount,
-                           kTestPoints);
+                           ToDlPoints(kTestPoints));
             }},
            {1, 8 + (TestPointCount - 1) * 8, 1,
             [](DlOpReceiver& r) {
               r.drawPoints(DlCanvas::PointMode::kPoints, TestPointCount - 1,
-                           kTestPoints);
+                           ToDlPoints(kTestPoints));
             }},
            {1, 8 + TestPointCount * 8, 1,
             [](DlOpReceiver& r) {
               r.drawPoints(DlCanvas::PointMode::kLines, TestPointCount,
-                           kTestPoints);
+                           ToDlPoints(kTestPoints));
             }},
            {1, 8 + TestPointCount * 8, 1,
             [](DlOpReceiver& r) {
               r.drawPoints(DlCanvas::PointMode::kPolygon, TestPointCount,
-                           kTestPoints);
+                           ToDlPoints(kTestPoints));
             }},
        }},
       {"DrawVertices",
@@ -785,50 +794,57 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
        {
            {1, 56, 1,
             [](DlOpReceiver& r) {
-              r.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
+              r.drawImageRect(TestImage1, DlRect::MakeLTRB(10, 10, 20, 20),
+                              DlRect::MakeLTRB(10, 10, 80, 80),
                               kNearestSampling, false,
                               DlCanvas::SrcRectConstraint::kFast);
             }},
            {1, 56, 1,
             [](DlOpReceiver& r) {
-              r.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
+              r.drawImageRect(TestImage1, DlRect::MakeLTRB(10, 10, 20, 20),
+                              DlRect::MakeLTRB(10, 10, 80, 80),
                               kNearestSampling, true,
                               DlCanvas::SrcRectConstraint::kFast);
             }},
            {1, 56, 1,
             [](DlOpReceiver& r) {
-              r.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
+              r.drawImageRect(TestImage1, DlRect::MakeLTRB(10, 10, 20, 20),
+                              DlRect::MakeLTRB(10, 10, 80, 80),
                               kNearestSampling, false,
                               DlCanvas::SrcRectConstraint::kStrict);
             }},
            {1, 56, 1,
             [](DlOpReceiver& r) {
-              r.drawImageRect(TestImage1, {10, 10, 25, 20}, {10, 10, 80, 80},
+              r.drawImageRect(TestImage1, DlRect::MakeLTRB(10, 10, 25, 20),
+                              DlRect::MakeLTRB(10, 10, 80, 80),
                               kNearestSampling, false,
                               DlCanvas::SrcRectConstraint::kFast);
             }},
            {1, 56, 1,
             [](DlOpReceiver& r) {
-              r.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 85, 80},
+              r.drawImageRect(TestImage1, DlRect::MakeLTRB(10, 10, 20, 20),
+                              DlRect::MakeLTRB(10, 10, 85, 80),
                               kNearestSampling, false,
                               DlCanvas::SrcRectConstraint::kFast);
             }},
            {1, 56, 1,
             [](DlOpReceiver& r) {
-              r.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
-                              kLinearSampling, false,
-                              DlCanvas::SrcRectConstraint::kFast);
+              r.drawImageRect(TestImage1, DlRect::MakeLTRB(10, 10, 20, 20),
+                              DlRect::MakeLTRB(10, 10, 80, 80), kLinearSampling,
+                              false, DlCanvas::SrcRectConstraint::kFast);
             }},
            {1, 56, 1,
             [](DlOpReceiver& r) {
-              r.drawImageRect(TestImage2, {10, 10, 15, 15}, {10, 10, 80, 80},
+              r.drawImageRect(TestImage2, DlRect::MakeLTRB(10, 10, 15, 15),
+                              DlRect::MakeLTRB(10, 10, 80, 80),
                               kNearestSampling, false,
                               DlCanvas::SrcRectConstraint::kFast);
             }},
            {1, 56, 1,
             [](DlOpReceiver& r) {
               auto dl_image = DlImage::Make(TestSkImage);
-              r.drawImageRect(dl_image, {10, 10, 15, 15}, {10, 10, 80, 80},
+              r.drawImageRect(dl_image, DlRect::MakeLTRB(10, 10, 15, 15),
+                              DlRect::MakeLTRB(10, 10, 80, 80),
                               kNearestSampling, false,
                               DlCanvas::SrcRectConstraint::kFast);
             }},
@@ -837,38 +853,45 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
        {
            {1, 48, 9,
             [](DlOpReceiver& r) {
-              r.drawImageNine(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
+              r.drawImageNine(TestImage1, DlIRect::MakeLTRB(10, 10, 20, 20),
+                              DlRect::MakeLTRB(10, 10, 80, 80),
                               DlFilterMode::kNearest, false);
             }},
            {1, 48, 9,
             [](DlOpReceiver& r) {
-              r.drawImageNine(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
+              r.drawImageNine(TestImage1, DlIRect::MakeLTRB(10, 10, 20, 20),
+                              DlRect::MakeLTRB(10, 10, 80, 80),
                               DlFilterMode::kNearest, true);
             }},
            {1, 48, 9,
             [](DlOpReceiver& r) {
-              r.drawImageNine(TestImage1, {10, 10, 25, 20}, {10, 10, 80, 80},
+              r.drawImageNine(TestImage1, DlIRect::MakeLTRB(10, 10, 25, 20),
+                              DlRect::MakeLTRB(10, 10, 80, 80),
                               DlFilterMode::kNearest, false);
             }},
            {1, 48, 9,
             [](DlOpReceiver& r) {
-              r.drawImageNine(TestImage1, {10, 10, 20, 20}, {10, 10, 85, 80},
+              r.drawImageNine(TestImage1, DlIRect::MakeLTRB(10, 10, 20, 20),
+                              DlRect::MakeLTRB(10, 10, 85, 80),
                               DlFilterMode::kNearest, false);
             }},
            {1, 48, 9,
             [](DlOpReceiver& r) {
-              r.drawImageNine(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
+              r.drawImageNine(TestImage1, DlIRect::MakeLTRB(10, 10, 20, 20),
+                              DlRect::MakeLTRB(10, 10, 80, 80),
                               DlFilterMode::kLinear, false);
             }},
            {1, 48, 9,
             [](DlOpReceiver& r) {
-              r.drawImageNine(TestImage2, {10, 10, 15, 15}, {10, 10, 80, 80},
+              r.drawImageNine(TestImage2, DlIRect::MakeLTRB(10, 10, 15, 15),
+                              DlRect::MakeLTRB(10, 10, 80, 80),
                               DlFilterMode::kNearest, false);
             }},
            {1, 48, 9,
             [](DlOpReceiver& r) {
               auto dl_image = DlImage::Make(TestSkImage);
-              r.drawImageNine(dl_image, {10, 10, 15, 15}, {10, 10, 80, 80},
+              r.drawImageNine(dl_image, DlIRect::MakeLTRB(10, 10, 15, 15),
+                              DlRect::MakeLTRB(10, 10, 80, 80),
                               DlFilterMode::kNearest, false);
             }},
        }},
@@ -877,7 +900,8 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
            {1, 48 + 32 + 8, 1,
             [](DlOpReceiver& r) {
               static SkRSXform xforms[] = {{1, 0, 0, 0}, {0, 1, 0, 0}};
-              static SkRect texs[] = {{10, 10, 20, 20}, {20, 20, 30, 30}};
+              static DlRect texs[] = {DlRect::MakeLTRB(10, 10, 20, 20),
+                                      DlRect::MakeLTRB(20, 20, 30, 30)};
               r.drawAtlas(TestImage1, xforms, texs, nullptr, 2,
                           DlBlendMode::kSrcIn, kNearestSampling, nullptr,
                           false);
@@ -885,14 +909,16 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
            {1, 48 + 32 + 8, 1,
             [](DlOpReceiver& r) {
               static SkRSXform xforms[] = {{1, 0, 0, 0}, {0, 1, 0, 0}};
-              static SkRect texs[] = {{10, 10, 20, 20}, {20, 20, 30, 30}};
+              static DlRect texs[] = {DlRect::MakeLTRB(10, 10, 20, 20),
+                                      DlRect::MakeLTRB(20, 20, 30, 30)};
               r.drawAtlas(TestImage1, xforms, texs, nullptr, 2,
                           DlBlendMode::kSrcIn, kNearestSampling, nullptr, true);
             }},
            {1, 48 + 32 + 8, 1,
             [](DlOpReceiver& r) {
               static SkRSXform xforms[] = {{0, 1, 0, 0}, {0, 1, 0, 0}};
-              static SkRect texs[] = {{10, 10, 20, 20}, {20, 20, 30, 30}};
+              static DlRect texs[] = {DlRect::MakeLTRB(10, 10, 20, 20),
+                                      DlRect::MakeLTRB(20, 20, 30, 30)};
               r.drawAtlas(TestImage1, xforms, texs, nullptr, 2,
                           DlBlendMode::kSrcIn, kNearestSampling, nullptr,
                           false);
@@ -900,7 +926,8 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
            {1, 48 + 32 + 8, 1,
             [](DlOpReceiver& r) {
               static SkRSXform xforms[] = {{1, 0, 0, 0}, {0, 1, 0, 0}};
-              static SkRect texs[] = {{10, 10, 20, 20}, {20, 25, 30, 30}};
+              static DlRect texs[] = {DlRect::MakeLTRB(10, 10, 20, 20),
+                                      DlRect::MakeLTRB(20, 25, 30, 30)};
               r.drawAtlas(TestImage1, xforms, texs, nullptr, 2,
                           DlBlendMode::kSrcIn, kNearestSampling, nullptr,
                           false);
@@ -908,14 +935,16 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
            {1, 48 + 32 + 8, 1,
             [](DlOpReceiver& r) {
               static SkRSXform xforms[] = {{1, 0, 0, 0}, {0, 1, 0, 0}};
-              static SkRect texs[] = {{10, 10, 20, 20}, {20, 20, 30, 30}};
+              static DlRect texs[] = {DlRect::MakeLTRB(10, 10, 20, 20),
+                                      DlRect::MakeLTRB(20, 20, 30, 30)};
               r.drawAtlas(TestImage1, xforms, texs, nullptr, 2,
                           DlBlendMode::kSrcIn, kLinearSampling, nullptr, false);
             }},
            {1, 48 + 32 + 8, 1,
             [](DlOpReceiver& r) {
               static SkRSXform xforms[] = {{1, 0, 0, 0}, {0, 1, 0, 0}};
-              static SkRect texs[] = {{10, 10, 20, 20}, {20, 20, 30, 30}};
+              static DlRect texs[] = {DlRect::MakeLTRB(10, 10, 20, 20),
+                                      DlRect::MakeLTRB(20, 20, 30, 30)};
               r.drawAtlas(TestImage1, xforms, texs, nullptr, 2,
                           DlBlendMode::kDstIn, kNearestSampling, nullptr,
                           false);
@@ -923,8 +952,9 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
            {1, 64 + 32 + 8, 1,
             [](DlOpReceiver& r) {
               static SkRSXform xforms[] = {{1, 0, 0, 0}, {0, 1, 0, 0}};
-              static SkRect texs[] = {{10, 10, 20, 20}, {20, 20, 30, 30}};
-              static SkRect cull_rect = {0, 0, 200, 200};
+              static DlRect texs[] = {DlRect::MakeLTRB(10, 10, 20, 20),
+                                      DlRect::MakeLTRB(20, 20, 30, 30)};
+              static DlRect cull_rect = DlRect::MakeLTRB(0, 0, 200, 200);
               r.drawAtlas(TestImage2, xforms, texs, nullptr, 2,
                           DlBlendMode::kSrcIn, kNearestSampling, &cull_rect,
                           false);
@@ -932,7 +962,8 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
            {1, 128, 1,
             [](DlOpReceiver& r) {
               static SkRSXform xforms[] = {{1, 0, 0, 0}, {0, 1, 0, 0}};
-              static SkRect texs[] = {{10, 10, 20, 20}, {20, 20, 30, 30}};
+              static DlRect texs[] = {DlRect::MakeLTRB(10, 10, 20, 20),
+                                      DlRect::MakeLTRB(20, 20, 30, 30)};
               static DlColor colors[] = {DlColor::kBlue(), DlColor::kGreen()};
               r.drawAtlas(TestImage1, xforms, texs, colors, 2,
                           DlBlendMode::kSrcIn, kNearestSampling, nullptr,
@@ -941,9 +972,10 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
            {1, 144, 1,
             [](DlOpReceiver& r) {
               static SkRSXform xforms[] = {{1, 0, 0, 0}, {0, 1, 0, 0}};
-              static SkRect texs[] = {{10, 10, 20, 20}, {20, 20, 30, 30}};
+              static DlRect texs[] = {DlRect::MakeLTRB(10, 10, 20, 20),
+                                      DlRect::MakeLTRB(20, 20, 30, 30)};
               static DlColor colors[] = {DlColor::kBlue(), DlColor::kGreen()};
-              static SkRect cull_rect = {0, 0, 200, 200};
+              static DlRect cull_rect = DlRect::MakeLTRB(0, 0, 200, 200);
               r.drawAtlas(TestImage1, xforms, texs, colors, 2,
                           DlBlendMode::kSrcIn, kNearestSampling, &cull_rect,
                           false);
@@ -952,7 +984,8 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
             [](DlOpReceiver& r) {
               auto dl_image = DlImage::Make(TestSkImage);
               static SkRSXform xforms[] = {{1, 0, 0, 0}, {0, 1, 0, 0}};
-              static SkRect texs[] = {{10, 10, 20, 20}, {20, 20, 30, 30}};
+              static DlRect texs[] = {DlRect::MakeLTRB(10, 10, 20, 20),
+                                      DlRect::MakeLTRB(20, 20, 30, 30)};
               r.drawAtlas(dl_image, xforms, texs, nullptr, 2,
                           DlBlendMode::kSrcIn, kNearestSampling, nullptr,
                           false);

--- a/display_list/testing/dl_test_snippets.h
+++ b/display_list/testing/dl_test_snippets.h
@@ -176,13 +176,14 @@ static const DlBlurMaskFilter kTestMaskFilter2(DlBlurStyle::kNormal, 5.0);
 static const DlBlurMaskFilter kTestMaskFilter3(DlBlurStyle::kSolid, 3.0);
 static const DlBlurMaskFilter kTestMaskFilter4(DlBlurStyle::kInner, 3.0);
 static const DlBlurMaskFilter kTestMaskFilter5(DlBlurStyle::kOuter, 3.0);
-constexpr SkRect kTestBounds = SkRect::MakeLTRB(10, 10, 50, 60);
-static const SkRRect kTestRRect = SkRRect::MakeRectXY(kTestBounds, 5, 5);
-static const SkRRect kTestRRectRect = SkRRect::MakeRect(kTestBounds);
+constexpr DlRect kTestBounds = DlRect::MakeLTRB(10, 10, 50, 60);
+constexpr SkRect kTestSkBounds = SkRect::MakeLTRB(10, 10, 50, 60);
+static const SkRRect kTestRRect = SkRRect::MakeRectXY(kTestSkBounds, 5, 5);
+static const SkRRect kTestRRectRect = SkRRect::MakeRect(kTestSkBounds);
 static const SkRRect kTestInnerRRect =
-    SkRRect::MakeRectXY(kTestBounds.makeInset(5, 5), 2, 2);
-static const SkPath kTestPathRect = SkPath::Rect(kTestBounds);
-static const SkPath kTestPathOval = SkPath::Oval(kTestBounds);
+    SkRRect::MakeRectXY(kTestSkBounds.makeInset(5, 5), 2, 2);
+static const SkPath kTestPathRect = SkPath::Rect(kTestSkBounds);
+static const SkPath kTestPathOval = SkPath::Oval(kTestSkBounds);
 static const SkPath kTestPathRRect = SkPath::RRect(kTestRRect);
 static const SkPath kTestPath1 =
     SkPath::Polygon({{0, 0}, {10, 10}, {10, 0}, {0, 10}}, true);

--- a/display_list/utils/dl_accumulation_rect.cc
+++ b/display_list/utils/dl_accumulation_rect.cc
@@ -72,6 +72,12 @@ void AccumulationRect::accumulate(AccumulationRect& ar) {
   }
 }
 
+DlRect AccumulationRect::GetBounds() const {
+  return (max_x_ >= min_x_ && max_y_ >= min_y_)
+             ? DlRect::MakeLTRB(min_x_, min_y_, max_x_, max_y_)
+             : DlRect();
+}
+
 SkRect AccumulationRect::bounds() const {
   return (max_x_ >= min_x_ && max_y_ >= min_y_)
              ? SkRect::MakeLTRB(min_x_, min_y_, max_x_, max_y_)

--- a/display_list/utils/dl_accumulation_rect.h
+++ b/display_list/utils/dl_accumulation_rect.h
@@ -36,6 +36,7 @@ class AccumulationRect {
   bool is_empty() const { return min_x_ >= max_x_ || min_y_ >= max_y_; }
   bool is_not_empty() const { return min_x_ < max_x_ && min_y_ < max_y_; }
 
+  DlRect GetBounds() const;
   SkRect bounds() const;
 
   void reset();

--- a/display_list/utils/dl_receiver_utils.h
+++ b/display_list/utils/dl_receiver_utils.h
@@ -41,10 +41,10 @@ class IgnoreAttributeDispatchHelper : public virtual DlOpReceiver {
 // A utility class that will ignore all DlOpReceiver methods relating
 // to setting a clip.
 class IgnoreClipDispatchHelper : public virtual DlOpReceiver {
-  void clipRect(const SkRect& rect,
+  void clipRect(const DlRect& rect,
                 DlCanvas::ClipOp clip_op,
                 bool is_aa) override {}
-  void clipOval(const SkRect& bounds,
+  void clipOval(const DlRect& bounds,
                 DlCanvas::ClipOp clip_op,
                 bool is_aa) override {}
   void clipRRect(const SkRRect& rrect,
@@ -59,20 +59,20 @@ class IgnoreClipDispatchHelper : public virtual DlOpReceiver {
 // to modifying the transform.
 class IgnoreTransformDispatchHelper : public virtual DlOpReceiver {
  public:
-  void translate(SkScalar tx, SkScalar ty) override {}
-  void scale(SkScalar sx, SkScalar sy) override {}
-  void rotate(SkScalar degrees) override {}
-  void skew(SkScalar sx, SkScalar sy) override {}
+  void translate(DlScalar tx, DlScalar ty) override {}
+  void scale(DlScalar sx, DlScalar sy) override {}
+  void rotate(DlScalar degrees) override {}
+  void skew(DlScalar sx, DlScalar sy) override {}
   // clang-format off
   // 2x3 2D affine subset of a 4x4 transform in row major order
-  void transform2DAffine(SkScalar mxx, SkScalar mxy, SkScalar mxt,
-                         SkScalar myx, SkScalar myy, SkScalar myt) override {}
+  void transform2DAffine(DlScalar mxx, DlScalar mxy, DlScalar mxt,
+                         DlScalar myx, DlScalar myy, DlScalar myt) override {}
   // full 4x4 transform in row major order
   void transformFullPerspective(
-      SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
-      SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
-      SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
-      SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) override {}
+      DlScalar mxx, DlScalar mxy, DlScalar mxz, DlScalar mxt,
+      DlScalar myx, DlScalar myy, DlScalar myz, DlScalar myt,
+      DlScalar mzx, DlScalar mzy, DlScalar mzz, DlScalar mzt,
+      DlScalar mwx, DlScalar mwy, DlScalar mwz, DlScalar mwt) override {}
   // clang-format on
   void transformReset() override {}
 };
@@ -80,69 +80,69 @@ class IgnoreTransformDispatchHelper : public virtual DlOpReceiver {
 class IgnoreDrawDispatchHelper : public virtual DlOpReceiver {
  public:
   void save() override {}
-  void saveLayer(const SkRect& bounds,
+  void saveLayer(const DlRect& bounds,
                  const SaveLayerOptions options,
                  const DlImageFilter* backdrop) override {}
   void restore() override {}
   void drawColor(DlColor color, DlBlendMode mode) override {}
   void drawPaint() override {}
-  void drawLine(const SkPoint& p0, const SkPoint& p1) override {}
+  void drawLine(const DlPoint& p0, const DlPoint& p1) override {}
   void drawDashedLine(const DlPoint& p0,
                       const DlPoint& p1,
                       DlScalar on_length,
                       DlScalar off_length) override {}
-  void drawRect(const SkRect& rect) override {}
-  void drawOval(const SkRect& bounds) override {}
-  void drawCircle(const SkPoint& center, SkScalar radius) override {}
+  void drawRect(const DlRect& rect) override {}
+  void drawOval(const DlRect& bounds) override {}
+  void drawCircle(const DlPoint& center, DlScalar radius) override {}
   void drawRRect(const SkRRect& rrect) override {}
   void drawDRRect(const SkRRect& outer, const SkRRect& inner) override {}
   void drawPath(const SkPath& path) override {}
-  void drawArc(const SkRect& oval_bounds,
-               SkScalar start_degrees,
-               SkScalar sweep_degrees,
+  void drawArc(const DlRect& oval_bounds,
+               DlScalar start_degrees,
+               DlScalar sweep_degrees,
                bool use_center) override {}
   void drawPoints(DlCanvas::PointMode mode,
                   uint32_t count,
-                  const SkPoint points[]) override {}
+                  const DlPoint points[]) override {}
   void drawVertices(const std::shared_ptr<DlVertices>& vertices,
                     DlBlendMode mode) override {}
   void drawImage(const sk_sp<DlImage> image,
-                 const SkPoint point,
+                 const DlPoint& point,
                  DlImageSampling sampling,
                  bool render_with_attributes) override {}
   void drawImageRect(const sk_sp<DlImage> image,
-                     const SkRect& src,
-                     const SkRect& dst,
+                     const DlRect& src,
+                     const DlRect& dst,
                      DlImageSampling sampling,
                      bool render_with_attributes,
                      SrcRectConstraint constraint) override {}
   void drawImageNine(const sk_sp<DlImage> image,
-                     const SkIRect& center,
-                     const SkRect& dst,
+                     const DlIRect& center,
+                     const DlRect& dst,
                      DlFilterMode filter,
                      bool render_with_attributes) override {}
   void drawAtlas(const sk_sp<DlImage> atlas,
                  const SkRSXform xform[],
-                 const SkRect tex[],
+                 const DlRect tex[],
                  const DlColor colors[],
                  int count,
                  DlBlendMode mode,
                  DlImageSampling sampling,
-                 const SkRect* cull_rect,
+                 const DlRect* cull_rect,
                  bool render_with_attributes) override {}
   void drawDisplayList(const sk_sp<DisplayList> display_list,
-                       SkScalar opacity) override {}
+                       DlScalar opacity) override {}
   void drawTextBlob(const sk_sp<SkTextBlob> blob,
-                    SkScalar x,
-                    SkScalar y) override {}
+                    DlScalar x,
+                    DlScalar y) override {}
   void drawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                     SkScalar x,
-                     SkScalar y) override {}
+                     DlScalar x,
+                     DlScalar y) override {}
   void drawShadow(const SkPath& path,
                   const DlColor color,
-                  const SkScalar elevation,
+                  const DlScalar elevation,
                   bool transparent_occluder,
-                  SkScalar dpr) override {}
+                  DlScalar dpr) override {}
 };
 
 }  // namespace flutter

--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -281,14 +281,14 @@ void DlDispatcherBase::setColor(flutter::DlColor color) {
 }
 
 // |flutter::DlOpReceiver|
-void DlDispatcherBase::setStrokeWidth(SkScalar width) {
+void DlDispatcherBase::setStrokeWidth(DlScalar width) {
   AUTO_DEPTH_WATCHER(0u);
 
   paint_.stroke_width = width;
 }
 
 // |flutter::DlOpReceiver|
-void DlDispatcherBase::setStrokeMiter(SkScalar limit) {
+void DlDispatcherBase::setStrokeMiter(DlScalar limit) {
   AUTO_DEPTH_WATCHER(0u);
 
   paint_.stroke_miter = limit;
@@ -412,10 +412,10 @@ void DlDispatcherBase::setColorSource(const flutter::DlColorSource* source) {
           source->asConicalGradient();
       FML_DCHECK(conical_gradient);
       Point center = skia_conversions::ToPoint(conical_gradient->end_center());
-      SkScalar radius = conical_gradient->end_radius();
+      DlScalar radius = conical_gradient->end_radius();
       Point focus_center =
           skia_conversions::ToPoint(conical_gradient->start_center());
-      SkScalar focus_radius = conical_gradient->start_radius();
+      DlScalar focus_radius = conical_gradient->start_radius();
       std::vector<Color> colors;
       std::vector<float> stops;
       skia_conversions::ConvertStops(conical_gradient, colors, stops);
@@ -713,7 +713,7 @@ void DlDispatcherBase::save(uint32_t total_content_depth) {
 }
 
 // |flutter::DlOpReceiver|
-void DlDispatcherBase::saveLayer(const SkRect& bounds,
+void DlDispatcherBase::saveLayer(const DlRect& bounds,
                                  const flutter::SaveLayerOptions& options,
                                  uint32_t total_content_depth,
                                  flutter::DlBlendMode max_content_mode,
@@ -728,7 +728,7 @@ void DlDispatcherBase::saveLayer(const SkRect& bounds,
   // If the content is unbounded but has developer specified bounds, we take
   // the original bounds so that we clip the content as expected.
   if (!options.content_is_unbounded() || options.bounds_from_caller()) {
-    impeller_bounds = skia_conversions::ToRect(bounds);
+    impeller_bounds = bounds;
   }
 
   GetCanvas().SaveLayer(
@@ -745,40 +745,40 @@ void DlDispatcherBase::restore() {
 }
 
 // |flutter::DlOpReceiver|
-void DlDispatcherBase::translate(SkScalar tx, SkScalar ty) {
+void DlDispatcherBase::translate(DlScalar tx, DlScalar ty) {
   AUTO_DEPTH_WATCHER(0u);
 
   GetCanvas().Translate({tx, ty, 0.0});
 }
 
 // |flutter::DlOpReceiver|
-void DlDispatcherBase::scale(SkScalar sx, SkScalar sy) {
+void DlDispatcherBase::scale(DlScalar sx, DlScalar sy) {
   AUTO_DEPTH_WATCHER(0u);
 
   GetCanvas().Scale({sx, sy, 1.0});
 }
 
 // |flutter::DlOpReceiver|
-void DlDispatcherBase::rotate(SkScalar degrees) {
+void DlDispatcherBase::rotate(DlScalar degrees) {
   AUTO_DEPTH_WATCHER(0u);
 
   GetCanvas().Rotate(Degrees{degrees});
 }
 
 // |flutter::DlOpReceiver|
-void DlDispatcherBase::skew(SkScalar sx, SkScalar sy) {
+void DlDispatcherBase::skew(DlScalar sx, DlScalar sy) {
   AUTO_DEPTH_WATCHER(0u);
 
   GetCanvas().Skew(sx, sy);
 }
 
 // |flutter::DlOpReceiver|
-void DlDispatcherBase::transform2DAffine(SkScalar mxx,
-                                         SkScalar mxy,
-                                         SkScalar mxt,
-                                         SkScalar myx,
-                                         SkScalar myy,
-                                         SkScalar myt) {
+void DlDispatcherBase::transform2DAffine(DlScalar mxx,
+                                         DlScalar mxy,
+                                         DlScalar mxt,
+                                         DlScalar myx,
+                                         DlScalar myy,
+                                         DlScalar myt) {
   AUTO_DEPTH_WATCHER(0u);
 
   // clang-format off
@@ -792,22 +792,22 @@ void DlDispatcherBase::transform2DAffine(SkScalar mxx,
 }
 
 // |flutter::DlOpReceiver|
-void DlDispatcherBase::transformFullPerspective(SkScalar mxx,
-                                                SkScalar mxy,
-                                                SkScalar mxz,
-                                                SkScalar mxt,
-                                                SkScalar myx,
-                                                SkScalar myy,
-                                                SkScalar myz,
-                                                SkScalar myt,
-                                                SkScalar mzx,
-                                                SkScalar mzy,
-                                                SkScalar mzz,
-                                                SkScalar mzt,
-                                                SkScalar mwx,
-                                                SkScalar mwy,
-                                                SkScalar mwz,
-                                                SkScalar mwt) {
+void DlDispatcherBase::transformFullPerspective(DlScalar mxx,
+                                                DlScalar mxy,
+                                                DlScalar mxz,
+                                                DlScalar mxt,
+                                                DlScalar myx,
+                                                DlScalar myy,
+                                                DlScalar myz,
+                                                DlScalar myt,
+                                                DlScalar mzx,
+                                                DlScalar mzy,
+                                                DlScalar mzz,
+                                                DlScalar mzt,
+                                                DlScalar mwx,
+                                                DlScalar mwy,
+                                                DlScalar mwz,
+                                                DlScalar mwt) {
   AUTO_DEPTH_WATCHER(0u);
 
   // The order of arguments is row-major but Impeller matrices are
@@ -842,23 +842,21 @@ static Entity::ClipOperation ToClipOperation(
 }
 
 // |flutter::DlOpReceiver|
-void DlDispatcherBase::clipRect(const SkRect& rect,
+void DlDispatcherBase::clipRect(const DlRect& rect,
                                 ClipOp clip_op,
                                 bool is_aa) {
   AUTO_DEPTH_WATCHER(0u);
 
-  GetCanvas().ClipRect(skia_conversions::ToRect(rect),
-                       ToClipOperation(clip_op));
+  GetCanvas().ClipRect(rect, ToClipOperation(clip_op));
 }
 
 // |flutter::DlOpReceiver|
-void DlDispatcherBase::clipOval(const SkRect& bounds,
+void DlDispatcherBase::clipOval(const DlRect& bounds,
                                 ClipOp clip_op,
                                 bool is_aa) {
   AUTO_DEPTH_WATCHER(0u);
 
-  GetCanvas().ClipOval(skia_conversions::ToRect(bounds),
-                       ToClipOperation(clip_op));
+  GetCanvas().ClipOval(bounds, ToClipOperation(clip_op));
 }
 
 // |flutter::DlOpReceiver|
@@ -937,11 +935,10 @@ void DlDispatcherBase::drawPaint() {
 }
 
 // |flutter::DlOpReceiver|
-void DlDispatcherBase::drawLine(const SkPoint& p0, const SkPoint& p1) {
+void DlDispatcherBase::drawLine(const DlPoint& p0, const DlPoint& p1) {
   AUTO_DEPTH_WATCHER(1u);
 
-  GetCanvas().DrawLine(skia_conversions::ToPoint(p0),
-                       skia_conversions::ToPoint(p1), paint_);
+  GetCanvas().DrawLine(p0, p1, paint_);
 }
 
 void DlDispatcherBase::drawDashedLine(const DlPoint& p0,
@@ -981,29 +978,29 @@ void DlDispatcherBase::drawDashedLine(const DlPoint& p0,
     stroke_paint.style = Paint::Style::kStroke;
     GetCanvas().DrawPath(builder.TakePath(), stroke_paint);
   } else {
-    drawLine(flutter::ToSkPoint(p0), flutter::ToSkPoint(p1));
+    drawLine(p0, p1);
   }
 }
 
 // |flutter::DlOpReceiver|
-void DlDispatcherBase::drawRect(const SkRect& rect) {
+void DlDispatcherBase::drawRect(const DlRect& rect) {
   AUTO_DEPTH_WATCHER(1u);
 
-  GetCanvas().DrawRect(skia_conversions::ToRect(rect), paint_);
+  GetCanvas().DrawRect(rect, paint_);
 }
 
 // |flutter::DlOpReceiver|
-void DlDispatcherBase::drawOval(const SkRect& bounds) {
+void DlDispatcherBase::drawOval(const DlRect& bounds) {
   AUTO_DEPTH_WATCHER(1u);
 
-  GetCanvas().DrawOval(skia_conversions::ToRect(bounds), paint_);
+  GetCanvas().DrawOval(bounds, paint_);
 }
 
 // |flutter::DlOpReceiver|
-void DlDispatcherBase::drawCircle(const SkPoint& center, SkScalar radius) {
+void DlDispatcherBase::drawCircle(const DlPoint& center, DlScalar radius) {
   AUTO_DEPTH_WATCHER(1u);
 
-  GetCanvas().DrawCircle(skia_conversions::ToPoint(center), radius, paint_);
+  GetCanvas().DrawCircle(center, radius, paint_);
 }
 
 // |flutter::DlOpReceiver|
@@ -1070,22 +1067,22 @@ void DlDispatcherBase::SimplifyOrDrawPath(Canvas& canvas,
 }
 
 // |flutter::DlOpReceiver|
-void DlDispatcherBase::drawArc(const SkRect& oval_bounds,
-                               SkScalar start_degrees,
-                               SkScalar sweep_degrees,
+void DlDispatcherBase::drawArc(const DlRect& oval_bounds,
+                               DlScalar start_degrees,
+                               DlScalar sweep_degrees,
                                bool use_center) {
   AUTO_DEPTH_WATCHER(1u);
 
   PathBuilder builder;
-  builder.AddArc(skia_conversions::ToRect(oval_bounds), Degrees(start_degrees),
-                 Degrees(sweep_degrees), use_center);
+  builder.AddArc(oval_bounds, Degrees(start_degrees), Degrees(sweep_degrees),
+                 use_center);
   GetCanvas().DrawPath(builder.TakePath(), paint_);
 }
 
 // |flutter::DlOpReceiver|
 void DlDispatcherBase::drawPoints(PointMode mode,
                                   uint32_t count,
-                                  const SkPoint points[]) {
+                                  const DlPoint points[]) {
   AUTO_DEPTH_WATCHER(1u);
 
   Paint paint = paint_;
@@ -1104,16 +1101,16 @@ void DlDispatcherBase::drawPoints(PointMode mode,
     } break;
     case flutter::DlCanvas::PointMode::kLines:
       for (uint32_t i = 1; i < count; i += 2) {
-        Point p0 = skia_conversions::ToPoint(points[i - 1]);
-        Point p1 = skia_conversions::ToPoint(points[i]);
+        Point p0 = points[i - 1];
+        Point p1 = points[i];
         GetCanvas().DrawLine(p0, p1, paint);
       }
       break;
     case flutter::DlCanvas::PointMode::kPolygon:
       if (count > 1) {
-        Point p0 = skia_conversions::ToPoint(points[0]);
+        Point p0 = points[0];
         for (uint32_t i = 1; i < count; i++) {
-          Point p1 = skia_conversions::ToPoint(points[i]);
+          Point p1 = points[i];
           GetCanvas().DrawLine(p0, p1, paint);
           p0 = p1;
         }
@@ -1134,7 +1131,7 @@ void DlDispatcherBase::drawVertices(
 
 // |flutter::DlOpReceiver|
 void DlDispatcherBase::drawImage(const sk_sp<flutter::DlImage> image,
-                                 const SkPoint point,
+                                 const DlPoint& point,
                                  flutter::DlImageSampling sampling,
                                  bool render_with_attributes) {
   AUTO_DEPTH_WATCHER(1u);
@@ -1149,9 +1146,8 @@ void DlDispatcherBase::drawImage(const sk_sp<flutter::DlImage> image,
   }
 
   const auto size = texture->GetSize();
-  const auto src = SkRect::MakeWH(size.width, size.height);
-  const auto dest =
-      SkRect::MakeXYWH(point.fX, point.fY, size.width, size.height);
+  const auto src = DlRect::MakeWH(size.width, size.height);
+  const auto dest = DlRect::MakeXYWH(point.x, point.y, size.width, size.height);
 
   drawImageRect(image,                      // image
                 src,                        // source rect
@@ -1165,16 +1161,16 @@ void DlDispatcherBase::drawImage(const sk_sp<flutter::DlImage> image,
 // |flutter::DlOpReceiver|
 void DlDispatcherBase::drawImageRect(
     const sk_sp<flutter::DlImage> image,
-    const SkRect& src,
-    const SkRect& dst,
+    const DlRect& src,
+    const DlRect& dst,
     flutter::DlImageSampling sampling,
     bool render_with_attributes,
     SrcRectConstraint constraint = SrcRectConstraint::kFast) {
   AUTO_DEPTH_WATCHER(1u);
 
-  GetCanvas().DrawImageRect(image->impeller_texture(),      // image
-                            skia_conversions::ToRect(src),  // source rect
-                            skia_conversions::ToRect(dst),  // destination rect
+  GetCanvas().DrawImageRect(image->impeller_texture(),  // image
+                            src,                        // source rect
+                            dst,                        // destination rect
                             render_with_attributes ? paint_ : Paint(),  // paint
                             ToSamplerDescriptor(sampling)  // sampling
   );
@@ -1182,29 +1178,29 @@ void DlDispatcherBase::drawImageRect(
 
 // |flutter::DlOpReceiver|
 void DlDispatcherBase::drawImageNine(const sk_sp<flutter::DlImage> image,
-                                     const SkIRect& center,
-                                     const SkRect& dst,
+                                     const DlIRect& center,
+                                     const DlRect& dst,
                                      flutter::DlFilterMode filter,
                                      bool render_with_attributes) {
   AUTO_DEPTH_WATCHER(9u);
 
   NinePatchConverter converter = {};
-  converter.DrawNinePatch(
-      image->impeller_texture(),
-      Rect::MakeLTRB(center.fLeft, center.fTop, center.fRight, center.fBottom),
-      skia_conversions::ToRect(dst), ToSamplerDescriptor(filter), &GetCanvas(),
-      &paint_);
+  converter.DrawNinePatch(image->impeller_texture(),
+                          Rect::MakeLTRB(center.GetLeft(), center.GetTop(),
+                                         center.GetRight(), center.GetBottom()),
+                          dst, ToSamplerDescriptor(filter), &GetCanvas(),
+                          &paint_);
 }
 
 // |flutter::DlOpReceiver|
 void DlDispatcherBase::drawAtlas(const sk_sp<flutter::DlImage> atlas,
                                  const SkRSXform xform[],
-                                 const SkRect tex[],
+                                 const DlRect tex[],
                                  const flutter::DlColor colors[],
                                  int count,
                                  flutter::DlBlendMode mode,
                                  flutter::DlImageSampling sampling,
-                                 const SkRect* cull_rect,
+                                 const DlRect* cull_rect,
                                  bool render_with_attributes) {
   AUTO_DEPTH_WATCHER(1u);
 
@@ -1218,7 +1214,7 @@ void DlDispatcherBase::drawAtlas(const sk_sp<flutter::DlImage> atlas,
 // |flutter::DlOpReceiver|
 void DlDispatcherBase::drawDisplayList(
     const sk_sp<flutter::DisplayList> display_list,
-    SkScalar opacity) {
+    DlScalar opacity) {
   AUTO_DEPTH_WATCHER(display_list->total_depth());
 
   // Save all values that must remain untouched after the operation.
@@ -1282,8 +1278,8 @@ void DlDispatcherBase::drawDisplayList(
 
 // |flutter::DlOpReceiver|
 void DlDispatcherBase::drawTextBlob(const sk_sp<SkTextBlob> blob,
-                                    SkScalar x,
-                                    SkScalar y) {
+                                    DlScalar x,
+                                    DlScalar y) {
   // When running with Impeller enabled Skia text blobs are converted to
   // Impeller text frames in paragraph_skia.cc
   UNIMPLEMENTED;
@@ -1292,8 +1288,8 @@ void DlDispatcherBase::drawTextBlob(const sk_sp<SkTextBlob> blob,
 // |flutter::DlOpReceiver|
 void DlDispatcherBase::drawTextFrame(
     const std::shared_ptr<TextFrame>& text_frame,
-    SkScalar x,
-    SkScalar y) {
+    DlScalar x,
+    DlScalar y) {
   AUTO_DEPTH_WATCHER(1u);
 
   GetCanvas().DrawTextFrame(text_frame,             //
@@ -1305,18 +1301,18 @@ void DlDispatcherBase::drawTextFrame(
 // |flutter::DlOpReceiver|
 void DlDispatcherBase::drawShadow(const SkPath& path,
                                   const flutter::DlColor color,
-                                  const SkScalar elevation,
+                                  const DlScalar elevation,
                                   bool transparent_occluder,
-                                  SkScalar dpr) {
+                                  DlScalar dpr) {
   UNIMPLEMENTED;
 }
 
 // |flutter::DlOpReceiver|
 void DlDispatcherBase::drawShadow(const CacheablePath& cache,
                                   const flutter::DlColor color,
-                                  const SkScalar elevation,
+                                  const DlScalar elevation,
                                   bool transparent_occluder,
-                                  SkScalar dpr) {
+                                  DlScalar dpr) {
   AUTO_DEPTH_WATCHER(1u);
 
   Color spot_color = skia_conversions::ToColor(color);
@@ -1425,7 +1421,7 @@ void TextFrameDispatcher::save() {
   stack_.emplace_back(matrix_);
 }
 
-void TextFrameDispatcher::saveLayer(const SkRect& bounds,
+void TextFrameDispatcher::saveLayer(const DlRect& bounds,
                                     const flutter::SaveLayerOptions options,
                                     const flutter::DlImageFilter* backdrop) {
   save();
@@ -1436,26 +1432,26 @@ void TextFrameDispatcher::restore() {
   stack_.pop_back();
 }
 
-void TextFrameDispatcher::translate(SkScalar tx, SkScalar ty) {
+void TextFrameDispatcher::translate(DlScalar tx, DlScalar ty) {
   matrix_ = matrix_.Translate({tx, ty});
 }
 
-void TextFrameDispatcher::scale(SkScalar sx, SkScalar sy) {
+void TextFrameDispatcher::scale(DlScalar sx, DlScalar sy) {
   matrix_ = matrix_.Scale({sx, sy, 1.0f});
 }
 
-void TextFrameDispatcher::rotate(SkScalar degrees) {
+void TextFrameDispatcher::rotate(DlScalar degrees) {
   matrix_ = matrix_ * Matrix::MakeRotationZ(Degrees(degrees));
 }
 
-void TextFrameDispatcher::skew(SkScalar sx, SkScalar sy) {
+void TextFrameDispatcher::skew(DlScalar sx, DlScalar sy) {
   matrix_ = matrix_ * Matrix::MakeSkew(sx, sy);
 }
 
 // clang-format off
   // 2x3 2D affine subset of a 4x4 transform in row major order
-  void TextFrameDispatcher::transform2DAffine(SkScalar mxx, SkScalar mxy, SkScalar mxt,
-                         SkScalar myx, SkScalar myy, SkScalar myt) {
+  void TextFrameDispatcher::transform2DAffine(DlScalar mxx, DlScalar mxy, DlScalar mxt,
+                                              DlScalar myx, DlScalar myy, DlScalar myt) {
     matrix_ = matrix_ * Matrix::MakeColumn(
         mxx,  myx,  0.0f, 0.0f,
         mxy,  myy,  0.0f, 0.0f,
@@ -1466,10 +1462,10 @@ void TextFrameDispatcher::skew(SkScalar sx, SkScalar sy) {
 
   // full 4x4 transform in row major order
   void TextFrameDispatcher::transformFullPerspective(
-      SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
-      SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
-      SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
-      SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) {
+      DlScalar mxx, DlScalar mxy, DlScalar mxz, DlScalar mxt,
+      DlScalar myx, DlScalar myy, DlScalar myz, DlScalar myt,
+      DlScalar mzx, DlScalar mzy, DlScalar mzz, DlScalar mzt,
+      DlScalar mwx, DlScalar mwy, DlScalar mwz, DlScalar mwt) {
     matrix_ = matrix_ * Matrix::MakeColumn(
         mxx, myx, mzx, mwx,
         mxy, myy, mzy, mwy,
@@ -1485,8 +1481,8 @@ void TextFrameDispatcher::transformReset() {
 
 void TextFrameDispatcher::drawTextFrame(
     const std::shared_ptr<impeller::TextFrame>& text_frame,
-    SkScalar x,
-    SkScalar y) {
+    DlScalar x,
+    DlScalar y) {
   GlyphProperties properties;
   if (paint_.style == Paint::Style::kStroke) {
     properties.stroke = true;
@@ -1511,7 +1507,7 @@ void TextFrameDispatcher::drawTextFrame(
 
 void TextFrameDispatcher::drawDisplayList(
     const sk_sp<flutter::DisplayList> display_list,
-    SkScalar opacity) {
+    DlScalar opacity) {
   [[maybe_unused]] size_t stack_depth = stack_.size();
   save();
   Paint old_paint = paint_;
@@ -1533,12 +1529,12 @@ void TextFrameDispatcher::setColor(flutter::DlColor color) {
 }
 
 // |flutter::DlOpReceiver|
-void TextFrameDispatcher::setStrokeWidth(SkScalar width) {
+void TextFrameDispatcher::setStrokeWidth(DlScalar width) {
   paint_.stroke_width = width;
 }
 
 // |flutter::DlOpReceiver|
-void TextFrameDispatcher::setStrokeMiter(SkScalar limit) {
+void TextFrameDispatcher::setStrokeMiter(DlScalar limit) {
   paint_.stroke_miter = limit;
 }
 

--- a/impeller/display_list/dl_dispatcher.h
+++ b/impeller/display_list/dl_dispatcher.h
@@ -19,6 +19,8 @@ namespace impeller {
 
 using DlScalar = flutter::DlScalar;
 using DlPoint = flutter::DlPoint;
+using DlRect = flutter::DlRect;
+using DlIRect = flutter::DlIRect;
 
 class DlDispatcherBase : public flutter::DlOpReceiver {
  public:
@@ -37,10 +39,10 @@ class DlDispatcherBase : public flutter::DlOpReceiver {
   void setColor(flutter::DlColor color) override;
 
   // |flutter::DlOpReceiver|
-  void setStrokeWidth(SkScalar width) override;
+  void setStrokeWidth(DlScalar width) override;
 
   // |flutter::DlOpReceiver|
-  void setStrokeMiter(SkScalar limit) override;
+  void setStrokeMiter(DlScalar limit) override;
 
   // |flutter::DlOpReceiver|
   void setStrokeCap(flutter::DlStrokeCap cap) override;
@@ -70,7 +72,7 @@ class DlDispatcherBase : public flutter::DlOpReceiver {
   void save(uint32_t total_content_depth) override;
 
   // |flutter::DlOpReceiver|
-  void saveLayer(const SkRect& bounds,
+  void saveLayer(const DlRect& bounds,
                  const flutter::SaveLayerOptions& options,
                  uint32_t total_content_depth,
                  flutter::DlBlendMode max_content_mode,
@@ -80,51 +82,51 @@ class DlDispatcherBase : public flutter::DlOpReceiver {
   void restore() override;
 
   // |flutter::DlOpReceiver|
-  void translate(SkScalar tx, SkScalar ty) override;
+  void translate(DlScalar tx, DlScalar ty) override;
 
   // |flutter::DlOpReceiver|
-  void scale(SkScalar sx, SkScalar sy) override;
+  void scale(DlScalar sx, DlScalar sy) override;
 
   // |flutter::DlOpReceiver|
-  void rotate(SkScalar degrees) override;
+  void rotate(DlScalar degrees) override;
 
   // |flutter::DlOpReceiver|
-  void skew(SkScalar sx, SkScalar sy) override;
+  void skew(DlScalar sx, DlScalar sy) override;
 
   // |flutter::DlOpReceiver|
-  void transform2DAffine(SkScalar mxx,
-                         SkScalar mxy,
-                         SkScalar mxt,
-                         SkScalar myx,
-                         SkScalar myy,
-                         SkScalar myt) override;
+  void transform2DAffine(DlScalar mxx,
+                         DlScalar mxy,
+                         DlScalar mxt,
+                         DlScalar myx,
+                         DlScalar myy,
+                         DlScalar myt) override;
 
   // |flutter::DlOpReceiver|
-  void transformFullPerspective(SkScalar mxx,
-                                SkScalar mxy,
-                                SkScalar mxz,
-                                SkScalar mxt,
-                                SkScalar myx,
-                                SkScalar myy,
-                                SkScalar myz,
-                                SkScalar myt,
-                                SkScalar mzx,
-                                SkScalar mzy,
-                                SkScalar mzz,
-                                SkScalar mzt,
-                                SkScalar mwx,
-                                SkScalar mwy,
-                                SkScalar mwz,
-                                SkScalar mwt) override;
+  void transformFullPerspective(DlScalar mxx,
+                                DlScalar mxy,
+                                DlScalar mxz,
+                                DlScalar mxt,
+                                DlScalar myx,
+                                DlScalar myy,
+                                DlScalar myz,
+                                DlScalar myt,
+                                DlScalar mzx,
+                                DlScalar mzy,
+                                DlScalar mzz,
+                                DlScalar mzt,
+                                DlScalar mwx,
+                                DlScalar mwy,
+                                DlScalar mwz,
+                                DlScalar mwt) override;
 
   // |flutter::DlOpReceiver|
   void transformReset() override;
 
   // |flutter::DlOpReceiver|
-  void clipRect(const SkRect& rect, ClipOp clip_op, bool is_aa) override;
+  void clipRect(const DlRect& rect, ClipOp clip_op, bool is_aa) override;
 
   // |flutter::DlOpReceiver|
-  void clipOval(const SkRect& bounds, ClipOp clip_op, bool is_aa) override;
+  void clipOval(const DlRect& bounds, ClipOp clip_op, bool is_aa) override;
 
   // |flutter::DlOpReceiver|
   void clipRRect(const SkRRect& rrect, ClipOp clip_op, bool is_aa) override;
@@ -144,7 +146,7 @@ class DlDispatcherBase : public flutter::DlOpReceiver {
   void drawPaint() override;
 
   // |flutter::DlOpReceiver|
-  void drawLine(const SkPoint& p0, const SkPoint& p1) override;
+  void drawLine(const DlPoint& p0, const DlPoint& p1) override;
 
   // |flutter::DlOpReceiver|
   void drawDashedLine(const DlPoint& p0,
@@ -153,13 +155,13 @@ class DlDispatcherBase : public flutter::DlOpReceiver {
                       DlScalar off_length) override;
 
   // |flutter::DlOpReceiver|
-  void drawRect(const SkRect& rect) override;
+  void drawRect(const DlRect& rect) override;
 
   // |flutter::DlOpReceiver|
-  void drawOval(const SkRect& bounds) override;
+  void drawOval(const DlRect& bounds) override;
 
   // |flutter::DlOpReceiver|
-  void drawCircle(const SkPoint& center, SkScalar radius) override;
+  void drawCircle(const DlPoint& center, DlScalar radius) override;
 
   // |flutter::DlOpReceiver|
   void drawRRect(const SkRRect& rrect) override;
@@ -174,15 +176,15 @@ class DlDispatcherBase : public flutter::DlOpReceiver {
   void drawPath(const CacheablePath& cache) override;
 
   // |flutter::DlOpReceiver|
-  void drawArc(const SkRect& oval_bounds,
-               SkScalar start_degrees,
-               SkScalar sweep_degrees,
+  void drawArc(const DlRect& oval_bounds,
+               DlScalar start_degrees,
+               DlScalar sweep_degrees,
                bool use_center) override;
 
   // |flutter::DlOpReceiver|
   void drawPoints(PointMode mode,
                   uint32_t count,
-                  const SkPoint points[]) override;
+                  const DlPoint points[]) override;
 
   // |flutter::DlOpReceiver|
   void drawVertices(const std::shared_ptr<flutter::DlVertices>& vertices,
@@ -190,63 +192,63 @@ class DlDispatcherBase : public flutter::DlOpReceiver {
 
   // |flutter::DlOpReceiver|
   void drawImage(const sk_sp<flutter::DlImage> image,
-                 const SkPoint point,
+                 const DlPoint& point,
                  flutter::DlImageSampling sampling,
                  bool render_with_attributes) override;
 
   // |flutter::DlOpReceiver|
   void drawImageRect(const sk_sp<flutter::DlImage> image,
-                     const SkRect& src,
-                     const SkRect& dst,
+                     const DlRect& src,
+                     const DlRect& dst,
                      flutter::DlImageSampling sampling,
                      bool render_with_attributes,
                      SrcRectConstraint constraint) override;
 
   // |flutter::DlOpReceiver|
   void drawImageNine(const sk_sp<flutter::DlImage> image,
-                     const SkIRect& center,
-                     const SkRect& dst,
+                     const DlIRect& center,
+                     const DlRect& dst,
                      flutter::DlFilterMode filter,
                      bool render_with_attributes) override;
 
   // |flutter::DlOpReceiver|
   void drawAtlas(const sk_sp<flutter::DlImage> atlas,
                  const SkRSXform xform[],
-                 const SkRect tex[],
+                 const DlRect tex[],
                  const flutter::DlColor colors[],
                  int count,
                  flutter::DlBlendMode mode,
                  flutter::DlImageSampling sampling,
-                 const SkRect* cull_rect,
+                 const DlRect* cull_rect,
                  bool render_with_attributes) override;
 
   // |flutter::DlOpReceiver|
   void drawDisplayList(const sk_sp<flutter::DisplayList> display_list,
-                       SkScalar opacity) override;
+                       DlScalar opacity) override;
 
   // |flutter::DlOpReceiver|
   void drawTextBlob(const sk_sp<SkTextBlob> blob,
-                    SkScalar x,
-                    SkScalar y) override;
+                    DlScalar x,
+                    DlScalar y) override;
 
   // |flutter::DlOpReceiver|
   void drawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                     SkScalar x,
-                     SkScalar y) override;
+                     DlScalar x,
+                     DlScalar y) override;
 
   // |flutter::DlOpReceiver|
   void drawShadow(const SkPath& path,
                   const flutter::DlColor color,
-                  const SkScalar elevation,
+                  const DlScalar elevation,
                   bool transparent_occluder,
-                  SkScalar dpr) override;
+                  DlScalar dpr) override;
 
   // |flutter::DlOpReceiver|
   void drawShadow(const CacheablePath& cache,
                   const flutter::DlColor color,
-                  const SkScalar elevation,
+                  const DlScalar elevation,
                   bool transparent_occluder,
-                  SkScalar dpr) override;
+                  DlScalar dpr) override;
 
   virtual Canvas& GetCanvas() = 0;
 
@@ -282,7 +284,7 @@ class DlDispatcher : public DlDispatcherBase {
   using DlDispatcherBase::save;
 
   // |flutter::DlOpReceiver|
-  void saveLayer(const SkRect& bounds,
+  void saveLayer(const DlRect& bounds,
                  const flutter::SaveLayerOptions options,
                  const flutter::DlImageFilter* backdrop) override {
     // This dispatcher is used from test cases that might not supply
@@ -319,7 +321,7 @@ class ExperimentalDlDispatcher : public DlDispatcherBase {
   using DlDispatcherBase::save;
 
   // |flutter::DlOpReceiver|
-  void saveLayer(const SkRect& bounds,
+  void saveLayer(const DlRect& bounds,
                  const flutter::SaveLayerOptions options,
                  const flutter::DlImageFilter* backdrop) override {
     // This dispatcher should never be used with the saveLayer() variant
@@ -345,40 +347,40 @@ class TextFrameDispatcher : public flutter::IgnoreAttributeDispatchHelper,
                       const Matrix& initial_matrix);
   void save() override;
 
-  void saveLayer(const SkRect& bounds,
+  void saveLayer(const DlRect& bounds,
                  const flutter::SaveLayerOptions options,
                  const flutter::DlImageFilter* backdrop) override;
 
   void restore() override;
 
-  void translate(SkScalar tx, SkScalar ty) override;
+  void translate(DlScalar tx, DlScalar ty) override;
 
-  void scale(SkScalar sx, SkScalar sy) override;
+  void scale(DlScalar sx, DlScalar sy) override;
 
-  void rotate(SkScalar degrees) override;
+  void rotate(DlScalar degrees) override;
 
-  void skew(SkScalar sx, SkScalar sy) override;
+  void skew(DlScalar sx, DlScalar sy) override;
 
   // clang-format off
   // 2x3 2D affine subset of a 4x4 transform in row major order
-  void transform2DAffine(SkScalar mxx, SkScalar mxy, SkScalar mxt,
-                         SkScalar myx, SkScalar myy, SkScalar myt) override;
+  void transform2DAffine(DlScalar mxx, DlScalar mxy, DlScalar mxt,
+                         DlScalar myx, DlScalar myy, DlScalar myt) override;
 
   // full 4x4 transform in row major order
   void transformFullPerspective(
-      SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
-      SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
-      SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
-      SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) override;
+      DlScalar mxx, DlScalar mxy, DlScalar mxz, DlScalar mxt,
+      DlScalar myx, DlScalar myy, DlScalar myz, DlScalar myt,
+      DlScalar mzx, DlScalar mzy, DlScalar mzz, DlScalar mzt,
+      DlScalar mwx, DlScalar mwy, DlScalar mwz, DlScalar mwt) override;
 
   void transformReset() override;
 
   void drawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                     SkScalar x,
-                     SkScalar y) override;
+                     DlScalar x,
+                     DlScalar y) override;
 
   void drawDisplayList(const sk_sp<flutter::DisplayList> display_list,
-                       SkScalar opacity) override;
+                       DlScalar opacity) override;
 
   // |flutter::DlOpReceiver|
   void setDrawStyle(flutter::DlDrawStyle style) override;
@@ -387,10 +389,10 @@ class TextFrameDispatcher : public flutter::IgnoreAttributeDispatchHelper,
   void setColor(flutter::DlColor color) override;
 
   // |flutter::DlOpReceiver|
-  void setStrokeWidth(SkScalar width) override;
+  void setStrokeWidth(DlScalar width) override;
 
   // |flutter::DlOpReceiver|
-  void setStrokeMiter(SkScalar limit) override;
+  void setStrokeMiter(DlScalar limit) override;
 
   // |flutter::DlOpReceiver|
   void setStrokeCap(flutter::DlStrokeCap cap) override;

--- a/impeller/display_list/skia_conversions.cc
+++ b/impeller/display_list/skia_conversions.cc
@@ -38,6 +38,13 @@ std::optional<Rect> ToRect(const SkRect* rect) {
   return Rect::MakeLTRB(rect->fLeft, rect->fTop, rect->fRight, rect->fBottom);
 }
 
+std::optional<const Rect> ToRect(const flutter::DlRect* rect) {
+  if (rect == nullptr) {
+    return std::nullopt;
+  }
+  return *rect;
+}
+
 std::vector<Rect> ToRects(const SkRect tex[], int count) {
   auto result = std::vector<Rect>();
   for (int i = 0; i < count; i++) {
@@ -46,10 +53,26 @@ std::vector<Rect> ToRects(const SkRect tex[], int count) {
   return result;
 }
 
+std::vector<Rect> ToRects(const flutter::DlRect tex[], int count) {
+  auto result = std::vector<Rect>();
+  for (int i = 0; i < count; i++) {
+    result.push_back(tex[i]);
+  }
+  return result;
+}
+
 std::vector<Point> ToPoints(const SkPoint points[], int count) {
   std::vector<Point> result(count);
   for (auto i = 0; i < count; i++) {
     result[i] = ToPoint(points[i]);
+  }
+  return result;
+}
+
+std::vector<Point> ToPoints(const flutter::DlPoint points[], int count) {
+  std::vector<Point> result(count);
+  for (auto i = 0; i < count; i++) {
+    result[i] = points[i];
   }
   return result;
 }

--- a/impeller/display_list/skia_conversions.h
+++ b/impeller/display_list/skia_conversions.h
@@ -34,10 +34,13 @@ bool IsNearlySimpleRRect(const SkRRect& rr);
 Rect ToRect(const SkRect& rect);
 
 std::optional<Rect> ToRect(const SkRect* rect);
+std::optional<const Rect> ToRect(const flutter::DlRect* rect);
 
 std::vector<Rect> ToRects(const SkRect tex[], int count);
+std::vector<Rect> ToRects(const flutter::DlRect tex[], int count);
 
 std::vector<Point> ToPoints(const SkPoint points[], int count);
+std::vector<Point> ToPoints(const flutter::DlPoint points[], int count);
 
 Point ToPoint(const SkPoint& point);
 

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -137,6 +137,10 @@ struct TRect {
     return TRect(x, y, saturated::Add(x, width), saturated::Add(y, height));
   }
 
+  constexpr static TRect MakeWH(Type width, Type height) {
+    return TRect(0, 0, width, height);
+  }
+
   constexpr static TRect MakeOriginSize(const TPoint<Type>& origin,
                                         const TSize<Type>& size) {
     return MakeXYWH(origin.x, origin.y, size.width, size.height);
@@ -527,6 +531,10 @@ struct TRect {
     } else {
       return std::nullopt;
     }
+  }
+
+  [[nodiscard]] constexpr TRect IntersectionOrEmpty(const TRect& o) const {
+    return Intersection(o).value_or(TRect());
   }
 
   [[nodiscard]] constexpr bool IntersectsWithRect(const TRect& o) const {

--- a/impeller/geometry/rect_unittests.cc
+++ b/impeller/geometry/rect_unittests.cc
@@ -130,6 +130,37 @@ TEST(RectTest, IRectSimpleXYWH) {
   EXPECT_FALSE(rect.IsEmpty());
 }
 
+TEST(RectTest, RectSimpleWH) {
+  // Using fractional-power-of-2 friendly values for equality tests
+  Rect rect = Rect::MakeWH(15.5f, 15.125f);
+
+  EXPECT_EQ(rect.GetLeft(), 0.0f);
+  EXPECT_EQ(rect.GetTop(), 0.0f);
+  EXPECT_EQ(rect.GetRight(), 15.5f);
+  EXPECT_EQ(rect.GetBottom(), 15.125f);
+  EXPECT_EQ(rect.GetX(), 0.0f);
+  EXPECT_EQ(rect.GetY(), 0.0f);
+  EXPECT_EQ(rect.GetWidth(), 15.5f);
+  EXPECT_EQ(rect.GetHeight(), 15.125f);
+  EXPECT_FALSE(rect.IsEmpty());
+  EXPECT_TRUE(rect.IsFinite());
+}
+
+TEST(RectTest, IRectSimpleWH) {
+  // Using fractional-power-of-2 friendly values for equality tests
+  IRect rect = IRect::MakeWH(15, 25);
+
+  EXPECT_EQ(rect.GetLeft(), 0);
+  EXPECT_EQ(rect.GetTop(), 0);
+  EXPECT_EQ(rect.GetRight(), 15);
+  EXPECT_EQ(rect.GetBottom(), 25);
+  EXPECT_EQ(rect.GetX(), 0);
+  EXPECT_EQ(rect.GetY(), 0);
+  EXPECT_EQ(rect.GetWidth(), 15);
+  EXPECT_EQ(rect.GetHeight(), 25);
+  EXPECT_FALSE(rect.IsEmpty());
+}
+
 TEST(RectTest, RectOverflowXYWH) {
   auto min = std::numeric_limits<Scalar>::lowest();
   auto max = std::numeric_limits<Scalar>::max();
@@ -1604,18 +1635,28 @@ TEST(RectTest, RectIntersection) {
 
     // unflipped a vs flipped (empty) b yields a
     EXPECT_FALSE(a.Intersection(flip_lr(b)).has_value()) << label;
+    EXPECT_TRUE(a.IntersectionOrEmpty(flip_lr(b)).IsEmpty()) << label;
     EXPECT_FALSE(a.Intersection(flip_tb(b)).has_value()) << label;
+    EXPECT_TRUE(a.IntersectionOrEmpty(flip_tb(b)).IsEmpty()) << label;
     EXPECT_FALSE(a.Intersection(flip_lrtb(b)).has_value()) << label;
+    EXPECT_TRUE(a.IntersectionOrEmpty(flip_lrtb(b)).IsEmpty()) << label;
 
     // flipped (empty) a vs unflipped b yields b
     EXPECT_FALSE(flip_lr(a).Intersection(b).has_value()) << label;
+    EXPECT_TRUE(flip_lr(a).IntersectionOrEmpty(b).IsEmpty()) << label;
     EXPECT_FALSE(flip_tb(a).Intersection(b).has_value()) << label;
+    EXPECT_TRUE(flip_tb(a).IntersectionOrEmpty(b).IsEmpty()) << label;
     EXPECT_FALSE(flip_lrtb(a).Intersection(b).has_value()) << label;
+    EXPECT_TRUE(flip_lrtb(a).IntersectionOrEmpty(b).IsEmpty()) << label;
 
     // flipped (empty) a vs flipped (empty) b yields empty
     EXPECT_FALSE(flip_lr(a).Intersection(flip_lr(b)).has_value()) << label;
+    EXPECT_TRUE(flip_lr(a).IntersectionOrEmpty(flip_lr(b)).IsEmpty()) << label;
     EXPECT_FALSE(flip_tb(a).Intersection(flip_tb(b)).has_value()) << label;
+    EXPECT_TRUE(flip_tb(a).IntersectionOrEmpty(flip_tb(b)).IsEmpty()) << label;
     EXPECT_FALSE(flip_lrtb(a).Intersection(flip_lrtb(b)).has_value()) << label;
+    EXPECT_TRUE(flip_lrtb(a).IntersectionOrEmpty(flip_lrtb(b)).IsEmpty())
+        << label;
   };
 
   auto test_non_empty = [&check_nans, &check_empty_flips](
@@ -1645,7 +1686,9 @@ TEST(RectTest, RectIntersection) {
     auto label = stream.str();
 
     EXPECT_FALSE(a.Intersection(b).has_value()) << label;
+    EXPECT_TRUE(a.IntersectionOrEmpty(b).IsEmpty()) << label;
     EXPECT_FALSE(b.Intersection(a).has_value()) << label;
+    EXPECT_TRUE(b.IntersectionOrEmpty(a).IsEmpty()) << label;
     check_empty_flips(a, b, label);
     check_nans(a, b, label);
   };

--- a/shell/common/dl_op_spy.cc
+++ b/shell/common/dl_op_spy.cc
@@ -29,7 +29,7 @@ void DlOpSpy::setColorSource(const DlColorSource* source) {
   will_draw_ = true;
 }
 void DlOpSpy::save() {}
-void DlOpSpy::saveLayer(const SkRect& bounds,
+void DlOpSpy::saveLayer(const DlRect& bounds,
                         const SaveLayerOptions options,
                         const DlImageFilter* backdrop) {}
 void DlOpSpy::restore() {}
@@ -41,7 +41,7 @@ void DlOpSpy::drawPaint() {
 }
 // TODO(cyanglaz): check whether the shape (line, rect, oval, etc) needs to be
 // evaluated. https://github.com/flutter/flutter/issues/123803
-void DlOpSpy::drawLine(const SkPoint& p0, const SkPoint& p1) {
+void DlOpSpy::drawLine(const DlPoint& p0, const DlPoint& p1) {
   did_draw_ |= will_draw_;
 }
 void DlOpSpy::drawDashedLine(const DlPoint& p0,
@@ -50,13 +50,13 @@ void DlOpSpy::drawDashedLine(const DlPoint& p0,
                              DlScalar off_length) {
   did_draw_ |= will_draw_;
 }
-void DlOpSpy::drawRect(const SkRect& rect) {
+void DlOpSpy::drawRect(const DlRect& rect) {
   did_draw_ |= will_draw_;
 }
-void DlOpSpy::drawOval(const SkRect& bounds) {
+void DlOpSpy::drawOval(const DlRect& bounds) {
   did_draw_ |= will_draw_;
 }
-void DlOpSpy::drawCircle(const SkPoint& center, SkScalar radius) {
+void DlOpSpy::drawCircle(const DlPoint& center, DlScalar radius) {
   did_draw_ |= will_draw_;
 }
 void DlOpSpy::drawRRect(const SkRRect& rrect) {
@@ -68,15 +68,15 @@ void DlOpSpy::drawDRRect(const SkRRect& outer, const SkRRect& inner) {
 void DlOpSpy::drawPath(const SkPath& path) {
   did_draw_ |= will_draw_;
 }
-void DlOpSpy::drawArc(const SkRect& oval_bounds,
-                      SkScalar start_degrees,
-                      SkScalar sweep_degrees,
+void DlOpSpy::drawArc(const DlRect& oval_bounds,
+                      DlScalar start_degrees,
+                      DlScalar sweep_degrees,
                       bool use_center) {
   did_draw_ |= will_draw_;
 }
 void DlOpSpy::drawPoints(PointMode mode,
                          uint32_t count,
-                         const SkPoint points[]) {
+                         const DlPoint points[]) {
   did_draw_ |= will_draw_;
 }
 void DlOpSpy::drawVertices(const std::shared_ptr<DlVertices>& vertices,
@@ -89,39 +89,39 @@ void DlOpSpy::drawVertices(const std::shared_ptr<DlVertices>& vertices,
 // Drawing a completely transparent image is not a valid use case, thus, such
 // case is ignored.
 void DlOpSpy::drawImage(const sk_sp<DlImage> image,
-                        const SkPoint point,
+                        const DlPoint& point,
                         DlImageSampling sampling,
                         bool render_with_attributes) {
   did_draw_ = true;
 }
 void DlOpSpy::drawImageRect(const sk_sp<DlImage> image,
-                            const SkRect& src,
-                            const SkRect& dst,
+                            const DlRect& src,
+                            const DlRect& dst,
                             DlImageSampling sampling,
                             bool render_with_attributes,
                             SrcRectConstraint constraint) {
   did_draw_ = true;
 }
 void DlOpSpy::drawImageNine(const sk_sp<DlImage> image,
-                            const SkIRect& center,
-                            const SkRect& dst,
+                            const DlIRect& center,
+                            const DlRect& dst,
                             DlFilterMode filter,
                             bool render_with_attributes) {
   did_draw_ = true;
 }
 void DlOpSpy::drawAtlas(const sk_sp<DlImage> atlas,
                         const SkRSXform xform[],
-                        const SkRect tex[],
+                        const DlRect tex[],
                         const DlColor colors[],
                         int count,
                         DlBlendMode mode,
                         DlImageSampling sampling,
-                        const SkRect* cull_rect,
+                        const DlRect* cull_rect,
                         bool render_with_attributes) {
   did_draw_ = true;
 }
 void DlOpSpy::drawDisplayList(const sk_sp<DisplayList> display_list,
-                              SkScalar opacity) {
+                              DlScalar opacity) {
   if (did_draw_ || opacity == 0) {
     return;
   }
@@ -130,23 +130,23 @@ void DlOpSpy::drawDisplayList(const sk_sp<DisplayList> display_list,
   did_draw_ |= receiver.did_draw();
 }
 void DlOpSpy::drawTextBlob(const sk_sp<SkTextBlob> blob,
-                           SkScalar x,
-                           SkScalar y) {
+                           DlScalar x,
+                           DlScalar y) {
   did_draw_ |= will_draw_;
 }
 
 void DlOpSpy::drawTextFrame(
     const std::shared_ptr<impeller::TextFrame>& text_frame,
-    SkScalar x,
-    SkScalar y) {
+    DlScalar x,
+    DlScalar y) {
   did_draw_ |= will_draw_;
 }
 
 void DlOpSpy::drawShadow(const SkPath& path,
                          const DlColor color,
-                         const SkScalar elevation,
+                         const DlScalar elevation,
                          bool transparent_occluder,
-                         SkScalar dpr) {
+                         DlScalar dpr) {
   did_draw_ |= !color.isTransparent();
 }
 

--- a/shell/common/dl_op_spy.h
+++ b/shell/common/dl_op_spy.h
@@ -39,70 +39,70 @@ class DlOpSpy final : public virtual DlOpReceiver,
   void setColor(DlColor color) override;
   void setColorSource(const DlColorSource* source) override;
   void save() override;
-  void saveLayer(const SkRect& bounds,
+  void saveLayer(const DlRect& bounds,
                  const SaveLayerOptions options,
                  const DlImageFilter* backdrop) override;
   void restore() override;
   void drawColor(DlColor color, DlBlendMode mode) override;
   void drawPaint() override;
-  void drawLine(const SkPoint& p0, const SkPoint& p1) override;
+  void drawLine(const DlPoint& p0, const DlPoint& p1) override;
   void drawDashedLine(const DlPoint& p0,
                       const DlPoint& p1,
                       DlScalar on_length,
                       DlScalar off_length) override;
-  void drawRect(const SkRect& rect) override;
-  void drawOval(const SkRect& bounds) override;
-  void drawCircle(const SkPoint& center, SkScalar radius) override;
+  void drawRect(const DlRect& rect) override;
+  void drawOval(const DlRect& bounds) override;
+  void drawCircle(const DlPoint& center, DlScalar radius) override;
   void drawRRect(const SkRRect& rrect) override;
   void drawDRRect(const SkRRect& outer, const SkRRect& inner) override;
   void drawPath(const SkPath& path) override;
-  void drawArc(const SkRect& oval_bounds,
-               SkScalar start_degrees,
-               SkScalar sweep_degrees,
+  void drawArc(const DlRect& oval_bounds,
+               DlScalar start_degrees,
+               DlScalar sweep_degrees,
                bool use_center) override;
   void drawPoints(PointMode mode,
                   uint32_t count,
-                  const SkPoint points[]) override;
+                  const DlPoint points[]) override;
   void drawVertices(const std::shared_ptr<DlVertices>& vertices,
                     DlBlendMode mode) override;
   void drawImage(const sk_sp<DlImage> image,
-                 const SkPoint point,
+                 const DlPoint& point,
                  DlImageSampling sampling,
                  bool render_with_attributes) override;
   void drawImageRect(
       const sk_sp<DlImage> image,
-      const SkRect& src,
-      const SkRect& dst,
+      const DlRect& src,
+      const DlRect& dst,
       DlImageSampling sampling,
       bool render_with_attributes,
       SrcRectConstraint constraint = SrcRectConstraint::kFast) override;
   void drawImageNine(const sk_sp<DlImage> image,
-                     const SkIRect& center,
-                     const SkRect& dst,
+                     const DlIRect& center,
+                     const DlRect& dst,
                      DlFilterMode filter,
                      bool render_with_attributes) override;
   void drawAtlas(const sk_sp<DlImage> atlas,
                  const SkRSXform xform[],
-                 const SkRect tex[],
+                 const DlRect tex[],
                  const DlColor colors[],
                  int count,
                  DlBlendMode mode,
                  DlImageSampling sampling,
-                 const SkRect* cull_rect,
+                 const DlRect* cull_rect,
                  bool render_with_attributes) override;
   void drawDisplayList(const sk_sp<DisplayList> display_list,
-                       SkScalar opacity = SK_Scalar1) override;
+                       DlScalar opacity = SK_Scalar1) override;
   void drawTextBlob(const sk_sp<SkTextBlob> blob,
-                    SkScalar x,
-                    SkScalar y) override;
+                    DlScalar x,
+                    DlScalar y) override;
   void drawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                     SkScalar x,
-                     SkScalar y) override;
+                     DlScalar x,
+                     DlScalar y) override;
   void drawShadow(const SkPath& path,
                   const DlColor color,
-                  const SkScalar elevation,
+                  const DlScalar elevation,
                   bool transparent_occluder,
-                  SkScalar dpr) override;
+                  DlScalar dpr) override;
 
   // Indicates if the attributes are set to values that will modify the
   // destination. For now, the test only checks if there is a non-transparent

--- a/testing/display_list_testing.cc
+++ b/testing/display_list_testing.cc
@@ -195,15 +195,6 @@ static std::ostream& operator<<(std::ostream& os, const SkPoint& point) {
   return os << "SkPoint(" << point.fX << ", " << point.fY << ")";
 }
 
-static std::ostream& operator<<(std::ostream& os, const SkIRect& rect) {
-  return os << "SkIRect("
-            << "left: " << rect.fLeft << ", "
-            << "top: " << rect.fTop << ", "
-            << "right: " << rect.fRight << ", "
-            << "bottom: " << rect.fBottom
-            << ")";
-}
-
 static std::ostream& operator<<(std::ostream& os, const SkRect& rect) {
   return os << "SkRect("
             << "left: " << rect.fLeft << ", "
@@ -211,10 +202,6 @@ static std::ostream& operator<<(std::ostream& os, const SkRect& rect) {
             << "right: " << rect.fRight << ", "
             << "bottom: " << rect.fBottom
             << ")";
-}
-
-static std::ostream& operator<<(std::ostream& os, const SkRect* rect) {
-  return rect ? (os << "&" << *rect) : os << "no rect";
 }
 
 static std::ostream& operator<<(std::ostream& os, const SkRRect& rrect) {
@@ -456,10 +443,10 @@ void DisplayListStreamDispatcher::setDrawStyle(DlDrawStyle style) {
 void DisplayListStreamDispatcher::setColor(DlColor color) {
   startl() << "setColor(" << color << ");" << std::endl;
 }
-void DisplayListStreamDispatcher::setStrokeWidth(SkScalar width) {
+void DisplayListStreamDispatcher::setStrokeWidth(DlScalar width) {
   startl() << "setStrokeWidth(" << width << ");" << std::endl;
 }
-void DisplayListStreamDispatcher::setStrokeMiter(SkScalar limit) {
+void DisplayListStreamDispatcher::setStrokeMiter(DlScalar limit) {
   startl() << "setStrokeMiter(" << limit << ");" << std::endl;
 }
 void DisplayListStreamDispatcher::setStrokeCap(DlStrokeCap cap) {
@@ -722,7 +709,7 @@ void DisplayListStreamDispatcher::save() {
   startl() << "{" << std::endl;
   indent();
 }
-void DisplayListStreamDispatcher::saveLayer(const SkRect& bounds,
+void DisplayListStreamDispatcher::saveLayer(const DlRect& bounds,
                                             const SaveLayerOptions options,
                                             const DlImageFilter* backdrop) {
   startl() << "saveLayer(" << bounds << ", " << options;
@@ -745,21 +732,21 @@ void DisplayListStreamDispatcher::restore() {
   startl() << "restore();" << std::endl;
 }
 
-void DisplayListStreamDispatcher::translate(SkScalar tx, SkScalar ty) {
+void DisplayListStreamDispatcher::translate(DlScalar tx, DlScalar ty) {
   startl() << "translate(" << tx << ", " << ty << ");" << std::endl;
 }
-void DisplayListStreamDispatcher::scale(SkScalar sx, SkScalar sy) {
+void DisplayListStreamDispatcher::scale(DlScalar sx, DlScalar sy) {
   startl() << "scale(" << sx << ", " << sy << ");" << std::endl;
 }
-void DisplayListStreamDispatcher::rotate(SkScalar degrees) {
+void DisplayListStreamDispatcher::rotate(DlScalar degrees) {
   startl() << "rotate(" << degrees << ");" << std::endl;
 }
-void DisplayListStreamDispatcher::skew(SkScalar sx, SkScalar sy) {
+void DisplayListStreamDispatcher::skew(DlScalar sx, DlScalar sy) {
   startl() << "skew(" << sx << ", " << sy << ");" << std::endl;
 }
 void DisplayListStreamDispatcher::transform2DAffine(
-    SkScalar mxx, SkScalar mxy, SkScalar mxt,
-    SkScalar myx, SkScalar myy, SkScalar myt) {
+    DlScalar mxx, DlScalar mxy, DlScalar mxt,
+    DlScalar myx, DlScalar myy, DlScalar myt) {
   startl() << "transform2DAffine(" << std::endl;
   indent();
   {
@@ -774,10 +761,10 @@ void DisplayListStreamDispatcher::transform2DAffine(
   startl() << ");" << std::endl;
 }
 void DisplayListStreamDispatcher::transformFullPerspective(
-    SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
-    SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
-    SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
-    SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) {
+    DlScalar mxx, DlScalar mxy, DlScalar mxz, DlScalar mxt,
+    DlScalar myx, DlScalar myy, DlScalar myz, DlScalar myt,
+    DlScalar mzx, DlScalar mzy, DlScalar mzz, DlScalar mzt,
+    DlScalar mwx, DlScalar mwy, DlScalar mwz, DlScalar mwt) {
   startl() << "transformFullPerspective(" << std::endl;
   indent();
   {
@@ -801,7 +788,7 @@ void DisplayListStreamDispatcher::transformReset() {
   startl() << "transformReset();" << std::endl;
 }
 
-void DisplayListStreamDispatcher::clipRect(const SkRect& rect, ClipOp clip_op,
+void DisplayListStreamDispatcher::clipRect(const DlRect& rect, ClipOp clip_op,
                                            bool is_aa) {
   startl() << "clipRect("
            << rect << ", "
@@ -809,7 +796,7 @@ void DisplayListStreamDispatcher::clipRect(const SkRect& rect, ClipOp clip_op,
            << "isaa: " << is_aa
            << ");" << std::endl;
 }
-void DisplayListStreamDispatcher::clipOval(const SkRect& bounds, ClipOp clip_op,
+void DisplayListStreamDispatcher::clipOval(const DlRect& bounds, ClipOp clip_op,
                                            bool is_aa) {
   startl() << "clipOval("
            << bounds << ", "
@@ -844,8 +831,8 @@ void DisplayListStreamDispatcher::drawColor(DlColor color, DlBlendMode mode) {
 void DisplayListStreamDispatcher::drawPaint() {
   startl() << "drawPaint();" << std::endl;
 }
-void DisplayListStreamDispatcher::drawLine(const SkPoint& p0,
-                                           const SkPoint& p1) {
+void DisplayListStreamDispatcher::drawLine(const DlPoint& p0,
+                                           const DlPoint& p1) {
   startl() << "drawLine(" << p0 << ", " << p1 << ");" << std::endl;
 }
 void DisplayListStreamDispatcher::drawDashedLine(const DlPoint& p0,
@@ -859,14 +846,14 @@ void DisplayListStreamDispatcher::drawDashedLine(const DlPoint& p0,
            << off_length
            << ");" << std::endl;
 }
-void DisplayListStreamDispatcher::drawRect(const SkRect& rect) {
+void DisplayListStreamDispatcher::drawRect(const DlRect& rect) {
   startl() << "drawRect(" << rect << ");" << std::endl;
 }
-void DisplayListStreamDispatcher::drawOval(const SkRect& bounds) {
+void DisplayListStreamDispatcher::drawOval(const DlRect& bounds) {
   startl() << "drawOval(" << bounds << ");" << std::endl;
 }
-void DisplayListStreamDispatcher::drawCircle(const SkPoint& center,
-                                             SkScalar radius) {
+void DisplayListStreamDispatcher::drawCircle(const DlPoint& center,
+                                             DlScalar radius) {
   startl() << "drawCircle(" << center << ", " << radius << ");" << std::endl;
 }
 void DisplayListStreamDispatcher::drawRRect(const SkRRect& rrect) {
@@ -880,9 +867,9 @@ void DisplayListStreamDispatcher::drawDRRect(const SkRRect& outer,
 void DisplayListStreamDispatcher::drawPath(const SkPath& path) {
   startl() << "drawPath(" << path << ");" << std::endl;
 }
-void DisplayListStreamDispatcher::drawArc(const SkRect& oval_bounds,
-                                          SkScalar start_degrees,
-                                          SkScalar sweep_degrees,
+void DisplayListStreamDispatcher::drawArc(const DlRect& oval_bounds,
+                                          DlScalar start_degrees,
+                                          DlScalar sweep_degrees,
                                           bool use_center) {
   startl() << "drawArc("
            << oval_bounds << ", "
@@ -893,7 +880,7 @@ void DisplayListStreamDispatcher::drawArc(const SkRect& oval_bounds,
 }
 void DisplayListStreamDispatcher::drawPoints(PointMode mode,
                                              uint32_t count,
-                                             const SkPoint points[]) {
+                                             const DlPoint points[]) {
   startl() << "drawPoints(" << mode << ", ";
                           out_array("points", count, points)
            << ");" << std::endl;
@@ -910,7 +897,7 @@ void DisplayListStreamDispatcher::drawVertices(const std::shared_ptr<DlVertices>
                    << "), " << mode << ");" << std::endl;
 }
 void DisplayListStreamDispatcher::drawImage(const sk_sp<DlImage> image,
-                                            const SkPoint point,
+                                            const DlPoint& point,
                                             DlImageSampling sampling,
                                             bool render_with_attributes) {
   startl() << "drawImage(" << image.get() << "," << std::endl;
@@ -920,8 +907,8 @@ void DisplayListStreamDispatcher::drawImage(const sk_sp<DlImage> image,
            << ");" << std::endl;
 }
 void DisplayListStreamDispatcher::drawImageRect(const sk_sp<DlImage> image,
-                                                const SkRect& src,
-                                                const SkRect& dst,
+                                                const DlRect& src,
+                                                const DlRect& dst,
                                                 DlImageSampling sampling,
                                                 bool render_with_attributes,
                                                 SrcRectConstraint constraint) {
@@ -934,8 +921,8 @@ void DisplayListStreamDispatcher::drawImageRect(const sk_sp<DlImage> image,
            << ");" << std::endl;
 }
 void DisplayListStreamDispatcher::drawImageNine(const sk_sp<DlImage> image,
-                                                const SkIRect& center,
-                                                const SkRect& dst,
+                                                const DlIRect& center,
+                                                const DlRect& dst,
                                                 DlFilterMode filter,
                                                 bool render_with_attributes) {
   startl() << "drawImageNine(" << image.get() << "," << std::endl;
@@ -947,12 +934,12 @@ void DisplayListStreamDispatcher::drawImageNine(const sk_sp<DlImage> image,
 }
 void DisplayListStreamDispatcher::drawAtlas(const sk_sp<DlImage> atlas,
                                             const SkRSXform xform[],
-                                            const SkRect tex[],
+                                            const DlRect tex[],
                                             const DlColor colors[],
                                             int count,
                                             DlBlendMode mode,
                                             DlImageSampling sampling,
-                                            const SkRect* cull_rect,
+                                            const DlRect* cull_rect,
                                             bool render_with_attributes) {
   startl() << "drawAtlas(" << atlas.get() << ", ";
                    out_array("xforms", count, xform) << ", ";
@@ -963,7 +950,7 @@ void DisplayListStreamDispatcher::drawAtlas(const sk_sp<DlImage> atlas,
            << ");" << std::endl;
 }
 void DisplayListStreamDispatcher::drawDisplayList(
-    const sk_sp<DisplayList> display_list, SkScalar opacity) {
+    const sk_sp<DisplayList> display_list, DlScalar opacity) {
   startl() << "drawDisplayList("
            << "ID: " << display_list->unique_id() << ", "
            << "bounds: " << display_list->bounds() << ", "
@@ -971,8 +958,8 @@ void DisplayListStreamDispatcher::drawDisplayList(
            << ");" << std::endl;
 }
 void DisplayListStreamDispatcher::drawTextBlob(const sk_sp<SkTextBlob> blob,
-                                               SkScalar x,
-                                               SkScalar y) {
+                                               DlScalar x,
+                                               DlScalar y) {
   startl() << "drawTextBlob("
            << blob.get() << ", "
            << x << ", " << y << ");" << std::endl;
@@ -980,8 +967,8 @@ void DisplayListStreamDispatcher::drawTextBlob(const sk_sp<SkTextBlob> blob,
 
 void DisplayListStreamDispatcher::drawTextFrame(
     const std::shared_ptr<impeller::TextFrame>& text_frame,
-    SkScalar x,
-    SkScalar y) {
+    DlScalar x,
+    DlScalar y) {
   startl() << "drawTextFrame("
     << text_frame.get() << ", "
     << x << ", " << y << ");" << std::endl;
@@ -989,9 +976,9 @@ void DisplayListStreamDispatcher::drawTextFrame(
 
 void DisplayListStreamDispatcher::drawShadow(const SkPath& path,
                                              const DlColor color,
-                                             const SkScalar elevation,
+                                             const DlScalar elevation,
                                              bool transparent_occluder,
-                                             SkScalar dpr) {
+                                             DlScalar dpr) {
   startl() << "drawShadow("
            << path << ", "
            << color << ", "

--- a/testing/display_list_testing.h
+++ b/testing/display_list_testing.h
@@ -95,8 +95,8 @@ class DisplayListStreamDispatcher final : public DlOpReceiver {
   void setAntiAlias(bool aa) override;
   void setDrawStyle(DlDrawStyle style) override;
   void setColor(DlColor color) override;
-  void setStrokeWidth(SkScalar width) override;
-  void setStrokeMiter(SkScalar limit) override;
+  void setStrokeWidth(DlScalar width) override;
+  void setStrokeMiter(DlScalar limit) override;
   void setStrokeCap(DlStrokeCap cap) override;
   void setStrokeJoin(DlStrokeJoin join) override;
   void setColorSource(const DlColorSource* source) override;
@@ -107,90 +107,90 @@ class DisplayListStreamDispatcher final : public DlOpReceiver {
   void setImageFilter(const DlImageFilter* filter) override;
 
   void save() override;
-  void saveLayer(const SkRect& bounds,
+  void saveLayer(const DlRect& bounds,
                  const SaveLayerOptions options,
                  const DlImageFilter* backdrop) override;
   void restore() override;
 
-  void translate(SkScalar tx, SkScalar ty) override;
-  void scale(SkScalar sx, SkScalar sy) override;
-  void rotate(SkScalar degrees) override;
-  void skew(SkScalar sx, SkScalar sy) override;
+  void translate(DlScalar tx, DlScalar ty) override;
+  void scale(DlScalar sx, DlScalar sy) override;
+  void rotate(DlScalar degrees) override;
+  void skew(DlScalar sx, DlScalar sy) override;
   // clang-format off
-  void transform2DAffine(SkScalar mxx, SkScalar mxy, SkScalar mxt,
-                                 SkScalar myx, SkScalar myy, SkScalar myt) override;
+  void transform2DAffine(DlScalar mxx, DlScalar mxy, DlScalar mxt,
+                         DlScalar myx, DlScalar myy, DlScalar myt) override;
   void transformFullPerspective(
-      SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
-      SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
-      SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
-      SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) override;
+      DlScalar mxx, DlScalar mxy, DlScalar mxz, DlScalar mxt,
+      DlScalar myx, DlScalar myy, DlScalar myz, DlScalar myt,
+      DlScalar mzx, DlScalar mzy, DlScalar mzz, DlScalar mzt,
+      DlScalar mwx, DlScalar mwy, DlScalar mwz, DlScalar mwt) override;
   // clang-format on
   void transformReset() override;
 
-  void clipRect(const SkRect& rect, ClipOp clip_op, bool is_aa) override;
-  void clipOval(const SkRect& bounds, ClipOp clip_op, bool is_aa) override;
+  void clipRect(const DlRect& rect, ClipOp clip_op, bool is_aa) override;
+  void clipOval(const DlRect& bounds, ClipOp clip_op, bool is_aa) override;
   void clipRRect(const SkRRect& rrect, ClipOp clip_op, bool is_aa) override;
   void clipPath(const SkPath& path, ClipOp clip_op, bool is_aa) override;
 
   void drawColor(DlColor color, DlBlendMode mode) override;
   void drawPaint() override;
-  void drawLine(const SkPoint& p0, const SkPoint& p1) override;
+  void drawLine(const DlPoint& p0, const DlPoint& p1) override;
   void drawDashedLine(const DlPoint& p0,
                       const DlPoint& p1,
                       DlScalar on_length,
                       DlScalar off_length) override;
-  void drawRect(const SkRect& rect) override;
-  void drawOval(const SkRect& bounds) override;
-  void drawCircle(const SkPoint& center, SkScalar radius) override;
+  void drawRect(const DlRect& rect) override;
+  void drawOval(const DlRect& bounds) override;
+  void drawCircle(const DlPoint& center, DlScalar radius) override;
   void drawRRect(const SkRRect& rrect) override;
   void drawDRRect(const SkRRect& outer, const SkRRect& inner) override;
   void drawPath(const SkPath& path) override;
-  void drawArc(const SkRect& oval_bounds,
-               SkScalar start_degrees,
-               SkScalar sweep_degrees,
+  void drawArc(const DlRect& oval_bounds,
+               DlScalar start_degrees,
+               DlScalar sweep_degrees,
                bool use_center) override;
   void drawPoints(PointMode mode,
                   uint32_t count,
-                  const SkPoint points[]) override;
+                  const DlPoint points[]) override;
   void drawVertices(const std::shared_ptr<DlVertices>& vertices,
                     DlBlendMode mode) override;
   void drawImage(const sk_sp<DlImage> image,
-                 const SkPoint point,
+                 const DlPoint& point,
                  DlImageSampling sampling,
                  bool render_with_attributes) override;
   void drawImageRect(const sk_sp<DlImage> image,
-                     const SkRect& src,
-                     const SkRect& dst,
+                     const DlRect& src,
+                     const DlRect& dst,
                      DlImageSampling sampling,
                      bool render_with_attributes,
                      SrcRectConstraint constraint) override;
   void drawImageNine(const sk_sp<DlImage> image,
-                     const SkIRect& center,
-                     const SkRect& dst,
+                     const DlIRect& center,
+                     const DlRect& dst,
                      DlFilterMode filter,
                      bool render_with_attributes) override;
   void drawAtlas(const sk_sp<DlImage> atlas,
                  const SkRSXform xform[],
-                 const SkRect tex[],
+                 const DlRect tex[],
                  const DlColor colors[],
                  int count,
                  DlBlendMode mode,
                  DlImageSampling sampling,
-                 const SkRect* cull_rect,
+                 const DlRect* cull_rect,
                  bool render_with_attributes) override;
   void drawDisplayList(const sk_sp<DisplayList> display_list,
-                       SkScalar opacity) override;
+                       DlScalar opacity) override;
   void drawTextBlob(const sk_sp<SkTextBlob> blob,
-                    SkScalar x,
-                    SkScalar y) override;
+                    DlScalar x,
+                    DlScalar y) override;
   void drawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                     SkScalar x,
-                     SkScalar y) override;
+                     DlScalar x,
+                     DlScalar y) override;
   void drawShadow(const SkPath& path,
                   const DlColor color,
-                  const SkScalar elevation,
+                  const DlScalar elevation,
                   bool transparent_occluder,
-                  SkScalar dpr) override;
+                  DlScalar dpr) override;
 
  private:
   std::ostream& os_;
@@ -318,30 +318,30 @@ class DisplayListGeneralReceiver : public DlOpReceiver {
     }
   }
 
-  void translate(SkScalar tx, SkScalar ty) override {
+  void translate(DlScalar tx, DlScalar ty) override {
     RecordByType(DisplayListOpType::kTranslate);
   }
-  void scale(SkScalar sx, SkScalar sy) override {
+  void scale(DlScalar sx, DlScalar sy) override {
     RecordByType(DisplayListOpType::kScale);
   }
-  void rotate(SkScalar degrees) override {
+  void rotate(DlScalar degrees) override {
     RecordByType(DisplayListOpType::kRotate);
   }
-  void skew(SkScalar sx, SkScalar sy) override {
+  void skew(DlScalar sx, DlScalar sy) override {
     RecordByType(DisplayListOpType::kSkew);
   }
   // clang-format off
   // 2x3 2D affine subset of a 4x4 transform in row major order
-  void transform2DAffine(SkScalar mxx, SkScalar mxy, SkScalar mxt,
-                         SkScalar myx, SkScalar myy, SkScalar myt) override {
+  void transform2DAffine(DlScalar mxx, DlScalar mxy, DlScalar mxt,
+                         DlScalar myx, DlScalar myy, DlScalar myt) override {
     RecordByType(DisplayListOpType::kTransform2DAffine);
   }
   // full 4x4 transform in row major order
   void transformFullPerspective(
-      SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
-      SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
-      SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
-      SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) override {
+      DlScalar mxx, DlScalar mxy, DlScalar mxz, DlScalar mxt,
+      DlScalar myx, DlScalar myy, DlScalar myz, DlScalar myt,
+      DlScalar mzx, DlScalar mzy, DlScalar mzz, DlScalar mzt,
+      DlScalar mwx, DlScalar mwy, DlScalar mwz, DlScalar mwt) override {
     RecordByType(DisplayListOpType::kTransformFullPerspective);
   }
   // clang-format on
@@ -349,7 +349,7 @@ class DisplayListGeneralReceiver : public DlOpReceiver {
     RecordByType(DisplayListOpType::kTransformReset);
   }
 
-  void clipRect(const SkRect& rect,
+  void clipRect(const DlRect& rect,
                 DlCanvas::ClipOp clip_op,
                 bool is_aa) override {
     switch (clip_op) {
@@ -361,7 +361,7 @@ class DisplayListGeneralReceiver : public DlOpReceiver {
         break;
     }
   }
-  void clipOval(const SkRect& bounds,
+  void clipOval(const DlRect& bounds,
                 DlCanvas::ClipOp clip_op,
                 bool is_aa) override {
     switch (clip_op) {
@@ -399,7 +399,7 @@ class DisplayListGeneralReceiver : public DlOpReceiver {
   }
 
   void save() override { RecordByType(DisplayListOpType::kSave); }
-  void saveLayer(const SkRect& bounds,
+  void saveLayer(const DlRect& bounds,
                  const SaveLayerOptions options,
                  const DlImageFilter* backdrop) override {
     if (backdrop) {
@@ -414,7 +414,7 @@ class DisplayListGeneralReceiver : public DlOpReceiver {
     RecordByType(DisplayListOpType::kDrawColor);
   }
   void drawPaint() override { RecordByType(DisplayListOpType::kDrawPaint); }
-  void drawLine(const SkPoint& p0, const SkPoint& p1) override {
+  void drawLine(const DlPoint& p0, const DlPoint& p1) override {
     RecordByType(DisplayListOpType::kDrawLine);
   }
   void drawDashedLine(const DlPoint& p0,
@@ -423,13 +423,13 @@ class DisplayListGeneralReceiver : public DlOpReceiver {
                       DlScalar off_length) override {
     RecordByType(DisplayListOpType::kDrawDashedLine);
   }
-  void drawRect(const SkRect& rect) override {
+  void drawRect(const DlRect& rect) override {
     RecordByType(DisplayListOpType::kDrawRect);
   }
-  void drawOval(const SkRect& bounds) override {
+  void drawOval(const DlRect& bounds) override {
     RecordByType(DisplayListOpType::kDrawOval);
   }
-  void drawCircle(const SkPoint& center, SkScalar radius) override {
+  void drawCircle(const DlPoint& center, DlScalar radius) override {
     RecordByType(DisplayListOpType::kDrawCircle);
   }
   void drawRRect(const SkRRect& rrect) override {
@@ -441,15 +441,15 @@ class DisplayListGeneralReceiver : public DlOpReceiver {
   void drawPath(const SkPath& path) override {
     RecordByType(DisplayListOpType::kDrawPath);
   }
-  void drawArc(const SkRect& oval_bounds,
-               SkScalar start_degrees,
-               SkScalar sweep_degrees,
+  void drawArc(const DlRect& oval_bounds,
+               DlScalar start_degrees,
+               DlScalar sweep_degrees,
                bool use_center) override {
     RecordByType(DisplayListOpType::kDrawArc);
   }
   void drawPoints(DlCanvas::PointMode mode,
                   uint32_t count,
-                  const SkPoint points[]) override {
+                  const DlPoint points[]) override {
     switch (mode) {
       case DlCanvas::PointMode::kPoints:
         RecordByType(DisplayListOpType::kDrawPoints);
@@ -467,7 +467,7 @@ class DisplayListGeneralReceiver : public DlOpReceiver {
     RecordByType(DisplayListOpType::kDrawVertices);
   }
   void drawImage(const sk_sp<DlImage> image,
-                 const SkPoint point,
+                 const DlPoint& point,
                  DlImageSampling sampling,
                  bool render_with_attributes) override {
     if (render_with_attributes) {
@@ -477,16 +477,16 @@ class DisplayListGeneralReceiver : public DlOpReceiver {
     }
   }
   void drawImageRect(const sk_sp<DlImage> image,
-                     const SkRect& src,
-                     const SkRect& dst,
+                     const DlRect& src,
+                     const DlRect& dst,
                      DlImageSampling sampling,
                      bool render_with_attributes,
                      SrcRectConstraint constraint) override {
     RecordByType(DisplayListOpType::kDrawImageRect);
   }
   void drawImageNine(const sk_sp<DlImage> image,
-                     const SkIRect& center,
-                     const SkRect& dst,
+                     const DlIRect& center,
+                     const DlRect& dst,
                      DlFilterMode filter,
                      bool render_with_attributes) override {
     if (render_with_attributes) {
@@ -497,12 +497,12 @@ class DisplayListGeneralReceiver : public DlOpReceiver {
   }
   void drawAtlas(const sk_sp<DlImage> atlas,
                  const SkRSXform xform[],
-                 const SkRect tex[],
+                 const DlRect tex[],
                  const DlColor colors[],
                  int count,
                  DlBlendMode mode,
                  DlImageSampling sampling,
-                 const SkRect* cull_rect,
+                 const DlRect* cull_rect,
                  bool render_with_attributes) override {
     if (cull_rect) {
       RecordByType(DisplayListOpType::kDrawAtlasCulled);
@@ -511,24 +511,24 @@ class DisplayListGeneralReceiver : public DlOpReceiver {
     }
   }
   void drawDisplayList(const sk_sp<DisplayList> display_list,
-                       SkScalar opacity) override {
+                       DlScalar opacity) override {
     RecordByType(DisplayListOpType::kDrawDisplayList);
   }
   void drawTextBlob(const sk_sp<SkTextBlob> blob,
-                    SkScalar x,
-                    SkScalar y) override {
+                    DlScalar x,
+                    DlScalar y) override {
     RecordByType(DisplayListOpType::kDrawTextBlob);
   }
   void drawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                     SkScalar x,
-                     SkScalar y) override {
+                     DlScalar x,
+                     DlScalar y) override {
     RecordByType(DisplayListOpType::kDrawTextFrame);
   }
   void drawShadow(const SkPath& path,
                   const DlColor color,
-                  const SkScalar elevation,
+                  const DlScalar elevation,
                   bool transparent_occluder,
-                  SkScalar dpr) override {
+                  DlScalar dpr) override {
     if (transparent_occluder) {
       RecordByType(DisplayListOpType::kDrawShadowTransparentOccluder);
     } else {

--- a/testing/mock_canvas.cc
+++ b/testing/mock_canvas.cc
@@ -187,7 +187,7 @@ void MockCanvas::DrawShadow(const SkPath& path,
 }
 
 void MockCanvas::DrawImage(const sk_sp<DlImage>& image,
-                           SkPoint point,
+                           const SkPoint& point,
                            const DlImageSampling options,
                            const DlPaint* paint) {
   if (paint) {

--- a/testing/mock_canvas.h
+++ b/testing/mock_canvas.h
@@ -255,7 +255,7 @@ class MockCanvas final : public DlCanvas {
                     const DlPaint& paint) override;
 
   void DrawImage(const sk_sp<DlImage>& image,
-                 const SkPoint point,
+                 const SkPoint& point,
                  DlImageSampling sampling,
                  const DlPaint* paint = nullptr) override;
   void DrawImageRect(

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -50,7 +50,7 @@ class DlOpRecorder final : public virtual DlOpReceiver,
   int blobCount() const { return blobs_.size(); }
 
  private:
-  void drawLine(const SkPoint& p0, const SkPoint& p1) override {
+  void drawLine(const DlPoint& p0, const DlPoint& p1) override {
     lines_.emplace_back(p0, p1);
   }
 
@@ -73,15 +73,15 @@ class DlOpRecorder final : public virtual DlOpReceiver,
     blobs_.push_back(blob);
   }
 
-  void drawRect(const SkRect& rect) override { rects_.push_back(rect); }
+  void drawRect(const DlRect& rect) override { rects_.push_back(rect); }
 
   void drawPath(const SkPath& path) override { paths_.push_back(path); }
 
   std::vector<std::shared_ptr<impeller::TextFrame>> text_frames_;
   std::vector<sk_sp<SkTextBlob>> blobs_;
-  std::vector<std::pair<SkPoint, SkPoint>> lines_;
+  std::vector<std::pair<DlPoint, DlPoint>> lines_;
   std::vector<std::tuple<DlPoint, DlPoint, DlPoint>> dashed_lines_;
-  std::vector<SkRect> rects_;
+  std::vector<DlRect> rects_;
   std::vector<SkPath> paths_;
 };
 


### PR DESCRIPTION
Wean the DlOpReceiver interface and implementations off of using the SkScalar, Sk[I]Rect, and SkPoint objects in favor of our own DL/Impeller versions.

The start of an ongoing effort to eventually compartmentalize all use of Skia interfaces into a single backend rendering module that is one of 2 semi-pluggable renderers.