### PR TITLE
[ios] Update gesture position on every event

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -2430,7 +2430,11 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   return self.presentedViewController != nil || self.isPresentingViewControllerAnimating;
 }
 
-- (flutter::PointerData)generatePointerDataAtLastMouseLocation API_AVAILABLE(ios(13.4)) {
+- (flutter::PointerData)updateMousePointerDataFrom:(UIGestureRecognizer*)gestureRecognizer
+    API_AVAILABLE(ios(13.4)) {
+  CGPoint location = [gestureRecognizer locationInView:self.view];
+  CGFloat scale = [self flutterScreenIfViewLoaded].scale;
+  _mouseState.location = {location.x * scale, location.y * scale};
   flutter::PointerData pointer_data;
   pointer_data.Clear();
   pointer_data.time_stamp = [[NSProcessInfo processInfo] systemUptime] * kMicrosecondsPerSecond;
@@ -2450,7 +2454,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   if (gestureRecognizer == _continuousScrollingPanGestureRecognizer &&
       event.type == UIEventTypeScroll) {
     // Events with type UIEventTypeScroll are only received when running on macOS under emulation.
-    flutter::PointerData pointer_data = [self generatePointerDataAtLastMouseLocation];
+    flutter::PointerData pointer_data = [self updateMousePointerDataFrom:gestureRecognizer];
     pointer_data.device = reinterpret_cast<int64_t>(_continuousScrollingPanGestureRecognizer);
     pointer_data.kind = flutter::PointerData::DeviceKind::kTrackpad;
     pointer_data.signal_kind = flutter::PointerData::SignalKind::kScrollInertiaCancel;
@@ -2469,13 +2473,10 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   return YES;
 }
 
-- (void)hoverEvent:(UIPanGestureRecognizer*)recognizer API_AVAILABLE(ios(13.4)) {
-  CGPoint location = [recognizer locationInView:self.view];
-  CGFloat scale = [self flutterScreenIfViewLoaded].scale;
+- (void)hoverEvent:(UIHoverGestureRecognizer*)recognizer API_AVAILABLE(ios(13.4)) {
   CGPoint oldLocation = _mouseState.location;
-  _mouseState.location = {location.x * scale, location.y * scale};
 
-  flutter::PointerData pointer_data = [self generatePointerDataAtLastMouseLocation];
+  flutter::PointerData pointer_data = [self updateMousePointerDataFrom:recognizer];
   pointer_data.device = reinterpret_cast<int64_t>(recognizer);
   pointer_data.kind = flutter::PointerData::DeviceKind::kMouse;
   pointer_data.view_id = self.viewIdentifier;
@@ -2535,7 +2536,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   translation.x *= scale;
   translation.y *= scale;
 
-  flutter::PointerData pointer_data = [self generatePointerDataAtLastMouseLocation];
+  flutter::PointerData pointer_data = [self updateMousePointerDataFrom:recognizer];
   pointer_data.device = reinterpret_cast<int64_t>(recognizer);
   pointer_data.kind = flutter::PointerData::DeviceKind::kMouse;
   pointer_data.signal_kind = flutter::PointerData::SignalKind::kScroll;
@@ -2562,7 +2563,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   CGPoint translation = [recognizer translationInView:self.view];
   const CGFloat scale = [self flutterScreenIfViewLoaded].scale;
 
-  flutter::PointerData pointer_data = [self generatePointerDataAtLastMouseLocation];
+  flutter::PointerData pointer_data = [self updateMousePointerDataFrom:recognizer];
   pointer_data.device = reinterpret_cast<int64_t>(recognizer);
   pointer_data.kind = flutter::PointerData::DeviceKind::kTrackpad;
   pointer_data.view_id = self.viewIdentifier;
@@ -2611,7 +2612,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 }
 
 - (void)pinchEvent:(UIPinchGestureRecognizer*)recognizer API_AVAILABLE(ios(13.4)) {
-  flutter::PointerData pointer_data = [self generatePointerDataAtLastMouseLocation];
+  flutter::PointerData pointer_data = [self updateMousePointerDataFrom:recognizer];
   pointer_data.device = reinterpret_cast<int64_t>(recognizer);
   pointer_data.kind = flutter::PointerData::DeviceKind::kTrackpad;
   pointer_data.view_id = self.viewIdentifier;

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -1851,6 +1851,8 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 
   [vc discreteScrollEvent:mockPanGestureRecognizer];
 
+  // The mouse position within panGestureRecognizer should be checked
+  [[mockPanGestureRecognizer verify] locationInView:[OCMArg any]];
   [[[self.mockEngine verify] ignoringNonObjectArgs]
       dispatchPointerDataPacket:std::make_unique<flutter::PointerDataPacket>(0)];
 }


### PR DESCRIPTION
Previously, gesture origin position relied on hover events. But iOS 18 screen mirroring feature sends only pan/scale gestures, but doesn't hover. So we need to check the gesture location every time.

Fixes https://github.com/flutter/flutter/issues/153897

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.