### PR TITLE
[Impeller] finish wiring up external textures for macOS embedder.

### DIFF
--- a/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.h
+++ b/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.h
@@ -8,7 +8,9 @@
 #import <Foundation/Foundation.h>
 #import <Metal/Metal.h>
 
+#include "display_list/image/dl_image.h"
 #include "flutter/common/graphics/texture.h"
+#include "flutter/impeller/aiks/aiks_context.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterTexture.h"
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkImage.h"
@@ -26,6 +28,18 @@
                         grContext:(nonnull GrDirectContext*)grContext
                             width:(size_t)width
                            height:(size_t)height;
+
+@end
+
+@interface FlutterDarwinExternalTextureImpellerImageWrapper : NSObject
+
++ (sk_sp<flutter::DlImage>)wrapYUVATexture:(nonnull id<MTLTexture>)yTex
+                                     UVTex:(nonnull id<MTLTexture>)uvTex
+                             YUVColorSpace:(impeller::YUVColorSpace)colorSpace
+                               aiksContext:(nonnull impeller::AiksContext*)aiksContext;
+
++ (sk_sp<flutter::DlImage>)wrapRGBATexture:(nonnull id<MTLTexture>)rgbaTex
+                               aiksContext:(nonnull impeller::AiksContext*)aiks_context;
 
 @end
 

--- a/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.h
+++ b/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.h
@@ -8,8 +8,8 @@
 #import <Foundation/Foundation.h>
 #import <Metal/Metal.h>
 
-#include "display_list/image/dl_image.h"
 #include "flutter/common/graphics/texture.h"
+#include "flutter/display_list/image/dl_image.h"
 #include "flutter/impeller/aiks/aiks_context.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterTexture.h"
 #include "third_party/skia/include/core/SkCanvas.h"

--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderExternalTextureTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderExternalTextureTest.mm
@@ -4,6 +4,10 @@
 
 #import <Foundation/Foundation.h>
 #import <Metal/Metal.h>
+#include "display_list/display_list.h"
+#include "display_list/dl_builder.h"
+#include "fml/synchronization/sync_switch.h"
+#include "shell/platform/darwin/graphics/FlutterDarwinContextMetalImpeller.h"
 
 #include <memory>
 #include <vector>
@@ -16,11 +20,29 @@
 #include "flutter/shell/platform/embedder/embedder_external_texture_metal.h"
 #include "flutter/testing/autoreleasepool_test.h"
 #include "flutter/testing/testing.h"
+#include "impeller/aiks/aiks_context.h"
+#include "impeller/entity/mtl/entity_shaders.h"
+#include "impeller/entity/mtl/framebuffer_blend_shaders.h"
+#include "impeller/entity/mtl/modern_shaders.h"
+#include "impeller/renderer/backend/metal/context_mtl.h"
 #include "third_party/googletest/googletest/include/gtest/gtest.h"
 #include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkSamplingOptions.h"
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/ganesh/SkSurfaceGanesh.h"
+
+static std::shared_ptr<impeller::ContextMTL> CreateImpellerContext() {
+  std::vector<std::shared_ptr<fml::Mapping>> shader_mappings = {
+      std::make_shared<fml::NonOwnedMapping>(impeller_entity_shaders_data,
+                                             impeller_entity_shaders_length),
+      std::make_shared<fml::NonOwnedMapping>(impeller_modern_shaders_data,
+                                             impeller_modern_shaders_length),
+      std::make_shared<fml::NonOwnedMapping>(impeller_framebuffer_blend_shaders_data,
+                                             impeller_framebuffer_blend_shaders_length),
+  };
+  auto sync_switch = std::make_shared<fml::SyncSwitch>(false);
+  return impeller::ContextMTL::Create(shader_mappings, sync_switch, "Impeller Library");
+}
 
 @interface TestExternalTexture : NSObject <FlutterTexture>
 
@@ -331,6 +353,254 @@ TEST_F(FlutterEmbedderExternalTextureTest, TestPopulateUnsupportedExternalTextur
       .canvas = &canvas,
       .gr_context = grContext,
   };
+  texture->Paint(context, bounds, /*freeze=*/false, sampling);
+}
+
+TEST_F(FlutterEmbedderExternalTextureTest, TestTextureResolutionImpeller) {
+  // Constants.
+  const size_t width = 100;
+  const size_t height = 100;
+  const int64_t texture_id = 1;
+
+  // Set up the surface.
+  auto device = ::MTLCreateSystemDefaultDevice();
+  impeller::AiksContext aiks_context(CreateImpellerContext(), nullptr);
+
+  SkImageInfo info = SkImageInfo::MakeN32Premul(width, height);
+
+  // Create a texture.
+  MTLTextureDescriptor* textureDescriptor = [[MTLTextureDescriptor alloc] init];
+  textureDescriptor.pixelFormat = MTLPixelFormatBGRA8Unorm;
+  textureDescriptor.width = width;
+  textureDescriptor.height = height;
+  textureDescriptor.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
+  id<MTLTexture> mtlTexture = [device newTextureWithDescriptor:textureDescriptor];
+  std::vector<FlutterMetalTextureHandle> textures = {
+      (__bridge FlutterMetalTextureHandle)mtlTexture,
+  };
+
+  // Callback to resolve the texture.
+  EmbedderExternalTextureMetal::ExternalTextureCallback callback = [&](int64_t texture_id, size_t w,
+                                                                       size_t h) {
+    EXPECT_TRUE(w == width);
+    EXPECT_TRUE(h == height);
+
+    auto texture = std::make_unique<FlutterMetalExternalTexture>();
+    texture->struct_size = sizeof(FlutterMetalExternalTexture);
+    texture->num_textures = 1;
+    texture->height = h;
+    texture->width = w;
+    texture->pixel_format = FlutterMetalExternalTexturePixelFormat::kRGBA;
+    texture->textures = textures.data();
+    return texture;
+  };
+
+  // Render the texture.
+  std::unique_ptr<flutter::Texture> texture =
+      std::make_unique<EmbedderExternalTextureMetal>(texture_id, callback);
+  SkRect bounds = SkRect::MakeWH(info.width(), info.height());
+  DlImageSampling sampling = DlImageSampling::kNearestNeighbor;
+
+  DisplayListBuilder builder;
+  flutter::Texture::PaintContext context{
+      .canvas = &builder, .gr_context = nullptr, .aiks_context = &aiks_context};
+  texture->Paint(context, bounds, /*freeze=*/false, sampling);
+
+  ASSERT_TRUE(mtlTexture != nil);
+}
+
+TEST_F(FlutterEmbedderExternalTextureTest, TestPopulateExternalTextureImpeller) {
+  // Constants.
+  const size_t width = 100;
+  const size_t height = 100;
+  const int64_t texture_id = 1;
+
+  // Set up the surface.
+  FlutterDarwinContextMetalSkia* darwinContextMetal =
+      [[FlutterDarwinContextMetalSkia alloc] initWithDefaultMTLDevice];
+  impeller::AiksContext aiks_context(CreateImpellerContext(), nullptr);
+  SkImageInfo info = SkImageInfo::MakeN32Premul(width, height);
+
+  // Create a texture.
+  TestExternalTexture* testExternalTexture =
+      [[TestExternalTexture alloc] initWidth:width
+                                      height:height
+                             pixelFormatType:kCVPixelFormatType_32BGRA];
+  FlutterExternalTexture* textureHolder =
+      [[FlutterExternalTexture alloc] initWithFlutterTexture:testExternalTexture
+                                          darwinMetalContext:darwinContextMetal];
+
+  // Callback to resolve the texture.
+  EmbedderExternalTextureMetal::ExternalTextureCallback callback = [&](int64_t texture_id, size_t w,
+                                                                       size_t h) {
+    EXPECT_TRUE(w == width);
+    EXPECT_TRUE(h == height);
+
+    auto texture = std::make_unique<FlutterMetalExternalTexture>();
+    [textureHolder populateTexture:texture.get()];
+
+    EXPECT_TRUE(texture->num_textures == 1);
+    EXPECT_TRUE(texture->textures != nullptr);
+    EXPECT_TRUE(texture->pixel_format == FlutterMetalExternalTexturePixelFormat::kRGBA);
+    return texture;
+  };
+
+  // Render the texture.
+  std::unique_ptr<flutter::Texture> texture =
+      std::make_unique<EmbedderExternalTextureMetal>(texture_id, callback);
+  SkRect bounds = SkRect::MakeWH(info.width(), info.height());
+  DlImageSampling sampling = DlImageSampling::kNearestNeighbor;
+
+  DisplayListBuilder builder;
+  flutter::Texture::PaintContext context{
+      .canvas = &builder,
+      .gr_context = nullptr,
+      .aiks_context = &aiks_context,
+  };
+  texture->Paint(context, bounds, /*freeze=*/false, sampling);
+}
+
+TEST_F(FlutterEmbedderExternalTextureTest, TestPopulateExternalTextureYUVAImpeller) {
+  // Constants.
+  const size_t width = 100;
+  const size_t height = 100;
+  const int64_t texture_id = 1;
+
+  // Set up the surface.
+  FlutterDarwinContextMetalSkia* darwinContextMetal =
+      [[FlutterDarwinContextMetalSkia alloc] initWithDefaultMTLDevice];
+  impeller::AiksContext aiks_context(CreateImpellerContext(), nullptr);
+  SkImageInfo info = SkImageInfo::MakeN32Premul(width, height);
+
+  // Create a texture.
+  TestExternalTexture* testExternalTexture =
+      [[TestExternalTexture alloc] initWidth:width
+                                      height:height
+                             pixelFormatType:kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange];
+  FlutterExternalTexture* textureHolder =
+      [[FlutterExternalTexture alloc] initWithFlutterTexture:testExternalTexture
+                                          darwinMetalContext:darwinContextMetal];
+
+  // Callback to resolve the texture.
+  EmbedderExternalTextureMetal::ExternalTextureCallback callback = [&](int64_t texture_id, size_t w,
+                                                                       size_t h) {
+    EXPECT_TRUE(w == width);
+    EXPECT_TRUE(h == height);
+
+    auto texture = std::make_unique<FlutterMetalExternalTexture>();
+    [textureHolder populateTexture:texture.get()];
+
+    EXPECT_TRUE(texture->num_textures == 2);
+    EXPECT_TRUE(texture->textures != nullptr);
+    EXPECT_TRUE(texture->pixel_format == FlutterMetalExternalTexturePixelFormat::kYUVA);
+    EXPECT_TRUE(texture->yuv_color_space ==
+                FlutterMetalExternalTextureYUVColorSpace::kBT601LimitedRange);
+    return texture;
+  };
+
+  // Render the texture.
+  std::unique_ptr<flutter::Texture> texture =
+      std::make_unique<EmbedderExternalTextureMetal>(texture_id, callback);
+  SkRect bounds = SkRect::MakeWH(info.width(), info.height());
+  DlImageSampling sampling = DlImageSampling::kNearestNeighbor;
+
+  DisplayListBuilder builder;
+  flutter::Texture::PaintContext context{
+      .canvas = &builder, .gr_context = nullptr, .aiks_context = &aiks_context};
+  texture->Paint(context, bounds, /*freeze=*/false, sampling);
+}
+
+TEST_F(FlutterEmbedderExternalTextureTest, TestPopulateExternalTextureYUVA2Impeller) {
+  // Constants.
+  const size_t width = 100;
+  const size_t height = 100;
+  const int64_t texture_id = 1;
+
+  // Set up the surface.
+  FlutterDarwinContextMetalSkia* darwinContextMetal =
+      [[FlutterDarwinContextMetalSkia alloc] initWithDefaultMTLDevice];
+  impeller::AiksContext aiks_context(CreateImpellerContext(), nullptr);
+  SkImageInfo info = SkImageInfo::MakeN32Premul(width, height);
+
+  // Create a texture.
+  TestExternalTexture* testExternalTexture =
+      [[TestExternalTexture alloc] initWidth:width
+                                      height:height
+                             pixelFormatType:kCVPixelFormatType_420YpCbCr8BiPlanarFullRange];
+  FlutterExternalTexture* textureHolder =
+      [[FlutterExternalTexture alloc] initWithFlutterTexture:testExternalTexture
+                                          darwinMetalContext:darwinContextMetal];
+
+  // Callback to resolve the texture.
+  EmbedderExternalTextureMetal::ExternalTextureCallback callback = [&](int64_t texture_id, size_t w,
+                                                                       size_t h) {
+    EXPECT_TRUE(w == width);
+    EXPECT_TRUE(h == height);
+
+    auto texture = std::make_unique<FlutterMetalExternalTexture>();
+    [textureHolder populateTexture:texture.get()];
+
+    EXPECT_TRUE(texture->num_textures == 2);
+    EXPECT_TRUE(texture->textures != nullptr);
+    EXPECT_TRUE(texture->pixel_format == FlutterMetalExternalTexturePixelFormat::kYUVA);
+    EXPECT_TRUE(texture->yuv_color_space ==
+                FlutterMetalExternalTextureYUVColorSpace::kBT601FullRange);
+    return texture;
+  };
+
+  // Render the texture.
+  std::unique_ptr<flutter::Texture> texture =
+      std::make_unique<EmbedderExternalTextureMetal>(texture_id, callback);
+  SkRect bounds = SkRect::MakeWH(info.width(), info.height());
+  DlImageSampling sampling = DlImageSampling::kNearestNeighbor;
+
+  DisplayListBuilder builder;
+  flutter::Texture::PaintContext context{
+      .canvas = &builder, .gr_context = nullptr, .aiks_context = &aiks_context};
+  texture->Paint(context, bounds, /*freeze=*/false, sampling);
+}
+
+TEST_F(FlutterEmbedderExternalTextureTest, TestPopulateUnsupportedExternalTextureImpeller) {
+  // Constants.
+  const size_t width = 100;
+  const size_t height = 100;
+  const int64_t texture_id = 1;
+
+  // Set up the surface.
+  FlutterDarwinContextMetalSkia* darwinContextMetal =
+      [[FlutterDarwinContextMetalSkia alloc] initWithDefaultMTLDevice];
+  impeller::AiksContext aiks_context(CreateImpellerContext(), nullptr);
+  SkImageInfo info = SkImageInfo::MakeN32Premul(width, height);
+
+  // Create a texture.
+  TestExternalTexture* testExternalTexture =
+      [[TestExternalTexture alloc] initWidth:width
+                                      height:height
+                             pixelFormatType:kCVPixelFormatType_420YpCbCr8PlanarFullRange];
+  FlutterExternalTexture* textureHolder =
+      [[FlutterExternalTexture alloc] initWithFlutterTexture:testExternalTexture
+                                          darwinMetalContext:darwinContextMetal];
+
+  // Callback to resolve the texture.
+  EmbedderExternalTextureMetal::ExternalTextureCallback callback = [&](int64_t texture_id, size_t w,
+                                                                       size_t h) {
+    EXPECT_TRUE(w == width);
+    EXPECT_TRUE(h == height);
+
+    auto texture = std::make_unique<FlutterMetalExternalTexture>();
+    EXPECT_FALSE([textureHolder populateTexture:texture.get()]);
+    return nullptr;
+  };
+
+  // Render the texture.
+  std::unique_ptr<flutter::Texture> texture =
+      std::make_unique<EmbedderExternalTextureMetal>(texture_id, callback);
+  SkRect bounds = SkRect::MakeWH(info.width(), info.height());
+  DlImageSampling sampling = DlImageSampling::kNearestNeighbor;
+
+  DisplayListBuilder builder;
+  flutter::Texture::PaintContext context{
+      .canvas = &builder, .gr_context = nullptr, .aiks_context = &aiks_context};
   texture->Paint(context, bounds, /*freeze=*/false, sampling);
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderExternalTextureTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderExternalTextureTest.mm
@@ -4,15 +4,15 @@
 
 #import <Foundation/Foundation.h>
 #import <Metal/Metal.h>
-#include "display_list/display_list.h"
-#include "display_list/dl_builder.h"
-#include "fml/synchronization/sync_switch.h"
-#include "shell/platform/darwin/graphics/FlutterDarwinContextMetalImpeller.h"
 
 #include <memory>
 #include <vector>
 
+#include "flutter/display_list/display_list.h"
+#include "flutter/display_list/dl_builder.h"
 #import "flutter/display_list/skia/dl_sk_canvas.h"
+#include "flutter/fml/synchronization/sync_switch.h"
+#include "flutter/shell/platform/darwin/graphics/FlutterDarwinContextMetalImpeller.h"
 #import "flutter/shell/platform/darwin/graphics/FlutterDarwinContextMetalSkia.h"
 #import "flutter/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterExternalTexture.h"
@@ -20,11 +20,11 @@
 #include "flutter/shell/platform/embedder/embedder_external_texture_metal.h"
 #include "flutter/testing/autoreleasepool_test.h"
 #include "flutter/testing/testing.h"
-#include "impeller/aiks/aiks_context.h"
-#include "impeller/entity/mtl/entity_shaders.h"
-#include "impeller/entity/mtl/framebuffer_blend_shaders.h"
-#include "impeller/entity/mtl/modern_shaders.h"
-#include "impeller/renderer/backend/metal/context_mtl.h"
+#include "impeller/aiks/aiks_context.h"                     // nogncheck
+#include "impeller/entity/mtl/entity_shaders.h"             // nogncheck
+#include "impeller/entity/mtl/framebuffer_blend_shaders.h"  // nogncheck
+#include "impeller/entity/mtl/modern_shaders.h"             // nogncheck
+#include "impeller/renderer/backend/metal/context_mtl.h"    // nogncheck
 #include "third_party/googletest/googletest/include/gtest/gtest.h"
 #include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkSamplingOptions.h"

--- a/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -38,6 +38,7 @@ void EmbedderExternalTextureGL::Paint(PaintContext& context,
     last_image_ =
         ResolveTexture(Id(),                                           //
                        context.gr_context,                             //
+                       context.aiks_context,                           //
                        SkISize::Make(bounds.width(), bounds.height())  //
         );
   }
@@ -58,6 +59,7 @@ void EmbedderExternalTextureGL::Paint(PaintContext& context,
 sk_sp<DlImage> EmbedderExternalTextureGL::ResolveTexture(
     int64_t texture_id,
     GrDirectContext* context,
+    impeller::AiksContext* aiks_context,
     const SkISize& size) {
   context->flushAndSubmit();
   context->resetContext(kAll_GrBackendState);

--- a/shell/platform/embedder/embedder_external_texture_gl.h
+++ b/shell/platform/embedder/embedder_external_texture_gl.h
@@ -28,6 +28,7 @@ class EmbedderExternalTextureGL : public flutter::Texture {
 
   sk_sp<DlImage> ResolveTexture(int64_t texture_id,
                                 GrDirectContext* context,
+                                impeller::AiksContext* aiks_context,
                                 const SkISize& size);
 
   // |flutter::Texture|

--- a/shell/platform/embedder/embedder_external_texture_metal.h
+++ b/shell/platform/embedder/embedder_external_texture_metal.h
@@ -8,6 +8,7 @@
 #include "flutter/common/graphics/texture.h"
 #include "flutter/fml/macros.h"
 #include "flutter/shell/platform/embedder/embedder.h"
+#include "impeller/aiks/aiks_context.h"
 #include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkSize.h"
 
@@ -29,6 +30,7 @@ class EmbedderExternalTextureMetal : public flutter::Texture {
 
   sk_sp<DlImage> ResolveTexture(int64_t texture_id,
                                 GrDirectContext* context,
+                                impeller::AiksContext* aiks_context,
                                 const SkISize& size);
 
   // |flutter::Texture|


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/135898

Note that the macOS embedder is still using the apple texture cache object from the SkiaMetalContext. it can't initialize an equivalent ImpellerMetalContext without creating a second copy of the content context and all that jazz, so I'm leaving that as is for now.