### PR TITLE
[Impeller] fix double reset host buffer call.

### DIFF
--- a/shell/gpu/gpu_surface_vulkan_impeller.cc
+++ b/shell/gpu/gpu_surface_vulkan_impeller.cc
@@ -94,7 +94,6 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
     display_list->Dispatch(impeller_dispatcher,
                            SkIRect::MakeWH(cull_rect.width, cull_rect.height));
     impeller_dispatcher.FinishRecording();
-    aiks_context->GetContentContext().GetTransientsBuffer().Reset();
     aiks_context->GetContentContext().GetLazyGlyphAtlas()->ResetTextFrames();
     if (reset_host_buffer) {
       aiks_context->GetContentContext().GetTransientsBuffer().Reset();


### PR DESCRIPTION
In https://github.com/flutter/engine/pull/55019 I'll clean this up so each gpu surface isn't responsible for its own potentially error prone layering of dispatcher interaction, but for now lets just clean this one up.
