### PR TITLE
Replace `System.loadLibrary` with `ReLinker.loadLibrary()` in `FlutterJNI.loadLibrary()`

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -780,7 +780,7 @@ deps = {
      'packages': [
        {
         'package': 'flutter/android/embedding_bundle',
-        'version': 'last_updated:2024-06-18T12:13:41-0700'
+        'version': 'last_updated:2024-09-10T16:32:16-0700'
        }
      ],
      'condition': 'download_android_deps',

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -394,6 +394,7 @@ embedding_dependencies_jars = [
   "//flutter/third_party/android_embedding_dependencies/lib/viewpager-1.0.0.jar",
   "//flutter/third_party/android_embedding_dependencies/lib/window-1.2.0.jar",
   "//flutter/third_party/android_embedding_dependencies/lib/window-java-1.2.0.jar",
+  "//flutter/third_party/android_embedding_dependencies/lib/relinker-1.4.5.jar",
 ]
 
 action("check_imports") {

--- a/shell/platform/android/build.gradle
+++ b/shell/platform/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.4.1"
+        classpath "com.android.tools.build:gradle:7.4.2"
     }
 }
 

--- a/shell/platform/android/build.gradle
+++ b/shell/platform/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.4.2"
+        classpath "com.android.tools.build:gradle:7.4.1"
     }
 }
 

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -24,6 +24,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import androidx.annotation.VisibleForTesting;
+import com.getkeepsafe.relinker.ReLinker;
 import io.flutter.Log;
 import io.flutter.embedding.engine.FlutterEngine.EngineLifecycleListener;
 import io.flutter.embedding.engine.dart.PlatformMessageHandler;
@@ -139,12 +140,11 @@ public class FlutterJNI {
    *
    * <p>This method should only be called once across all FlutterJNI instances.
    */
-  public void loadLibrary() {
+  public void loadLibrary(Context context) {
     if (FlutterJNI.loadLibraryCalled) {
       Log.w(TAG, "FlutterJNI.loadLibrary called more than once");
     }
-
-    System.loadLibrary("flutter");
+    ReLinker.loadLibrary(context, "flutter");
     FlutterJNI.loadLibraryCalled = true;
   }
 

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -139,7 +139,7 @@ public class FlutterJNI {
    * loading native libraries.
    *
    * <p>This method should only be called once across all FlutterJNI instances.
-   *
+   * 
    * @deprecated replaced by {@link #loadLibrary(Context)}.
    */
   @Deprecated
@@ -150,7 +150,7 @@ public class FlutterJNI {
     System.loadLibrary("flutter");
     FlutterJNI.loadLibraryCalled = true;
   }
-
+  
   /**
    * Loads the libflutter.so C++ library.
    *

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -139,6 +139,25 @@ public class FlutterJNI {
    * loading native libraries.
    *
    * <p>This method should only be called once across all FlutterJNI instances.
+   * 
+   * @deprecated replaced by {@link #loadLibrary(Context)}.
+   */
+  @Deprecated
+  public void loadLibrary() {
+    if (FlutterJNI.loadLibraryCalled) {
+      Log.w(TAG, "FlutterJNI.loadLibrary called more than once");
+    }
+    System.loadLibrary("flutter");
+    FlutterJNI.loadLibraryCalled = true;
+  }
+  
+  /**
+   * Loads the libflutter.so C++ library.
+   *
+   * <p>This must be called before any other native methods, and can be overridden by tests to avoid
+   * loading native libraries.
+   *
+   * <p>This method should only be called once across all FlutterJNI instances.
    */
   public void loadLibrary(Context context) {
     if (FlutterJNI.loadLibraryCalled) {

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -139,7 +139,7 @@ public class FlutterJNI {
    * loading native libraries.
    *
    * <p>This method should only be called once across all FlutterJNI instances.
-   * 
+   *
    * @deprecated replaced by {@link #loadLibrary(Context)}.
    */
   @Deprecated
@@ -150,7 +150,7 @@ public class FlutterJNI {
     System.loadLibrary("flutter");
     FlutterJNI.loadLibraryCalled = true;
   }
-  
+
   /**
    * Loads the libflutter.so C++ library.
    *

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -139,25 +139,6 @@ public class FlutterJNI {
    * loading native libraries.
    *
    * <p>This method should only be called once across all FlutterJNI instances.
-   * 
-   * @deprecated replaced by {@link #loadLibrary(Context)}.
-   */
-  @Deprecated
-  public void loadLibrary() {
-    if (FlutterJNI.loadLibraryCalled) {
-      Log.w(TAG, "FlutterJNI.loadLibrary called more than once");
-    }
-    System.loadLibrary("flutter");
-    FlutterJNI.loadLibraryCalled = true;
-  }
-  
-  /**
-   * Loads the libflutter.so C++ library.
-   *
-   * <p>This must be called before any other native methods, and can be overridden by tests to avoid
-   * loading native libraries.
-   *
-   * <p>This method should only be called once across all FlutterJNI instances.
    */
   public void loadLibrary(Context context) {
     if (FlutterJNI.loadLibraryCalled) {

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -182,7 +182,7 @@ public class FlutterLoader {
                 ResourceExtractor resourceExtractor = initResources(appContext);
 
                 try {
-                  flutterJNI.loadLibrary();
+                  flutterJNI.loadLibrary(appContext);
                 } catch (UnsatisfiedLinkError unsatisfiedLinkError) {
                   String couldntFindVersion = "couldn't find \"libflutter.so\"";
                   String notFoundVersion = "dlopen failed: library \"libflutter.so\" not found";

--- a/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
@@ -58,7 +58,7 @@ public class FlutterLoaderTest {
     flutterLoader.ensureInitializationComplete(ctx, null);
     shadowOf(getMainLooper()).idle();
     assertTrue(flutterLoader.initialized());
-    verify(mockFlutterJNI, times(1)).loadLibrary();
+    verify(mockFlutterJNI, times(1)).loadLibrary(ctx);
     verify(mockFlutterJNI, times(1)).updateRefreshRate();
   }
 
@@ -70,7 +70,7 @@ public class FlutterLoaderTest {
 
     Mockito.doThrow(new UnsatisfiedLinkError("couldn't find \"libflutter.so\""))
         .when(mockFlutterJNI)
-        .loadLibrary();
+        .loadLibrary(ctx);
     try {
       flutterLoader.startInitialization(ctx);
     } catch (UnsupportedOperationException e) {

--- a/tools/androidx/README.md
+++ b/tools/androidx/README.md
@@ -1,0 +1,3 @@
+Defines the additional Android build time dependencies downloaded by `engine/tools/cipd/android_embedding_bundle`, which then get uploaded to CIPD and pulled by `gclient sync` into `third_party/android_embedding_dependencies/lib/`.
+
+Despite the directory name, `files.json` actually includes one non-androidx dependency: [ReLinker](https://github.com/KeepSafe/ReLinker).

--- a/tools/androidx/files.json
+++ b/tools/androidx/files.json
@@ -86,5 +86,11 @@
     "out_file_name": "core-1.10.3.aar",
     "maven_dependency": "com.google.android.play:core:1.10.3",
     "provides": []
+  },
+  {
+    "url": "https://repo1.maven.org/maven2/com/getkeepsafe/relinker/relinker/1.4.5/relinker-1.4.5.aar",
+    "out_file_name": "relinker-1.4.5.aar",
+    "maven_dependency": "com.getkeepsafe.relinker:relinker:1.4.5",
+    "provides": ["com.getkeepsafe.relinker.ReLinker"]
   }
 ]


### PR DESCRIPTION
Could fix? https://github.com/flutter/flutter/issues/83596

The communication on https://issuetracker.google.com/issues/346717090#comment2 recommends using [ReLinker](https://github.com/KeepSafe/ReLinker) to avoid a bug in how library loading interacts with the [Play delivery feature](https://developer.android.com/guide/playcore/feature-delivery) (used in turn by Flutter's deferred components).

The ReLinker docs also suggest that if you have `minSdk` less than `23`, then you should be using ReLinker regardless, as `System.loadLibrary` is unreliable for other reasons.

I don't have any strong evidence to suggest that either one of these two root causes is the definitive cause of https://github.com/flutter/flutter/issues/83596, but it probably wouldn't hurt 🤷 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
