### PR TITLE
Revert "Add `crossOrigin` property to <img> tag used for decoding (#54961)"

### DIFF
--- a/lib/web_ui/lib/src/engine/html_image_element_codec.dart
+++ b/lib/web_ui/lib/src/engine/html_image_element_codec.dart
@@ -45,7 +45,6 @@ abstract class HtmlImageElementCodec implements ui.Codec {
     imgElement = createDomHTMLImageElement();
     imgElement!.src = src;
     setJsProperty<String>(imgElement!, 'decoding', 'async');
-    setJsProperty<String>(imgElement!, 'crossOrigin', 'anonymous');
 
     // Ignoring the returned future on purpose because we're communicating
     // through the `completer`.

--- a/lib/web_ui/lib/src/engine/safe_browser_api.dart
+++ b/lib/web_ui/lib/src/engine/safe_browser_api.dart
@@ -40,7 +40,6 @@ T getJsProperty<T>(Object object, String name) {
 }
 
 const Set<String> _safeJsProperties = <String>{
-  'crossOrigin',
   'decoding',
   '__flutter_state',
 };

--- a/lib/web_ui/test/canvaskit/image_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/image_golden_test.dart
@@ -253,19 +253,6 @@ Future<void> testMain() async {
       }
     });
 
-    test('crossOrigin requests cause an error', () async {
-      final String otherOrigin =
-          domWindow.location.origin.replaceAll('localhost', '127.0.0.1');
-      bool gotError = false;
-      try {
-        final ui.Codec _ = await renderer.instantiateImageCodecFromUrl(
-            Uri.parse('$otherOrigin/test_images/1x1.png'));
-      } catch (e) {
-        gotError = true;
-      }
-      expect(gotError, isTrue, reason: 'Should have got CORS error');
-    });
-
     _testCkAnimatedImage();
 
     test('isAvif', () {


### PR DESCRIPTION
This reverts commit 4844cb489b3fa599cad5b0e499fb709ac490f5ed.

Reason for revert: We broke users (including a Google internal customer) that depend on credentialed image requests. See https://github.com/flutter/flutter/issues/154809

Fixes https://github.com/flutter/flutter/issues/154809