### PR TITLE
[skwasm] use temporary RawPaint objects (attempt #2)

### DIFF
--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/canvas.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/canvas.dart
@@ -29,27 +29,29 @@ class SkwasmCanvas implements SceneCanvas {
 
   @override
   void saveLayer(ui.Rect? bounds, ui.Paint paint) {
-    paint as SkwasmPaint;
+    final paintHandle = (paint as SkwasmPaint).toRawPaint();
     if (bounds != null) {
       withStackScope((StackScope s) {
-        canvasSaveLayer(_handle, s.convertRectToNative(bounds), paint.handle, nullptr);
+        canvasSaveLayer(_handle, s.convertRectToNative(bounds), paintHandle, nullptr);
       });
     } else {
-      canvasSaveLayer(_handle, nullptr, paint.handle, nullptr);
+      canvasSaveLayer(_handle, nullptr, paintHandle, nullptr);
     }
+    paintDispose(paintHandle);
   }
 
   @override
   void saveLayerWithFilter(ui.Rect? bounds, ui.Paint paint, ui.ImageFilter imageFilter) {
     final SkwasmImageFilter nativeFilter = SkwasmImageFilter.fromUiFilter(imageFilter);
-    paint as SkwasmPaint;
+    final paintHandle = (paint as SkwasmPaint).toRawPaint();
     if (bounds != null) {
       withStackScope((StackScope s) {
-        canvasSaveLayer(_handle, s.convertRectToNative(bounds), paint.handle, nativeFilter.handle);
+        canvasSaveLayer(_handle, s.convertRectToNative(bounds), paintHandle, nativeFilter.handle);
       });
     } else {
-      canvasSaveLayer(_handle, nullptr, paint.handle, nativeFilter.handle);
+      canvasSaveLayer(_handle, nullptr, paintHandle, nativeFilter.handle);
     }
+    paintDispose(paintHandle);
   }
 
   @override
@@ -111,71 +113,78 @@ class SkwasmCanvas implements SceneCanvas {
 
   @override
   void drawLine(ui.Offset p1, ui.Offset p2, ui.Paint paint) {
-    paint as SkwasmPaint;
-    canvasDrawLine(_handle, p1.dx, p1.dy, p2.dx, p2.dy, paint.handle);
+    final paintHandle = (paint as SkwasmPaint).toRawPaint();
+    canvasDrawLine(_handle, p1.dx, p1.dy, p2.dx, p2.dy, paintHandle);
+    paintDispose(paintHandle);
   }
 
   @override
   void drawPaint(ui.Paint paint) {
-    paint as SkwasmPaint;
-    canvasDrawPaint(_handle, paint.handle);
+    final paintHandle = (paint as SkwasmPaint).toRawPaint();
+    canvasDrawPaint(_handle, paintHandle);
+    paintDispose(paintHandle);
   }
 
   @override
   void drawRect(ui.Rect rect, ui.Paint paint) {
-    paint as SkwasmPaint;
+    final paintHandle = (paint as SkwasmPaint).toRawPaint();
     withStackScope((StackScope s) {
       canvasDrawRect(
         _handle,
         s.convertRectToNative(rect),
-        paint.handle
+        paintHandle
       );
     });
+    paintDispose(paintHandle);
   }
 
   @override
   void drawRRect(ui.RRect rrect, ui.Paint paint) {
-    paint as SkwasmPaint;
+    final paintHandle = (paint as SkwasmPaint).toRawPaint();
     withStackScope((StackScope s) {
       canvasDrawRRect(
         _handle,
         s.convertRRectToNative(rrect),
-        paint.handle
+        paintHandle
       );
     });
+    paintDispose(paintHandle);
   }
 
   @override
   void drawDRRect(ui.RRect outer, ui.RRect inner, ui.Paint paint) {
-    paint as SkwasmPaint;
+    final paintHandle = (paint as SkwasmPaint).toRawPaint();
     withStackScope((StackScope s) {
       canvasDrawDRRect(
         _handle,
         s.convertRRectToNative(outer),
         s.convertRRectToNative(inner),
-        paint.handle
+        paintHandle
       );
     });
+    paintDispose(paintHandle);
   }
 
   @override
   void drawOval(ui.Rect rect, ui.Paint paint) {
-    paint as SkwasmPaint;
+    final paintHandle = (paint as SkwasmPaint).toRawPaint();
     withStackScope((StackScope s) {
-      canvasDrawOval(_handle, s.convertRectToNative(rect), paint.handle);
+      canvasDrawOval(_handle, s.convertRectToNative(rect), paintHandle);
     });
+    paintDispose(paintHandle);
   }
 
   @override
   void drawCircle(ui.Offset center, double radius, ui.Paint paint) {
-    paint as SkwasmPaint;
-    canvasDrawCircle(_handle, center.dx, center.dy, radius, paint.handle);
+    final paintHandle = (paint as SkwasmPaint).toRawPaint();
+    canvasDrawCircle(_handle, center.dx, center.dy, radius, paintHandle);
+    paintDispose(paintHandle);
   }
 
   @override
   void drawArc(ui.Rect rect, double startAngle, double sweepAngle,
       bool useCenter, ui.Paint paint) {
-    paint as SkwasmPaint;
+    final paintHandle = (paint as SkwasmPaint).toRawPaint();
     withStackScope((StackScope s) {
       canvasDrawArc(
         _handle,
@@ -183,64 +192,79 @@ class SkwasmCanvas implements SceneCanvas {
         ui.toDegrees(startAngle),
         ui.toDegrees(sweepAngle),
         useCenter,
-        paint.handle
+        paintHandle,
       );
     });
+    paintDispose(paintHandle);
   }
 
   @override
   void drawPath(ui.Path path, ui.Paint paint) {
-    paint as SkwasmPaint;
     path as SkwasmPath;
-    canvasDrawPath(_handle, path.handle, paint.handle);
+    final paintHandle = (paint as SkwasmPaint).toRawPaint();
+    canvasDrawPath(_handle, path.handle, paintHandle);
+    paintDispose(paintHandle);
   }
 
   @override
-  void drawImage(ui.Image image, ui.Offset offset, ui.Paint paint) =>
+  void drawImage(ui.Image image, ui.Offset offset, ui.Paint paint) {
+    final paintHandle = (paint as SkwasmPaint).toRawPaint();
     canvasDrawImage(
       _handle,
       (image as SkwasmImage).handle,
       offset.dx,
       offset.dy,
-      (paint as SkwasmPaint).handle,
+      paintHandle,
       paint.filterQuality.index,
     );
+    paintDispose(paintHandle);
+  }
 
   @override
   void drawImageRect(
     ui.Image image,
     ui.Rect src,
     ui.Rect dst,
-    ui.Paint paint) => withStackScope((StackScope scope) {
-    final Pointer<Float> sourceRect = scope.convertRectToNative(src);
-    final Pointer<Float> destRect = scope.convertRectToNative(dst);
-    canvasDrawImageRect(
-      _handle,
-      (image as SkwasmImage).handle,
-      sourceRect,
-      destRect,
-      (paint as SkwasmPaint).handle,
-      paint.filterQuality.index,
-    );
-  });
+    ui.Paint paint,
+  ) {
+    withStackScope((StackScope scope) {
+      final Pointer<Float> sourceRect = scope.convertRectToNative(src);
+      final Pointer<Float> destRect = scope.convertRectToNative(dst);
+      final paintHandle = (paint as SkwasmPaint).toRawPaint();
+      canvasDrawImageRect(
+        _handle,
+        (image as SkwasmImage).handle,
+        sourceRect,
+        destRect,
+        paintHandle,
+        paint.filterQuality.index,
+      );
+      paintDispose(paintHandle);
+    });
+  }
 
   @override
   void drawImageNine(
     ui.Image image,
     ui.Rect center,
     ui.Rect dst,
-    ui.Paint paint) => withStackScope((StackScope scope) {
-    final Pointer<Int32> centerRect = scope.convertIRectToNative(center);
-    final Pointer<Float> destRect = scope.convertRectToNative(dst);
-    canvasDrawImageNine(
-      _handle,
-      (image as SkwasmImage).handle,
-      centerRect,
-      destRect,
-      (paint as SkwasmPaint).handle,
-      paint.filterQuality.index,
-    );
-  });
+    ui.Paint paint,
+  ) {
+    withStackScope((StackScope scope) {
+      final Pointer<Int32> centerRect = scope.convertIRectToNative(center);
+      final Pointer<Float> destRect = scope.convertRectToNative(dst);
+      final paintHandle = (paint as SkwasmPaint).toRawPaint();
+      canvasDrawImageNine(
+        _handle,
+        (image as SkwasmImage).handle,
+        centerRect,
+        destRect,
+        paintHandle,
+        paint.filterQuality.index,
+      );
+      paintDispose(paintHandle);
+    });
+  }
 
   @override
   void drawPicture(ui.Picture picture) {
@@ -264,13 +288,15 @@ class SkwasmCanvas implements SceneCanvas {
     ui.Paint paint
   ) => withStackScope((StackScope scope) {
     final RawPointArray rawPoints = scope.convertPointArrayToNative(points);
+    final paintHandle = (paint as SkwasmPaint).toRawPaint();
     canvasDrawPoints(
       _handle,
       pointMode.index,
       rawPoints,
       points.length,
-      (paint as SkwasmPaint).handle,
+      paintHandle,
     );
+    paintDispose(paintHandle);
   });
 
   @override
@@ -280,13 +306,15 @@ class SkwasmCanvas implements SceneCanvas {
     ui.Paint paint
   ) => withStackScope((StackScope scope) {
     final RawPointArray rawPoints = scope.convertDoublesToNative(points);
+    final paintHandle = (paint as SkwasmPaint).toRawPaint();
     canvasDrawPoints(
       _handle,
       pointMode.index,
       rawPoints,
       points.length ~/ 2,
-      (paint as SkwasmPaint).handle,
+      paintHandle,
     );
+    paintDispose(paintHandle);
   });
 
   @override
@@ -294,12 +322,16 @@ class SkwasmCanvas implements SceneCanvas {
     ui.Vertices vertices,
     ui.BlendMode blendMode,
     ui.Paint paint,
-  ) => canvasDrawVertices(
-    _handle,
-    (vertices as SkwasmVertices).handle,
-    blendMode.index,
-    (paint as SkwasmPaint).handle,
-  );
+  ) {
+    final paintHandle = (paint as SkwasmPaint).toRawPaint();
+    canvasDrawVertices(
+      _handle,
+      (vertices as SkwasmVertices).handle,
+      blendMode.index,
+      paintHandle,
+    );
+    paintDispose(paintHandle);
+  }
 
   @override
   void drawAtlas(
@@ -319,6 +351,7 @@ class SkwasmCanvas implements SceneCanvas {
     final RawRect rawCullRect = cullRect != null
       ? scope.convertRectToNative(cullRect)
       : nullptr;
+    final paintHandle = (paint as SkwasmPaint).toRawPaint();
     canvasDrawAtlas(
       _handle,
       (atlas as SkwasmImage).handle,
@@ -328,8 +361,9 @@ class SkwasmCanvas implements SceneCanvas {
       transforms.length,
       (blendMode ?? ui.BlendMode.src).index,
       rawCullRect,
-      (paint as SkwasmPaint).handle,
+      paintHandle,
     );
+    paintDispose(paintHandle);
   });
 
   @override
@@ -350,6 +384,7 @@ class SkwasmCanvas implements SceneCanvas {
     final RawRect rawCullRect = cullRect != null
       ? scope.convertRectToNative(cullRect)
       : nullptr;
+    final paintHandle = (paint as SkwasmPaint).toRawPaint();
     canvasDrawAtlas(
       _handle,
       (atlas as SkwasmImage).handle,
@@ -359,8 +394,9 @@ class SkwasmCanvas implements SceneCanvas {
       rstTransforms.length ~/ 4,
       (blendMode ?? ui.BlendMode.src).index,
       rawCullRect,
-      (paint as SkwasmPaint).handle,
+      paintHandle,
     );
+    paintDispose(paintHandle);
   });
 
   @override

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/canvas.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/canvas.dart
@@ -46,10 +46,14 @@ class SkwasmCanvas implements SceneCanvas {
     final paintHandle = (paint as SkwasmPaint).toRawPaint();
     if (bounds != null) {
       withStackScope((StackScope s) {
-        canvasSaveLayer(_handle, s.convertRectToNative(bounds), paintHandle, nativeFilter.handle);
+        nativeFilter.withRawImageFilter((nativeFilterHandle) {
+          canvasSaveLayer(_handle, s.convertRectToNative(bounds), paintHandle, nativeFilterHandle);
+        });
       });
     } else {
-      canvasSaveLayer(_handle, nullptr, paintHandle, nativeFilter.handle);
+      nativeFilter.withRawImageFilter((nativeFilterHandle) {
+        canvasSaveLayer(_handle, nullptr, paintHandle, nativeFilterHandle);
+      });
     }
     paintDispose(paintHandle);
   }

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/filters.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/filters.dart
@@ -8,8 +8,10 @@ import 'package:ui/src/engine.dart';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
 
-abstract class SkwasmImageFilter extends SkwasmObjectWrapper<RawImageFilter> implements SceneImageFilter {
-  SkwasmImageFilter(ImageFilterHandle handle) : super(handle, _registry);
+typedef ImageFilterHandleBorrow = void Function(ImageFilterHandle handle);
+
+abstract class SkwasmImageFilter implements SceneImageFilter {
+  const SkwasmImageFilter();
 
   factory SkwasmImageFilter.blur({
     double sigmaX = 0.0,
@@ -37,11 +39,9 @@ abstract class SkwasmImageFilter extends SkwasmObjectWrapper<RawImageFilter> imp
 
   factory SkwasmImageFilter.fromUiFilter(ui.ImageFilter filter) {
     if (filter is ui.ColorFilter) {
-      final SkwasmColorFilter colorFilter =
-        SkwasmColorFilter.fromEngineColorFilter(filter as EngineColorFilter);
-      final SkwasmImageFilter outputFilter = SkwasmImageFilter.fromColorFilter(colorFilter);
-      colorFilter.dispose();
-      return outputFilter;
+      return SkwasmImageFilter.fromColorFilter(
+        SkwasmColorFilter.fromEngineColorFilter(filter as EngineColorFilter),
+      );
     } else {
       return filter as SkwasmImageFilter;
     }
@@ -55,106 +55,146 @@ abstract class SkwasmImageFilter extends SkwasmObjectWrapper<RawImageFilter> imp
     SkwasmImageFilter.fromUiFilter(inner),
   );
 
-  static final SkwasmFinalizationRegistry<RawImageFilter> _registry =
-    SkwasmFinalizationRegistry<RawImageFilter>(imageFilterDispose);
+  /// Creates a temporary [ImageFilterHandle] and passes it to the [borrow]
+  /// function.
+  ///
+  /// The handle is deleted immediately after [borrow] returns. The [borrow]
+  /// function must not store the handle to avoid dangling pointer bugs.
+  void withRawImageFilter(ImageFilterHandleBorrow borrow);
 
   @override
   ui.Rect filterBounds(ui.Rect inputBounds) => withStackScope((StackScope scope) {
     final RawIRect rawRect = scope.convertIRectToNative(inputBounds);
-    imageFilterGetFilterBounds(handle, rawRect);
+    withRawImageFilter((handle) {
+      imageFilterGetFilterBounds(handle, rawRect);
+    });
     return scope.convertIRectFromNative(rawRect);
   });
 }
 
 class SkwasmBlurFilter extends SkwasmImageFilter {
-  SkwasmBlurFilter(
-    this.sigmaX,
-    this.sigmaY,
-    this.tileMode,
-  ) : super(imageFilterCreateBlur(sigmaX, sigmaY, tileMode.index));
+  const SkwasmBlurFilter(this.sigmaX, this.sigmaY, this.tileMode);
 
   final double sigmaX;
   final double sigmaY;
-  ui.TileMode tileMode;
+  final ui.TileMode tileMode;
+
+  @override
+  void withRawImageFilter(ImageFilterHandleBorrow borrow) {
+    final rawImageFilter = imageFilterCreateBlur(sigmaX, sigmaY, tileMode.index);
+    borrow(rawImageFilter);
+    imageFilterDispose(rawImageFilter);
+  }
 
   @override
   String toString() => 'ImageFilter.blur($sigmaX, $sigmaY, ${tileModeString(tileMode)})';
 }
 
 class SkwasmDilateFilter extends SkwasmImageFilter {
-  SkwasmDilateFilter(
-    this.radiusX,
-    this.radiusY,
-  ) : super(imageFilterCreateDilate(radiusX, radiusY));
+  const SkwasmDilateFilter(this.radiusX, this.radiusY);
 
   final double radiusX;
   final double radiusY;
+
+  @override
+  void withRawImageFilter(ImageFilterHandleBorrow borrow) {
+    final rawImageFilter = imageFilterCreateDilate(radiusX, radiusY);
+    borrow(rawImageFilter);
+    imageFilterDispose(rawImageFilter);
+  }
 
   @override
   String toString() => 'ImageFilter.dilate($radiusX, $radiusY)';
 }
 
 class SkwasmErodeFilter extends SkwasmImageFilter {
-  SkwasmErodeFilter(
-    this.radiusX,
-    this.radiusY,
-  ) : super(imageFilterCreateErode(radiusX, radiusY));
+  const SkwasmErodeFilter(this.radiusX, this.radiusY);
 
   final double radiusX;
   final double radiusY;
+
+  @override
+  void withRawImageFilter(ImageFilterHandleBorrow borrow) {
+    final rawImageFilter = imageFilterCreateErode(radiusX, radiusY);
+    borrow(rawImageFilter);
+    imageFilterDispose(rawImageFilter);
+  }
 
   @override
   String toString() => 'ImageFilter.erode($radiusX, $radiusY)';
 }
 
 class SkwasmMatrixFilter extends SkwasmImageFilter {
-  SkwasmMatrixFilter(
-    this.matrix4,
-    this.filterQuality,
-  ) : super(withStackScope((StackScope scope) => imageFilterCreateMatrix(
-    scope.convertMatrix4toSkMatrix(matrix4),
-    filterQuality.index,
-  )));
+  const SkwasmMatrixFilter(this.matrix4, this.filterQuality);
 
   final Float64List matrix4;
   final ui.FilterQuality filterQuality;
+
+  @override
+  void withRawImageFilter(ImageFilterHandleBorrow borrow) {
+    withStackScope((scope) {
+      final rawImageFilter = imageFilterCreateMatrix(
+        scope.convertMatrix4toSkMatrix(matrix4),
+        filterQuality.index,
+      );
+      borrow(rawImageFilter);
+      imageFilterDispose(rawImageFilter);
+    });
+  }
 
   @override
   String toString() => 'ImageFilter.matrix($matrix4, $filterQuality)';
 }
 
 class SkwasmColorImageFilter extends SkwasmImageFilter {
-  SkwasmColorImageFilter(
-    this.filter,
-  ) : super(imageFilterCreateFromColorFilter(filter.handle));
+  const SkwasmColorImageFilter(this.filter);
 
   final SkwasmColorFilter filter;
+
+  @override
+  void withRawImageFilter(ImageFilterHandleBorrow borrow) {
+    filter.withRawColorFilter((colroFilterHandle) {
+      final rawImageFilter = imageFilterCreateFromColorFilter(colroFilterHandle);
+      borrow(rawImageFilter);
+      imageFilterDispose(rawImageFilter);
+    });
+  }
 
   @override
   String toString() => filter.toString();
 }
 
 class SkwasmComposedImageFilter extends SkwasmImageFilter {
-  SkwasmComposedImageFilter(
-    this.outer,
-    this.inner,
-  ) : super(imageFilterCompose(outer.handle, inner.handle));
+  const SkwasmComposedImageFilter(this.outer, this.inner);
 
   final SkwasmImageFilter outer;
   final SkwasmImageFilter inner;
 
   @override
+  void withRawImageFilter(ImageFilterHandleBorrow borrow) {
+    outer.withRawImageFilter((outerHandle) {
+      inner.withRawImageFilter((innerHandle) {
+        final rawImageFilter = imageFilterCompose(outerHandle, innerHandle);
+        borrow(rawImageFilter);
+        imageFilterDispose(rawImageFilter);
+      });
+    });
+  }
+
+  @override
   String toString() => 'ImageFilter.compose($outer, $inner)';
 }
 
-abstract class SkwasmColorFilter extends SkwasmObjectWrapper<RawColorFilter> {
-  SkwasmColorFilter(ColorFilterHandle handle) : super(handle, _registry);
+typedef ColorFilterHandleBorrow = void Function(ColorFilterHandle handle);
+
+abstract class SkwasmColorFilter {
+  const SkwasmColorFilter();
 
   factory SkwasmColorFilter.fromEngineColorFilter(EngineColorFilter colorFilter) =>
     switch (colorFilter.type) {
       ColorFilterType.mode => SkwasmModeColorFilter(colorFilter.color!, colorFilter.blendMode!),
-      ColorFilterType.linearToSrgbGamma => SkwasmLinearToSrgbGammaColorFilter(),
-      ColorFilterType.srgbToLinearGamma => SkwasmSrgbToLinearGammaColorFilter(),
+      ColorFilterType.linearToSrgbGamma => const SkwasmLinearToSrgbGammaColorFilter(),
+      ColorFilterType.srgbToLinearGamma => const SkwasmSrgbToLinearGammaColorFilter(),
       ColorFilterType.matrix => SkwasmMatrixColorFilter(colorFilter.matrix!),
     };
 
@@ -163,59 +203,105 @@ abstract class SkwasmColorFilter extends SkwasmObjectWrapper<RawColorFilter> {
     SkwasmColorFilter inner,
   ) => SkwasmComposedColorFilter(outer, inner);
 
-  static final SkwasmFinalizationRegistry<RawColorFilter> _registry =
-    SkwasmFinalizationRegistry<RawColorFilter>(colorFilterDispose);
+  /// Creates a temporary [ColorFilterHandle] and passes it to the [borrow]
+  /// function.
+  ///
+  /// The handle is deleted immediately after [borrow] returns. The [borrow]
+  /// function must not store the handle to avoid dangling pointer bugs.
+  void withRawColorFilter(ColorFilterHandleBorrow borrow);
 }
 
 class SkwasmModeColorFilter extends SkwasmColorFilter {
-  SkwasmModeColorFilter(
+  const SkwasmModeColorFilter(
     this.color,
     this.blendMode,
-  ) : super(colorFilterCreateMode(
-      color.value,
-      blendMode.index,
-    ));
+  );
 
   final ui.Color color;
   final ui.BlendMode blendMode;
+
+  @override
+  void withRawColorFilter(ColorFilterHandleBorrow borrow) {
+    final rawColorFilter = colorFilterCreateMode(
+      color.value,
+      blendMode.index,
+    );
+    borrow(rawColorFilter);
+    colorFilterDispose(rawColorFilter);
+  }
 
   @override
   String toString() => 'ColorFilter.mode($color, $blendMode)';
 }
 
 class SkwasmLinearToSrgbGammaColorFilter extends SkwasmColorFilter {
-  SkwasmLinearToSrgbGammaColorFilter() : super(colorFilterCreateLinearToSRGBGamma());
+  const SkwasmLinearToSrgbGammaColorFilter();
+
+  /// This filter does not need to be deleted, because the same instance can
+  /// reused everywhere (it's not configurable).
+  static final _rawColorFilter = colorFilterCreateLinearToSRGBGamma();
+
+  @override
+  void withRawColorFilter(ColorFilterHandleBorrow borrow) {
+    borrow(_rawColorFilter);
+  }
 
   @override
   String toString() => 'ColorFilter.linearToSrgbGamma()';
 }
 
 class SkwasmSrgbToLinearGammaColorFilter extends SkwasmColorFilter {
-  SkwasmSrgbToLinearGammaColorFilter() : super(colorFilterCreateSRGBToLinearGamma());
+  const SkwasmSrgbToLinearGammaColorFilter();
+
+  /// This filter does not need to be deleted, because the same instance can
+  /// reused everywhere (it's not configurable).
+  static final _rawColorFilter = colorFilterCreateSRGBToLinearGamma();
+
+  @override
+  void withRawColorFilter(ColorFilterHandleBorrow borrow) {
+    borrow(_rawColorFilter);
+  }
 
   @override
   String toString() => 'ColorFilter.srgbToLinearGamma()';
 }
 
 class SkwasmMatrixColorFilter extends SkwasmColorFilter {
-  SkwasmMatrixColorFilter(this.matrix) : super(withStackScope((StackScope scope) =>
-    colorFilterCreateMatrix(scope.convertDoublesToNative(matrix))
-  ));
+  const SkwasmMatrixColorFilter(this.matrix);
 
   final List<double> matrix;
+
+  @override
+  void withRawColorFilter(ColorFilterHandleBorrow borrow) {
+    withStackScope((scope) {
+      final rawColorFilter = colorFilterCreateMatrix(
+        scope.convertDoublesToNative(matrix),
+      );
+      borrow(rawColorFilter);
+      colorFilterDispose(rawColorFilter);
+    });
+  }
 
   @override
   String toString() => 'ColorFilter.matrix($matrix)';
 }
 
 class SkwasmComposedColorFilter extends SkwasmColorFilter {
-  SkwasmComposedColorFilter(
-    this.outer,
-    this.inner,
-  ) : super(colorFilterCompose(outer.handle, inner.handle));
+  const SkwasmComposedColorFilter(this.outer, this.inner);
 
   final SkwasmColorFilter outer;
   final SkwasmColorFilter inner;
+
+  @override
+  void withRawColorFilter(ColorFilterHandleBorrow borrow) {
+    outer.withRawColorFilter((outerHandle) {
+      inner.withRawColorFilter((innerHandle) {
+        final rawColorFilter = colorFilterCompose(outerHandle, innerHandle);
+        borrow(rawColorFilter);
+        colorFilterDispose(rawColorFilter);
+      });
+    });
+  }
 
   @override
   String toString() => 'ColorFilter.compose($outer, $inner)';

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paint.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paint.dart
@@ -8,31 +8,73 @@ import 'package:ui/src/engine.dart';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
 
-class SkwasmPaint extends SkwasmObjectWrapper<RawPaint> implements ui.Paint {
-  SkwasmPaint() : super(paintCreate(), _registry);
+class SkwasmPaint implements ui.Paint {
+  SkwasmPaint();
 
-  // Must be kept in sync with the default in paint.cc.
-  static const double _kStrokeMiterLimitDefault = 4.0;
+  /// Creates the C++ side paint object based on the current state of this
+  /// paint object, and returns it with ownership.
+  ///
+  /// It is the responsibility of the caller to dispose of the returned handle
+  /// when it's no longer needed.
+  PaintHandle toRawPaint() {
+    final rawPaint = paintCreate(
+      isAntiAlias,
+      blendMode.index,
+      _colorValue,
+      style.index,
+      strokeWidth,
+      strokeCap.index,
+      strokeJoin.index,
+      strokeMiterLimit,
+    );
 
-  // Must be kept in sync with the default in paint.cc.
-  static const int _kColorDefault = 0xFF000000;
+    _maybeSetEffectiveColorFilter(rawPaint);
 
-  // Must be kept in sync with the default in paint.cc.
-  static final int _kBlendModeDefault = ui.BlendMode.srcOver.index;
+    final shaderHandle = _shader?.handle;
+    if (shaderHandle != null) {
+      paintSetShader(rawPaint, shaderHandle);
+    }
 
-  static final SkwasmFinalizationRegistry<RawPaint> _registry =
-    SkwasmFinalizationRegistry<RawPaint>(paintDispose);
+    final localMaskFilter = maskFilter;
+    if (localMaskFilter != null) {
+      final nativeFilter = SkwasmMaskFilter.fromUiMaskFilter(localMaskFilter);
+      paintSetMaskFilter(rawPaint, nativeFilter.handle);
+      nativeFilter.dispose();
+    }
 
-  ui.BlendMode _cachedBlendMode = ui.BlendMode.srcOver;
+    final filter = imageFilter;
+    if (filter != null) {
+      final nativeImageFilter = SkwasmImageFilter.fromUiFilter(filter);
+      paintSetImageFilter(rawPaint, nativeImageFilter.handle);
+      nativeImageFilter.dispose();
+    }
 
-  SkwasmShader? _shader;
-  ui.ImageFilter? _imageFilter;
+    return rawPaint;
+  }
 
-  EngineColorFilter? _colorFilter;
-
-  ui.MaskFilter? _maskFilter;
-
-  bool _invertColors = false;
+  /// If `invertColors` is true or `colorFilter` is not null, sets the
+  /// appropriate Skia color filter. Otherwise, does nothing.
+  void _maybeSetEffectiveColorFilter(Pointer<RawPaint> handle) {
+    final nativeFilter = _colorFilter != null
+      ? SkwasmColorFilter.fromEngineColorFilter(_colorFilter!)
+      : null;
+    if (invertColors) {
+      if (nativeFilter != null) {
+        final composedFilter = SkwasmColorFilter.composed(
+          _invertColorFilter,
+          nativeFilter,
+        );
+        nativeFilter.dispose();
+        paintSetColorFilter(handle, composedFilter.handle);
+        composedFilter.dispose();
+      } else {
+        paintSetColorFilter(handle, _invertColorFilter.handle);
+      }
+    } else if (nativeFilter != null) {
+      paintSetColorFilter(handle, nativeFilter.handle);
+      nativeFilter.dispose();
+    }
+  }
 
   static final SkwasmColorFilter _invertColorFilter = SkwasmColorFilter.fromEngineColorFilter(
     const EngineColorFilter.matrix(<double>[
@@ -44,143 +86,71 @@ class SkwasmPaint extends SkwasmObjectWrapper<RawPaint> implements ui.Paint {
   );
 
   @override
-  ui.BlendMode get blendMode {
-    return _cachedBlendMode;
+  ui.BlendMode blendMode = _kBlendModeDefault;
+
+  // Must be kept in sync with the default in paint.cc.
+  static const ui.BlendMode _kBlendModeDefault = ui.BlendMode.srcOver;
+
+  @override
+  ui.PaintingStyle style = ui.PaintingStyle.fill;
+
+  @override
+  double strokeWidth = 0.0;
+
+  @override
+  ui.StrokeCap strokeCap = ui.StrokeCap.butt;
+
+  @override
+  ui.StrokeJoin strokeJoin = ui.StrokeJoin.miter;
+
+  @override
+  bool isAntiAlias = true;
+
+  @override
+  ui.Color get color => ui.Color(_colorValue);
+  @override
+  set color(ui.Color value) {
+    _colorValue = value.value;
   }
 
-  @override
-  set blendMode(ui.BlendMode blendMode) {
-    if (_cachedBlendMode != blendMode) {
-      _cachedBlendMode = blendMode;
-      paintSetBlendMode(handle, blendMode.index);
-    }
-  }
+  static const int _kColorDefault = 0xFF000000;
+  int _colorValue = _kColorDefault;
 
   @override
-  ui.PaintingStyle get style => ui.PaintingStyle.values[paintGetStyle(handle)];
-
-  @override
-  set style(ui.PaintingStyle style) => paintSetStyle(handle, style.index);
-
-  @override
-  double get strokeWidth => paintGetStrokeWidth(handle);
-
-  @override
-  set strokeWidth(double width) => paintSetStrokeWidth(handle, width);
-
-  @override
-  ui.StrokeCap get strokeCap => ui.StrokeCap.values[paintGetStrokeCap(handle)];
-
-  @override
-  set strokeCap(ui.StrokeCap cap) => paintSetStrokeCap(handle, cap.index);
-
-  @override
-  ui.StrokeJoin get strokeJoin => ui.StrokeJoin.values[paintGetStrokeJoin(handle)];
-
-  @override
-  set strokeJoin(ui.StrokeJoin join) => paintSetStrokeJoin(handle, join.index);
-
-  @override
-  bool get isAntiAlias => paintGetAntiAlias(handle);
-
-  @override
-  set isAntiAlias(bool value) => paintSetAntiAlias(handle, value);
-
-  @override
-  ui.Color get color => ui.Color(paintGetColorInt(handle));
-
-  @override
-  set color(ui.Color color) => paintSetColorInt(handle, color.value);
-
-  @override
-  double get strokeMiterLimit => paintGetMiterLimit(handle);
-
-  @override
-  set strokeMiterLimit(double limit) => paintSetMiterLimit(handle, limit);
+  double strokeMiterLimit = _kStrokeMiterLimitDefault;
+  static const double _kStrokeMiterLimitDefault = 4.0;
 
   @override
   ui.Shader? get shader => _shader;
 
   @override
   set shader(ui.Shader? uiShader) {
-    final SkwasmShader? skwasmShader = uiShader as SkwasmShader?;
-    _shader = skwasmShader;
-    final ShaderHandle shaderHandle =
-      skwasmShader != null ? skwasmShader.handle : nullptr;
-    paintSetShader(handle, shaderHandle);
+    uiShader as SkwasmShader?;
+    _shader = uiShader;
   }
+  SkwasmShader? _shader;
 
   @override
   ui.FilterQuality filterQuality = ui.FilterQuality.none;
 
   @override
-  ui.ImageFilter? get imageFilter => _imageFilter;
-
-  @override
-  set imageFilter(ui.ImageFilter? filter) {
-    _imageFilter = filter;
-
-    final SkwasmImageFilter? nativeImageFilter = filter != null
-      ? SkwasmImageFilter.fromUiFilter(filter)
-      : null;
-    paintSetImageFilter(handle, nativeImageFilter != null ? nativeImageFilter.handle : nullptr);
-  }
+  ui.ImageFilter? imageFilter;
 
   @override
   ui.ColorFilter? get colorFilter => _colorFilter;
 
-  void _setEffectiveColorFilter() {
-    final SkwasmColorFilter? nativeFilter = _colorFilter != null
-      ? SkwasmColorFilter.fromEngineColorFilter(_colorFilter!) : null;
-    if (_invertColors) {
-      if (nativeFilter != null) {
-        final SkwasmColorFilter composedFilter = SkwasmColorFilter.composed(_invertColorFilter, nativeFilter);
-        nativeFilter.dispose();
-        paintSetColorFilter(handle, composedFilter.handle);
-        composedFilter.dispose();
-      } else {
-        paintSetColorFilter(handle, _invertColorFilter.handle);
-      }
-    } else if (nativeFilter != null) {
-      paintSetColorFilter(handle, nativeFilter.handle);
-      nativeFilter.dispose();
-    } else {
-      paintSetColorFilter(handle, nullptr);
-    }
-  }
-
   @override
   set colorFilter(ui.ColorFilter? filter) {
     _colorFilter = filter as EngineColorFilter?;
-    _setEffectiveColorFilter();
   }
 
-  @override
-  ui.MaskFilter? get maskFilter => _maskFilter;
+  EngineColorFilter? _colorFilter;
 
   @override
-  set maskFilter(ui.MaskFilter? filter) {
-    _maskFilter = filter;
-    if (filter == null) {
-      paintSetMaskFilter(handle, nullptr);
-    } else {
-      final SkwasmMaskFilter nativeFilter = SkwasmMaskFilter.fromUiMaskFilter(filter);
-      paintSetMaskFilter(handle, nativeFilter.handle);
-      nativeFilter.dispose();
-    }
-  }
+  ui.MaskFilter? maskFilter;
 
   @override
-  bool get invertColors => _invertColors;
-
-  @override
-  set invertColors(bool invertColors) {
-    if (_invertColors == invertColors) {
-      return;
-    }
-    _invertColors = invertColors;
-    _setEffectiveColorFilter();
-  }
+  bool invertColors = false;
 
   @override
   String toString() {
@@ -217,7 +187,7 @@ class SkwasmPaint extends SkwasmObjectWrapper<RawPaint> implements ui.Paint {
         result.write('$semicolon$color');
         semicolon = '; ';
       }
-      if (blendMode.index != _kBlendModeDefault) {
+      if (blendMode.index != _kBlendModeDefault.index) {
         result.write('$semicolon$blendMode');
         semicolon = '; ';
       }

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paint.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paint.dart
@@ -44,9 +44,10 @@ class SkwasmPaint implements ui.Paint {
 
     final filter = imageFilter;
     if (filter != null) {
-      final nativeImageFilter = SkwasmImageFilter.fromUiFilter(filter);
-      paintSetImageFilter(rawPaint, nativeImageFilter.handle);
-      nativeImageFilter.dispose();
+      final skwasmImageFilter = SkwasmImageFilter.fromUiFilter(filter);
+      skwasmImageFilter.withRawImageFilter((nativeHandle) {
+        paintSetImageFilter(rawPaint, nativeHandle);
+      });
     }
 
     return rawPaint;
@@ -64,15 +65,18 @@ class SkwasmPaint implements ui.Paint {
           _invertColorFilter,
           nativeFilter,
         );
-        nativeFilter.dispose();
-        paintSetColorFilter(handle, composedFilter.handle);
-        composedFilter.dispose();
+        composedFilter.withRawColorFilter((composedFilterHandle) {
+          paintSetColorFilter(handle, composedFilterHandle);
+        });
       } else {
-        paintSetColorFilter(handle, _invertColorFilter.handle);
+        _invertColorFilter.withRawColorFilter((invertFilterHandle) {
+          paintSetColorFilter(handle, invertFilterHandle);
+        });
       }
     } else if (nativeFilter != null) {
-      paintSetColorFilter(handle, nativeFilter.handle);
-      nativeFilter.dispose();
+      nativeFilter.withRawColorFilter((nativeFilterHandle) {
+        paintSetColorFilter(handle, nativeFilterHandle);
+      });
     }
   }
 

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -398,10 +398,14 @@ class SkwasmTextStyle implements ui.TextStyle {
       skStringFree(localeHandle);
     }
     if (background != null) {
-      textStyleSetBackground(handle, (background! as SkwasmPaint).handle);
+      final backgroundPaint = (background! as SkwasmPaint).toRawPaint();
+      textStyleSetBackground(handle, backgroundPaint);
+      paintDispose(backgroundPaint);
     }
     if (foreground != null) {
-      textStyleSetForeground(handle, (foreground! as SkwasmPaint).handle);
+      final foregroundPaint = (foreground! as SkwasmPaint).toRawPaint();
+      textStyleSetForeground(handle, foregroundPaint);
+      paintDispose(foregroundPaint);
     }
     if (shadows != null) {
       for (final ui.Shadow shadow in shadows!) {

--- a/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_paint.dart
+++ b/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_paint.dart
@@ -13,56 +13,31 @@ final class RawPaint extends Opaque {}
 
 typedef PaintHandle = Pointer<RawPaint>;
 
-@Native<PaintHandle Function()>(symbol: 'paint_create', isLeaf: true)
-external PaintHandle paintCreate();
+typedef _PaintCreateInitSignature = PaintHandle Function(
+  Bool,
+  Int,
+  Int,
+  Int,
+  Float,
+  Int,
+  Int,
+  Float,
+);
+
+@Native<_PaintCreateInitSignature>(symbol: 'paint_create', isLeaf: true)
+external PaintHandle paintCreate(
+  bool isAntiAlias,
+  int blendMode,
+  int color,
+  int style,
+  double strokeWidth,
+  int strokeCap,
+  int strokeJoin,
+  double strokeMiterLimit,
+);
 
 @Native<Void Function(PaintHandle)>(symbol: 'paint_dispose', isLeaf: true)
 external void paintDispose(PaintHandle paint);
-
-@Native<Void Function(PaintHandle, Int)>(symbol: 'paint_setBlendMode', isLeaf: true)
-external void paintSetBlendMode(PaintHandle paint, int blendMode);
-
-@Native<Void Function(PaintHandle, Int)>(symbol: 'paint_setStyle', isLeaf: true)
-external void paintSetStyle(PaintHandle paint, int paintStyle);
-
-@Native<Int Function(PaintHandle)>(symbol: 'paint_getStyle', isLeaf: true)
-external int paintGetStyle(PaintHandle paint);
-
-@Native<Void Function(PaintHandle, Float)>(symbol: 'paint_setStrokeWidth', isLeaf: true)
-external void paintSetStrokeWidth(PaintHandle paint, double strokeWidth);
-
-@Native<Float Function(PaintHandle)>(symbol: 'paint_getStrokeWidth', isLeaf: true)
-external double paintGetStrokeWidth(PaintHandle paint);
-
-@Native<Void Function(PaintHandle, Int)>(symbol: 'paint_setStrokeCap', isLeaf: true)
-external void paintSetStrokeCap(PaintHandle paint, int cap);
-
-@Native<Int Function(PaintHandle)>(symbol: 'paint_getStrokeCap', isLeaf: true)
-external int paintGetStrokeCap(PaintHandle paint);
-
-@Native<Void Function(PaintHandle, Int)>(symbol: 'paint_setStrokeJoin', isLeaf: true)
-external void paintSetStrokeJoin(PaintHandle paint, int join);
-
-@Native<Int Function(PaintHandle)>(symbol: 'paint_getStrokeJoin', isLeaf: true)
-external int paintGetStrokeJoin(PaintHandle paint);
-
-@Native<Void Function(PaintHandle, Bool)>(symbol: 'paint_setAntiAlias', isLeaf: true)
-external void paintSetAntiAlias(PaintHandle paint, bool antiAlias);
-
-@Native<Bool Function(PaintHandle)>(symbol: 'paint_getAntiAlias', isLeaf: true)
-external bool paintGetAntiAlias(PaintHandle paint);
-
-@Native<Void Function(PaintHandle, Uint32)>(symbol: 'paint_setColorInt', isLeaf: true)
-external void paintSetColorInt(PaintHandle paint, int color);
-
-@Native<Uint32 Function(PaintHandle)>(symbol: 'paint_getColorInt', isLeaf: true)
-external int paintGetColorInt(PaintHandle paint);
-
-@Native<Void Function(PaintHandle, Float)>(symbol: 'paint_setMiterLimit', isLeaf: true)
-external void paintSetMiterLimit(PaintHandle paint, double miterLimit);
-
-@Native<Float Function(PaintHandle)>(symbol: 'paint_getMiterLimit', isLeaf: true)
-external double paintGetMiterLimit(PaintHandle paint);
 
 @Native<Void Function(PaintHandle, ShaderHandle)>(symbol: 'paint_setShader', isLeaf: true)
 external void paintSetShader(PaintHandle handle, ShaderHandle shader);

--- a/lib/web_ui/skwasm/paint.cpp
+++ b/lib/web_ui/skwasm/paint.cpp
@@ -12,78 +12,28 @@
 
 using namespace Skwasm;
 
-SKWASM_EXPORT SkPaint* paint_create() {
+SKWASM_EXPORT SkPaint* paint_create(bool isAntiAlias,
+                                    SkBlendMode blendMode,
+                                    SkColor color,
+                                    SkPaint::Style style,
+                                    SkScalar strokeWidth,
+                                    SkPaint::Cap strokeCap,
+                                    SkPaint::Join strokeJoin,
+                                    SkScalar strokeMiterLimit) {
   auto paint = new SkPaint();
-
-  // Antialias defaults to true in flutter.
-  paint->setAntiAlias(true);
+  paint->setAntiAlias(isAntiAlias);
+  paint->setBlendMode(blendMode);
+  paint->setStyle(style);
+  paint->setStrokeWidth(strokeWidth);
+  paint->setStrokeCap(strokeCap);
+  paint->setStrokeJoin(strokeJoin);
+  paint->setColor(color);
+  paint->setStrokeMiter(strokeMiterLimit);
   return paint;
 }
 
 SKWASM_EXPORT void paint_dispose(SkPaint* paint) {
   delete paint;
-}
-
-SKWASM_EXPORT void paint_setBlendMode(SkPaint* paint, SkBlendMode mode) {
-  paint->setBlendMode(mode);
-}
-
-// No getter for blend mode, as it's non trivial. Cache on the dart side.
-
-SKWASM_EXPORT void paint_setStyle(SkPaint* paint, SkPaint::Style style) {
-  paint->setStyle(style);
-}
-
-SKWASM_EXPORT SkPaint::Style paint_getStyle(SkPaint* paint) {
-  return paint->getStyle();
-}
-
-SKWASM_EXPORT void paint_setStrokeWidth(SkPaint* paint, SkScalar width) {
-  paint->setStrokeWidth(width);
-}
-
-SKWASM_EXPORT SkScalar paint_getStrokeWidth(SkPaint* paint) {
-  return paint->getStrokeWidth();
-}
-
-SKWASM_EXPORT void paint_setStrokeCap(SkPaint* paint, SkPaint::Cap cap) {
-  paint->setStrokeCap(cap);
-}
-
-SKWASM_EXPORT SkPaint::Cap paint_getStrokeCap(SkPaint* paint) {
-  return paint->getStrokeCap();
-}
-
-SKWASM_EXPORT void paint_setStrokeJoin(SkPaint* paint, SkPaint::Join join) {
-  paint->setStrokeJoin(join);
-}
-
-SKWASM_EXPORT SkPaint::Join paint_getStrokeJoin(SkPaint* paint) {
-  return paint->getStrokeJoin();
-}
-
-SKWASM_EXPORT void paint_setAntiAlias(SkPaint* paint, bool antiAlias) {
-  paint->setAntiAlias(antiAlias);
-}
-
-SKWASM_EXPORT bool paint_getAntiAlias(SkPaint* paint) {
-  return paint->isAntiAlias();
-}
-
-SKWASM_EXPORT void paint_setColorInt(SkPaint* paint, SkColor colorInt) {
-  paint->setColor(colorInt);
-}
-
-SKWASM_EXPORT SkColor paint_getColorInt(SkPaint* paint) {
-  return paint->getColor();
-}
-
-SKWASM_EXPORT void paint_setMiterLimit(SkPaint* paint, SkScalar miterLimit) {
-  paint->setStrokeMiter(miterLimit);
-}
-
-SKWASM_EXPORT SkScalar paint_getMiterLimit(SkPaint* paint) {
-  return paint->getStrokeMiter();
 }
 
 SKWASM_EXPORT void paint_setShader(SkPaint* paint, SkShader* shader) {


### PR DESCRIPTION
Relands https://github.com/flutter/engine/pull/54917. The change is the same as before, except now the native resources for `SkwasmColorFilter` and `SkwasmImageFilter` classes are no longer GC'd. Instead, we use manually managed native handles (vended and scoped by `withRawColorFilter` and `withRawImageFilter`). The bug in the previous PR was that filter objects were disposed with the paint while the framework continued holding onto them. When GC kicked the finalization registry, it attempted to double-free the filters.