### PR TITLE
[engine] dispatch platform channel messages through event loop, except navigation on start.

### DIFF
--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -100,7 +100,7 @@ RuntimeController::~RuntimeController() {
   }
 }
 
-bool RuntimeController::IsRootIsolateRunning() {
+bool RuntimeController::IsRootIsolateRunning() const {
   std::shared_ptr<DartIsolate> root_isolate = root_isolate_.lock();
   if (root_isolate) {
     return root_isolate->GetPhase() == DartIsolate::Phase::Running;

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -452,7 +452,7 @@ class RuntimeController : public PlatformConfigurationClient,
   ///
   /// @return     True if root isolate running, False otherwise.
   ///
-  virtual bool IsRootIsolateRunning();
+  virtual bool IsRootIsolateRunning() const;
 
   //----------------------------------------------------------------------------
   /// @brief      Dispatch the specified platform message to running root

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -144,7 +144,7 @@ class MockRuntimeController : public RuntimeController {
   MockRuntimeController(RuntimeDelegate& client,
                         const TaskRunners& p_task_runners)
       : RuntimeController(client, p_task_runners) {}
-  MOCK_METHOD(bool, IsRootIsolateRunning, (), (override));
+  MOCK_METHOD(bool, IsRootIsolateRunning, (), (override, const));
   MOCK_METHOD(bool,
               DispatchPlatformMessage,
               (std::unique_ptr<PlatformMessage>),

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -4302,11 +4302,11 @@ TEST_F(ShellTest, NavigationMessageDispachedImmediately) {
         "flutter/navigation",
         {{"method", "setInitialRoute"}, {"args", "/testo"}}, nullptr);
     SendPlatformMessage(shell.get(), std::move(message));
+    EXPECT_EQ(shell->GetEngine()->InitialRoute(), "/testo");
+
     latch->CountDown();
   });
   latch->Wait();
-
-  EXPECT_EQ(shell->GetEngine()->InitialRoute(), "/testo");
 
   DestroyShell(std::move(shell), task_runners);
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -68,6 +68,33 @@ using ::testing::_;
 using ::testing::Return;
 
 namespace {
+
+std::unique_ptr<PlatformMessage> MakePlatformMessage(
+    const std::string& channel,
+    const std::map<std::string, std::string>& values,
+    const fml::RefPtr<PlatformMessageResponse>& response) {
+  rapidjson::Document document;
+  auto& allocator = document.GetAllocator();
+  document.SetObject();
+
+  for (const auto& pair : values) {
+    rapidjson::Value key(pair.first.c_str(), strlen(pair.first.c_str()),
+                         allocator);
+    rapidjson::Value value(pair.second.c_str(), strlen(pair.second.c_str()),
+                           allocator);
+    document.AddMember(key, value, allocator);
+  }
+
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+  document.Accept(writer);
+  const uint8_t* data = reinterpret_cast<const uint8_t*>(buffer.GetString());
+
+  std::unique_ptr<PlatformMessage> message = std::make_unique<PlatformMessage>(
+      channel, fml::MallocMapping::Copy(data, buffer.GetSize()), response);
+  return message;
+}
+
 class MockPlatformViewDelegate : public PlatformView::Delegate {
   MOCK_METHOD(void,
               OnPlatformViewCreated,
@@ -4258,6 +4285,31 @@ TEST_F(ShellTest, PrintsErrorWhenPlatformMessageSentFromWrongThread) {
   DestroyShell(std::move(shell), task_runners);
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 #endif
+}
+
+TEST_F(ShellTest, NavigationMessageDispachedImmediately) {
+  Settings settings = CreateSettingsForFixture();
+  ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
+                         ThreadHost::Type::kPlatform);
+  auto task_runner = thread_host.platform_thread->GetTaskRunner();
+  TaskRunners task_runners("test", task_runner, task_runner, task_runner,
+                           task_runner);
+  auto shell = CreateShell(settings, task_runners);
+
+  auto latch = std::make_shared<fml::CountDownLatch>(1u);
+  task_runner->PostTask([&]() {
+    auto message = MakePlatformMessage(
+        "flutter/navigation",
+        {{"method", "setInitialRoute"}, {"args", "/testo"}}, nullptr);
+    SendPlatformMessage(shell.get(), std::move(message));
+    latch->CountDown();
+  });
+  latch->Wait();
+
+  EXPECT_EQ(shell->GetEngine()->InitialRoute(), "/testo");
+
+  DestroyShell(std::move(shell), task_runners);
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
 TEST_F(ShellTest, DiesIfSoftwareRenderingAndImpellerAreEnabledDeathTest) {


### PR DESCRIPTION
This is a re-land of https://github.com/flutter/engine/pull/55006, except that we special case the navigation channel to immediately dispatch its message if the isolate is not yet running.

This preserves the existing behavior relied upon by several iOS add2app tests, as well as the still used embedder v1 - and potentially undicovered future embedders.