### PR TITLE
Roll buildroot to f85c3be4bf808add6ba867b8ff7943fd235b7b5e.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -278,7 +278,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '6ef931b950d5b9477dba0e278b7006ae327e12f7',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'f85c3be4bf808add6ba867b8ff7943fd235b7b5e',
 
   'src/flutter/third_party/depot_tools':
   Var('chromium_git') + '/chromium/tools/depot_tools.git' + '@' + '580b4ff3f5cd0dcaa2eacda28cefe0f45320e8f7',


### PR DESCRIPTION
- Report the exit code for failed build-time executions.

Bug: https://github.com/dart-lang/sdk/issues/56529