### PR TITLE
[impeller] add Android flag for disabling surface control for debugging.

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -230,7 +230,7 @@ struct Settings {
 #endif
 
   // Force disable the android surface control even where supported.
-  bool disable_surface_control = true;
+  bool disable_surface_control = false;
 
   // If true, the UI thread is the platform thread on supported
   // platforms.

--- a/common/settings.h
+++ b/common/settings.h
@@ -229,6 +229,9 @@ struct Settings {
   bool enable_impeller = false;
 #endif
 
+  // Force disable the android surface control even where supported.
+  bool disable_surface_control = true;
+
   // If true, the UI thread is the platform thread on supported
   // platforms.
   bool merged_platform_ui_thread = true;

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -445,6 +445,7 @@ void ContextVK::Setup(Settings settings) {
   descriptor_pool_recycler_ = std::move(descriptor_pool_recycler);
   device_name_ = std::string(physical_device_properties.deviceName);
   command_queue_vk_ = std::make_shared<CommandQueueVK>(weak_from_this());
+  should_disable_surface_control_ = settings.disable_surface_control;
   is_valid_ = true;
 
   // Create the GPU Tracer later because it depends on state from
@@ -614,6 +615,10 @@ ContextVK::GetYUVConversionLibrary() const {
 
 const std::unique_ptr<DriverInfoVK>& ContextVK::GetDriverInfo() const {
   return driver_info_;
+}
+
+bool ContextVK::GetShouldDisableSurfaceControlSwapchain() const {
+  return should_disable_surface_control_;
 }
 
 }  // namespace impeller

--- a/impeller/renderer/backend/vulkan/context_vk.h
+++ b/impeller/renderer/backend/vulkan/context_vk.h
@@ -49,6 +49,7 @@ class ContextVK final : public Context,
     fml::UniqueFD cache_directory;
     bool enable_validation = false;
     bool enable_gpu_tracing = false;
+    bool disable_surface_control = false;
     /// If validations are requested but cannot be enabled, log a fatal error.
     bool fatal_missing_validations = false;
 
@@ -168,6 +169,10 @@ class ContextVK final : public Context,
 
   void InitializeCommonlyUsedShadersIfNeeded() const override;
 
+  /// @brief Whether the Android Surface control based swapchain should be
+  /// disabled, even if the device is capable of supporting it.
+  bool GetShouldDisableSurfaceControlSwapchain() const;
+
  private:
   struct DeviceHolderImpl : public DeviceHolderVK {
     // |DeviceHolder|
@@ -200,6 +205,7 @@ class ContextVK final : public Context,
   std::shared_ptr<GPUTracerVK> gpu_tracer_;
   std::shared_ptr<DescriptorPoolRecyclerVK> descriptor_pool_recycler_;
   std::shared_ptr<CommandQueue> command_queue_vk_;
+  bool should_disable_surface_control_ = false;
 
   const uint64_t hash_;
 

--- a/impeller/renderer/backend/vulkan/swapchain/swapchain_vk.cc
+++ b/impeller/renderer/backend/vulkan/swapchain/swapchain_vk.cc
@@ -57,11 +57,14 @@ std::shared_ptr<SwapchainVK> SwapchainVK::Create(
   }
 
   // TODO(147533): AHB swapchains on emulators are not functional.
-  const auto emulator = ContextVK::Cast(*context).GetDriverInfo()->IsEmulator();
+  auto& context_vk = ContextVK::Cast(*context);
+  const auto emulator = context_vk.GetDriverInfo()->IsEmulator();
+  const auto should_disable_sc =
+      context_vk.GetShouldDisableSurfaceControlSwapchain();
 
   // Try AHB swapchains first.
   if (!emulator && AHBSwapchainVK::IsAvailableOnPlatform() &&
-      !android::ShadowRealm::ShouldDisableAHB()) {
+      !android::ShadowRealm::ShouldDisableAHB() && !should_disable_sc) {
     auto ahb_swapchain = std::shared_ptr<AHBSwapchainVK>(new AHBSwapchainVK(
         context,             //
         window.GetHandle(),  //

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -524,6 +524,9 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
   settings.enable_platform_isolates =
       command_line.HasOption(FlagForSwitch(Switch::EnablePlatformIsolates));
 
+  settings.disable_surface_control = command_line.HasOption(
+      FlagForSwitch(Switch::DisableAndroidSurfaceControl));
+
   return settings;
 }
 

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -297,6 +297,9 @@ DEF_SWITCH(EnablePlatformIsolates,
 DEF_SWITCH(EnableMergedPlatformUIThread,
            "enable-merged-platform-ui-thread",
            "Merge the ui thread and platform thread.")
+DEF_SWITCH(DisableAndroidSurfaceControl,
+           "disable-surface-control",
+           "Disable the SurfaceControl backed swapchain even when supported.")
 DEF_SWITCHES_END
 
 void PrintUsage(const std::string& executable_name);

--- a/shell/platform/android/android_context_vk_impeller.h
+++ b/shell/platform/android/android_context_vk_impeller.h
@@ -14,9 +14,8 @@ namespace flutter {
 
 class AndroidContextVKImpeller : public AndroidContext {
  public:
-  AndroidContextVKImpeller(bool enable_validation,
-                           bool enable_gpu_tracing,
-                           bool quiet = false);
+  explicit AndroidContextVKImpeller(
+      const AndroidContext::ContextSettings& settings);
 
   ~AndroidContextVKImpeller();
 

--- a/shell/platform/android/context/android_context.h
+++ b/shell/platform/android/context/android_context.h
@@ -22,6 +22,13 @@ class AndroidContext {
 
   virtual ~AndroidContext();
 
+  struct ContextSettings {
+    bool enable_validation = false;
+    bool enable_gpu_tracing = false;
+    bool disable_surface_control = false;
+    bool quiet = false;
+  };
+
   AndroidRenderingAPI RenderingApi() const;
 
   virtual bool IsValid() const;

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -23,6 +23,7 @@
 #include "flutter/shell/common/shell.h"
 #include "flutter/shell/common/switches.h"
 #include "flutter/shell/platform/android/android_context_vk_impeller.h"
+#include "flutter/shell/platform/android/context/android_context.h"
 #include "flutter/shell/platform/android/flutter_main.h"
 #include "impeller/base/validation.h"
 #include "impeller/toolkit/android/proc_table.h"
@@ -269,9 +270,9 @@ AndroidRenderingAPI FlutterMain::SelectedRenderingAPI(
     // checking if it is valid.
     impeller::ScopedValidationDisable disable_validation;
     auto vulkan_backend = std::make_unique<AndroidContextVKImpeller>(
-        /*enable_vulkan_validation=*/false,
-        /*enable_vulkan_gpu_tracing=*/false,
-        /*quiet=*/true);
+        AndroidContext::ContextSettings{.enable_validation = false,
+                                        .enable_gpu_tracing = false,
+                                        .quiet = true});
     if (!vulkan_backend->IsValid()) {
       return kVulkanUnsupportedFallback;
     }

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -49,6 +49,8 @@ public class FlutterLoader {
       "io.flutter.embedding.android.EnableVulkanGPUTracing";
   private static final String ENABLED_MERGED_PLATFORM_UI_THREAD_KEY =
       "io.flutter.embedding.android.EnableMergedPlatformUIThread";
+  private static final String DISABLE_SURFACE_CONTROL =
+      "io.flutter.embedding.android.DisableSurfaceControl";
 
   /**
    * Set whether leave or clean up the VM after the last shell shuts down. It can be set from app's
@@ -361,6 +363,9 @@ public class FlutterLoader {
         if (metaData.getBoolean(IMPELLER_VULKAN_GPU_TRACING_DATA_KEY, false)) {
           shellArgs.add("--enable-vulkan-gpu-tracing");
         }
+        if (metaData.getBoolean(DISABLE_SURFACE_CONTROL, false)) {
+          shellArgs.add("--disable-surface-control");
+        }
         if (metaData.containsKey(ENABLED_MERGED_PLATFORM_UI_THREAD_KEY)) {
           if (metaData.getBoolean(ENABLED_MERGED_PLATFORM_UI_THREAD_KEY)) {
             shellArgs.add("--enable-merged-platform-ui-thread");
@@ -368,6 +373,7 @@ public class FlutterLoader {
             shellArgs.add("--no-enable-merged-platform-ui-thread");
           }
         }
+
         String backend = metaData.getString(IMPELLER_BACKEND_META_DATA_KEY);
         if (backend != null) {
           shellArgs.add("--impeller-backend=" + backend);

--- a/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
@@ -237,6 +237,28 @@ public class FlutterLoaderTest {
   }
 
   @Test
+  public void itSetsDisableSurfaceControlFromMetaData() {
+    FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
+    FlutterLoader flutterLoader = new FlutterLoader(mockFlutterJNI);
+    Bundle metaData = new Bundle();
+    metaData.putBoolean("io.flutter.embedding.android.DisableSurfaceControl", true);
+    ctx.getApplicationInfo().metaData = metaData;
+
+    FlutterLoader.Settings settings = new FlutterLoader.Settings();
+    assertFalse(flutterLoader.initialized());
+    flutterLoader.startInitialization(ctx, settings);
+    flutterLoader.ensureInitializationComplete(ctx, null);
+    shadowOf(getMainLooper()).idle();
+
+    final String disabledControlArg = "--disable-surface-control";
+    ArgumentCaptor<String[]> shellArgsCaptor = ArgumentCaptor.forClass(String[].class);
+    verify(mockFlutterJNI, times(1))
+        .init(eq(ctx), shellArgsCaptor.capture(), anyString(), anyString(), anyString(), anyLong());
+    List<String> arguments = Arrays.asList(shellArgsCaptor.getValue());
+    assertTrue(arguments.contains(disabledControlArg));
+  }
+
+  @Test
   @TargetApi(API_LEVELS.API_23)
   @Config(sdk = API_LEVELS.API_23)
   public void itReportsFpsToVsyncWaiterAndroidM() {


### PR DESCRIPTION
I've found a few instances where Vulkan worked correctly but surface control did not. lets add a debugging flag we can ask folks to try to narrow down the issue.