### PR TITLE
[Impeller] remove usage of VBB when allocating vertices of a fixed size.

### DIFF
--- a/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/border_mask_blur_filter_contents.cc
@@ -91,15 +91,15 @@ std::optional<Entity> BorderMaskBlurFilterContents::RenderFilter(
                                const Entity& entity, RenderPass& pass) -> bool {
     auto& host_buffer = renderer.GetTransientsBuffer();
 
-    VertexBufferBuilder<VS::PerVertexData> vtx_builder;
     auto origin = coverage.GetOrigin();
     auto size = coverage.GetSize();
-    vtx_builder.AddVertices({
-        {origin, input_uvs[0]},
-        {{origin.x + size.width, origin.y}, input_uvs[1]},
-        {{origin.x, origin.y + size.height}, input_uvs[2]},
-        {{origin.x + size.width, origin.y + size.height}, input_uvs[3]},
-    });
+    std::array<VS::PerVertexData, 4> vertices = {
+        VS::PerVertexData{origin, input_uvs[0]},
+        VS::PerVertexData{{origin.x + size.width, origin.y}, input_uvs[1]},
+        VS::PerVertexData{{origin.x, origin.y + size.height}, input_uvs[2]},
+        VS::PerVertexData{{origin.x + size.width, origin.y + size.height},
+                          input_uvs[3]},
+    };
 
     auto options = OptionsFromPassAndEntity(pass, entity);
     options.primitive_type = PrimitiveType::kTriangleStrip;
@@ -117,7 +117,7 @@ std::optional<Entity> BorderMaskBlurFilterContents::RenderFilter(
 
     pass.SetCommandLabel("Border Mask Blur Filter");
     pass.SetPipeline(renderer.GetBorderMaskBlurPipeline(options));
-    pass.SetVertexBuffer(vtx_builder.CreateVertexBuffer(host_buffer));
+    pass.SetVertexBuffer(CreateVertexBuffer(vertices, host_buffer));
 
     FS::BindFragInfo(pass, host_buffer.EmplaceUniform(frag_info));
     VS::BindFrameInfo(pass, host_buffer.EmplaceUniform(frame_info));

--- a/impeller/entity/contents/filters/color_matrix_filter_contents.cc
+++ b/impeller/entity/contents/filters/color_matrix_filter_contents.cc
@@ -63,15 +63,15 @@ std::optional<Entity> ColorMatrixFilterContents::RenderFilter(
 
     auto size = input_snapshot->texture->GetSize();
 
-    VertexBufferBuilder<VS::PerVertexData> vtx_builder;
-    vtx_builder.AddVertices({
-        {Point(0, 0)},
-        {Point(1, 0)},
-        {Point(0, 1)},
-        {Point(1, 1)},
-    });
+    std::array<VS::PerVertexData, 4> vertices = {
+        VS::PerVertexData{Point(0, 0)},
+        VS::PerVertexData{Point(1, 0)},
+        VS::PerVertexData{Point(0, 1)},
+        VS::PerVertexData{Point(1, 1)},
+    };
     auto& host_buffer = renderer.GetTransientsBuffer();
-    pass.SetVertexBuffer(vtx_builder.CreateVertexBuffer(host_buffer));
+    pass.SetVertexBuffer(
+        CreateVertexBuffer(vertices, renderer.GetTransientsBuffer()));
 
     VS::FrameInfo frame_info;
     frame_info.mvp = Entity::GetShaderTransform(

--- a/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/linear_to_srgb_filter_contents.cc
@@ -51,17 +51,15 @@ std::optional<Entity> LinearToSrgbFilterContents::RenderFilter(
     pass.SetPipeline(renderer.GetLinearToSrgbFilterPipeline(options));
 
     auto size = input_snapshot->texture->GetSize();
-
-    VertexBufferBuilder<VS::PerVertexData> vtx_builder;
-    vtx_builder.AddVertices({
-        {Point(0, 0)},
-        {Point(1, 0)},
-        {Point(0, 1)},
-        {Point(1, 1)},
-    });
+    std::array<VS::PerVertexData, 4> vertices = {
+        VS::PerVertexData{Point(0, 0)},
+        VS::PerVertexData{Point(1, 0)},
+        VS::PerVertexData{Point(0, 1)},
+        VS::PerVertexData{Point(1, 1)},
+    };
 
     auto& host_buffer = renderer.GetTransientsBuffer();
-    pass.SetVertexBuffer(vtx_builder.CreateVertexBuffer(host_buffer));
+    pass.SetVertexBuffer(CreateVertexBuffer(vertices, host_buffer));
 
     VS::FrameInfo frame_info;
     frame_info.mvp = Entity::GetShaderTransform(

--- a/impeller/entity/contents/filters/morphology_filter_contents.cc
+++ b/impeller/entity/contents/filters/morphology_filter_contents.cc
@@ -76,13 +76,12 @@ std::optional<Entity> DirectionalMorphologyFilterContents::RenderFilter(
                                                  RenderPass& pass) {
     auto& host_buffer = renderer.GetTransientsBuffer();
 
-    VertexBufferBuilder<VS::PerVertexData> vtx_builder;
-    vtx_builder.AddVertices({
-        {Point(0, 0), input_uvs[0]},
-        {Point(1, 0), input_uvs[1]},
-        {Point(0, 1), input_uvs[2]},
-        {Point(1, 1), input_uvs[3]},
-    });
+    std::array<VS::PerVertexData, 4> vertices = {
+        VS::PerVertexData{Point(0, 0), input_uvs[0]},
+        VS::PerVertexData{Point(1, 0), input_uvs[1]},
+        VS::PerVertexData{Point(0, 1), input_uvs[2]},
+        VS::PerVertexData{Point(1, 1), input_uvs[3]},
+    };
 
     VS::FrameInfo frame_info;
     frame_info.mvp = Matrix::MakeOrthographic(ISize(1, 1));
@@ -116,7 +115,7 @@ std::optional<Entity> DirectionalMorphologyFilterContents::RenderFilter(
     options.primitive_type = PrimitiveType::kTriangleStrip;
     options.blend_mode = BlendMode::kSource;
     pass.SetPipeline(renderer.GetMorphologyFilterPipeline(options));
-    pass.SetVertexBuffer(vtx_builder.CreateVertexBuffer(host_buffer));
+    pass.SetVertexBuffer(CreateVertexBuffer(vertices, host_buffer));
 
     auto sampler_descriptor = input_snapshot->sampler_descriptor;
     if (renderer.GetDeviceCapabilities().SupportsDecalSamplerAddressMode()) {

--- a/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
+++ b/impeller/entity/contents/filters/srgb_to_linear_filter_contents.cc
@@ -52,16 +52,16 @@ std::optional<Entity> SrgbToLinearFilterContents::RenderFilter(
 
     auto size = input_snapshot->texture->GetSize();
 
-    VertexBufferBuilder<VS::PerVertexData> vtx_builder;
-    vtx_builder.AddVertices({
-        {Point(0, 0)},
-        {Point(1, 0)},
-        {Point(0, 1)},
-        {Point(1, 1)},
-    });
+    std::array<VS::PerVertexData, 4> vertices = {
+        VS::PerVertexData{Point(0, 0)},
+        VS::PerVertexData{Point(1, 0)},
+        VS::PerVertexData{Point(0, 1)},
+        VS::PerVertexData{Point(1, 1)},
+    };
 
     auto& host_buffer = renderer.GetTransientsBuffer();
-    pass.SetVertexBuffer(vtx_builder.CreateVertexBuffer(host_buffer));
+    pass.SetVertexBuffer(
+        CreateVertexBuffer(vertices, renderer.GetTransientsBuffer()));
 
     VS::FrameInfo frame_info;
     frame_info.mvp = Entity::GetShaderTransform(

--- a/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
+++ b/impeller/entity/contents/filters/yuv_to_rgb_filter_contents.cc
@@ -81,16 +81,16 @@ std::optional<Entity> YUVToRGBFilterContents::RenderFilter(
 
     auto size = y_input_snapshot->texture->GetSize();
 
-    VertexBufferBuilder<VS::PerVertexData> vtx_builder;
-    vtx_builder.AddVertices({
-        {Point(0, 0)},
-        {Point(1, 0)},
-        {Point(0, 1)},
-        {Point(1, 1)},
-    });
+    std::array<VS::PerVertexData, 4> vertices = {
+        VS::PerVertexData{Point(0, 0)},
+        VS::PerVertexData{Point(1, 0)},
+        VS::PerVertexData{Point(0, 1)},
+        VS::PerVertexData{Point(1, 1)},
+    };
 
     auto& host_buffer = renderer.GetTransientsBuffer();
-    pass.SetVertexBuffer(vtx_builder.CreateVertexBuffer(host_buffer));
+    pass.SetVertexBuffer(
+        CreateVertexBuffer(vertices, renderer.GetTransientsBuffer()));
 
     VS::FrameInfo frame_info;
     frame_info.mvp = Entity::GetShaderTransform(

--- a/impeller/entity/contents/framebuffer_blend_contents.cc
+++ b/impeller/entity/contents/framebuffer_blend_contents.cc
@@ -54,20 +54,21 @@ bool FramebufferBlendContents::Render(const ContentContext& renderer,
   }
 
   auto size = src_snapshot->texture->GetSize();
-  VertexBufferBuilder<VS::PerVertexData> vtx_builder;
-  vtx_builder.AddVertices({
-      {Point(0, 0), Point(0, 0)},
-      {Point(size.width, 0), Point(1, 0)},
-      {Point(0, size.height), Point(0, 1)},
-      {Point(size.width, size.height), Point(1, 1)},
-  });
+
+  std::array<VS::PerVertexData, 4> vertices = {
+      VS::PerVertexData{Point(0, 0), Point(0, 0)},
+      VS::PerVertexData{Point(size.width, 0), Point(1, 0)},
+      VS::PerVertexData{Point(0, size.height), Point(0, 1)},
+      VS::PerVertexData{Point(size.width, size.height), Point(1, 1)},
+  };
 
   auto options = OptionsFromPass(pass);
   options.blend_mode = BlendMode::kSource;
   options.primitive_type = PrimitiveType::kTriangleStrip;
 
   pass.SetCommandLabel("Framebuffer Advanced Blend Filter");
-  pass.SetVertexBuffer(vtx_builder.CreateVertexBuffer(host_buffer));
+  pass.SetVertexBuffer(
+      CreateVertexBuffer(vertices, renderer.GetTransientsBuffer()));
 
   switch (blend_mode_) {
     case BlendMode::kScreen:

--- a/impeller/entity/contents/texture_contents.cc
+++ b/impeller/entity/contents/texture_contents.cc
@@ -124,16 +124,19 @@ bool TextureContents::Render(const ContentContext& renderer,
 
   auto texture_coords =
       Rect::MakeSize(texture_->GetSize()).Project(source_rect_);
-
-  VertexBufferBuilder<VS::PerVertexData> vertex_builder;
-  vertex_builder.AddVertices({
-      {destination_rect_.GetLeftTop(), texture_coords.GetLeftTop()},
-      {destination_rect_.GetRightTop(), texture_coords.GetRightTop()},
-      {destination_rect_.GetLeftBottom(), texture_coords.GetLeftBottom()},
-      {destination_rect_.GetRightBottom(), texture_coords.GetRightBottom()},
-  });
-
   auto& host_buffer = renderer.GetTransientsBuffer();
+
+  std::array<VS::PerVertexData, 4> vertices = {
+      VS::PerVertexData{destination_rect_.GetLeftTop(),
+                        texture_coords.GetLeftTop()},
+      VS::PerVertexData{destination_rect_.GetRightTop(),
+                        texture_coords.GetRightTop()},
+      VS::PerVertexData{destination_rect_.GetLeftBottom(),
+                        texture_coords.GetLeftBottom()},
+      VS::PerVertexData{destination_rect_.GetRightBottom(),
+                        texture_coords.GetRightBottom()},
+  };
+  auto vertex_buffer = CreateVertexBuffer(vertices, host_buffer);
 
   VS::FrameInfo frame_info;
   frame_info.mvp = entity.GetShaderTransform(pass);
@@ -160,7 +163,7 @@ bool TextureContents::Render(const ContentContext& renderer,
                        ? renderer.GetTextureStrictSrcPipeline(pipeline_options)
                        : renderer.GetTexturePipeline(pipeline_options));
 
-  pass.SetVertexBuffer(vertex_builder.CreateVertexBuffer(host_buffer));
+  pass.SetVertexBuffer(vertex_buffer);
   VS::BindFrameInfo(pass, host_buffer.EmplaceUniform(frame_info));
 
   if (strict_source_rect_enabled_) {

--- a/impeller/renderer/vertex_buffer_builder.h
+++ b/impeller/renderer/vertex_buffer_builder.h
@@ -24,10 +24,11 @@ template <class VertexType, size_t size>
 VertexBuffer CreateVertexBuffer(std::array<VertexType, size> input,
                                 HostBuffer& host_buffer) {
   return VertexBuffer{
-      .vertex_buffer = host_buffer.Emplace(input, sizeof(VertexType) * size,
-                                           alignof(VertexType)),  //
-      .vertex_count = size,                                       //
-      .index_type = IndexType::kNone,                             //
+      .vertex_buffer =
+          host_buffer.Emplace(input.data(), sizeof(VertexType) * size,
+                              alignof(VertexType)),  //
+      .vertex_count = size,                          //
+      .index_type = IndexType::kNone,                //
   };
 }
 

--- a/impeller/renderer/vertex_buffer_builder.h
+++ b/impeller/renderer/vertex_buffer_builder.h
@@ -6,6 +6,8 @@
 #define FLUTTER_IMPELLER_RENDERER_VERTEX_BUFFER_BUILDER_H_
 
 #include <initializer_list>
+#include <memory>
+#include <type_traits>
 #include <vector>
 
 #include "impeller/base/strings.h"
@@ -16,6 +18,18 @@
 #include "impeller/core/vertex_buffer.h"
 
 namespace impeller {
+
+/// @brief Create an index-less vertex buffer from a fixed size array.
+template <class VertexType, size_t size>
+VertexBuffer CreateVertexBuffer(std::array<VertexType, size> input,
+                                HostBuffer& host_buffer) {
+  return VertexBuffer{
+      .vertex_buffer = host_buffer.Emplace(input, sizeof(VertexType) * size,
+                                           alignof(VertexType)),  //
+      .vertex_count = size,                                       //
+      .index_type = IndexType::kNone,                             //
+  };
+}
 
 template <class VertexType_, class IndexType_ = uint16_t>
 class VertexBufferBuilder {


### PR DESCRIPTION
The VertexBufferBuilder (VBB) always does a heap allocation of its vertices before copying them into the host buffer. This is unecessary when uploading a fixed set of vertices, like many filters do. Instead create a helper function that uploads from a  std::array. In most cases this is the same or less code.

We could go template madness to emplace directly but that doesnt seem necessary.
