### PR TITLE
Add xcprivacy privacy manifest to macOS framework

### DIFF
--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -248,7 +248,7 @@ copy("copy_framework_module_map") {
   outputs = [ "$_flutter_framework_dir/Versions/A/Modules/module.modulemap" ]
 }
 
-# Copy privacy manifest. This empty plist is required by Apple for third-party SDKs.
+# Copy privacy manifest. This file is required by Apple for third-party SDKs.
 # See https://developer.apple.com/documentation/bundleresources/privacy_manifest_files
 copy("copy_framework_privacy_manifest") {
   visibility = [ ":*" ]

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -248,6 +248,14 @@ copy("copy_framework_module_map") {
   outputs = [ "$_flutter_framework_dir/Versions/A/Modules/module.modulemap" ]
 }
 
+# Copy privacy manifest. This empty plist is required by Apple for third-party SDKs.
+# See https://developer.apple.com/documentation/bundleresources/privacy_manifest_files
+copy("copy_framework_privacy_manifest") {
+  visibility = [ ":*" ]
+  sources = [ "framework/PrivacyInfo.xcprivacy" ]
+  outputs = [ "$_flutter_framework_dir/PrivacyInfo.xcprivacy" ]
+}
+
 action("copy_framework_headers") {
   script = "//flutter/sky/tools/install_framework_headers.py"
   visibility = [ ":*" ]
@@ -304,6 +312,7 @@ action("_generate_symlinks") {
     ":copy_framework_icu",
     ":copy_framework_info_plist",
     ":copy_framework_module_map",
+    ":copy_framework_privacy_manifest",
     ":copy_license",
   ]
   metadata = {

--- a/shell/platform/darwin/macos/framework/PrivacyInfo.xcprivacy
+++ b/shell/platform/darwin/macos/framework/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/shell/platform/darwin/macos/framework/PrivacyInfo.xcprivacy
+++ b/shell/platform/darwin/macos/framework/PrivacyInfo.xcprivacy
@@ -8,7 +8,5 @@
 	<array/>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array/>
-	<key>NSPrivacyAccessedAPITypes</key>
-	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
Create a `PrivacyInfo.xcprivacy` (this name is required) plist and move it to the top-level of the macOS framework bundle.  `NSPrivacyTracking*` and `NSPrivacyCollectedDataTypes` keys are required, but the values are blank.  macOS explicitly does not need the `NSPrivacyAccessedAPITypes` (see more info in https://github.com/flutter/flutter/issues/143381)

You can see on this PR it's copied to the correct path in the framework https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8737163270670636097/+/u/Global_generators/Release-FlutterMacOS.framework/stdout:

```
  adding: FlutterMacOS.xcframework/macos-arm64_x86_64/FlutterMacOS.framework/PrivacyInfo.xcprivacy (deflated 35%)
```

There's no way to test this except to submit a macOS app with this framework to TestFlight.

I can't find a good spot in the engine to validate the structure of the framework output.  I hereby pledge to add a macOS test to the framework post-roll https://github.com/flutter/flutter/pull/155189 ✋ 

iOS framework variant of this PR https://github.com/flutter/engine/pull/48951
Fixes https://github.com/flutter/flutter/issues/131494

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
