### PR TITLE
FlutterViewTest add back part 4 and 5

### DIFF
--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -94,7 +94,7 @@ public class FlutterViewTest {
   // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void attachToFlutterEngine_alertsPlatformViews() {
-    FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
+    FlutterView flutterView = new FlutterView(ctx);
     FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     when(flutterEngine.getPlatformViewsController()).thenReturn(platformViewsController);
 
@@ -108,7 +108,7 @@ public class FlutterViewTest {
   // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void flutterView_importantForAutofillDoesNotExcludeDescendants() {
-    FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
+    FlutterView flutterView = new FlutterView(ctx);
 
     // Value should not exclude descendants because platform views are added as child views and
     // can be eligible for autofill (e.g. a WebView).
@@ -120,7 +120,7 @@ public class FlutterViewTest {
   // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void detachFromFlutterEngine_alertsPlatformViews() {
-    FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
+    FlutterView flutterView = new FlutterView(ctx);
     FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     when(flutterEngine.getPlatformViewsController()).thenReturn(platformViewsController);
 
@@ -135,7 +135,7 @@ public class FlutterViewTest {
   // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void detachFromFlutterEngine_turnsOffA11y() {
-    FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
+    FlutterView flutterView = new FlutterView(ctx);
     FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
     when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
@@ -234,7 +234,7 @@ public class FlutterViewTest {
   // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void onConfigurationChanged_fizzlesWhenNullEngine() {
-    FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
+    FlutterView flutterView = new FlutterView(ctx);
     FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
 
     Configuration configuration = ctx.getResources().getConfiguration();
@@ -274,7 +274,7 @@ public class FlutterViewTest {
     // Setup test.
     AtomicReference<Boolean> reportedShowPassword = new AtomicReference<>();
 
-    FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
+    FlutterView flutterView = new FlutterView(ctx);
     FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     Settings.System.putInt(
         flutterView.getContext().getContentResolver(), Settings.System.TEXT_SHOW_PASSWORD, 0);
@@ -314,7 +314,7 @@ public class FlutterViewTest {
   @Config(sdk = 30)
   public void reportSystemInsetWhenNotFullscreen() {
     // Without custom shadows, the default system ui visibility flags is 0.
-    FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
+    FlutterView flutterView = new FlutterView(ctx);
     assertEquals(0, flutterView.getSystemUiVisibility());
 
     FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
@@ -355,7 +355,7 @@ public class FlutterViewTest {
   @Config(sdk = 28)
   public void reportSystemInsetWhenNotFullscreenLegacy() {
     // Without custom shadows, the default system ui visibility flags is 0.
-    FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
+    FlutterView flutterView = new FlutterView(ctx);
     assertEquals(0, flutterView.getSystemUiVisibility());
 
     FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
@@ -893,7 +893,7 @@ public class FlutterViewTest {
     // Setup test.
     AtomicReference<Boolean> reportedShowPassword = new AtomicReference<>();
 
-    FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
+    FlutterView flutterView = new FlutterView(ctx);
     FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     Settings.System.putInt(
         flutterView.getContext().getContentResolver(), Settings.System.TEXT_SHOW_PASSWORD, 1);
@@ -950,7 +950,7 @@ public class FlutterViewTest {
   @TargetApi(30)
   @Config(sdk = 30)
   public void setPaddingTopToZeroForFullscreenMode() {
-    FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
+    FlutterView flutterView = new FlutterView(ctx);
     FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
     FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
     when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
@@ -1037,7 +1037,7 @@ public class FlutterViewTest {
     AtomicReference<SettingsChannel.PlatformBrightness> reportedBrightness =
         new AtomicReference<>();
 
-    Context spiedContext = spy(Robolectric.setupActivity(Activity.class));
+    Context spiedContext = spy(ctx);
 
     Resources spiedResources = spy(spiedContext.getResources());
     when(spiedContext.getResources()).thenReturn(spiedResources);
@@ -1094,7 +1094,7 @@ public class FlutterViewTest {
         new AtomicReference<>();
 
     // FYI - The default brightness is LIGHT, which is why we don't need to configure it.
-    FlutterView flutterView = new FlutterView(Robolectric.setupActivity(Activity.class));
+    FlutterView flutterView = new FlutterView(ctx);
     FlutterEngine flutterEngine = spy(new FlutterEngine(ctx, mockFlutterLoader, mockFlutterJni));
 
     SettingsChannel fakeSettingsChannel = mock(SettingsChannel.class);

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -89,7 +89,6 @@ public class FlutterViewTest {
     // ShadowLog.stream = System.out;
   }
 
-  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void attachToFlutterEngine_alertsPlatformViews() {
     FlutterView flutterView = new FlutterView(ctx);

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -89,8 +89,6 @@ public class FlutterViewTest {
     // ShadowLog.stream = System.out;
   }
 
-  @SuppressWarnings("deprecation")
-  // Robolectric.setupActivity
   // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void attachToFlutterEngine_alertsPlatformViews() {
@@ -103,9 +101,6 @@ public class FlutterViewTest {
     verify(platformViewsController, times(1)).attachToView(flutterView);
   }
 
-  @SuppressWarnings("deprecation")
-  // Robolectric.setupActivity
-  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void flutterView_importantForAutofillDoesNotExcludeDescendants() {
     FlutterView flutterView = new FlutterView(ctx);
@@ -115,9 +110,6 @@ public class FlutterViewTest {
     assertEquals(View.IMPORTANT_FOR_AUTOFILL_YES, flutterView.getImportantForAutofill());
   }
 
-  @SuppressWarnings("deprecation")
-  // Robolectric.setupActivity
-  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void detachFromFlutterEngine_alertsPlatformViews() {
     FlutterView flutterView = new FlutterView(ctx);
@@ -130,9 +122,6 @@ public class FlutterViewTest {
     verify(platformViewsController, times(1)).detachFromView();
   }
 
-  @SuppressWarnings("deprecation")
-  // Robolectric.setupActivity
-  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void detachFromFlutterEngine_turnsOffA11y() {
     FlutterView flutterView = new FlutterView(ctx);
@@ -229,9 +218,6 @@ public class FlutterViewTest {
     mockFlutterJni.onFirstFrame();
   }
 
-  @SuppressWarnings("deprecation")
-  // Robolectric.setupActivity
-  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   @Test
   public void onConfigurationChanged_fizzlesWhenNullEngine() {
     FlutterView flutterView = new FlutterView(ctx);
@@ -267,9 +253,6 @@ public class FlutterViewTest {
         .updateDisplayMetrics(any(Float.class), any(Float.class), any(Float.class));
   }
 
-  @SuppressWarnings("deprecation")
-  // Robolectric.setupActivity
-  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   public void itSendsTextHidePasswordToFrameworkOnAttach() {
     // Setup test.
     AtomicReference<Boolean> reportedShowPassword = new AtomicReference<>();
@@ -305,8 +288,7 @@ public class FlutterViewTest {
   }
 
   @SuppressWarnings("deprecation")
-  // Robolectric.setupActivity, getSystemUiVisibility
-  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
+  // getSystemUiVisibility
   // This test uses the API 30+ Algorithm for window insets. The legacy algorithm is
   // set to -1 values, so it is clear if the wrong algorithm is used.
   @Test
@@ -347,8 +329,7 @@ public class FlutterViewTest {
   }
 
   @SuppressWarnings("deprecation")
-  // Robolectric.setupActivity, getSystemUiVisibility
-  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
+  // getSystemUiVisibility
   // This test uses the pre-API 30 Algorithm for window insets.
   @Test
   @TargetApi(28)
@@ -886,8 +867,6 @@ public class FlutterViewTest {
     assertEquals(null, flutterView.findViewByAccessibilityIdTraversal(accessibilityViewId));
   }
 
-  @SuppressWarnings("deprecation")
-  // Robolectric.setupActivity
   @Test
   public void itSendsTextShowPasswordToFrameworkOnAttach() {
     // Setup test.
@@ -941,9 +920,6 @@ public class FlutterViewTest {
     assertFalse(-1 == viewportMetricsCaptor.getValue().physicalTouchSlop);
   }
 
-  @SuppressWarnings("deprecation")
-  // Robolectric.setupActivity
-  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   // This test uses the API 30+ Algorithm for window insets. The legacy algorithm is
   // set to -1 values, so it is clear if the wrong algorithm is used.
   @Test
@@ -980,8 +956,7 @@ public class FlutterViewTest {
   }
 
   @SuppressWarnings("deprecation")
-  // Robolectric.setupActivity
-  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
+  // SYSTEM_UI_FLAG_FULLSCREEN, getWindowSystemUiVisibility
   // This test uses the pre-API 30 Algorithm for window insets.
   @Test
   @TargetApi(28)
@@ -1027,9 +1002,6 @@ public class FlutterViewTest {
     validateViewportMetricPadding(viewportMetricsCaptor, 100, 0, 100, 0);
   }
 
-  @SuppressWarnings("deprecation")
-  // Robolectric.setupActivity
-  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
   // TODO(mattcarroll): turn this into an e2e test. GitHub #42990
   @Test
   public void itSendsDarkPlatformBrightnessToFlutter() {
@@ -1084,8 +1056,7 @@ public class FlutterViewTest {
   }
 
   @SuppressWarnings("deprecation")
-  // Robolectric.setupActivity
-  // TODO(reidbaker): https://github.com/flutter/flutter/issues/133151
+  // SYSTEM_UI_FLAG_FULLSCREEN, getWindowSystemUiVisibility
   // TODO(mattcarroll): turn this into an e2e test. GitHub #42990
   @Test
   public void itSendsLightPlatformBrightnessToFlutter() {


### PR DESCRIPTION
- **Add light and dark test back to FlutterView.java**
- **Migrate some but not all usages of Robolectric.setupActivity in FlutterViewTest.java**
- **Remove suppress warnings on tests that no longer need it, update documentation for ones that still need the suppression**
Fixes https://github.com/flutter/flutter/issues/154746 
Partial work on https://github.com/flutter/flutter/issues/133151

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
