### PR TITLE
[Impeller] fix Impeller on windows.

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -1038,6 +1038,23 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
 #endif
 }
 
+#if defined(SHELL_ENABLE_GL) && defined(IMPELLER_SUPPORTS_RENDERING)
+static std::optional<impeller::PixelFormat> FlutterFormatToImpellerPixelFormat(
+    uint32_t format) {
+  switch (format) {
+    case GL_BGRA8_EXT:
+      return impeller::PixelFormat::kB8G8R8A8UNormInt;
+    case GL_RGBA8:
+      return impeller::PixelFormat::kR8G8B8A8UNormInt;
+    default:
+      FML_LOG(ERROR) << "Cannot convert format " << format
+                     << " to impeller::PixelFormat.";
+      return std::nullopt;
+  }
+}
+
+#endif  // defined(SHELL_ENABLE_GL) && defined(IMPELLER_SUPPORTS_RENDERING)
+
 static std::unique_ptr<flutter::EmbedderRenderTarget>
 MakeRenderTargetFromBackingStoreImpeller(
     FlutterBackingStore backing_store,
@@ -1046,34 +1063,40 @@ MakeRenderTargetFromBackingStoreImpeller(
     const FlutterBackingStoreConfig& config,
     const FlutterOpenGLFramebuffer* framebuffer) {
 #if defined(SHELL_ENABLE_GL) && defined(IMPELLER_SUPPORTS_RENDERING)
+  auto format = FlutterFormatToImpellerPixelFormat(framebuffer->target);
+  if (!format.has_value()) {
+    return nullptr;
+  }
 
   const auto& gl_context =
       impeller::ContextGLES::Cast(*aiks_context->GetContext());
   const auto size = impeller::ISize(config.size.width, config.size.height);
 
   impeller::TextureDescriptor color0_tex;
-  color0_tex.type = impeller::TextureType::kTexture2D;
-  color0_tex.format = impeller::PixelFormat::kR8G8B8A8UNormInt;
+  color0_tex.type = impeller::TextureType::kTexture2DMultisample;
+  color0_tex.format = format.value();
   color0_tex.size = size;
   color0_tex.usage = static_cast<impeller::TextureUsageMask>(
       impeller::TextureUsage::kRenderTarget);
-  color0_tex.sample_count = impeller::SampleCount::kCount1;
+  color0_tex.sample_count = impeller::SampleCount::kCount4;
   color0_tex.storage_mode = impeller::StorageMode::kDevicePrivate;
 
   impeller::ColorAttachment color0;
   color0.texture = impeller::TextureGLES::WrapFBO(
       gl_context.GetReactor(), color0_tex, framebuffer->name);
+  color0.resolve_texture = color0.texture;
   color0.clear_color = impeller::Color::DarkSlateGray();
   color0.load_action = impeller::LoadAction::kClear;
-  color0.store_action = impeller::StoreAction::kStore;
+  color0.store_action = impeller::StoreAction::kMultisampleResolve;
 
   impeller::TextureDescriptor depth_stencil_texture_desc;
-  depth_stencil_texture_desc.type = impeller::TextureType::kTexture2D;
-  depth_stencil_texture_desc.format = impeller::PixelFormat::kR8G8B8A8UNormInt;
+  depth_stencil_texture_desc.type =
+      impeller::TextureType::kTexture2DMultisample;
+  depth_stencil_texture_desc.format = impeller::PixelFormat::kD24UnormS8Uint;
   depth_stencil_texture_desc.size = size;
   depth_stencil_texture_desc.usage = static_cast<impeller::TextureUsageMask>(
       impeller::TextureUsage::kRenderTarget);
-  depth_stencil_texture_desc.sample_count = impeller::SampleCount::kCount1;
+  depth_stencil_texture_desc.sample_count = impeller::SampleCount::kCount4;
 
   auto depth_stencil_tex = std::make_shared<impeller::TextureGLES>(
       gl_context.GetReactor(), depth_stencil_texture_desc,

--- a/shell/platform/windows/compositor_opengl.cc
+++ b/shell/platform/windows/compositor_opengl.cc
@@ -52,16 +52,13 @@ bool CompositorOpenGL::CreateBackingStore(
   gl_->BindTexture(GL_TEXTURE_2D, 0);
 
   if (enable_impeller_) {
+    // Impeller requries that its onscreen surface is Multisampled and already
+    // has depth/stencil attached in order for anti-aliasing to work.
     gl_->FramebufferTexture2DMultisampleEXT(GL_FRAMEBUFFER,
                                             GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
                                             store->texture_id, 0, 4);
-  } else {
-    gl_->FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
-                              GL_TEXTURE_2D, store->texture_id, 0);
-  }
 
-  // Set up depth/stencil attachment for impeller renderer.
-  if (enable_impeller_) {
+    // Set up depth/stencil attachment for impeller renderer.
     GLuint depth_stencil;
     gl_->GenRenderbuffers(1, &depth_stencil);
     gl_->BindRenderbuffer(GL_RENDERBUFFER, depth_stencil);
@@ -76,6 +73,10 @@ bool CompositorOpenGL::CreateBackingStore(
                                  GL_RENDERBUFFER, depth_stencil);
     gl_->FramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT,
                                  GL_RENDERBUFFER, depth_stencil);
+
+  } else {
+    gl_->FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                              GL_TEXTURE_2D, store->texture_id, 0);
   }
 
   result->type = kFlutterBackingStoreTypeOpenGL;

--- a/shell/platform/windows/compositor_opengl.h
+++ b/shell/platform/windows/compositor_opengl.h
@@ -19,7 +19,8 @@ namespace flutter {
 class CompositorOpenGL : public Compositor {
  public:
   CompositorOpenGL(FlutterWindowsEngine* engine,
-                   impeller::ProcTableGLES::Resolver resolver);
+                   impeller::ProcTableGLES::Resolver resolver,
+                   bool enable_impeller);
 
   /// |Compositor|
   bool CreateBackingStore(const FlutterBackingStoreConfig& config,
@@ -58,6 +59,9 @@ class CompositorOpenGL : public Compositor {
   // The OpenGL texture format for backing stores. Invalid value until
   // the compositor is initialized.
   TextureFormat format_;
+
+  // Whether the Impeller rendering backend is enabled.
+  bool enable_impeller_ = false;
 
   // Initialize the compositor. This must run on the raster thread.
   bool Initialize();

--- a/shell/platform/windows/compositor_opengl_unittests.cc
+++ b/shell/platform/windows/compositor_opengl_unittests.cc
@@ -125,7 +125,22 @@ class CompositorOpenGLTest : public WindowsTest {
 TEST_F(CompositorOpenGLTest, CreateBackingStore) {
   UseHeadlessEngine();
 
-  auto compositor = CompositorOpenGL{engine(), kMockResolver};
+  auto compositor =
+      CompositorOpenGL{engine(), kMockResolver, /*enable_impeller=*/false};
+
+  FlutterBackingStoreConfig config = {};
+  FlutterBackingStore backing_store = {};
+
+  EXPECT_CALL(*render_context(), MakeCurrent).WillOnce(Return(true));
+  ASSERT_TRUE(compositor.CreateBackingStore(config, &backing_store));
+  ASSERT_TRUE(compositor.CollectBackingStore(&backing_store));
+}
+
+TEST_F(CompositorOpenGLTest, CreateBackingStoreImpeller) {
+  UseHeadlessEngine();
+
+  auto compositor =
+      CompositorOpenGL{engine(), kMockResolver, /*enable_impeller=*/true};
 
   FlutterBackingStoreConfig config = {};
   FlutterBackingStore backing_store = {};
@@ -138,7 +153,8 @@ TEST_F(CompositorOpenGLTest, CreateBackingStore) {
 TEST_F(CompositorOpenGLTest, InitializationFailure) {
   UseHeadlessEngine();
 
-  auto compositor = CompositorOpenGL{engine(), kMockResolver};
+  auto compositor =
+      CompositorOpenGL{engine(), kMockResolver, /*enable_impeller=*/false};
 
   FlutterBackingStoreConfig config = {};
   FlutterBackingStore backing_store = {};
@@ -150,7 +166,8 @@ TEST_F(CompositorOpenGLTest, InitializationFailure) {
 TEST_F(CompositorOpenGLTest, Present) {
   UseEngineWithView();
 
-  auto compositor = CompositorOpenGL{engine(), kMockResolver};
+  auto compositor =
+      CompositorOpenGL{engine(), kMockResolver, /*enable_impeller=*/false};
 
   FlutterBackingStoreConfig config = {};
   FlutterBackingStore backing_store = {};
@@ -174,7 +191,8 @@ TEST_F(CompositorOpenGLTest, Present) {
 TEST_F(CompositorOpenGLTest, PresentEmpty) {
   UseEngineWithView();
 
-  auto compositor = CompositorOpenGL{engine(), kMockResolver};
+  auto compositor =
+      CompositorOpenGL{engine(), kMockResolver, /*enable_impeller=*/false};
 
   // The context will be bound twice: first to initialize the compositor, second
   // to clear the surface.
@@ -188,7 +206,8 @@ TEST_F(CompositorOpenGLTest, PresentEmpty) {
 TEST_F(CompositorOpenGLTest, NoSurfaceIgnored) {
   UseEngineWithView(/*add_surface = */ false);
 
-  auto compositor = CompositorOpenGL{engine(), kMockResolver};
+  auto compositor =
+      CompositorOpenGL{engine(), kMockResolver, /*enable_impeller=*/false};
 
   FlutterBackingStoreConfig config = {};
   FlutterBackingStore backing_store = {};

--- a/shell/platform/windows/egl/manager.h
+++ b/shell/platform/windows/egl/manager.h
@@ -30,7 +30,7 @@ namespace egl {
 // destroy surfaces
 class Manager {
  public:
-  static std::unique_ptr<Manager> Create(bool enable_impeller);
+  static std::unique_ptr<Manager> Create();
 
   virtual ~Manager();
 
@@ -74,7 +74,7 @@ class Manager {
  protected:
   // Creates a new surface manager retaining reference to the passed-in target
   // for the lifetime of the manager.
-  explicit Manager(bool enable_impeller);
+  explicit Manager();
 
  private:
   // Number of active instances of Manager
@@ -84,7 +84,7 @@ class Manager {
   bool InitializeDisplay();
 
   // Initialize the EGL configs.
-  bool InitializeConfig(bool enable_impeller);
+  bool InitializeConfig();
 
   // Initialize the EGL render and resource contexts.
   bool InitializeContexts();

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -194,7 +194,7 @@ FlutterWindowsEngine::FlutterWindowsEngine(
   enable_impeller_ = std::find(switches.begin(), switches.end(),
                                "--enable-impeller=true") != switches.end();
 
-  egl_manager_ = egl::Manager::Create(enable_impeller_);
+  egl_manager_ = egl::Manager::Create();
   window_proc_delegate_manager_ = std::make_unique<WindowProcDelegateManager>();
   window_proc_delegate_manager_->RegisterTopLevelWindowProcDelegate(
       [](HWND hwnd, UINT msg, WPARAM wpar, LPARAM lpar, void* user_data,
@@ -393,7 +393,8 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
 
     // TODO(schectman) Pass the platform view manager to the compositor
     // constructors: https://github.com/flutter/flutter/issues/143375
-    compositor_ = std::make_unique<CompositorOpenGL>(this, resolver);
+    compositor_ =
+        std::make_unique<CompositorOpenGL>(this, resolver, enable_impeller_);
   } else {
     compositor_ = std::make_unique<CompositorSoftware>();
   }

--- a/shell/platform/windows/flutter_windows_unittests.cc
+++ b/shell/platform/windows/flutter_windows_unittests.cc
@@ -31,7 +31,7 @@ namespace {
 // An EGL manager that initializes EGL but fails to create surfaces.
 class HalfBrokenEGLManager : public egl::Manager {
  public:
-  HalfBrokenEGLManager() : egl::Manager(/*enable_impeller = */ false) {}
+  HalfBrokenEGLManager() : egl::Manager() {}
 
   std::unique_ptr<egl::WindowSurface>
   CreateWindowSurface(HWND hwnd, size_t width, size_t height) override {

--- a/shell/platform/windows/testing/egl/mock_manager.h
+++ b/shell/platform/windows/testing/egl/mock_manager.h
@@ -16,7 +16,7 @@ namespace egl {
 /// Mock for the |Manager| base class.
 class MockManager : public flutter::egl::Manager {
  public:
-  MockManager() : Manager(false) {}
+  MockManager() : Manager() {}
 
   MOCK_METHOD(std::unique_ptr<flutter::egl::WindowSurface>,
               CreateWindowSurface,


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/141482

Since the introduction of the flutter compositor, the windows embedder will create an offscreen framebuffer and then blit this to the onscreen framebuffer. Therefore, the onscreen framebuffer should not be constructed as a multisample framebuffer - and the EGL config can match skia.

Also cleans up selection of the impeller PixelFormat, which might not have matched the selected compositor format because it was hardcoded to RGBA_8888
