### PR TITLE
[CP] fix memory leak in host buffer reset.

### DIFF
--- a/shell/gpu/gpu_surface_metal_impeller.mm
+++ b/shell/gpu/gpu_surface_metal_impeller.mm
@@ -190,8 +190,8 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromCAMetalLa
 
         return renderer->Render(
             std::move(surface),
-            fml::MakeCopyable([aiks_context, picture = std::move(picture),
-                               reset_host_buffer](impeller::RenderTarget& render_target) -> bool {
+            fml::MakeCopyable([aiks_context, picture = std::move(picture)]
+                              (impeller::RenderTarget& render_target) -> bool {
               return aiks_context->Render(picture, render_target, /*reset_host_buffer=*/true);
             }));
 #endif

--- a/shell/gpu/gpu_surface_metal_impeller.mm
+++ b/shell/gpu/gpu_surface_metal_impeller.mm
@@ -190,8 +190,8 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromCAMetalLa
 
         return renderer->Render(
             std::move(surface),
-            fml::MakeCopyable([aiks_context, picture = std::move(picture)]
-                              (impeller::RenderTarget& render_target) -> bool {
+            fml::MakeCopyable([aiks_context, picture = std::move(picture)](
+                                  impeller::RenderTarget& render_target) -> bool {
               return aiks_context->Render(picture, render_target, /*reset_host_buffer=*/true);
             }));
 #endif

--- a/shell/gpu/gpu_surface_metal_impeller.mm
+++ b/shell/gpu/gpu_surface_metal_impeller.mm
@@ -187,13 +187,12 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromCAMetalLa
         impeller::DlDispatcher impeller_dispatcher(cull_rect);
         display_list->Dispatch(impeller_dispatcher, sk_cull_rect);
         auto picture = impeller_dispatcher.EndRecordingAsPicture();
-        const bool reset_host_buffer = surface_frame.submit_info().frame_boundary;
 
         return renderer->Render(
             std::move(surface),
             fml::MakeCopyable([aiks_context, picture = std::move(picture),
                                reset_host_buffer](impeller::RenderTarget& render_target) -> bool {
-              return aiks_context->Render(picture, render_target, reset_host_buffer);
+              return aiks_context->Render(picture, render_target, /*reset_host_buffer=*/true);
             }));
 #endif
       });

--- a/shell/gpu/gpu_surface_metal_impeller_unittests.mm
+++ b/shell/gpu/gpu_surface_metal_impeller_unittests.mm
@@ -97,7 +97,7 @@ TEST(GPUSurfaceMetalImpeller, AcquireFrameFromCAMetalLayerDoesNotRetainThis) {
   ASSERT_TRUE(frame->Submit());
 }
 
-TEST(GPUSurfaceMetalImpeller, ResetHostBufferBasedOnFrameBoundary) {
+TEST(GPUSurfaceMetalImpeller, DoesNotResetHostBufferBasedOnFrameBoundary) {
   auto delegate = std::make_shared<TestGPUSurfaceMetalDelegate>();
   delegate->SetDevice();
 
@@ -115,13 +115,13 @@ TEST(GPUSurfaceMetalImpeller, ResetHostBufferBasedOnFrameBoundary) {
   frame->set_submit_info({.frame_boundary = false});
 
   ASSERT_TRUE(frame->Submit());
-  EXPECT_EQ(host_buffer.GetStateForTest().current_frame, 0u);
+  EXPECT_EQ(host_buffer.GetStateForTest().current_frame, 1u);
 
   frame = surface->AcquireFrame(SkISize::Make(100, 100));
   frame->set_submit_info({.frame_boundary = true});
 
   ASSERT_TRUE(frame->Submit());
-  EXPECT_EQ(host_buffer.GetStateForTest().current_frame, 1u);
+  EXPECT_EQ(host_buffer.GetStateForTest().current_frame, 2u);
 }
 
 }  // namespace testing


### PR DESCRIPTION
Always resets host buffer, since each overlay context has its own host buffer