### PR TITLE
[Impeller] fix obvious memory leak.

### DIFF
--- a/shell/gpu/gpu_surface_gl_impeller.cc
+++ b/shell/gpu/gpu_surface_gl_impeller.cc
@@ -117,7 +117,6 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceGLImpeller::AcquireFrame(
 
     auto cull_rect = render_target.GetRenderTargetSize();
     impeller::Rect dl_cull_rect = impeller::Rect::MakeSize(cull_rect);
-    const bool reset_host_buffer = surface_frame.submit_info().frame_boundary;
 
 #if EXPERIMENTAL_CANVAS
     auto skia_cull_rect = SkIRect::MakeWH(cull_rect.width, cull_rect.height);
@@ -133,9 +132,7 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceGLImpeller::AcquireFrame(
     display_list->Dispatch(impeller_dispatcher, skia_cull_rect);
     impeller_dispatcher.FinishRecording();
     aiks_context->GetContentContext().GetLazyGlyphAtlas()->ResetTextFrames();
-    if (reset_host_buffer) {
-      aiks_context->GetContentContext().GetTransientsBuffer().Reset();
-    }
+    aiks_context->GetContentContext().GetTransientsBuffer().Reset();
     return true;
 #else
     impeller::DlDispatcher impeller_dispatcher(dl_cull_rect);
@@ -143,7 +140,8 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceGLImpeller::AcquireFrame(
                            SkIRect::MakeWH(cull_rect.width, cull_rect.height));
     auto picture = impeller_dispatcher.EndRecordingAsPicture();
 
-    return aiks_context->Render(picture, render_target, reset_host_buffer);
+    return aiks_context->Render(picture, render_target,
+                                /*reset_host_buffer=*/false);
 
 #endif  // EXPERIMENTAL_CANVAS
   };

--- a/shell/gpu/gpu_surface_metal_impeller.mm
+++ b/shell/gpu/gpu_surface_metal_impeller.mm
@@ -166,7 +166,6 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromCAMetalLa
 
         impeller::IRect cull_rect = surface->coverage();
         SkIRect sk_cull_rect = SkIRect::MakeWH(cull_rect.GetWidth(), cull_rect.GetHeight());
-        const bool reset_host_buffer = surface_frame.submit_info().frame_boundary;
 
         impeller::RenderTarget render_target = surface->GetTargetRenderPassDescriptor();
         surface->SetFrameBoundary(surface_frame.submit_info().frame_boundary);
@@ -183,9 +182,7 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromCAMetalLa
         display_list->Dispatch(impeller_dispatcher, sk_cull_rect);
         impeller_dispatcher.FinishRecording();
         aiks_context->GetContentContext().GetLazyGlyphAtlas()->ResetTextFrames();
-        if (reset_host_buffer) {
-          aiks_context->GetContentContext().GetTransientsBuffer().Reset();
-        }
+        aiks_context->GetContentContext().GetTransientsBuffer().Reset();
 
         if (!surface->PreparePresent()) {
           return false;

--- a/shell/gpu/gpu_surface_metal_impeller_unittests.mm
+++ b/shell/gpu/gpu_surface_metal_impeller_unittests.mm
@@ -97,7 +97,8 @@ TEST(GPUSurfaceMetalImpeller, AcquireFrameFromCAMetalLayerDoesNotRetainThis) {
   ASSERT_TRUE(frame->Submit());
 }
 
-TEST(GPUSurfaceMetalImpeller, ResetHostBufferBasedOnFrameBoundary) {
+// Because each overlay surface gets its own HostBuffer, we always need to reset.
+TEST(GPUSurfaceMetalImpeller, DoesNotResetHostBufferBasedOnFrameBoundary) {
   auto delegate = std::make_shared<TestGPUSurfaceMetalDelegate>();
   delegate->SetDevice();
 
@@ -115,13 +116,13 @@ TEST(GPUSurfaceMetalImpeller, ResetHostBufferBasedOnFrameBoundary) {
   frame->set_submit_info({.frame_boundary = false});
 
   ASSERT_TRUE(frame->Submit());
-  EXPECT_EQ(host_buffer.GetStateForTest().current_frame, 0u);
+  EXPECT_EQ(host_buffer.GetStateForTest().current_frame, 1u);
 
   frame = surface->AcquireFrame(SkISize::Make(100, 100));
   frame->set_submit_info({.frame_boundary = true});
 
   ASSERT_TRUE(frame->Submit());
-  EXPECT_EQ(host_buffer.GetStateForTest().current_frame, 1u);
+  EXPECT_EQ(host_buffer.GetStateForTest().current_frame, 2u);
 }
 
 #ifdef IMPELLER_DEBUG

--- a/shell/gpu/gpu_surface_vulkan_impeller.cc
+++ b/shell/gpu/gpu_surface_vulkan_impeller.cc
@@ -80,7 +80,6 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
       return false;
     }
 
-    const bool reset_host_buffer = surface_frame.submit_info().frame_boundary;
 #if EXPERIMENTAL_CANVAS
     impeller::TextFrameDispatcher collector(aiks_context->GetContentContext(),
                                             impeller::Matrix());
@@ -94,11 +93,8 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
     display_list->Dispatch(impeller_dispatcher,
                            SkIRect::MakeWH(cull_rect.width, cull_rect.height));
     impeller_dispatcher.FinishRecording();
-    aiks_context->GetContentContext().GetTransientsBuffer().Reset();
     aiks_context->GetContentContext().GetLazyGlyphAtlas()->ResetTextFrames();
-    if (reset_host_buffer) {
-      aiks_context->GetContentContext().GetTransientsBuffer().Reset();
-    }
+    aiks_context->GetContentContext().GetTransientsBuffer().Reset();
     return true;
 #else
     impeller::Rect dl_cull_rect = impeller::Rect::MakeSize(cull_rect);
@@ -106,7 +102,8 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
     display_list->Dispatch(impeller_dispatcher,
                            SkIRect::MakeWH(cull_rect.width, cull_rect.height));
     auto picture = impeller_dispatcher.EndRecordingAsPicture();
-    return aiks_context->Render(picture, render_target, reset_host_buffer);
+    return aiks_context->Render(picture, render_target,
+                                /*reset_host_buffer=*/false);
 #endif
   };
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/154549

Each overlay surface gets its own content context and each cc gets its own transient buffer. So not reseting the overlay surfaces causes a memory leak. The overlay surfaces would just continue to allocate into the same buffer which would allocate endlessly