### PR TITLE
Zip and upload Xcode xcresults on scenario test failure

### DIFF
--- a/testing/scenario_app/bin/run_ios_tests.dart
+++ b/testing/scenario_app/bin/run_ios_tests.dart
@@ -382,7 +382,7 @@ String _zipAndStoreFailedTestResults({
   required io.Directory resultBundle,
   required String storePath,
 }) {
-  final outputPath = path.join(storePath, '$iosEngineVariant.zip');
+  final outputPath = path.join(storePath, '${iosEngineVariant.replaceAll('/', '_')}.zip');
   final result = io.Process.runSync(
     'zip',
     [

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/SpawnEngineTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/SpawnEngineTest.m
@@ -10,7 +10,6 @@
 @implementation SpawnEngineTest
 
 - (void)testSpawnEngineWorks {
-  XCTFail();
   self.continueAfterFailure = NO;
 
   XCUIApplication* application = [[XCUIApplication alloc] init];

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/SpawnEngineTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/SpawnEngineTest.m
@@ -10,6 +10,7 @@
 @implementation SpawnEngineTest
 
 - (void)testSpawnEngineWorks {
+  XCTFail();
   self.continueAfterFailure = NO;
 
   XCUIApplication* application = [[XCUIApplication alloc] init];


### PR DESCRIPTION
The `FLUTTER_ENGINE` has a `/` in it: `ci/ios_debug_unopt_sim`.  
```
path.join(storePath, '$iosEngineVariant.zip');
```
was resolving to `path_to_output/ci/ios_debug_unopt_sim.zip`.  `path_to_output` existed, but the `ci` directory didn't:

> zip error: Could not create output file (/Volumes/Work/s/w/ir/x/w/rc/flutter_logs_dir/ci/ios_debug_unopt_sim.zip)

Change the output zip path to `path_to_output/ci_ios_debug_unopt_sim.zip` with an underscore instead.

Fixes https://github.com/flutter/flutter/issues/154956

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
