### PR TITLE
Remove `assert(() {... })` and other unnecessary patterns in `dart:ui` tests

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -4322,7 +4322,7 @@ base class Shader extends NativeFieldWrapperClass1 {
   /// Classes that override this method must call `super.dispose()`.
   void dispose() {
     assert(() {
-      assert(!_debugDisposed);
+      assert(!_debugDisposed, 'A Shader cannot be disposed more than once.');
       _debugDisposed = true;
       return true;
     }());

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -38,12 +38,13 @@ Future<Image> createImage(int width, int height) {
 void testCanvas(CanvasCallback callback) {
   try {
     callback(Canvas(PictureRecorder(), Rect.zero));
-  } catch (error) { } // ignore: empty_catches
+  } catch (error) {} // ignore: empty_catches
 }
 
 Future<Image> toImage(CanvasCallback callback, int width, int height) {
   final PictureRecorder recorder = PictureRecorder();
-  final Canvas canvas = Canvas(recorder, Rect.fromLTRB(0, 0, width.toDouble(), height.toDouble()));
+  final Canvas canvas = Canvas(
+      recorder, Rect.fromLTRB(0, 0, width.toDouble(), height.toDouble()));
   callback(canvas);
   final Picture picture = recorder.endRecording();
   return picture.toImage(width, height);
@@ -52,7 +53,8 @@ Future<Image> toImage(CanvasCallback callback, int width, int height) {
 void testNoCrashes() {
   test('canvas APIs should not crash', () async {
     final Paint paint = Paint();
-    const Rect rect = Rect.fromLTRB(double.nan, double.nan, double.nan, double.nan);
+    const Rect rect =
+        Rect.fromLTRB(double.nan, double.nan, double.nan, double.nan);
     final RRect rrect = RRect.fromRectAndCorners(rect);
     const Offset offset = Offset(double.nan, double.nan);
     final Path path = Path();
@@ -65,41 +67,54 @@ void testNoCrashes() {
     final Picture picture = recorder.endRecording();
     final Image image = await picture.toImage(1, 1);
 
-    try { Canvas(PictureRecorder()); } catch (error) { } // ignore: empty_catches
-    try { Canvas(PictureRecorder(), rect); } catch (error) { } // ignore: empty_catches
+    try {
+      Canvas(PictureRecorder());
+    } catch (error) {} // ignore: empty_catches
+    try {
+      Canvas(PictureRecorder(), rect);
+    } catch (error) {} // ignore: empty_catches
 
     try {
       PictureRecorder()
         ..endRecording()
         ..endRecording()
         ..endRecording();
-    } catch (error) { } // ignore: empty_catches
+    } catch (error) {} // ignore: empty_catches
 
     testCanvas((Canvas canvas) => canvas.clipPath(path));
     testCanvas((Canvas canvas) => canvas.clipRect(rect));
     testCanvas((Canvas canvas) => canvas.clipRRect(rrect));
     testCanvas((Canvas canvas) => canvas.drawArc(rect, 0.0, 0.0, false, paint));
-    testCanvas((Canvas canvas) => canvas.drawAtlas(image, <RSTransform>[], <Rect>[], <Color>[], BlendMode.src, rect, paint));
+    testCanvas((Canvas canvas) => canvas.drawAtlas(image, <RSTransform>[],
+        <Rect>[], <Color>[], BlendMode.src, rect, paint));
     testCanvas((Canvas canvas) => canvas.drawCircle(offset, double.nan, paint));
     testCanvas((Canvas canvas) => canvas.drawColor(color, BlendMode.src));
     testCanvas((Canvas canvas) => canvas.drawDRRect(rrect, rrect, paint));
     testCanvas((Canvas canvas) => canvas.drawImage(image, offset, paint));
-    testCanvas((Canvas canvas) => canvas.drawImageNine(image, rect, rect, paint));
-    testCanvas((Canvas canvas) => canvas.drawImageRect(image, rect, rect, paint));
+    testCanvas(
+        (Canvas canvas) => canvas.drawImageNine(image, rect, rect, paint));
+    testCanvas(
+        (Canvas canvas) => canvas.drawImageRect(image, rect, rect, paint));
     testCanvas((Canvas canvas) => canvas.drawLine(offset, offset, paint));
     testCanvas((Canvas canvas) => canvas.drawOval(rect, paint));
     testCanvas((Canvas canvas) => canvas.drawPaint(paint));
     testCanvas((Canvas canvas) => canvas.drawParagraph(paragraph, offset));
     testCanvas((Canvas canvas) => canvas.drawPath(path, paint));
     testCanvas((Canvas canvas) => canvas.drawPicture(picture));
-    testCanvas((Canvas canvas) => canvas.drawPoints(PointMode.points, <Offset>[], paint));
-    testCanvas((Canvas canvas) => canvas.drawRawAtlas(image, Float32List(0), Float32List(0), Int32List(0), BlendMode.src, rect, paint));
-    testCanvas((Canvas canvas) => canvas.drawRawPoints(PointMode.points, Float32List(0), paint));
+    testCanvas((Canvas canvas) =>
+        canvas.drawPoints(PointMode.points, <Offset>[], paint));
+    testCanvas((Canvas canvas) => canvas.drawRawAtlas(image, Float32List(0),
+        Float32List(0), Int32List(0), BlendMode.src, rect, paint));
+    testCanvas((Canvas canvas) =>
+        canvas.drawRawPoints(PointMode.points, Float32List(0), paint));
     testCanvas((Canvas canvas) => canvas.drawRect(rect, paint));
     testCanvas((Canvas canvas) => canvas.drawRRect(rrect, paint));
-    testCanvas((Canvas canvas) => canvas.drawShadow(path, color, double.nan, false));
-    testCanvas((Canvas canvas) => canvas.drawShadow(path, color, double.nan, true));
-    testCanvas((Canvas canvas) => canvas.drawVertices(Vertices(VertexMode.triangles, <Offset>[]), BlendMode.screen, paint));
+    testCanvas(
+        (Canvas canvas) => canvas.drawShadow(path, color, double.nan, false));
+    testCanvas(
+        (Canvas canvas) => canvas.drawShadow(path, color, double.nan, true));
+    testCanvas((Canvas canvas) => canvas.drawVertices(
+        Vertices(VertexMode.triangles, <Offset>[]), BlendMode.screen, paint));
     testCanvas((Canvas canvas) => canvas.getSaveCount());
     testCanvas((Canvas canvas) => canvas.restore());
     testCanvas((Canvas canvas) => canvas.rotate(double.nan));
@@ -110,17 +125,25 @@ void testNoCrashes() {
     testCanvas((Canvas canvas) => canvas.skew(double.nan, double.nan));
     testCanvas((Canvas canvas) => canvas.transform(Float64List(16)));
     testCanvas((Canvas canvas) => canvas.translate(double.nan, double.nan));
-    testCanvas((Canvas canvas) => canvas.drawVertices(Vertices(VertexMode.triangles, <Offset>[],
-                                                               indices: <int>[]), BlendMode.screen, paint));
-    testCanvas((Canvas canvas) => canvas.drawVertices(Vertices(VertexMode.triangles, <Offset>[])..dispose(), BlendMode.screen, paint));
+    testCanvas((Canvas canvas) => canvas.drawVertices(
+        Vertices(VertexMode.triangles, <Offset>[], indices: <int>[]),
+        BlendMode.screen,
+        paint));
+    testCanvas((Canvas canvas) => canvas.drawVertices(
+        Vertices(VertexMode.triangles, <Offset>[])..dispose(),
+        BlendMode.screen,
+        paint));
 
     // Regression test for https://github.com/flutter/flutter/issues/115143
-    testCanvas((Canvas canvas) => canvas.drawPaint(Paint()..imageFilter = const ColorFilter.mode(Color(0x00000000), BlendMode.xor)));
+    testCanvas((Canvas canvas) => canvas.drawPaint(Paint()
+      ..imageFilter =
+          const ColorFilter.mode(Color(0x00000000), BlendMode.xor)));
 
     // Regression test for https://github.com/flutter/flutter/issues/120278
-    testCanvas((Canvas canvas) => canvas.drawPaint(Paint()..imageFilter = ImageFilter.compose(
-      outer: ImageFilter.matrix(Matrix4.identity().storage),
-      inner: ImageFilter.blur())));
+    testCanvas((Canvas canvas) => canvas.drawPaint(Paint()
+      ..imageFilter = ImageFilter.compose(
+          outer: ImageFilter.matrix(Matrix4.identity().storage),
+          inner: ImageFilter.blur())));
   });
 }
 
@@ -181,16 +204,24 @@ void main() async {
     final RSTransform transform = RSTransform(1, 0, 0, 0);
     const Color color = Color(0x00000000);
     final Paint paint = Paint();
-    canvas.drawAtlas(image, <RSTransform>[transform], <Rect>[rect], <Color>[color], BlendMode.src, rect, paint);
-    canvas.drawAtlas(image, <RSTransform>[transform], <Rect>[rect], <Color>[color], BlendMode.src, null, paint);
-    canvas.drawAtlas(image, <RSTransform>[transform], <Rect>[rect], <Color>[], null, rect, paint);
-    canvas.drawAtlas(image, <RSTransform>[transform], <Rect>[rect], null, null, rect, paint);
-    canvas.drawRawAtlas(image, Float32List(0), Float32List(0), Int32List(0), BlendMode.src, rect, paint);
-    canvas.drawRawAtlas(image, Float32List(0), Float32List(0), Int32List(0), BlendMode.src, null, paint);
-    canvas.drawRawAtlas(image, Float32List(0), Float32List(0), null, null, rect, paint);
+    canvas.drawAtlas(image, <RSTransform>[transform], <Rect>[rect],
+        <Color>[color], BlendMode.src, rect, paint);
+    canvas.drawAtlas(image, <RSTransform>[transform], <Rect>[rect],
+        <Color>[color], BlendMode.src, null, paint);
+    canvas.drawAtlas(image, <RSTransform>[transform], <Rect>[rect], <Color>[],
+        null, rect, paint);
+    canvas.drawAtlas(
+        image, <RSTransform>[transform], <Rect>[rect], null, null, rect, paint);
+    canvas.drawRawAtlas(image, Float32List(0), Float32List(0), Int32List(0),
+        BlendMode.src, rect, paint);
+    canvas.drawRawAtlas(image, Float32List(0), Float32List(0), Int32List(0),
+        BlendMode.src, null, paint);
+    canvas.drawRawAtlas(
+        image, Float32List(0), Float32List(0), null, null, rect, paint);
 
     expect(
-      () => canvas.drawAtlas(image, <RSTransform>[transform], <Rect>[rect], <Color>[color], null, rect, paint),
+      () => canvas.drawAtlas(image, <RSTransform>[transform], <Rect>[rect],
+          <Color>[color], null, rect, paint),
       throwsA(isA<AssertionError>()),
     );
   });
@@ -203,28 +234,62 @@ void main() async {
     final RSTransform transform = RSTransform(1, 0, 0, 0);
     const Color color = Color(0x00000000);
     final Paint paint = Paint();
-    canvas.drawAtlas(image, <RSTransform>[transform], <Rect>[rect], <Color>[color], BlendMode.src, rect, paint);
-    canvas.drawAtlas(image, <RSTransform>[transform, transform], <Rect>[rect, rect], <Color>[color, color], BlendMode.src, rect, paint);
-    canvas.drawAtlas(image, <RSTransform>[transform], <Rect>[rect], <Color>[], null, rect, paint);
-    canvas.drawAtlas(image, <RSTransform>[transform], <Rect>[rect], null, null, rect, paint);
-    canvas.drawRawAtlas(image, Float32List(0), Float32List(0), Int32List(0), BlendMode.src, rect, paint);
-    canvas.drawRawAtlas(image, Float32List(4), Float32List(4), Int32List(1), BlendMode.src, rect, paint);
-    canvas.drawRawAtlas(image, Float32List(4), Float32List(4), null, null, rect, paint);
+    canvas.drawAtlas(image, <RSTransform>[transform], <Rect>[rect],
+        <Color>[color], BlendMode.src, rect, paint);
+    canvas.drawAtlas(image, <RSTransform>[transform, transform],
+        <Rect>[rect, rect], <Color>[color, color], BlendMode.src, rect, paint);
+    canvas.drawAtlas(image, <RSTransform>[transform], <Rect>[rect], <Color>[],
+        null, rect, paint);
+    canvas.drawAtlas(
+        image, <RSTransform>[transform], <Rect>[rect], null, null, rect, paint);
+    canvas.drawRawAtlas(image, Float32List(0), Float32List(0), Int32List(0),
+        BlendMode.src, rect, paint);
+    canvas.drawRawAtlas(image, Float32List(4), Float32List(4), Int32List(1),
+        BlendMode.src, rect, paint);
+    canvas.drawRawAtlas(
+        image, Float32List(4), Float32List(4), null, null, rect, paint);
 
-    expect(() => canvas.drawAtlas(image, <RSTransform>[transform], <Rect>[], <Color>[color], BlendMode.src, rect, paint), throwsArgumentError);
-    expect(() => canvas.drawAtlas(image, <RSTransform>[], <Rect>[rect], <Color>[color], BlendMode.src, rect, paint), throwsArgumentError);
-    expect(() => canvas.drawAtlas(image, <RSTransform>[transform], <Rect>[rect], <Color>[color, color], BlendMode.src, rect, paint), throwsArgumentError);
-    expect(() => canvas.drawAtlas(image, <RSTransform>[transform], <Rect>[rect, rect], <Color>[color], BlendMode.src, rect, paint), throwsArgumentError);
-    expect(() => canvas.drawAtlas(image, <RSTransform>[transform, transform], <Rect>[rect], <Color>[color], BlendMode.src, rect, paint), throwsArgumentError);
-    expect(() => canvas.drawRawAtlas(image, Float32List(3), Float32List(3), null, null, rect, paint), throwsArgumentError);
-    expect(() => canvas.drawRawAtlas(image, Float32List(4), Float32List(0), null, null, rect, paint), throwsArgumentError);
-    expect(() => canvas.drawRawAtlas(image, Float32List(0), Float32List(4), null, null, rect, paint), throwsArgumentError);
-    expect(() => canvas.drawRawAtlas(image, Float32List(4), Float32List(4), Int32List(2), BlendMode.src, rect, paint), throwsArgumentError);
+    expect(
+        () => canvas.drawAtlas(image, <RSTransform>[transform], <Rect>[],
+            <Color>[color], BlendMode.src, rect, paint),
+        throwsArgumentError);
+    expect(
+        () => canvas.drawAtlas(image, <RSTransform>[], <Rect>[rect],
+            <Color>[color], BlendMode.src, rect, paint),
+        throwsArgumentError);
+    expect(
+        () => canvas.drawAtlas(image, <RSTransform>[transform], <Rect>[rect],
+            <Color>[color, color], BlendMode.src, rect, paint),
+        throwsArgumentError);
+    expect(
+        () => canvas.drawAtlas(image, <RSTransform>[transform],
+            <Rect>[rect, rect], <Color>[color], BlendMode.src, rect, paint),
+        throwsArgumentError);
+    expect(
+        () => canvas.drawAtlas(image, <RSTransform>[transform, transform],
+            <Rect>[rect], <Color>[color], BlendMode.src, rect, paint),
+        throwsArgumentError);
+    expect(
+        () => canvas.drawRawAtlas(
+            image, Float32List(3), Float32List(3), null, null, rect, paint),
+        throwsArgumentError);
+    expect(
+        () => canvas.drawRawAtlas(
+            image, Float32List(4), Float32List(0), null, null, rect, paint),
+        throwsArgumentError);
+    expect(
+        () => canvas.drawRawAtlas(
+            image, Float32List(0), Float32List(4), null, null, rect, paint),
+        throwsArgumentError);
+    expect(
+        () => canvas.drawRawAtlas(image, Float32List(4), Float32List(4),
+            Int32List(2), BlendMode.src, rect, paint),
+        throwsArgumentError);
   });
 
   test('Canvas preserves perspective data in Matrix4', () async {
-    const double rotateAroundX = pi / 6;  // 30 degrees
-    const double rotateAroundY = pi / 9;  // 20 degrees
+    const double rotateAroundX = pi / 6; // 30 degrees
+    const double rotateAroundY = pi / 9; // 20 degrees
     const int width = 150;
     const int height = 150;
     const Color black = Color.fromARGB(255, 0, 0, 0);
@@ -235,9 +300,12 @@ void main() async {
       const double width3 = width / 3.0;
       const double width5 = width / 5.0;
       const double width10 = width / 10.0;
-      canvas.drawRect(const Rect.fromLTRB(-width3, -width3, width3, width3), Paint()..color = green);
-      canvas.drawRect(const Rect.fromLTRB(-width5, -width5, -width10, width5), Paint()..color = black);
-      canvas.drawRect(const Rect.fromLTRB(-width5, -width5, width5, -width10), Paint()..color = black);
+      canvas.drawRect(const Rect.fromLTRB(-width3, -width3, width3, width3),
+          Paint()..color = green);
+      canvas.drawRect(const Rect.fromLTRB(-width5, -width5, -width10, width5),
+          Paint()..color = black);
+      canvas.drawRect(const Rect.fromLTRB(-width5, -width5, width5, -width10),
+          Paint()..color = black);
     }
 
     final Image incrementalMatrixImage = await toImage((Canvas canvas) {
@@ -261,12 +329,14 @@ void main() async {
       });
     }, width, height);
 
-    final bool areEqual = await comparer.fuzzyCompareImages(incrementalMatrixImage, combinedMatrixImage);
+    final bool areEqual = await comparer.fuzzyCompareImages(
+        incrementalMatrixImage, combinedMatrixImage);
 
     expect(areEqual, true);
   });
 
-  test('Path effects from Paragraphs do not affect further rendering', () async {
+  test('Path effects from Paragraphs do not affect further rendering',
+      () async {
     void drawText(Canvas canvas, String content, Offset offset,
         {TextDecorationStyle style = TextDecorationStyle.solid}) {
       final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle());
@@ -290,20 +360,29 @@ void main() async {
         ..style = PaintingStyle.stroke
         ..strokeWidth = 5;
       drawText(canvas, 'Hello World', const Offset(20, 10));
-      canvas.drawCircle(const Offset(150, 25), 15, paint..color = const Color(0xFF00FF00));
+      canvas.drawCircle(
+          const Offset(150, 25), 15, paint..color = const Color(0xFF00FF00));
       drawText(canvas, 'Regular text', const Offset(20, 60));
-      canvas.drawCircle(const Offset(150, 75), 15, paint..color = const Color(0xFFFFFF00));
-      drawText(canvas, 'Dotted text', const Offset(20, 110), style: TextDecorationStyle.dotted);
-      canvas.drawCircle(const Offset(150, 125), 15, paint..color = const Color(0xFFFF0000));
-      drawText(canvas, 'Dashed text', const Offset(20, 160), style: TextDecorationStyle.dashed);
-      canvas.drawCircle(const Offset(150, 175), 15, paint..color = const Color(0xFFFF0000));
-      drawText(canvas, 'Wavy text', const Offset(20, 210), style: TextDecorationStyle.wavy);
-      canvas.drawCircle(const Offset(150, 225), 15, paint..color = const Color(0xFFFF0000));
+      canvas.drawCircle(
+          const Offset(150, 75), 15, paint..color = const Color(0xFFFFFF00));
+      drawText(canvas, 'Dotted text', const Offset(20, 110),
+          style: TextDecorationStyle.dotted);
+      canvas.drawCircle(
+          const Offset(150, 125), 15, paint..color = const Color(0xFFFF0000));
+      drawText(canvas, 'Dashed text', const Offset(20, 160),
+          style: TextDecorationStyle.dashed);
+      canvas.drawCircle(
+          const Offset(150, 175), 15, paint..color = const Color(0xFFFF0000));
+      drawText(canvas, 'Wavy text', const Offset(20, 210),
+          style: TextDecorationStyle.wavy);
+      canvas.drawCircle(
+          const Offset(150, 225), 15, paint..color = const Color(0xFFFF0000));
     }, 200, 250);
     expect(image.width, equals(200));
     expect(image.height, equals(250));
 
-    await comparer.addGoldenImage(image, 'dotted_path_effect_mixed_with_stroked_geometry.png');
+    await comparer.addGoldenImage(
+        image, 'dotted_path_effect_mixed_with_stroked_geometry.png');
   });
 
   test('Gradients with matrices in Paragraphs render correctly', () async {
@@ -387,7 +466,8 @@ void main() async {
         caughtException = true;
         expect(
           e.message,
-          contains('unable to create bitmap render target at specified size ${image.width}x${image.height}'),
+          contains(
+              'unable to create bitmap render target at specified size ${image.width}x${image.height}'),
         );
         break;
       }
@@ -404,7 +484,8 @@ void main() async {
       throwsException,
     );
     expect(
-      () => canvas.drawAtlas(image, <RSTransform>[], <Rect>[], null, null, null, Paint()),
+      () => canvas.drawAtlas(
+          image, <RSTransform>[], <Rect>[], null, null, null, Paint()),
       throwsException,
     );
   });
@@ -435,7 +516,8 @@ void main() async {
       returnsNormally,
     );
     expect(
-      () => canvas.drawAtlas(image, <RSTransform>[], <Rect>[], null, null, null, Paint()),
+      () => canvas.drawAtlas(
+          image, <RSTransform>[], <Rect>[], null, null, null, Paint()),
       returnsNormally,
     );
   });
@@ -495,30 +577,17 @@ void main() async {
     expect(data.buffer.asUint8List(), equals(dataSync.buffer.asUint8List()));
   });
 
-  test('Canvas.drawParagraph throws when Paragraph.layout was not called', () async {
+  test('Canvas.drawParagraph throws when Paragraph.layout was not called',
+      () async {
     // Regression test for https://github.com/flutter/flutter/issues/97172
-    bool assertsEnabled = false;
-    assert(() {
-      assertsEnabled = true;
-      return true;
-    }());
-
-    Object? error;
-    try {
-      await toImage((Canvas canvas) {
+    expect(() {
+      toImage((Canvas canvas) {
         final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle());
         builder.addText('Woodstock!');
         final Paragraph woodstock = builder.build();
         canvas.drawParagraph(woodstock, const Offset(0, 50));
       }, 100, 100);
-    } catch (e) {
-      error = e;
-    }
-    if (assertsEnabled) {
-      expect(error, isNotNull);
-    } else {
-      expect(error, isNull);
-    }
+    }, throwsA(isA<AssertionError>()));
   });
 
   Future<Image> drawText(String text) {
@@ -543,7 +612,8 @@ void main() async {
     // Skia renders a tofu if the font does not have a glyph for a character.
     // However, Flutter opts-in to a Skia feature to render tabs as a single space.
     // See: https://github.com/flutter/flutter/issues/79153
-    final File file = File(path.join(_flutterBuildPath, 'flutter', 'third_party', 'txt', 'assets', 'Roboto-Regular.ttf'));
+    final File file = File(path.join(_flutterBuildPath, 'flutter',
+        'third_party', 'txt', 'assets', 'Roboto-Regular.ttf'));
     final Uint8List fontData = await file.readAsBytes();
     await loadFontFromList(fontData, fontFamily: 'RobotoSerif');
 
@@ -553,14 +623,17 @@ void main() async {
     final Image tofuImage = await drawText('>\b<');
 
     // The tab's image should be identical to the space's image but not the tofu's image.
-    final bool tabToSpaceComparison = await comparer.fuzzyCompareImages(tabImage, spaceImage);
-    final bool tabToTofuComparison = await comparer.fuzzyCompareImages(tabImage, tofuImage);
+    final bool tabToSpaceComparison =
+        await comparer.fuzzyCompareImages(tabImage, spaceImage);
+    final bool tabToTofuComparison =
+        await comparer.fuzzyCompareImages(tabImage, tofuImage);
 
     expect(tabToSpaceComparison, isTrue);
     expect(tabToTofuComparison, isFalse);
   });
 
-  test('drawRect, drawOval, and clipRect render with unsorted rectangles', () async {
+  test('drawRect, drawOval, and clipRect render with unsorted rectangles',
+      () async {
     final PictureRecorder recorder = PictureRecorder();
     final Canvas canvas = Canvas(recorder);
 
@@ -642,7 +715,8 @@ void main() async {
     draw(const Rect.fromLTRB(10, 10, 40, 40), 50, 50, const Color(0xFF2196F3));
     draw(const Rect.fromLTRB(40, 10, 10, 40), 250, 50, const Color(0xFF4CAF50));
     draw(const Rect.fromLTRB(10, 40, 40, 10), 50, 250, const Color(0xFF9C27B0));
-    draw(const Rect.fromLTRB(40, 40, 10, 10), 250, 250, const Color(0xFFFF9800));
+    draw(
+        const Rect.fromLTRB(40, 40, 10, 10), 250, 250, const Color(0xFFFF9800));
 
     final Picture picture = recorder.endRecording();
     final Image image = await picture.toImage(450, 450);
@@ -692,7 +766,10 @@ void main() async {
     final PictureRecorder recorder = PictureRecorder();
     final Canvas canvas = Canvas(recorder);
     canvas.skew(12, 14.5);
-    final Float64List matrix = (Matrix4.identity()..setEntry(0, 1, 12)..setEntry(1, 0, 14.5)).storage;
+    final Float64List matrix = (Matrix4.identity()
+          ..setEntry(0, 1, 12)
+          ..setEntry(1, 0, 14.5))
+        .storage;
     final Float64List curMatrix = canvas.getTransform();
     expect(curMatrix, closeToTransform(matrix));
     canvas.skew(10, 10);
@@ -704,7 +781,10 @@ void main() async {
   test('Canvas.transform affects canvas.getTransform', () async {
     final PictureRecorder recorder = PictureRecorder();
     final Canvas canvas = Canvas(recorder);
-    final Float64List matrix = (Matrix4.identity()..translate(12.0, 14.5)..scale(12.0, 14.5)).storage;
+    final Float64List matrix = (Matrix4.identity()
+          ..translate(12.0, 14.5)
+          ..scale(12.0, 14.5))
+        .storage;
     canvas.transform(matrix);
     final Float64List curMatrix = canvas.getTransform();
     expect(curMatrix, closeToTransform(matrix));
@@ -747,8 +827,10 @@ void main() async {
       canvas.save();
       canvas.clipRect(const Rect.fromLTRB(0, 0, 15, 15));
       // Both clip bounds have changed
-      expect(canvas.getLocalClipBounds(), isNot(closeToRect(clipExpandedBounds)));
-      expect(canvas.getDestinationClipBounds(), isNot(closeToRect(clipExpandedBounds)));
+      expect(
+          canvas.getLocalClipBounds(), isNot(closeToRect(clipExpandedBounds)));
+      expect(canvas.getDestinationClipBounds(),
+          isNot(closeToRect(clipExpandedBounds)));
       // Previous return values have not changed
       expect(initialLocalBounds, closeToRect(clipExpandedBounds));
       expect(initialDestinationBounds, closeToRect(clipExpandedBounds));
@@ -768,7 +850,8 @@ void main() async {
       );
       expect(canvas.getLocalClipBounds(), closeToRect(scaledExpandedBounds));
       // Destination bounds are unaffected by transform
-      expect(canvas.getDestinationClipBounds(), closeToRect(clipExpandedBounds));
+      expect(
+          canvas.getDestinationClipBounds(), closeToRect(clipExpandedBounds));
       canvas.restore();
 
       // save/restore returned the values to their original values
@@ -818,7 +901,8 @@ void main() async {
     final Canvas canvas = Canvas(recorder);
     const Rect clipBounds = Rect.fromLTRB(10.2, 11.3, 20.4, 25.7);
     const Rect clipExpandedBounds = Rect.fromLTRB(10, 11, 21, 26);
-    final RRect clip = RRect.fromRectAndRadius(clipBounds, const Radius.circular(3));
+    final RRect clip =
+        RRect.fromRectAndRadius(clipBounds, const Radius.circular(3));
     canvas.clipRRect(clip);
 
     // Save initial return values for testing restored values
@@ -831,7 +915,8 @@ void main() async {
     canvas.clipRect(const Rect.fromLTRB(0, 0, 15, 15));
     // Both clip bounds have changed
     expect(canvas.getLocalClipBounds(), isNot(closeToRect(clipExpandedBounds)));
-    expect(canvas.getDestinationClipBounds(), isNot(closeToRect(clipExpandedBounds)));
+    expect(canvas.getDestinationClipBounds(),
+        isNot(closeToRect(clipExpandedBounds)));
     // Previous return values have not changed
     expect(initialLocalBounds, closeToRect(clipExpandedBounds));
     expect(initialDestinationBounds, closeToRect(clipExpandedBounds));
@@ -858,7 +943,8 @@ void main() async {
     final PictureRecorder recorder = PictureRecorder();
     final Canvas canvas = Canvas(recorder);
     const Rect clipBounds = Rect.fromLTRB(10.2, 11.3, 20.4, 25.7);
-    final RRect clip = RRect.fromRectAndRadius(clipBounds, const Radius.circular(3));
+    final RRect clip =
+        RRect.fromRectAndRadius(clipBounds, const Radius.circular(3));
     canvas.clipRRect(clip, doAntiAlias: false);
 
     // Save initial return values for testing restored values
@@ -899,8 +985,10 @@ void main() async {
     final Canvas canvas = Canvas(recorder);
     const Rect clipBounds1 = Rect.fromLTRB(0.0, 0.0, 10.0, 10.0);
     const Rect clipBounds2 = Rect.fromLTRB(10.0, 10.0, 20.0, 20.0);
-    final RRect clip1 = RRect.fromRectAndRadius(clipBounds1, const Radius.circular(3));
-    final RRect clip2 = RRect.fromRectAndRadius(clipBounds2, const Radius.circular(3));
+    final RRect clip1 =
+        RRect.fromRectAndRadius(clipBounds1, const Radius.circular(3));
+    final RRect clip2 =
+        RRect.fromRectAndRadius(clipBounds2, const Radius.circular(3));
 
     canvas.save();
     canvas.clipRRect(clip1, doAntiAlias: false);
@@ -922,7 +1010,9 @@ void main() async {
     final Canvas canvas = Canvas(recorder);
     const Rect clipBounds = Rect.fromLTRB(10.2, 11.3, 20.4, 25.7);
     const Rect clipExpandedBounds = Rect.fromLTRB(10, 11, 21, 26);
-    final Path clip = Path()..addRect(clipBounds)..addOval(clipBounds);
+    final Path clip = Path()
+      ..addRect(clipBounds)
+      ..addOval(clipBounds);
     canvas.clipPath(clip);
 
     // Save initial return values for testing restored values
@@ -935,7 +1025,8 @@ void main() async {
     canvas.clipRect(const Rect.fromLTRB(0, 0, 15, 15));
     // Both clip bounds have changed
     expect(canvas.getLocalClipBounds(), isNot(closeToRect(clipExpandedBounds)));
-    expect(canvas.getDestinationClipBounds(), isNot(closeToRect(clipExpandedBounds)));
+    expect(canvas.getDestinationClipBounds(),
+        isNot(closeToRect(clipExpandedBounds)));
     // Previous return values have not changed
     expect(initialLocalBounds, closeToRect(clipExpandedBounds));
     expect(initialDestinationBounds, closeToRect(clipExpandedBounds));
@@ -962,7 +1053,9 @@ void main() async {
     final PictureRecorder recorder = PictureRecorder();
     final Canvas canvas = Canvas(recorder);
     const Rect clipBounds = Rect.fromLTRB(10.2, 11.3, 20.4, 25.7);
-    final Path clip = Path()..addRect(clipBounds)..addOval(clipBounds);
+    final Path clip = Path()
+      ..addRect(clipBounds)
+      ..addOval(clipBounds);
     canvas.clipPath(clip, doAntiAlias: false);
 
     // Save initial return values for testing restored values
@@ -1003,8 +1096,12 @@ void main() async {
     final Canvas canvas = Canvas(recorder);
     const Rect clipBounds1 = Rect.fromLTRB(0.0, 0.0, 10.0, 10.0);
     const Rect clipBounds2 = Rect.fromLTRB(10.0, 10.0, 20.0, 20.0);
-    final Path clip1 = Path()..addRect(clipBounds1)..addOval(clipBounds1);
-    final Path clip2 = Path()..addRect(clipBounds2)..addOval(clipBounds2);
+    final Path clip1 = Path()
+      ..addRect(clipBounds1)
+      ..addOval(clipBounds1);
+    final Path clip2 = Path()
+      ..addRect(clipBounds2)
+      ..addOval(clipBounds2);
 
     canvas.save();
     canvas.clipPath(clip1, doAntiAlias: false);
@@ -1033,7 +1130,8 @@ void main() async {
     expect(initialLocalBounds, closeToRect(clipBounds));
     expect(initialDestinationBounds, closeToRect(clipBounds));
 
-    canvas.clipRect(const Rect.fromLTRB(0, 0, 15, 15), clipOp: ClipOp.difference, doAntiAlias: false);
+    canvas.clipRect(const Rect.fromLTRB(0, 0, 15, 15),
+        clipOp: ClipOp.difference, doAntiAlias: false);
     expect(canvas.getLocalClipBounds(), initialLocalBounds);
     expect(canvas.getDestinationClipBounds(), initialDestinationBounds);
   });
@@ -1066,7 +1164,9 @@ void main() async {
     expect(canvas.getSaveCount(), equals(1));
   });
 
-  test('RestoreToCount count greater than current [getSaveCount], nothing would happend', () async {
+  test(
+      'RestoreToCount count greater than current [getSaveCount], nothing would happend',
+      () async {
     final PictureRecorder recorder = PictureRecorder();
     final Canvas canvas = Canvas(recorder);
     canvas.save();
@@ -1080,14 +1180,16 @@ void main() async {
   });
 
   test('TextDecoration renders non-solid lines', () async {
-    final File file = File(path.join(_flutterBuildPath, 'flutter', 'third_party', 'txt', 'assets', 'Roboto-Regular.ttf'));
+    final File file = File(path.join(_flutterBuildPath, 'flutter',
+        'third_party', 'txt', 'assets', 'Roboto-Regular.ttf'));
     final Uint8List fontData = await file.readAsBytes();
     await loadFontFromList(fontData, fontFamily: 'RobotoSlab');
 
     final PictureRecorder recorder = PictureRecorder();
     final Canvas canvas = Canvas(recorder);
 
-    for (final (int index, TextDecorationStyle style) in TextDecorationStyle.values.indexed) {
+    for (final (int index, TextDecorationStyle style)
+        in TextDecorationStyle.values.indexed) {
       final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle());
       builder.pushStyle(TextStyle(
         decoration: TextDecoration.underline,
@@ -1132,10 +1234,13 @@ void main() async {
     expect(paintCopy.strokeJoin, equals(StrokeJoin.round));
     expect(paintCopy.style, equals(PaintingStyle.stroke));
     expect(paintCopy.blendMode, equals(BlendMode.srcOver));
-    expect(paintCopy.maskFilter, equals(const MaskFilter.blur(BlurStyle.normal, 10.0)));
+    expect(paintCopy.maskFilter,
+        equals(const MaskFilter.blur(BlurStyle.normal, 10.0)));
     expect(paintCopy.filterQuality, equals(FilterQuality.high));
-    expect(paintCopy.colorFilter, equals(const ColorFilter.mode(Color(0xFF00FF00), BlendMode.color)));
-    expect(paintCopy.imageFilter, equals(ImageFilter.blur(sigmaX: 10.0, sigmaY: 10.0)));
+    expect(paintCopy.colorFilter,
+        equals(const ColorFilter.mode(Color(0xFF00FF00), BlendMode.color)));
+    expect(paintCopy.imageFilter,
+        equals(ImageFilter.blur(sigmaX: 10.0, sigmaY: 10.0)));
   });
 
   test('Paint, when copied, does not mutate the original instance', () {
@@ -1161,7 +1266,8 @@ void main() async {
       ..blendMode = BlendMode.srcIn
       ..maskFilter = const MaskFilter.blur(BlurStyle.solid, 20.0)
       ..filterQuality = FilterQuality.none
-      ..colorFilter = const ColorFilter.mode(Color(0xFFFF0000), BlendMode.modulate)
+      ..colorFilter =
+          const ColorFilter.mode(Color(0xFFFF0000), BlendMode.modulate)
       ..imageFilter = ImageFilter.blur(sigmaX: 20.0, sigmaY: 20.0);
 
     // The original paint should not have changed.
@@ -1171,13 +1277,17 @@ void main() async {
     expect(paint.strokeJoin, equals(StrokeJoin.round));
     expect(paint.style, equals(PaintingStyle.stroke));
     expect(paint.blendMode, equals(BlendMode.srcOver));
-    expect(paint.maskFilter, equals(const MaskFilter.blur(BlurStyle.normal, 10.0)));
+    expect(paint.maskFilter,
+        equals(const MaskFilter.blur(BlurStyle.normal, 10.0)));
     expect(paint.filterQuality, equals(FilterQuality.high));
-    expect(paint.colorFilter, equals(const ColorFilter.mode(Color(0xFF00FF00), BlendMode.color)));
-    expect(paint.imageFilter, equals(ImageFilter.blur(sigmaX: 10.0, sigmaY: 10.0)));
+    expect(paint.colorFilter,
+        equals(const ColorFilter.mode(Color(0xFF00FF00), BlendMode.color)));
+    expect(paint.imageFilter,
+        equals(ImageFilter.blur(sigmaX: 10.0, sigmaY: 10.0)));
   });
 
-  test('Paint, when copied, the original changing does not mutate the copy', () {
+  test('Paint, when copied, the original changing does not mutate the copy',
+      () {
     final Paint paint = Paint()
       ..color = const Color(0xFF0000FF)
       ..strokeWidth = 10.0
@@ -1201,7 +1311,8 @@ void main() async {
       ..blendMode = BlendMode.srcIn
       ..maskFilter = const MaskFilter.blur(BlurStyle.solid, 20.0)
       ..filterQuality = FilterQuality.none
-      ..colorFilter = const ColorFilter.mode(Color(0xFFFF0000), BlendMode.modulate)
+      ..colorFilter =
+          const ColorFilter.mode(Color(0xFFFF0000), BlendMode.modulate)
       ..imageFilter = ImageFilter.blur(sigmaX: 20.0, sigmaY: 20.0);
 
     // The copy should not have changed.
@@ -1211,13 +1322,17 @@ void main() async {
     expect(paintCopy.strokeJoin, equals(StrokeJoin.round));
     expect(paintCopy.style, equals(PaintingStyle.stroke));
     expect(paintCopy.blendMode, equals(BlendMode.srcOver));
-    expect(paintCopy.maskFilter, equals(const MaskFilter.blur(BlurStyle.normal, 10.0)));
+    expect(paintCopy.maskFilter,
+        equals(const MaskFilter.blur(BlurStyle.normal, 10.0)));
     expect(paintCopy.filterQuality, equals(FilterQuality.high));
-    expect(paintCopy.colorFilter, equals(const ColorFilter.mode(Color(0xFF00FF00), BlendMode.color)));
-    expect(paintCopy.imageFilter, equals(ImageFilter.blur(sigmaX: 10.0, sigmaY: 10.0)));
+    expect(paintCopy.colorFilter,
+        equals(const ColorFilter.mode(Color(0xFF00FF00), BlendMode.color)));
+    expect(paintCopy.imageFilter,
+        equals(ImageFilter.blur(sigmaX: 10.0, sigmaY: 10.0)));
   });
 
-  test('DrawAtlas correctly copies color values into display list format', () async {
+  test('DrawAtlas correctly copies color values into display list format',
+      () async {
     final Image testImage = await createTestImage();
     final PictureRecorder recorder = PictureRecorder();
     final Canvas canvas = Canvas(recorder);
@@ -1234,12 +1349,8 @@ void main() async {
           translateY: 0,
         ),
       ],
-      [
-        const Rect.fromLTWH(0, 0, 1, 1)
-      ],
-      [
-        const Color.fromARGB(255, 255, 0, 0)
-      ],
+      [const Rect.fromLTWH(0, 0, 1, 1)],
+      [const Color.fromARGB(255, 255, 0, 0)],
       BlendMode.dst,
       null,
       Paint(),
@@ -1264,6 +1375,7 @@ Future<Image> createTestImage() async {
 }
 
 Matcher closeToRect(Rect rect) => _CloseToRectMatcher(rect);
+
 final class _CloseToRectMatcher extends Matcher {
   const _CloseToRectMatcher(this._expectedRect);
   final Rect _expectedRect;
@@ -1274,9 +1386,9 @@ final class _CloseToRectMatcher extends Matcher {
       return false;
     }
     return (item.left - _expectedRect.left).abs() < 1e-6 &&
-           (item.top - _expectedRect.top).abs() < 1e-6 &&
-           (item.right - _expectedRect.right).abs() < 1e-6 &&
-           (item.bottom - _expectedRect.bottom).abs() < 1e-6;
+        (item.top - _expectedRect.top).abs() < 1e-6 &&
+        (item.right - _expectedRect.right).abs() < 1e-6 &&
+        (item.bottom - _expectedRect.bottom).abs() < 1e-6;
   }
 
   @override
@@ -1285,7 +1397,9 @@ final class _CloseToRectMatcher extends Matcher {
   }
 }
 
-Matcher closeToTransform(Float64List expected) => _CloseToTransformMatcher(expected);
+Matcher closeToTransform(Float64List expected) =>
+    _CloseToTransformMatcher(expected);
+
 final class _CloseToTransformMatcher extends Matcher {
   _CloseToTransformMatcher(this._expected);
   final Float64List _expected;

--- a/testing/dart/channel_buffers_test.dart
+++ b/testing/dart/channel_buffers_test.dart
@@ -22,12 +22,6 @@ void _resize(ui.ChannelBuffers buffers, String name, int newSize) {
 }
 
 void main() {
-  bool assertsEnabled = false;
-  assert(() {
-    assertsEnabled = true;
-    return true;
-  }());
-
   test('push drain', () async {
     const String channel = 'foo';
     final ByteData data = _makeByteData('bar');
@@ -363,19 +357,17 @@ void main() {
     const String channel = 'foo\u0000bar';
     final ByteData blabla = _makeByteData('blabla');
     final ui.ChannelBuffers buffers = ui.ChannelBuffers();
-    try {
-      buffers.push(channel, blabla, (ByteData? data) { });
-      fail('did not throw as expected');
-    } on AssertionError catch (e) {
-      expect(e.toString(), contains('U+0000 NULL'));
-    }
-    try {
-      buffers.setListener(channel, (ByteData? data, ui.PlatformMessageResponseCallback callback) { });
-      fail('did not throw as expected');
-    } on AssertionError catch (e) {
-      expect(e.toString(), contains('U+0000 NULL'));
-    }
-  }, skip: !assertsEnabled);
+
+    expect(
+      () => buffers.push(channel, blabla, (ByteData? data) { }),
+      throwsA(isA<AssertionError>().having((AssertionError e) => e.toString(), 'toString', contains('U+0000 NULL'))),
+    );
+
+    expect(
+      () => buffers.setListener(channel, (ByteData? data, ui.PlatformMessageResponseCallback callback) { }),
+      throwsA(isA<AssertionError>().having((AssertionError e) => e.toString(), 'toString', contains('U+0000 NULL'))),
+    );
+  });
 }
 
 class _TestChannelBuffers extends ui.ChannelBuffers {

--- a/testing/dart/compositing_test.dart
+++ b/testing/dart/compositing_test.dart
@@ -59,28 +59,19 @@ void main() {
   });
 
   test('addPicture with disposed picture does not crash', () {
-    bool assertsEnabled = false;
-    assert(() {
-      assertsEnabled = true;
-      return true;
-    }());
     final PictureRecorder recorder = PictureRecorder();
     final Canvas canvas = Canvas(recorder);
     canvas.drawPaint(Paint());
     final Picture picture = recorder.endRecording();
     picture.dispose();
 
-    assert(picture.debugDisposed);
+    expect(picture.debugDisposed, isTrue);
 
     final SceneBuilder builder = SceneBuilder();
-    if (assertsEnabled) {
-      expect(
-        () => builder.addPicture(Offset.zero, picture),
-        throwsA(const isInstanceOf<AssertionError>()),
-      );
-    } else {
-      builder.addPicture(Offset.zero, picture);
-    }
+    expect(
+      () => builder.addPicture(Offset.zero, picture),
+      throwsA(const isInstanceOf<AssertionError>()),
+    );
 
     final Scene scene = builder.build();
     scene.dispose();
@@ -102,13 +93,10 @@ void main() {
       0, 0, 1, 0,
       0, 0, 0,
     ]);
-    assert(() {
-      expect(
-        () => builder.pushTransform(matrix4WrongLength),
-        throwsA(isA<AssertionError>()),
-      );
-      return true;
-    }());
+    expect(
+      () => builder.pushTransform(matrix4WrongLength),
+      throwsA(isA<AssertionError>()),
+    );
 
     final Float64List matrix4NaN = Float64List.fromList(<double>[
       1, 0, 0, 0,
@@ -116,13 +104,10 @@ void main() {
       0, 0, 1, 0,
       0, 0, 0, double.nan,
     ]);
-    assert(() {
-      expect(
-        () => builder.pushTransform(matrix4NaN),
-        throwsA(isA<AssertionError>()),
-      );
-      return true;
-    }());
+    expect(
+      () => builder.pushTransform(matrix4NaN),
+      throwsA(isA<AssertionError>()),
+    );
 
     final Float64List matrix4Infinity = Float64List.fromList(<double>[
       1, 0, 0, 0,
@@ -130,13 +115,10 @@ void main() {
       0, 0, 1, 0,
       0, 0, 0, double.infinity,
     ]);
-    assert(() {
-      expect(
-        () => builder.pushTransform(matrix4Infinity),
-        throwsA(isA<AssertionError>()),
-      );
-      return true;
-    }());
+    expect(
+      () => builder.pushTransform(matrix4Infinity),
+      throwsA(isA<AssertionError>()),
+    );
   });
 
   test('SceneBuilder accepts typed layers', () {
@@ -163,15 +145,12 @@ void main() {
     final SceneBuilder builder2 = SceneBuilder();
     pushFunction(builder2, layer);
     builder2.pop();
-    assert(() {
-      try {
-        builder2.addRetained(layer);
-        fail('Expected addRetained to throw AssertionError but it returned successully');
-      } on AssertionError catch (error) {
-        expect(error.toString(), contains('The layer is already being used'));
-      }
-      return true;
-    }());
+
+    expect(() {
+      builder2.addRetained(layer);
+    }, throwsA(isA<AssertionError>()
+      .having((AssertionError e) => e.toString(), 'toString', 
+          contains('The layer is already being used'))));
     builder2.build();
   }
 
@@ -184,15 +163,12 @@ void main() {
 
     final SceneBuilder builder2 = SceneBuilder();
     builder2.addRetained(layer);
-    assert(() {
-      try {
-        pushFunction(builder2, layer);
-        fail('Expected push to throw AssertionError but it returned successully');
-      } on AssertionError catch (error) {
-        expect(error.toString(), contains('The layer is already being used'));
-      }
-      return true;
-    }());
+
+    expect(() {
+      pushFunction(builder2, layer);
+    }, throwsA(isA<AssertionError>()
+      .having((AssertionError e) => e.toString(), 'toString', 
+          contains('The layer is already being used'))));
     builder2.build();
   }
 
@@ -205,15 +181,11 @@ void main() {
 
     final SceneBuilder builder2 = SceneBuilder();
     builder2.addRetained(layer);
-    assert(() {
-      try {
-        builder2.addRetained(layer);
-        fail('Expected second addRetained to throw AssertionError but it returned successully');
-      } on AssertionError catch (error) {
-        expect(error.toString(), contains('The layer is already being used'));
-      }
-      return true;
-    }());
+    expect(() {
+      builder2.addRetained(layer);
+    }, throwsA(isA<AssertionError>()
+      .having((AssertionError e) => e.toString(), 'toString', 
+          contains('The layer is already being used'))));
     builder2.build();
   }
 
@@ -226,15 +198,11 @@ void main() {
 
     final SceneBuilder builder2 = SceneBuilder();
     pushFunction(builder2, layer);
-    assert(() {
-      try {
-        pushFunction(builder2, layer);
-        fail('Expected push to throw AssertionError but it returned successully');
-      } on AssertionError catch (error) {
-        expect(error.toString(), contains('was previously used as oldLayer'));
-      }
-      return true;
-    }());
+    expect(() {
+      pushFunction(builder2, layer);
+    }, throwsA(isA<AssertionError>()
+      .having((AssertionError e) => e.toString(), 'toString', 
+          contains('was previously used as oldLayer'))));
     builder2.build();
   }
 
@@ -249,15 +217,11 @@ void main() {
 
     final SceneBuilder builder2 = SceneBuilder();
     builder2.addRetained(layer);
-    assert(() {
-      try {
-        builder2.pushOpacity(321, oldLayer: childLayer);
-        fail('Expected pushOpacity to throw AssertionError but it returned successully');
-      } on AssertionError catch (error) {
-        expect(error.toString(), contains('The layer is already being used'));
-      }
-      return true;
-    }());
+    expect(() {
+      builder2.pushOpacity(321, oldLayer: childLayer);
+    }, throwsA(isA<AssertionError>()
+      .having((AssertionError e) => e.toString(), 'toString', 
+          contains('The layer is already being used'))));
     builder2.build();
   }
 
@@ -273,15 +237,11 @@ void main() {
     final SceneBuilder builder2 = SceneBuilder();
     builder2.pushOpacity(234, oldLayer: childLayer);
     builder2.pop();
-    assert(() {
-      try {
-        builder2.addRetained(layer);
-        fail('Expected addRetained to throw AssertionError but it returned successully');
-      } on AssertionError catch (error) {
-        expect(error.toString(), contains('The layer is already being used'));
-      }
-      return true;
-    }());
+    expect(() {
+      builder2.addRetained(layer);
+    }, throwsA(isA<AssertionError>()
+      .having((AssertionError e) => e.toString(), 'toString', 
+          contains('The layer is already being used'))));
     builder2.build();
   }
 
@@ -295,16 +255,12 @@ void main() {
     final SceneBuilder builder2 = SceneBuilder();
     pushFunction(builder2, layer);
     builder2.pop();
-    assert(() {
-      try {
-        final SceneBuilder builder3 = SceneBuilder();
-        builder3.addRetained(layer);
-        fail('Expected addRetained to throw AssertionError but it returned successully');
-      } on AssertionError catch (error) {
-        expect(error.toString(), contains('was previously used as oldLayer'));
-      }
-      return true;
-    }());
+    expect(() {
+      final SceneBuilder builder3 = SceneBuilder();
+      builder3.addRetained(layer);
+    }, throwsA(isA<AssertionError>()
+      .having((AssertionError e) => e.toString(), 'toString', 
+          contains('was previously used as oldLayer'))));
     builder2.build();
   }
 
@@ -318,16 +274,12 @@ void main() {
     final SceneBuilder builder2 = SceneBuilder();
     pushFunction(builder2, layer);
     builder2.pop();
-    assert(() {
-      try {
-        final SceneBuilder builder3 = SceneBuilder();
-        pushFunction(builder3, layer);
-        fail('Expected addRetained to throw AssertionError but it returned successully');
-      } on AssertionError catch (error) {
-        expect(error.toString(), contains('was previously used as oldLayer'));
-      }
-      return true;
-    }());
+    expect(() {
+      final SceneBuilder builder3 = SceneBuilder();
+      pushFunction(builder3, layer);
+    }, throwsA(isA<AssertionError>()
+      .having((AssertionError e) => e.toString(), 'toString', 
+          contains('was previously used as oldLayer'))));
     builder2.build();
   }
 
@@ -343,16 +295,12 @@ void main() {
     final SceneBuilder builder2 = SceneBuilder();
     builder2.pushOpacity(321, oldLayer: childLayer);
     builder2.pop();
-    assert(() {
-      try {
-        final SceneBuilder builder3 = SceneBuilder();
-        builder3.addRetained(parentLayer);
-        fail('Expected addRetained to throw AssertionError but it returned successully');
-      } on AssertionError catch (error) {
-        expect(error.toString(), contains('was previously used as oldLayer'));
-      }
-      return true;
-    }());
+    expect(() {
+      final SceneBuilder builder3 = SceneBuilder();
+      builder3.addRetained(parentLayer);
+    }, throwsA(isA<AssertionError>()
+      .having((AssertionError e) => e.toString(), 'toString', 
+          contains('was previously used as oldLayer'))));
     builder2.build();
   }
 

--- a/testing/dart/compositing_test.dart
+++ b/testing/dart/compositing_test.dart
@@ -149,7 +149,7 @@ void main() {
     expect(() {
       builder2.addRetained(layer);
     }, throwsA(isA<AssertionError>()
-      .having((AssertionError e) => e.toString(), 'toString', 
+      .having((AssertionError e) => e.toString(), 'toString',
           contains('The layer is already being used'))));
     builder2.build();
   }
@@ -167,7 +167,7 @@ void main() {
     expect(() {
       pushFunction(builder2, layer);
     }, throwsA(isA<AssertionError>()
-      .having((AssertionError e) => e.toString(), 'toString', 
+      .having((AssertionError e) => e.toString(), 'toString',
           contains('The layer is already being used'))));
     builder2.build();
   }
@@ -184,7 +184,7 @@ void main() {
     expect(() {
       builder2.addRetained(layer);
     }, throwsA(isA<AssertionError>()
-      .having((AssertionError e) => e.toString(), 'toString', 
+      .having((AssertionError e) => e.toString(), 'toString',
           contains('The layer is already being used'))));
     builder2.build();
   }
@@ -201,7 +201,7 @@ void main() {
     expect(() {
       pushFunction(builder2, layer);
     }, throwsA(isA<AssertionError>()
-      .having((AssertionError e) => e.toString(), 'toString', 
+      .having((AssertionError e) => e.toString(), 'toString',
           contains('was previously used as oldLayer'))));
     builder2.build();
   }
@@ -220,7 +220,7 @@ void main() {
     expect(() {
       builder2.pushOpacity(321, oldLayer: childLayer);
     }, throwsA(isA<AssertionError>()
-      .having((AssertionError e) => e.toString(), 'toString', 
+      .having((AssertionError e) => e.toString(), 'toString',
           contains('The layer is already being used'))));
     builder2.build();
   }
@@ -240,7 +240,7 @@ void main() {
     expect(() {
       builder2.addRetained(layer);
     }, throwsA(isA<AssertionError>()
-      .having((AssertionError e) => e.toString(), 'toString', 
+      .having((AssertionError e) => e.toString(), 'toString',
           contains('The layer is already being used'))));
     builder2.build();
   }
@@ -259,7 +259,7 @@ void main() {
       final SceneBuilder builder3 = SceneBuilder();
       builder3.addRetained(layer);
     }, throwsA(isA<AssertionError>()
-      .having((AssertionError e) => e.toString(), 'toString', 
+      .having((AssertionError e) => e.toString(), 'toString',
           contains('was previously used as oldLayer'))));
     builder2.build();
   }
@@ -278,7 +278,7 @@ void main() {
       final SceneBuilder builder3 = SceneBuilder();
       pushFunction(builder3, layer);
     }, throwsA(isA<AssertionError>()
-      .having((AssertionError e) => e.toString(), 'toString', 
+      .having((AssertionError e) => e.toString(), 'toString',
           contains('was previously used as oldLayer'))));
     builder2.build();
   }
@@ -299,7 +299,7 @@ void main() {
       final SceneBuilder builder3 = SceneBuilder();
       builder3.addRetained(parentLayer);
     }, throwsA(isA<AssertionError>()
-      .having((AssertionError e) => e.toString(), 'toString', 
+      .having((AssertionError e) => e.toString(), 'toString',
           contains('was previously used as oldLayer'))));
     builder2.build();
   }

--- a/testing/dart/fragment_shader_test.dart
+++ b/testing/dart/fragment_shader_test.dart
@@ -16,12 +16,6 @@ import 'impeller_enabled.dart';
 import 'shader_test_file_utils.dart';
 
 void main() async {
-  bool assertsEnabled = false;
-  assert(() {
-    assertsEnabled = true;
-    return true;
-  }());
-
   test('impellerc produces reasonable JSON encoded IPLR files', () async {
     final Directory directory = shaderDirectory('iplr-json');
     final Object? rawData = convert.json.decode(
@@ -80,9 +74,6 @@ void main() async {
   });
 
   test('FragmentShader with sampler asserts if sampler is missing when assigned to paint', () async {
-    if (!assertsEnabled) {
-      return;
-    }
     final FragmentProgram program = await FragmentProgram.fromAsset(
       'blue_green_sampler.frag.iplr',
     );
@@ -107,14 +98,9 @@ void main() async {
     final FragmentShader shader = program.fragmentShader()
       ..setImageSampler(0, blueGreenImage);
     shader.dispose();
-    try {
-      final Paint paint = Paint()..shader = shader;  // ignore: unused_local_variable
-      if (assertsEnabled) {
-        fail('Unreachable');
-      }
-    } catch (e) {
-      expect(e.toString(), contains('Attempted to set a disposed shader'));
-    }
+    expect(() {
+      Paint().shader = shader;
+    }, throwsA(isA<AssertionError>().having((AssertionError e) => e.message, 'message', contains('Attempted to set a disposed shader'))));
     blueGreenImage.dispose();
   });
 
@@ -125,21 +111,10 @@ void main() async {
     final FragmentShader shader = program.fragmentShader()
       ..setFloat(0, 0.0);
     shader.dispose();
-    try {
+
+    expect(() {
       shader.setFloat(0, 0.0);
-      if (assertsEnabled) {
-        fail('Unreachable');
-      }
-    } catch (e) {
-      if (assertsEnabled) {
-        expect(
-          e.toString(),
-          contains('Tried to accesss uniforms on a disposed Shader'),
-        );
-      } else {
-        expect(e is RangeError, true);
-      }
-    }
+    }, throwsA(isA<AssertionError>().having((AssertionError e) => e.message, 'message', contains('Tried to accesss uniforms on a disposed Shader'))));
   });
 
   test('Disposed FragmentShader setImageSampler', () async {
@@ -151,22 +126,9 @@ void main() async {
     final FragmentShader shader = program.fragmentShader()
       ..setImageSampler(0, blueGreenImage);
     shader.dispose();
-    try {
+    expect(() {
       shader.setImageSampler(0, blueGreenImage);
-      if (assertsEnabled) {
-        fail('Unreachable');
-      }
-    } on AssertionError catch (e) {
-      expect(
-        e.toString(),
-        contains('Tried to access uniforms on a disposed Shader'),
-      );
-    } on StateError catch (e) {
-      expect(
-        e.toString(),
-        contains('the native peer has been collected'),
-      );
-    }
+    }, throwsA(isA<AssertionError>().having((AssertionError e) => e.message, 'message', contains('Tried to access uniforms on a disposed Shader'))));
     blueGreenImage.dispose();
   });
 
@@ -177,18 +139,9 @@ void main() async {
     final FragmentShader shader = program.fragmentShader()
       ..setFloat(0, 0.0);
     shader.dispose();
-    try {
+    expect(() {
       shader.dispose();
-      if (assertsEnabled) {
-        fail('Unreachable');
-      }
-    } catch (e) {
-      if (assertsEnabled) {
-        expect(e is AssertionError, true);
-      } else {
-        expect(e is StateError, true);
-      }
-    }
+    }, throwsA(isA<AssertionError>().having((AssertionError e) => e.message, 'message', contains('Shader cannot be disposed more than once'))));
   });
 
   test('FragmentShader simple shader renders correctly', () async {

--- a/testing/dart/geometry_test.dart
+++ b/testing/dart/geometry_test.dart
@@ -378,15 +378,6 @@ void main() {
   });
 
   test('RRect asserts when corner radii are negative', () {
-    bool assertsEnabled = false;
-    assert(() {
-      assertsEnabled = true;
-      return true;
-    }());
-    if (!assertsEnabled) {
-      return;
-    }
-
     expect(() {
       RRect.fromRectAndCorners(
         const Rect.fromLTRB(10.0, 20.0, 30.0, 40.0),

--- a/testing/dart/gradient_test.dart
+++ b/testing/dart/gradient_test.dart
@@ -52,21 +52,18 @@ void main() {
   // this would result in div/0 on skia side.
   test('radial center and focal == Offset.zero and focalRadius != 0.0 assert',
     () {
-      assert(() {
-        expect(
-          () => Gradient.radial(
-                Offset.zero,
-                0.0,
-                <Color>[const Color(0xFFFFFFFF), const Color(0xFFFFFFFF)],
-                <double>[0.0, 1.0],
-                TileMode.mirror,
-                null,
-                Offset.zero,
-                1.0,
-              ),
-          throwsA(isA<AssertionError>()),
-        );
-        return true;
-      }());
+      expect(
+        () => Gradient.radial(
+              Offset.zero,
+              0.0,
+              <Color>[const Color(0xFFFFFFFF), const Color(0xFFFFFFFF)],
+              <double>[0.0, 1.0],
+              TileMode.mirror,
+              null,
+              Offset.zero,
+              1.0,
+            ),
+        throwsA(isA<AssertionError>()),
+      );
   });
 }

--- a/testing/dart/image_dispose_test.dart
+++ b/testing/dart/image_dispose_test.dart
@@ -10,12 +10,6 @@ import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
 void main() {
-  bool assertsEnabled = false;
-  assert(() {
-    assertsEnabled = true;
-    return true;
-  }());
-
   test('Handles are distinct', () async {
     final Uint8List bytes = await _readFile('2x2.png');
     final Codec codec = await instantiateImageCodec(bytes);
@@ -89,7 +83,7 @@ void main() {
 
     frame.image.dispose();
     expect(frame.image.debugGetOpenHandleStackTraces(), isEmpty);
-  }, skip: !assertsEnabled);
+  });
 
   test('Clones can be compared', () async {
     final Uint8List bytes = await _readFile('2x2.png');
@@ -119,18 +113,10 @@ void main() {
     final Codec codec = await instantiateImageCodec(bytes);
     final FrameInfo frame = await codec.getNextFrame();
 
-    if (assertsEnabled) {
-      expect(frame.image.debugDisposed, false);
-    } else {
-      expect(() => frame.image.debugDisposed, throwsStateError);
-    }
+    expect(frame.image.debugDisposed, false);
 
     frame.image.dispose();
-    if (assertsEnabled) {
-      expect(frame.image.debugDisposed, true);
-    } else {
-      expect(() => frame.image.debugDisposed, throwsStateError);
-    }
+    expect(frame.image.debugDisposed, true);
   });
 }
 

--- a/testing/dart/image_resize_test.dart
+++ b/testing/dart/image_resize_test.dart
@@ -11,12 +11,6 @@ import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
 void main() {
-  bool assertsEnabled = false;
-  assert(() {
-    assertsEnabled = true;
-    return true;
-  }());
-
   test('no resize by default', () async {
     final Uint8List bytes = await readFile('2x2.png');
     final Codec codec = await instantiateImageCodec(bytes);
@@ -119,8 +113,7 @@ void main() {
 
   test('pixels: upscale image by 5x - no upscaling', () async {
     final BlackSquare blackSquare = BlackSquare.create();
-    bool threw = false;
-    try {
+    expect(() {
       decodeImageFromPixels(
         blackSquare.pixels,
         blackSquare.width,
@@ -130,12 +123,8 @@ void main() {
         targetHeight: 10,
         allowUpscaling: false,
       );
-    } catch (e) {
-      expect(e is AssertionError, true);
-      threw = true;
-    }
-    expect(threw, true);
-  }, skip: !assertsEnabled);
+    }, throwsA(isA<AssertionError>()));
+  });
 
   test('pixels: upscale image varying width and height', () async {
     final BlackSquare blackSquare = BlackSquare.create();
@@ -147,8 +136,7 @@ void main() {
 
   test('pixels: upscale image varying width and height - no upscaling', () async {
     final BlackSquare blackSquare = BlackSquare.create();
-    bool threw = false;
-    try {
+    expect(() {
       decodeImageFromPixels(
         blackSquare.pixels,
         blackSquare.width,
@@ -159,12 +147,8 @@ void main() {
         targetWidth: 1,
         allowUpscaling: false,
       );
-    } catch (e) {
-      expect(e is AssertionError, true);
-      threw = true;
-    }
-    expect(threw, true);
-  }, skip: !assertsEnabled);
+    }, throwsA(isA<AssertionError>()));
+  });
 
   test('pixels: large negative dimensions', () async {
     final BlackSquare blackSquare = BlackSquare.create();

--- a/testing/dart/painting_test.dart
+++ b/testing/dart/painting_test.dart
@@ -34,21 +34,12 @@ void main() {
   });
 
   test('Vertices.raw checks', () {
-    bool assertsEnabled = false;
-    assert(() {
-      assertsEnabled = true;
-      return true;
-    }());
-
-    try {
+    expect(() {
       Vertices.raw(
         VertexMode.triangles,
         Float32List.fromList(const <double>[0.0]),
       );
-      throw 'Vertices.raw did not throw the expected error.';
-    } on ArgumentError catch (e) {
-      expect('$e', 'Invalid argument(s): "positions" must have an even number of entries (each coordinate is an x,y pair).');
-    }
+    }, throwsA(isA<ArgumentError>().having((ArgumentError e) => '$e', 'message', 'Invalid argument(s): "positions" must have an even number of entries (each coordinate is an x,y pair).')));
 
     Object? indicesError;
     try {
@@ -61,11 +52,7 @@ void main() {
     } on ArgumentError catch (e) {
       indicesError = e;
     }
-    if (assertsEnabled) {
-      expect('$indicesError', 'Invalid argument(s): "indices" values must be valid indices in the positions list (i.e. numbers in the range 0..2), but indices[2] is 5, which is too big.');
-    } else {
-      expect(indicesError, null);
-    }
+    expect('$indicesError', 'Invalid argument(s): "indices" values must be valid indices in the positions list (i.e. numbers in the range 0..2), but indices[2] is 5, which is too big.');
 
     Vertices.raw( // This one does not throw.
       VertexMode.triangles,

--- a/testing/dart/paragraph_test.dart
+++ b/testing/dart/paragraph_test.dart
@@ -333,7 +333,8 @@ void main() {
   test('rounding hack disabled', () {
     const double fontSize = 1.25;
     const String text = '12345';
-    assert((fontSize * text.length).truncate() != fontSize * text.length);
+
+    expect((fontSize * text.length).truncate(), isNot(fontSize * text.length));
     final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(fontSize: fontSize));
     builder.addText(text);
     final Paragraph paragraph = builder.build()


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/155054, where we decided this was correct to do.

As a bonus I improved an `assert` message :)