### PR TITLE
[engine] make UI thread the platform thread for Android. Still allows opt out as g3 escape hatch.

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -231,7 +231,7 @@ struct Settings {
 
   // If true, the UI thread is the platform thread on supported
   // platforms.
-  bool merged_platform_ui_thread = false;
+  bool merged_platform_ui_thread = true;
 
   // Log a warning during shell initialization if Impeller is not enabled.
   bool warn_on_impeller_opt_out = false;

--- a/shell/platform/android/android_shell_holder.cc
+++ b/shell/platform/android/android_shell_holder.cc
@@ -140,8 +140,6 @@ AndroidShellHolder::AndroidShellHolder(
       fml::MessageLoop::GetCurrent().GetTaskRunner();
   raster_runner = thread_host_->raster_thread->GetTaskRunner();
   if (settings.merged_platform_ui_thread) {
-    FML_LOG(IMPORTANT)
-        << "Warning: Using highly experimental merged thread mode.";
     ui_runner = platform_runner;
   } else {
     ui_runner = thread_host_->ui_thread->GetTaskRunner();

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -361,8 +361,12 @@ public class FlutterLoader {
         if (metaData.getBoolean(IMPELLER_VULKAN_GPU_TRACING_DATA_KEY, false)) {
           shellArgs.add("--enable-vulkan-gpu-tracing");
         }
-        if (metaData.getBoolean(ENABLED_MERGED_PLATFORM_UI_THREAD_KEY, false)) {
-          shellArgs.add("--enable-merged-platform-ui-thread");
+        if (metaData.containsKey(ENABLED_MERGED_PLATFORM_UI_THREAD_KEY)) {
+          if (metaData.getBoolean(ENABLED_MERGED_PLATFORM_UI_THREAD_KEY)) {
+            shellArgs.add("--enable-merged-platform-ui-thread");
+          } else {
+            shellArgs.add("--no-enable-merged-platform-ui-thread");
+          }
         }
         String backend = metaData.getString(IMPELLER_BACKEND_META_DATA_KEY);
         if (backend != null) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -208,12 +208,6 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
     settings.enable_dart_profiling = enableDartProfiling.boolValue;
   }
 
-  NSNumber* enableMergedPlatformUIThread =
-      [mainBundle objectForInfoDictionaryKey:@"FLTEnableMergedPlatformUIThread"];
-  if (enableMergedPlatformUIThread != nil) {
-    settings.merged_platform_ui_thread = enableMergedPlatformUIThread.boolValue;
-  }
-
   // Leak Dart VM settings, set whether leave or clean up the VM after the last shell shuts down.
   NSNumber* leakDartVM = [mainBundle objectForInfoDictionaryKey:@"FLTLeakDartVM"];
   // It will change the default leak_vm value in settings only if the key exists.

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -472,7 +472,6 @@ FLUTTER_ASSERT_ARC
 
 - (void)testCanMergePlatformAndUIThread {
   auto settings = FLTDefaultSettingsForBundle();
-  settings.merged_platform_ui_thread = true;
   settings.enable_impeller = true;
   FlutterDartProject* project = [[FlutterDartProject alloc] initWithSettings:settings];
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar" project:project];
@@ -484,7 +483,6 @@ FLUTTER_ASSERT_ARC
 
 - (void)testCanNotUnMergePlatformAndUIThread {
   auto settings = FLTDefaultSettingsForBundle();
-  settings.merged_platform_ui_thread = false;
   settings.enable_impeller = true;
   FlutterDartProject* project = [[FlutterDartProject alloc] initWithSettings:settings];
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar" project:project];


### PR DESCRIPTION
Part of  https://github.com/flutter/flutter/issues/150525
