### PR TITLE
Disallow time traveling frame times

### DIFF
--- a/fml/macros.h
+++ b/fml/macros.h
@@ -38,7 +38,13 @@
   TypeName() = delete;                               \
   FML_DISALLOW_COPY_ASSIGN_AND_MOVE(TypeName)
 
+#define FML_TEST_NAME(test_case_name, test_name) \
+  test_case_name##_##test_name##_Test
+
+#define FML_TEST_CLASS(test_case_name, test_name) \
+  class FML_TEST_NAME(test_case_name, test_name)
+
 #define FML_FRIEND_TEST(test_case_name, test_name) \
-  friend class test_case_name##_##test_name##_Test
+  friend FML_TEST_CLASS(test_case_name, test_name)
 
 #endif  // FLUTTER_FML_MACROS_H_

--- a/lib/ui/fixtures/ui_test.dart
+++ b/lib/ui/fixtures/ui_test.dart
@@ -492,6 +492,16 @@ void convertPaintToDlPaint() {
 @pragma('vm:external-name',  'ConvertPaintToDlPaint')
 external void _convertPaintToDlPaint(Paint paint);
 
+/// Hooks for platform_configuration_unittests.cc
+@pragma('vm:entry-point')
+void _beginFrameHijack(int microseconds, int frameNumber) {
+  nativeBeginFrame(microseconds, frameNumber);
+}
+
+@pragma('vm:entry-point')
+@pragma('vm:external-name', 'BeginFrame')
+external nativeBeginFrame(int microseconds, int frameNumber);
+
 @pragma('vm:entry-point')
 void hooksTests() async {
   Future<void> test(String name, FutureOr<void> Function() testFunction) async {

--- a/lib/ui/window/platform_configuration.cc
+++ b/lib/ui/window/platform_configuration.cc
@@ -377,7 +377,7 @@ void PlatformConfiguration::BeginFrame(fml::TimePoint frameTime,
   }
   tonic::DartState::Scope scope(dart_state);
 
-  int64_t microseconds = frameTime.ToEpochDelta().ToMicroseconds();
+  const int64_t microseconds = frameTime.ToEpochDelta().ToMicroseconds();
 
   static int64_t last_microseconds = 0;
   if (last_microseconds > microseconds) {

--- a/lib/ui/window/platform_configuration.cc
+++ b/lib/ui/window/platform_configuration.cc
@@ -377,7 +377,7 @@ void PlatformConfiguration::BeginFrame(fml::TimePoint frameTime,
   }
   tonic::DartState::Scope scope(dart_state);
 
-  const int64_t microseconds = frameTime.ToEpochDelta().ToMicroseconds();
+  int64_t microseconds = frameTime.ToEpochDelta().ToMicroseconds();
 
   static int64_t last_microseconds = 0;
   if (last_microseconds > microseconds) {

--- a/lib/ui/window/platform_configuration.cc
+++ b/lib/ui/window/platform_configuration.cc
@@ -377,18 +377,25 @@ void PlatformConfiguration::BeginFrame(fml::TimePoint frameTime,
   }
   tonic::DartState::Scope scope(dart_state);
 
-  int64_t microseconds = frameTime.ToEpochDelta().ToMicroseconds();
+  if (last_frame_number_ > frame_number) {
+    FML_LOG(ERROR) << "Frame number is out of order: " << frame_number << " < "
+                   << last_frame_number_;
+  }
+  last_frame_number_ = frame_number;
 
-  static int64_t last_microseconds = 0;
-  if (last_microseconds > microseconds) {
+  // frameTime is not a delta; its the timestamp of the presentation.
+  // This is just a type conversion.
+  int64_t microseconds = frameTime.ToEpochDelta().ToMicroseconds();
+  if (last_microseconds_ > microseconds) {
     // Do not allow time traveling frametimes
     // github.com/flutter/flutter/issues/106277
     FML_LOG(ERROR)
         << "Reported frame time is older than the last one; clamping. "
-        << microseconds << " < " << last_microseconds
-        << " ~= " << last_microseconds - microseconds;
-    microseconds = last_microseconds;
+        << microseconds << " < " << last_microseconds_
+        << " ~= " << last_microseconds_ - microseconds;
+    microseconds = last_microseconds_;
   }
+  last_microseconds_ = microseconds;
 
   tonic::CheckAndHandleError(
       tonic::DartInvoke(begin_frame_.Get(), {

--- a/lib/ui/window/platform_configuration.h
+++ b/lib/ui/window/platform_configuration.h
@@ -18,6 +18,7 @@
 #include "flutter/lib/ui/window/pointer_data_packet.h"
 #include "flutter/lib/ui/window/viewport_metrics.h"
 #include "flutter/shell/common/display.h"
+#include "fml/macros.h"
 #include "third_party/tonic/dart_persistent_value.h"
 #include "third_party/tonic/typed_data/dart_byte_data.h"
 
@@ -27,6 +28,11 @@ class PlatformMessage;
 class PlatformMessageHandler;
 class PlatformIsolateManager;
 class Scene;
+
+// Forward declaration of friendly tests.
+namespace testing {
+FML_TEST_CLASS(PlatformConfigurationTest, BeginFrameMonotonic);
+}
 
 //--------------------------------------------------------------------------
 /// @brief An enum for defining the different kinds of accessibility features
@@ -517,6 +523,8 @@ class PlatformConfiguration final {
   Dart_Handle on_error() { return on_error_.Get(); }
 
  private:
+  FML_FRIEND_TEST(testing::PlatformConfigurationTest, BeginFrameMonotonic);
+
   PlatformConfigurationClient* client_;
   tonic::DartPersistentValue on_error_;
   tonic::DartPersistentValue add_view_;
@@ -534,6 +542,9 @@ class PlatformConfiguration final {
   tonic::DartPersistentValue begin_frame_;
   tonic::DartPersistentValue draw_frame_;
   tonic::DartPersistentValue report_timings_;
+
+  uint64_t last_frame_number_;
+  int64_t last_microseconds_;
 
   // All current views' view metrics mapped from view IDs.
   std::unordered_map<int64_t, ViewportMetrics> metrics_;

--- a/lib/ui/window/platform_configuration.h
+++ b/lib/ui/window/platform_configuration.h
@@ -543,8 +543,8 @@ class PlatformConfiguration final {
   tonic::DartPersistentValue draw_frame_;
   tonic::DartPersistentValue report_timings_;
 
-  uint64_t last_frame_number_;
-  int64_t last_microseconds_;
+  uint64_t last_frame_number_ = 0;
+  int64_t last_microseconds_ = 0;
 
   // All current views' view metrics mapped from view IDs.
   std::unordered_map<int64_t, ViewportMetrics> metrics_;

--- a/shell/platform/android/vsync_waiter_android.cc
+++ b/shell/platform/android/vsync_waiter_android.cc
@@ -27,7 +27,7 @@ VsyncWaiterAndroid::~VsyncWaiterAndroid() = default;
 
 // |VsyncWaiter|
 void VsyncWaiterAndroid::AwaitVSync() {
-  static bool use_choreographer =
+  const static bool use_choreographer =
       impeller::android::Choreographer::IsAvailableOnPlatform();
   if (use_choreographer) {
     auto* weak_this = new std::weak_ptr<VsyncWaiter>(shared_from_this());

--- a/shell/platform/android/vsync_waiter_android.cc
+++ b/shell/platform/android/vsync_waiter_android.cc
@@ -27,7 +27,9 @@ VsyncWaiterAndroid::~VsyncWaiterAndroid() = default;
 
 // |VsyncWaiter|
 void VsyncWaiterAndroid::AwaitVSync() {
-  if (impeller::android::Choreographer::IsAvailableOnPlatform()) {
+  static bool use_choreographer =
+      impeller::android::Choreographer::IsAvailableOnPlatform();
+  if (use_choreographer) {
     auto* weak_this = new std::weak_ptr<VsyncWaiter>(shared_from_this());
     fml::TaskRunner::RunNowOrPostTask(
         task_runners_.GetUITaskRunner(), [weak_this]() {


### PR DESCRIPTION
Address bad developer experience in https://github.com/flutter/flutter/issues/106277

Leave as an error log and hope for more repro reports


```mermaid
sequenceDiagram
  Animator ->> Animator: AwaitVSync
  Animator ->> VsyncWaiter: AsyncWaitForVsync(callback)
  VsyncWaiter -> VsyncWaiterAndroid: AwaitVSync
  note over VsyncWaiterAndroid: GetUITaskRunner
  VsyncWaiterAndroid -> Choreographer: PostFrameCallback
  Choreographer -> NDK: AChoreographer_postFrameCallback64
  note over Choreographer,NDK: The time that the frame is being<br/>rendered as nanoseconds in the <br/>CLOCK_MONOTONIC time base
  NDK --> Choreographer: callback(nanos)
  Choreographer -> VsyncWaiterAndroid: callback
  note over VsyncWaiterAndroid: // Rollback suspicion<br/>if (frame_time > now) frame_time = now;
  VsyncWaiterAndroid -> VsyncWaiterAndroid: OnVsyncFromNDK(frame_nanos)
  VsyncWaiterAndroid -> VsyncWaiter: FireCallback(\n  frame_start_time,\n  target_time)
  VsyncWaiter -> Animator: callback(frame_timings_recorder)

  Animator -> Animator: BeginFrame(frame_timings_recorder)
  Animator -> Shell: OnAnimatorBeginFrame
  Shell -> Engine: BeginFrame(frame_time, frame_number)
  Engine -> RuntimeController: BeginFrame(frame_time, frame_number)
  RuntimeController -> PlatformConfiguration: BeginFrame(frame_time, frame_number)
  PlatformConfiguration -> hooks.dart: begin_frame_
```