### PR TITLE
Move `zircon_tests` from `package:litetest` to `package:async_helper`.

### DIFF
--- a/shell/platform/fuchsia/dart-pkg/zircon/BUILD.gn
+++ b/shell/platform/fuchsia/dart-pkg/zircon/BUILD.gn
@@ -65,7 +65,7 @@ dart_library("zircon_tests_lib") {
   package_root = "test"
 
   sources = [ "zircon_tests.dart" ]
-  deps = [ "//flutter/shell/platform/fuchsia/dart:litetest" ]
+  deps = [ "//flutter/shell/platform/fuchsia/dart:async_helper" ]
 }
 
 flutter_component("zircon_tests_component") {

--- a/shell/platform/fuchsia/dart-pkg/zircon/test/zircon_tests.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/test/zircon_tests.dart
@@ -8,7 +8,7 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'dart:zircon';
 
-import 'package:litetest/litetest.dart';
+import 'package:async_helper/async_minitest.dart';
 
 /// Helper method to turn a [String] into a [ByteData] containing the
 /// text of the string encoded as UTF-8.

--- a/shell/platform/fuchsia/dart-pkg/zircon/test/zircon_tests.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/test/zircon_tests.dart
@@ -198,7 +198,7 @@ void main() {
       final HandleResult vmo = System.vmoCreate(0);
       expect(vmo.status, equals(ZX.OK));
       int originalKoid = vmo.handle.koid;
-      expect(originalKoid, notEquals(ZX.KOID_INVALID));
+      expect(originalKoid != ZX.KOID_INVALID, true);
       // Cached koid should be same value.
       expect(originalKoid, equals(vmo.handle.koid));
       vmo.handle.close();

--- a/shell/platform/fuchsia/dart/BUILD.gn
+++ b/shell/platform/fuchsia/dart/BUILD.gn
@@ -59,9 +59,7 @@ dart_library("async_helper") {
 
   pubspec = "$package_root/pubspec.yaml"
 
-  deps = [
-    ":expect",
-  ]
+  deps = [ ":expect" ]
 
   sources = [
     "async_helper.dart",

--- a/shell/platform/fuchsia/dart/BUILD.gn
+++ b/shell/platform/fuchsia/dart/BUILD.gn
@@ -73,7 +73,7 @@ dart_library("expect") {
 
   pubspec = "$package_root/pubspec.yaml"
 
-  deps = [ "" ]
+  deps = []
 
   sources = [ "expect.dart" ]
 }

--- a/shell/platform/fuchsia/dart/BUILD.gn
+++ b/shell/platform/fuchsia/dart/BUILD.gn
@@ -67,6 +67,17 @@ dart_library("async_helper") {
   ]
 }
 
+dart_library("expect") {
+  package_root = "$dart_src/pkg/expect"
+  package_name = "expect"
+
+  pubspec = "$package_root/pubspec.yaml"
+
+  deps = [ ":expect" ]
+
+  sources = [ "expect.dart" ]
+}
+
 dart_library("meta") {
   package_root = "$dart_src/pkg/meta"
   package_name = "meta"

--- a/shell/platform/fuchsia/dart/BUILD.gn
+++ b/shell/platform/fuchsia/dart/BUILD.gn
@@ -59,7 +59,9 @@ dart_library("async_helper") {
 
   pubspec = "$package_root/pubspec.yaml"
 
-  deps = []
+  deps = [
+    ":expect",
+  ]
 
   sources = [
     "async_helper.dart",

--- a/shell/platform/fuchsia/dart/BUILD.gn
+++ b/shell/platform/fuchsia/dart/BUILD.gn
@@ -82,45 +82,6 @@ dart_library("meta") {
   ]
 }
 
-dart_library("expect") {
-  package_root = "$dart_src/pkg/expect"
-  package_name = "expect"
-
-  pubspec = "$package_root/pubspec.yaml"
-
-  deps = [ ":meta" ]
-
-  sources = [
-    "config.dart",
-    "expect.dart",
-    "minitest.dart",
-    "variations.dart",
-  ]
-}
-
-dart_library("litetest") {
-  package_root = "//flutter/testing/litetest"
-  package_name = "litetest"
-
-  pubspec = "$package_root/pubspec.yaml"
-
-  source_dir = "lib"
-
-  deps = [
-    ":async_helper",
-    ":expect",
-    ":meta",
-  ]
-
-  sources = [
-    "litetest.dart",
-    "src/async_minitest.dart",
-    "src/matchers.dart",
-    "src/test.dart",
-    "src/test_suite.dart",
-  ]
-}
-
 dart_library("args") {
   package_root = "$dart_src/third_party/pkg/args"
   package_name = "args"

--- a/shell/platform/fuchsia/dart/BUILD.gn
+++ b/shell/platform/fuchsia/dart/BUILD.gn
@@ -73,7 +73,7 @@ dart_library("expect") {
 
   pubspec = "$package_root/pubspec.yaml"
 
-  deps = [ ":expect" ]
+  deps = [ "" ]
 
   sources = [ "expect.dart" ]
 }

--- a/shell/platform/fuchsia/dart/BUILD.gn
+++ b/shell/platform/fuchsia/dart/BUILD.gn
@@ -75,7 +75,12 @@ dart_library("expect") {
 
   deps = []
 
-  sources = [ "expect.dart" ]
+  sources = [
+    "config.dart",
+    "expect.dart",
+    "minitest.dart",
+    "variations.dart",
+  ]
 }
 
 dart_library("meta") {


### PR DESCRIPTION
The engine has historically used `package:litetest`, a home grown invention that is a wrapper around the Dart SDK.

In https://github.com/flutter/flutter/issues/133569, we've moved over to the heavier weight `package:test`, which has been simplified since first evaluated by the Dart SDK vending the dependencies we need. The last user of `package:litetest` is a single test in the Fuchsia SDK, `zircon_tests`.

This PR migrates the test from `litetest` (which will be deleted) to the Dart SK vendored `async_minittest`. For this simple test case, there is only a 1-line behavioral change (`notEquals(foo)` becomes `!= foo, true`), and it allows us to remove dependencies from the tree.