### PR TITLE
Move `flutter_frontend_server` and tweak `run_tests.py` to allow env variables.

### DIFF
--- a/flutter_frontend_server/pubspec.yaml
+++ b/flutter_frontend_server/pubspec.yaml
@@ -13,5 +13,6 @@ environment:
 resolution: workspace
 
 dev_dependencies:
-  litetest: any
+  engine_repo_tools: any
   path: any
+  test: any

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -978,7 +978,7 @@ def uses_package_test_runner(package):
 def build_dart_host_test_list(build_dir):
   dart_host_tests = [
       (os.path.join('flutter', 'ci'), []),
-      (os.path.join('flutter', 'flutter_frontend_server'), {"ENGINE_BUILD_DIR": build_dir}),
+      (os.path.join('flutter', 'flutter_frontend_server'), {'ENGINE_BUILD_DIR': build_dir}),
       (os.path.join('flutter', 'testing', 'litetest'), []),
       (os.path.join('flutter', 'testing', 'skia_gold_client'), []),
       (os.path.join('flutter', 'testing', 'scenario_app'), []),

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -917,16 +917,23 @@ def gather_dart_smoke_test(build_dir, test_filter):
 
 def gather_dart_package_tests(build_dir, package_path, extra_opts):
   if uses_package_test_runner(package_path):
-    # Package that use package:test (dart test) do not support command-line arguments.
-    #
-    # The usual workaround is to use Platform.environment, but that would require changing
-    # the test execution a tiny bit. TODO(https://github.com/flutter/flutter/issues/133569).
-    #
-    # Until then, assert that no extra_opts are passed and explain the limitation.
-    assert not extra_opts, '%s uses package:test and cannot use CLI args' % package_path
+    # Assert that extra_opts is either None, or is an empty list, or is a dictionary.
+    assert len(extra_opts) == 0 or isinstance(
+        extra_opts, dict
+    ), '%s uses package:test and expects a dictionary, but passed a %s' % (
+        package_path, type(extra_opts)
+    )
+    extra_env = {}
+    if isinstance(extra_opts, dict):
+      extra_env = extra_opts
     opts = ['test', '--reporter=expanded']
     yield EngineExecutableTask(
-        build_dir, os.path.join('dart-sdk', 'bin', 'dart'), None, flags=opts, cwd=package_path
+        build_dir,
+        os.path.join('dart-sdk', 'bin', 'dart'),
+        None,
+        flags=opts,
+        cwd=package_path,
+        extra_env=extra_env
     )
   else:
     dart_tests = glob.glob('%s/test/*_test.dart' % package_path)
@@ -971,14 +978,7 @@ def uses_package_test_runner(package):
 def build_dart_host_test_list(build_dir):
   dart_host_tests = [
       (os.path.join('flutter', 'ci'), []),
-      (
-          os.path.join('flutter', 'flutter_frontend_server'),
-          [
-              build_dir,
-              os.path.join(build_dir, 'gen', 'frontend_server_aot.dart.snapshot'),
-              os.path.join(build_dir, 'flutter_patched_sdk')
-          ],
-      ),
+      (os.path.join('flutter', 'flutter_frontend_server'), {"ENGINE_BUILD_DIR": build_dir}),
       (os.path.join('flutter', 'testing', 'litetest'), []),
       (os.path.join('flutter', 'testing', 'skia_gold_client'), []),
       (os.path.join('flutter', 'testing', 'scenario_app'), []),


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/133569.

After another PR, `run_tests.py` `extra_args` can be deleted entirely.