### PR TITLE
[Flutter GPU] Add pipeline stencil config.

### DIFF
--- a/lib/gpu/render_pass.cc
+++ b/lib/gpu/render_pass.cc
@@ -62,6 +62,16 @@ RenderPass::GetDepthAttachmentDescriptor() {
   return depth_desc_;
 }
 
+impeller::StencilAttachmentDescriptor&
+RenderPass::GetStencilFrontAttachmentDescriptor() {
+  return stencil_front_desc_;
+}
+
+impeller::StencilAttachmentDescriptor&
+RenderPass::GetStencilBackAttachmentDescriptor() {
+  return stencil_back_desc_;
+}
+
 impeller::VertexBuffer& RenderPass::GetVertexBuffer() {
   return vertex_buffer_;
 }
@@ -516,6 +526,36 @@ void InternalFlutterGpu_RenderPass_SetStencilReference(
     int stencil_reference) {
   auto& command = wrapper->GetCommand();
   command.stencil_reference = static_cast<uint32_t>(stencil_reference);
+}
+
+void InternalFlutterGpu_RenderPass_SetStencilConfig(
+    flutter::gpu::RenderPass* wrapper,
+    int stencil_compare_operation,
+    int stencil_fail_operation,
+    int depth_fail_operation,
+    int depth_stencil_pass_operation,
+    int read_mask,
+    int write_mask,
+    int target_face) {
+  impeller::StencilAttachmentDescriptor desc;
+  desc.stencil_compare =
+      flutter::gpu::ToImpellerCompareFunction(stencil_compare_operation);
+  desc.stencil_failure =
+      flutter::gpu::ToImpellerStencilOperation(stencil_fail_operation);
+  desc.depth_failure =
+      flutter::gpu::ToImpellerStencilOperation(depth_fail_operation);
+  desc.depth_stencil_pass =
+      flutter::gpu::ToImpellerStencilOperation(depth_stencil_pass_operation);
+  desc.read_mask = static_cast<uint32_t>(read_mask);
+  desc.write_mask = static_cast<uint32_t>(write_mask);
+
+  // Corresponds to the `StencilFace` enum in `gpu/lib/src/render_pass.dart`.
+  if (target_face != 2 /* both or front */) {
+    wrapper->GetStencilFrontAttachmentDescriptor() = desc;
+  }
+  if (target_face != 1 /* both or back */) {
+    wrapper->GetStencilBackAttachmentDescriptor() = desc;
+  }
 }
 
 bool InternalFlutterGpu_RenderPass_Draw(flutter::gpu::RenderPass* wrapper) {

--- a/lib/gpu/render_pass.h
+++ b/lib/gpu/render_pass.h
@@ -46,6 +46,10 @@ class RenderPass : public RefCountedDartWrappable<RenderPass> {
 
   impeller::DepthAttachmentDescriptor& GetDepthAttachmentDescriptor();
 
+  impeller::StencilAttachmentDescriptor& GetStencilFrontAttachmentDescriptor();
+
+  impeller::StencilAttachmentDescriptor& GetStencilBackAttachmentDescriptor();
+
   impeller::VertexBuffer& GetVertexBuffer();
 
   bool Begin(flutter::gpu::CommandBuffer& command_buffer);
@@ -225,6 +229,17 @@ FLUTTER_GPU_EXPORT
 extern void InternalFlutterGpu_RenderPass_SetStencilReference(
     flutter::gpu::RenderPass* wrapper,
     int stencil_reference);
+
+FLUTTER_GPU_EXPORT
+extern void InternalFlutterGpu_RenderPass_SetStencilConfig(
+    flutter::gpu::RenderPass* wrapper,
+    int stencil_compare_operation,
+    int stencil_fail_operation,
+    int depth_fail_operation,
+    int depth_stencil_pass_operation,
+    int read_mask,
+    int write_mask,
+    int target);
 
 FLUTTER_GPU_EXPORT
 extern bool InternalFlutterGpu_RenderPass_Draw(


### PR DESCRIPTION
Also adds a golden that depends on https://github.com/flutter/engine/pull/55270.
Resolves https://github.com/flutter/flutter/issues/142731.

Allow setting the stencil compare function, pass/fail operations, and read/write masks.

Flutter GPU has light "shader object" style programs, so all of the stencil configuration state can be set on the `RenderPass` at any time.

New simple golden that exercises stencil ops:
![flutter_gpu_test_triangle_stencil](https://github.com/user-attachments/assets/acc98cd9-41fc-4988-97a2-afb898a8fc0c)
