### PR TITLE
Add a note about re generating Gradle lockfiles

### DIFF
--- a/tools/cipd/android_embedding_bundle/README.md
+++ b/tools/cipd/android_embedding_bundle/README.md
@@ -34,3 +34,11 @@ below explain how to fetch the license information for the dependencies.
    new tag: `last_updated:"$version_tag"`.
 1. Update the GN list `embedding_dependencies_jars` in
    `src/flutter/shell/platform/android/BUILD.gn`.
+
+## Updating Gradle Lockfiles in the Framework After Adding Dependencies
+If you land a pr that changes the versions of the embedding dependencies,
+or adds a new dependency and makes use of it, you will also need to
+perform a manual roll of that change to the framework that re-generates
+the Gradle lockfiles using the script at
+`<framework_repo>/dev/tools/bin/generate_gradle_lockfiles.dart`
+(run with the `--no-gradle-generation` and `--no-exclusion` flags).


### PR DESCRIPTION
Adds a note that Gradle lockfile generation is necessary when updating the android embedding dependencies bundle.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
