### PR TITLE
iOS,macOS: Add logging of duplicate codesign binaries

### DIFF
--- a/sky/tools/sky_utils.py
+++ b/sky/tools/sky_utils.py
@@ -33,18 +33,25 @@ def assert_valid_codesign_config(
   either entitlements or without_entitlements."""
   if _contains_duplicates(entitlements):
     log_error('ERROR: duplicate value(s) found in entitlements.txt')
+    log_error_items(sorted(entitlements))
     sys.exit(os.EX_DATAERR)
 
   if _contains_duplicates(without_entitlements):
     log_error('ERROR: duplicate value(s) found in without_entitlements.txt')
+    log_error_items(sorted(without_entitlements))
     sys.exit(os.EX_DATAERR)
 
   if _contains_duplicates(unsigned_binaries):
     log_error('ERROR: duplicate value(s) found in unsigned_binaries.txt')
+    log_error_items(sorted(unsigned_binaries))
     sys.exit(os.EX_DATAERR)
 
   if _contains_duplicates(entitlements + without_entitlements + unsigned_binaries):
-    log_error('ERROR: value(s) found in both entitlements and without_entitlements.txt')
+    log_error(
+        'ERROR: duplicate value(s) found between '
+        'entitlements.txt, without_entitlements.txt, unsigned_binaries.txt'
+    )
+    log_error_items(sorted(entitlements + without_entitlements + unsigned_binaries))
     sys.exit(os.EX_DATAERR)
 
   binaries = set()
@@ -252,6 +259,12 @@ def lipo(input_binaries, output_binary):
 def log_error(message):
   """Writes the message to stderr, followed by a newline."""
   print(message, file=sys.stderr)
+
+
+def log_error_items(items):
+  """Writes each item indented to stderr, followed by a newline."""
+  for item in items:
+    log_error('  ' + item)
 
 
 def strip_binary(binary_path, unstripped_copy_path):


### PR DESCRIPTION
When duplicates are found in the input lists, log them to stderr. For the case of duplicates across list, we print the whole list, sorted, rather than three separate lists, as it makes it simpler to spot the duplicate, at which point the file will be easy to spot in either `create_ios_framework.py` or `create_macos_framework.py`.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
