### PR TITLE
[web] make SkPaint frame-scoped

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvas.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvas.dart
@@ -81,15 +81,13 @@ class CkCanvas {
   ) {
     const double toDegrees = 180 / math.pi;
 
-    final skPaint = paint.toSkPaint();
     skCanvas.drawArc(
       toSkRect(oval),
       startAngle * toDegrees,
       sweepAngle * toDegrees,
       useCenter,
-      skPaint,
+      paint.toSkPaint(),
     );
-    skPaint.delete();
   }
 
   // TODO(flar): CanvasKit does not expose sampling options available on SkCanvas.drawAtlas
@@ -101,27 +99,23 @@ class CkCanvas {
     Uint32List? colors,
     ui.BlendMode blendMode,
   ) {
-    final skPaint = paint.toSkPaint();
     skCanvas.drawAtlas(
       atlas.skImage,
       rects,
       rstTransforms,
-      skPaint,
+      paint.toSkPaint(),
       toSkBlendMode(blendMode),
       colors,
     );
-    skPaint.delete();
   }
 
   void drawCircle(ui.Offset c, double radius, CkPaint paint) {
-    final skPaint = paint.toSkPaint();
     skCanvas.drawCircle(
       c.dx,
       c.dy,
       radius,
-      skPaint,
+      paint.toSkPaint(),
     );
-    skPaint.delete();
   }
 
   void drawColor(ui.Color color, ui.BlendMode blendMode) {
@@ -132,18 +126,15 @@ class CkCanvas {
   }
 
   void drawDRRect(ui.RRect outer, ui.RRect inner, CkPaint paint) {
-    final skPaint = paint.toSkPaint();
     skCanvas.drawDRRect(
       toSkRRect(outer),
       toSkRRect(inner),
-      skPaint,
+      paint.toSkPaint(),
     );
-    skPaint.delete();
   }
 
   void drawImage(CkImage image, ui.Offset offset, CkPaint paint) {
     final ui.FilterQuality filterQuality = paint.filterQuality;
-    final skPaint = paint.toSkPaint();
     if (filterQuality == ui.FilterQuality.high) {
       skCanvas.drawImageCubic(
         image.skImage,
@@ -151,7 +142,7 @@ class CkCanvas {
         offset.dy,
         _kMitchellNetravali_B,
         _kMitchellNetravali_C,
-        skPaint,
+        paint.toSkPaint(),
       );
     } else {
       skCanvas.drawImageOptions(
@@ -160,15 +151,13 @@ class CkCanvas {
         offset.dy,
         toSkFilterMode(filterQuality),
         toSkMipmapMode(filterQuality),
-        skPaint,
+        paint.toSkPaint(),
       );
     }
-    skPaint.delete();
   }
 
   void drawImageRect(CkImage image, ui.Rect src, ui.Rect dst, CkPaint paint) {
     final ui.FilterQuality filterQuality = paint.filterQuality;
-    final skPaint = paint.toSkPaint();
     if (filterQuality == ui.FilterQuality.high) {
       skCanvas.drawImageRectCubic(
         image.skImage,
@@ -176,7 +165,7 @@ class CkCanvas {
         toSkRect(dst),
         _kMitchellNetravali_B,
         _kMitchellNetravali_C,
-        skPaint,
+        paint.toSkPaint(),
       );
     } else {
       skCanvas.drawImageRectOptions(
@@ -185,50 +174,41 @@ class CkCanvas {
         toSkRect(dst),
         toSkFilterMode(filterQuality),
         toSkMipmapMode(filterQuality),
-        skPaint,
+        paint.toSkPaint(),
       );
     }
-    skPaint.delete();
   }
 
   void drawImageNine(
       CkImage image, ui.Rect center, ui.Rect dst, CkPaint paint) {
-    final skPaint = paint.toSkPaint();
     skCanvas.drawImageNine(
       image.skImage,
       toSkRect(center),
       toSkRect(dst),
       toSkFilterMode(paint.filterQuality),
-      skPaint,
+      paint.toSkPaint(),
     );
-    skPaint.delete();
   }
 
   void drawLine(ui.Offset p1, ui.Offset p2, CkPaint paint) {
-    final skPaint = paint.toSkPaint();
     skCanvas.drawLine(
       p1.dx,
       p1.dy,
       p2.dx,
       p2.dy,
-      skPaint,
+      paint.toSkPaint(),
     );
-    skPaint.delete();
   }
 
   void drawOval(ui.Rect rect, CkPaint paint) {
-    final skPaint = paint.toSkPaint();
     skCanvas.drawOval(
       toSkRect(rect),
-      skPaint,
+      paint.toSkPaint(),
     );
-    skPaint.delete();
   }
 
   void drawPaint(CkPaint paint) {
-    final skPaint = paint.toSkPaint();
-    skCanvas.drawPaint(skPaint);
-    skPaint.delete();
+    skCanvas.drawPaint(paint.toSkPaint());
   }
 
   void drawParagraph(CkParagraph paragraph, ui.Offset offset) {
@@ -240,9 +220,7 @@ class CkCanvas {
   }
 
   void drawPath(CkPath path, CkPaint paint) {
-    final skPaint = paint.toSkPaint();
-    skCanvas.drawPath(path.skiaObject, skPaint);
-    skPaint.delete();
+    skCanvas.drawPath(path.skiaObject, paint.toSkPaint());
   }
 
   void drawPicture(CkPicture picture) {
@@ -251,28 +229,22 @@ class CkCanvas {
   }
 
   void drawPoints(CkPaint paint, ui.PointMode pointMode, Float32List points) {
-    final skPaint = paint.toSkPaint();
     skCanvas.drawPoints(
       toSkPointMode(pointMode),
       points,
-      skPaint,
+      paint.toSkPaint(),
     );
-    skPaint.delete();
   }
 
   void drawRRect(ui.RRect rrect, CkPaint paint) {
-    final skPaint = paint.toSkPaint();
     skCanvas.drawRRect(
       toSkRRect(rrect),
-      skPaint,
+      paint.toSkPaint(),
     );
-    skPaint.delete();
   }
 
   void drawRect(ui.Rect rect, CkPaint paint) {
-    final skPaint = paint.toSkPaint();
-    skCanvas.drawRect(toSkRect(rect), skPaint);
-    skPaint.delete();
+    skCanvas.drawRect(toSkRect(rect), paint.toSkPaint());
   }
 
   void drawShadow(
@@ -283,13 +255,11 @@ class CkCanvas {
 
   void drawVertices(
       CkVertices vertices, ui.BlendMode blendMode, CkPaint paint) {
-    final skPaint = paint.toSkPaint();
     skCanvas.drawVertices(
       vertices.skiaObject,
       toSkBlendMode(blendMode),
-      skPaint,
+      paint.toSkPaint(),
     );
-    skPaint.delete();
   }
 
   void restore() {
@@ -309,20 +279,16 @@ class CkCanvas {
   }
 
   void saveLayer(ui.Rect bounds, CkPaint? paint) {
-    final skPaint = paint?.toSkPaint();
     skCanvas.saveLayer(
-      skPaint,
+      paint?.toSkPaint(),
       toSkRect(bounds),
       null,
       null,
     );
-    skPaint?.delete();
   }
 
   void saveLayerWithoutBounds(CkPaint? paint) {
-    final skPaint = paint?.toSkPaint();
-    skCanvas.saveLayer(skPaint, null, null, null);
-    skPaint?.delete();
+    skCanvas.saveLayer(paint?.toSkPaint(), null, null, null);
   }
 
   void saveLayerWithFilter(ui.Rect bounds, ui.ImageFilter filter,
@@ -334,14 +300,12 @@ class CkCanvas {
       convertible = filter as CkManagedSkImageFilterConvertible;
     }
     convertible.withSkImageFilter((SkImageFilter filter) {
-      final skPaint = paint?.toSkPaint();
       skCanvas.saveLayer(
-        skPaint,
+        paint?.toSkPaint(),
         toSkRect(bounds),
         filter,
         0,
       );
-      skPaint?.delete();
     });
   }
 

--- a/lib/web_ui/lib/src/engine/frame_reference.dart
+++ b/lib/web_ui/lib/src/engine/frame_reference.dart
@@ -2,11 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// A monotonically increasing frame number being rendered.
-///
-/// Used for debugging only.
-int debugFrameNumber = 1;
-
 List<FrameReference<dynamic>> frameReferences = <FrameReference<dynamic>>[];
 
 /// A temporary reference to a value of type [V].

--- a/lib/web_ui/lib/src/engine/frame_reference.dart
+++ b/lib/web_ui/lib/src/engine/frame_reference.dart
@@ -20,9 +20,12 @@ abstract class FrameScoped {
 /// All frame-scoped variables for the current frame.
 List<FrameScoped> _scopedObjects = <FrameScoped>[];
 
-/// Disposes of all the objects that were registered this frame.
+/// Disposes of all the frame-scoped objects that were registered this frame.
 ///
-/// This method is called at the end of every frame.
+/// This method is called at the end of every frame. It is idempotent, so it is
+/// safe to call it more than once per frame. Calling it multiple times will
+/// simply release whatever resources have accummulated since the last
+/// invocation.
 void endFrameScope() {
   final scopedObjects = _scopedObjects;
   _scopedObjects = <FrameScoped>[];

--- a/lib/web_ui/lib/src/engine/html/surface.dart
+++ b/lib/web_ui/lib/src/engine/html/surface.dart
@@ -40,6 +40,11 @@ bool debugShowClipLayers = false;
 /// reasonable.
 const double kScreenPixelRatioWarningThreshold = 6.0;
 
+/// A monotonically increasing frame number being rendered.
+///
+/// Used for debugging only.
+int _debugFrameNumber = 1;
+
 /// Performs any outstanding painting work enqueued by [PersistedPicture]s.
 void commitScene(PersistedScene scene) {
   if (paintQueue.isNotEmpty) {
@@ -74,7 +79,7 @@ void commitScene(PersistedScene scene) {
     retainedSurfaces = <PersistedSurface>[];
   }
   if (debugExplainSurfaceStats) {
-    debugPrintSurfaceStats(scene, debugFrameNumber);
+    debugPrintSurfaceStats(scene, _debugFrameNumber);
     debugRepaintSurfaceStatsOverlay(scene);
   }
 
@@ -97,7 +102,7 @@ void commitScene(PersistedScene scene) {
     surfaceStats = <PersistedSurface, DebugSurfaceStats>{};
   }
   assert(() {
-    debugFrameNumber++;
+    _debugFrameNumber++;
     return true;
   }());
 }

--- a/lib/web_ui/lib/src/engine/html/surface.dart
+++ b/lib/web_ui/lib/src/engine/html/surface.dart
@@ -93,11 +93,6 @@ void commitScene(PersistedScene scene) {
     return true;
   }());
 
-  for (int i = 0; i < frameReferences.length; i++) {
-    frameReferences[i].value = null;
-  }
-  frameReferences = <FrameReference<dynamic>>[];
-
   if (debugExplainSurfaceStats) {
     surfaceStats = <PersistedSurface, DebugSurfaceStats>{};
   }
@@ -205,7 +200,7 @@ bool debugAssertSurfaceState(
 abstract class PersistedSurface implements ui.EngineLayer {
   /// Creates a persisted surface.
   PersistedSurface(PersistedSurface? oldLayer)
-      : _oldLayer = FrameReference<PersistedSurface>(
+      : _oldLayer = FrameScopedValue<PersistedSurface>(
             oldLayer != null && oldLayer.isActive ? oldLayer : null);
 
   /// The surface that is being updated using this surface.
@@ -214,7 +209,7 @@ abstract class PersistedSurface implements ui.EngineLayer {
   ///
   /// This value is set to null at the end of the frame.
   PersistedSurface? get oldLayer => _oldLayer.value;
-  final FrameReference<PersistedSurface> _oldLayer;
+  final FrameScopedValue<PersistedSurface> _oldLayer;
 
   /// The index of this surface in its parent's [PersistedContainerSurface._children]
   /// list.

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -844,6 +844,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
     if (shouldRender || renderer.rendererTag == 'html') {
       await renderer.renderScene(scene, target);
     }
+    endFrameScope();
   }
 
   /// Additional accessibility features that may be enabled by the platform.

--- a/lib/web_ui/test/canvaskit/painting_test.dart
+++ b/lib/web_ui/test/canvaskit/painting_test.dart
@@ -19,9 +19,29 @@ void testMain() {
 
     test('toSkPaint', () {
       final paint = CkPaint();
+
+      expect(paint.debugRawSkPaint, isNull);
+
       final skPaint = paint.toSkPaint();
+
       expect(skPaint, isNotNull);
-      skPaint.delete();
+      expect(paint.debugRawSkPaint, same(skPaint));
+
+      paint.disposeFrameResources();
+      expect(paint.debugRawSkPaint, isNull);
+    });
+
+    test('is frame-scoped', () {
+      final paint = CkPaint();
+      final skPaint1 = paint.toSkPaint();
+      final skPaint2 = paint.toSkPaint();
+
+      expect(skPaint1, isNotNull);
+      expect(skPaint1, same(skPaint2));
+
+      expect(paint.debugRawSkPaint, same(skPaint1));
+      endFrameScope();
+      expect(paint.debugRawSkPaint, isNull);
     });
   });
 }

--- a/lib/web_ui/test/engine/frame_reference_test.dart
+++ b/lib/web_ui/test/engine/frame_reference_test.dart
@@ -11,6 +11,36 @@ void main() {
 }
 
 void testMain() {
+  group('FrameScoped', () {
+    test('lifecycle', () {
+      final v1 = TestFrameScoped();
+      final v2 = TestFrameScoped();
+      expect(TestFrameScoped.disposedList, isEmpty);
+
+      endFrameScope();
+
+      expect(
+        TestFrameScoped.disposedList,
+        [v1, v2],
+      );
+    });
+  });
+
+  group('FrameScopedValue', () {
+    test('Holds a value until end of frame', () {
+      final v1 = FrameScopedValue<int>(42);
+      final v2 = FrameScopedValue<int>(123);
+
+      expect(v1.value, 42);
+      expect(v2.value, 123);
+
+      endFrameScope();
+
+      expect(v1.value, isNull);
+      expect(v2.value, isNull);
+    });
+  });
+
   group('CrossFrameCache', () {
     test('Reuse returns no object when cache empty', () {
       final CrossFrameCache<TestItem> cache = CrossFrameCache<TestItem>();
@@ -77,4 +107,13 @@ void testMain() {
 class TestItem {
   TestItem(this.label);
   final String label;
+}
+
+class TestFrameScoped extends FrameScoped {
+  static final disposedList = <FrameScoped>[];
+
+  @override
+  void disposeFrameResources() {
+    disposedList.add(this);
+  }
 }


### PR DESCRIPTION
Rather than create `SkPaint` and immediately delete it after calling a `draw*` method, keep it around until the end of the frame. This would allow reuse of the paint object, fixing [this regression](https://flutter-flutter-perf.skia.org/e/?begin=1725044160&end=1725390847&keys=X436e5209f72f75a7d8258a58b35d36c6&num_commits=50&request_type=1&xbaroffset=42404). This does mean that if the paint is mutated, the cached `SkPaint` needs to be deleted. So it adds some complexity in the field setters. On the flip side, it removes the complexity in all the places `toSkPaint()` is used, as there's no longer need to stash the value in variables to call `SkPaint.delete()` later.

To accommodate `SkPaint`, the `FrameReference` class has been renamed to `FrameScoped` and generalized. Previously all it did was hold onto an object reference and null it out at the end of the frame. Now it's abstract, allowing supplying custom clean-up logic. In the case of `CkPaint`, it implements `FrameScoped` and implements clean-up by deleting the underlying `SkPaint`.