### PR TITLE
[dart2wasm] Move web wasm embedder to new dart2wasm embedder API

### DIFF
--- a/lib/web_ui/flutter_js/src/entrypoint_loader.js
+++ b/lib/web_ui/flutter_js/src/entrypoint_loader.js
@@ -155,7 +155,7 @@ export class FlutterEntrypointLoader {
       }
       const jsSupportRuntime = await import(jsSupportRuntimeUri);
 
-      const compiledDartApp = jsSupportRuntime.compileStreaming(fetch(moduleUri));
+      const compiledDartAppPromise = jsSupportRuntime.compileStreaming(fetch(moduleUri));
 
       let imports;
       if (build.renderer === "skwasm") {
@@ -173,6 +173,7 @@ export class FlutterEntrypointLoader {
       } else {
         imports = {};
       }
+      const compiledDartApp = await compiledDartAppPromise;
       const dartApp = await compiledDartApp.instantiate(imports);
       await dartApp.invokeMain();
     }

--- a/lib/web_ui/flutter_js/src/entrypoint_loader.js
+++ b/lib/web_ui/flutter_js/src/entrypoint_loader.js
@@ -155,7 +155,7 @@ export class FlutterEntrypointLoader {
       }
       const jsSupportRuntime = await import(jsSupportRuntimeUri);
 
-      const dartModulePromise = jsSupportRuntime.compileStreaming(fetch(moduleUri));
+      const compiledDartApp = jsSupportRuntime.compileStreaming(fetch(moduleUri));
 
       let imports;
       if (build.renderer === "skwasm") {
@@ -173,8 +173,8 @@ export class FlutterEntrypointLoader {
       } else {
         imports = {};
       }
-      const moduleInstance = await jsSupportRuntime.instantiate(dartModulePromise, imports);
-      await jsSupportRuntime.invoke(moduleInstance);
+      const dartApp = await compiledDartApp.instantiate(imports);
+      await dartApp.invokeMain();
     }
   }
 

--- a/lib/web_ui/flutter_js/src/entrypoint_loader.js
+++ b/lib/web_ui/flutter_js/src/entrypoint_loader.js
@@ -157,9 +157,9 @@ export class FlutterEntrypointLoader {
 
       const compiledDartAppPromise = jsSupportRuntime.compileStreaming(fetch(moduleUri));
 
-      let imports;
+      let importsPromise;
       if (build.renderer === "skwasm") {
-        imports = (async () => {
+        importsPromise = (async () => {
           const skwasmInstance = await deps.skwasm;
           window._flutter_skwasmInstance = skwasmInstance;
           return {
@@ -171,10 +171,10 @@ export class FlutterEntrypointLoader {
           };
         })();
       } else {
-        imports = {};
+        importsPromise = Promise.resolve({});
       }
       const compiledDartApp = await compiledDartAppPromise;
-      const dartApp = await compiledDartApp.instantiate(imports);
+      const dartApp = await compiledDartApp.instantiate(await importsPromise);
       await dartApp.invokeMain();
     }
   }


### PR DESCRIPTION
This removes usages of the deprecated top-level `instantiate` and `invoke` methods and replaces it by method calls to the embedder objects.

See [0] for the change that introduce this embedder API.

[0] https://dart-review.googlesource.com/c/sdk/+/383242/6