### PR TITLE
Filter out bad locales returned by g_get_language_names

### DIFF
--- a/shell/platform/linux/fl_engine.cc
+++ b/shell/platform/linux/fl_engine.cc
@@ -169,8 +169,8 @@ static void setup_locales(FlEngine* self) {
       continue;
     }
 
-    g_autofree gchar* language = NULL;
-    g_autofree gchar* territory = NULL;
+    g_autofree gchar* language = nullptr;
+    g_autofree gchar* territory = nullptr;
     parse_locale(locale_string, &language, &territory, nullptr, nullptr);
 
     // Ignore duplicate locales, caused by settings like `LANGUAGE=C` (returns

--- a/shell/platform/linux/fl_engine.cc
+++ b/shell/platform/linux/fl_engine.cc
@@ -150,28 +150,50 @@ static void view_removed_cb(const FlutterRemoveViewResult* result) {
   }
 }
 
+static void free_locale(FlutterLocale* locale) {
+  free(const_cast<gchar*>(locale->language_code));
+  free(const_cast<gchar*>(locale->country_code));
+  free(locale);
+}
+
 // Passes locale information to the Flutter engine.
 static void setup_locales(FlEngine* self) {
   const gchar* const* languages = g_get_language_names();
-  g_autoptr(GPtrArray) locales_array = g_ptr_array_new_with_free_func(g_free);
-  // Helper array to take ownership of the strings passed to Flutter.
-  g_autoptr(GPtrArray) locale_strings = g_ptr_array_new_with_free_func(g_free);
+  g_autoptr(GPtrArray) locales_array = g_ptr_array_new_with_free_func(
+      reinterpret_cast<GDestroyNotify>(free_locale));
   for (int i = 0; languages[i] != nullptr; i++) {
-    gchar *language, *territory;
-    parse_locale(languages[i], &language, &territory, nullptr, nullptr);
-    if (language != nullptr) {
-      g_ptr_array_add(locale_strings, language);
+    g_autofree gchar* locale_string = g_strstrip(g_strdup(languages[i]));
+
+    // Ignore empty locales, caused by settings like `LANGUAGE=pt_BR:`
+    if (strcmp(locale_string, "") == 0) {
+      continue;
     }
-    if (territory != nullptr) {
-      g_ptr_array_add(locale_strings, territory);
+
+    g_autofree gchar* language = NULL;
+    g_autofree gchar* territory = NULL;
+    parse_locale(locale_string, &language, &territory, nullptr, nullptr);
+
+    // Ignore duplicate locales, caused by settings like `LANGUAGE=C` (returns
+    // two "C") or `LANGUAGE=en:en`
+    gboolean has_locale = FALSE;
+    for (guint j = 0; !has_locale && j < locales_array->len; j++) {
+      FlutterLocale* locale =
+          reinterpret_cast<FlutterLocale*>(g_ptr_array_index(locales_array, j));
+      has_locale = g_strcmp0(locale->language_code, language) == 0 &&
+                   g_strcmp0(locale->country_code, territory) == 0;
+    }
+    if (has_locale) {
+      continue;
     }
 
     FlutterLocale* locale =
         static_cast<FlutterLocale*>(g_malloc0(sizeof(FlutterLocale)));
     g_ptr_array_add(locales_array, locale);
     locale->struct_size = sizeof(FlutterLocale);
-    locale->language_code = language;
-    locale->country_code = territory;
+    locale->language_code =
+        reinterpret_cast<const gchar*>(g_steal_pointer(&language));
+    locale->country_code =
+        reinterpret_cast<const gchar*>(g_steal_pointer(&territory));
     locale->script_code = nullptr;
     locale->variant_code = nullptr;
   }

--- a/shell/platform/linux/fl_engine_test.cc
+++ b/shell/platform/linux/fl_engine_test.cc
@@ -365,7 +365,7 @@ TEST(FlEngineTest, DartEntrypointArgs) {
 }
 
 TEST(FlEngineTest, Locales) {
-  gchar* initial_language = g_strdup(g_getenv("LANGUAGE"));
+  g_autofree gchar* initial_language = g_strdup(g_getenv("LANGUAGE"));
   g_setenv("LANGUAGE", "de:en_US", TRUE);
   g_autoptr(FlDartProject) project = fl_dart_project_new();
 
@@ -414,7 +414,137 @@ TEST(FlEngineTest, Locales) {
   } else {
     g_unsetenv("LANGUAGE");
   }
-  g_free(initial_language);
+}
+
+TEST(FlEngineTest, CLocale) {
+  g_autofree gchar* initial_language = g_strdup(g_getenv("LANGUAGE"));
+  g_setenv("LANGUAGE", "C", TRUE);
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+
+  g_autoptr(FlEngine) engine = make_mock_engine_with_project(project);
+  FlutterEngineProcTable* embedder_api = fl_engine_get_embedder_api(engine);
+
+  bool called = false;
+  embedder_api->UpdateLocales = MOCK_ENGINE_PROC(
+      UpdateLocales, ([&called](auto engine, const FlutterLocale** locales,
+                                size_t locales_count) {
+        called = true;
+
+        EXPECT_EQ(locales_count, static_cast<size_t>(1));
+
+        EXPECT_STREQ(locales[0]->language_code, "C");
+        EXPECT_STREQ(locales[0]->country_code, nullptr);
+        EXPECT_STREQ(locales[0]->script_code, nullptr);
+        EXPECT_STREQ(locales[0]->variant_code, nullptr);
+
+        return kSuccess;
+      }));
+
+  g_autoptr(GError) error = nullptr;
+  EXPECT_TRUE(fl_engine_start(engine, &error));
+  EXPECT_EQ(error, nullptr);
+
+  EXPECT_TRUE(called);
+
+  if (initial_language) {
+    g_setenv("LANGUAGE", initial_language, TRUE);
+  } else {
+    g_unsetenv("LANGUAGE");
+  }
+}
+
+TEST(FlEngineTest, DuplicateLocale) {
+  g_autofree gchar* initial_language = g_strdup(g_getenv("LANGUAGE"));
+  g_setenv("LANGUAGE", "en:en", TRUE);
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+
+  g_autoptr(FlEngine) engine = make_mock_engine_with_project(project);
+  FlutterEngineProcTable* embedder_api = fl_engine_get_embedder_api(engine);
+
+  bool called = false;
+  embedder_api->UpdateLocales = MOCK_ENGINE_PROC(
+      UpdateLocales, ([&called](auto engine, const FlutterLocale** locales,
+                                size_t locales_count) {
+        called = true;
+
+        EXPECT_EQ(locales_count, static_cast<size_t>(2));
+
+        EXPECT_STREQ(locales[0]->language_code, "en");
+        EXPECT_STREQ(locales[0]->country_code, nullptr);
+        EXPECT_STREQ(locales[0]->script_code, nullptr);
+        EXPECT_STREQ(locales[0]->variant_code, nullptr);
+
+        EXPECT_STREQ(locales[1]->language_code, "C");
+        EXPECT_STREQ(locales[1]->country_code, nullptr);
+        EXPECT_STREQ(locales[1]->script_code, nullptr);
+        EXPECT_STREQ(locales[1]->variant_code, nullptr);
+
+        return kSuccess;
+      }));
+
+  g_autoptr(GError) error = nullptr;
+  EXPECT_TRUE(fl_engine_start(engine, &error));
+  EXPECT_EQ(error, nullptr);
+
+  EXPECT_TRUE(called);
+
+  if (initial_language) {
+    g_setenv("LANGUAGE", initial_language, TRUE);
+  } else {
+    g_unsetenv("LANGUAGE");
+  }
+}
+
+TEST(FlEngineTest, EmptyLocales) {
+  g_autofree gchar* initial_language = g_strdup(g_getenv("LANGUAGE"));
+  g_setenv("LANGUAGE", "de:: :en_US", TRUE);
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+
+  g_autoptr(FlEngine) engine = make_mock_engine_with_project(project);
+  FlutterEngineProcTable* embedder_api = fl_engine_get_embedder_api(engine);
+
+  bool called = false;
+  embedder_api->UpdateLocales = MOCK_ENGINE_PROC(
+      UpdateLocales, ([&called](auto engine, const FlutterLocale** locales,
+                                size_t locales_count) {
+        called = true;
+
+        EXPECT_EQ(locales_count, static_cast<size_t>(4));
+
+        EXPECT_STREQ(locales[0]->language_code, "de");
+        EXPECT_STREQ(locales[0]->country_code, nullptr);
+        EXPECT_STREQ(locales[0]->script_code, nullptr);
+        EXPECT_STREQ(locales[0]->variant_code, nullptr);
+
+        EXPECT_STREQ(locales[1]->language_code, "en");
+        EXPECT_STREQ(locales[1]->country_code, "US");
+        EXPECT_STREQ(locales[1]->script_code, nullptr);
+        EXPECT_STREQ(locales[1]->variant_code, nullptr);
+
+        EXPECT_STREQ(locales[2]->language_code, "en");
+        EXPECT_STREQ(locales[2]->country_code, nullptr);
+        EXPECT_STREQ(locales[2]->script_code, nullptr);
+        EXPECT_STREQ(locales[2]->variant_code, nullptr);
+
+        EXPECT_STREQ(locales[3]->language_code, "C");
+        EXPECT_STREQ(locales[3]->country_code, nullptr);
+        EXPECT_STREQ(locales[3]->script_code, nullptr);
+        EXPECT_STREQ(locales[3]->variant_code, nullptr);
+
+        return kSuccess;
+      }));
+
+  g_autoptr(GError) error = nullptr;
+  EXPECT_TRUE(fl_engine_start(engine, &error));
+  EXPECT_EQ(error, nullptr);
+
+  EXPECT_TRUE(called);
+
+  if (initial_language) {
+    g_setenv("LANGUAGE", initial_language, TRUE);
+  } else {
+    g_unsetenv("LANGUAGE");
+  }
 }
 
 TEST(FlEngineTest, SwitchesEmpty) {


### PR DESCRIPTION
We're seeing issues with and "und" (undefined) locale and exceptions in applications (see https://github.com/ubuntu/app-center/issues/1659). It seems the GLib method for getting the language names doesn't clean up invalid values, so we should do that.