### PR TITLE
[Flutter GPU] Add setStencilReference to RenderPass.

### DIFF
--- a/lib/gpu/lib/src/render_pass.dart
+++ b/lib/gpu/lib/src/render_pass.dart
@@ -212,6 +212,14 @@ base class RenderPass extends NativeFieldWrapperClass1 {
     _setDepthCompareOperation(compareFunction.index);
   }
 
+  void setStencilReference(int referenceValue) {
+    if (referenceValue < 0 || referenceValue > 0xFFFFFFFF) {
+      throw Exception(
+          "The stencil reference value must be in the range [0, 2^32 - 1]");
+    }
+    _setStencilReference(referenceValue);
+  }
+
   void draw() {
     if (!_draw()) {
       throw Exception("Failed to append draw");
@@ -334,6 +342,10 @@ base class RenderPass extends NativeFieldWrapperClass1 {
   @Native<Void Function(Pointer<Void>, Int)>(
       symbol: 'InternalFlutterGpu_RenderPass_SetDepthCompareOperation')
   external void _setDepthCompareOperation(int compareOperation);
+
+  @Native<Void Function(Pointer<Void>, Int)>(
+      symbol: 'InternalFlutterGpu_RenderPass_SetStencilReference')
+  external void _setStencilReference(int referenceValue);
 
   @Native<Bool Function(Pointer<Void>)>(
       symbol: 'InternalFlutterGpu_RenderPass_Draw')

--- a/lib/gpu/render_pass.cc
+++ b/lib/gpu/render_pass.cc
@@ -511,6 +511,13 @@ void InternalFlutterGpu_RenderPass_SetDepthCompareOperation(
       flutter::gpu::ToImpellerCompareFunction(compare_operation);
 }
 
+void InternalFlutterGpu_RenderPass_SetStencilReference(
+    flutter::gpu::RenderPass* wrapper,
+    int stencil_reference) {
+  auto& command = wrapper->GetCommand();
+  command.stencil_reference = static_cast<uint32_t>(stencil_reference);
+}
+
 bool InternalFlutterGpu_RenderPass_Draw(flutter::gpu::RenderPass* wrapper) {
   return wrapper->Draw();
 }

--- a/lib/gpu/render_pass.h
+++ b/lib/gpu/render_pass.h
@@ -222,6 +222,11 @@ extern void InternalFlutterGpu_RenderPass_SetDepthCompareOperation(
     int compare_operation);
 
 FLUTTER_GPU_EXPORT
+extern void InternalFlutterGpu_RenderPass_SetStencilReference(
+    flutter::gpu::RenderPass* wrapper,
+    int stencil_reference);
+
+FLUTTER_GPU_EXPORT
 extern bool InternalFlutterGpu_RenderPass_Draw(
     flutter::gpu::RenderPass* wrapper);
 


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/142731.

We're missing the pipeline stencil state as well. Will add in a follow-up.