### PR TITLE
[DisplayList] Optimize draws of simple shapes expressed as paths

### DIFF
--- a/display_list/dl_builder.cc
+++ b/display_list/dl_builder.cc
@@ -1227,6 +1227,24 @@ void DisplayListBuilder::DrawDRRect(const SkRRect& outer,
   drawDRRect(outer, inner);
 }
 void DisplayListBuilder::drawPath(const DlPath& path) {
+  if (!path.IsInverseFillType()) {
+    SkRect rect;
+    bool is_closed;
+    if (path.IsSkRect(&rect, &is_closed) &&
+        (is_closed || current_.getDrawStyle() == DlDrawStyle::kFill)) {
+      drawRect(ToDlRect(rect));
+      return;
+    }
+    if (path.IsSkOval(&rect)) {
+      drawOval(ToDlRect(rect));
+      return;
+    }
+    SkRRect rrect;
+    if (path.IsSkRRect(&rrect)) {
+      drawRRect(rrect);
+      return;
+    }
+  }
   DisplayListAttributeFlags flags = kDrawPathFlags;
   OpResult result = PaintResult(current_, flags);
   if (result != OpResult::kNoEffect) {

--- a/display_list/testing/dl_test_snippets.cc
+++ b/display_list/testing/dl_test_snippets.cc
@@ -700,10 +700,11 @@ std::vector<DisplayListInvocationGroup> CreateAllRenderingOps() {
            {1, 24, 1, [](DlOpReceiver& r) { r.drawPath(kTestPath1); }},
            {1, 24, 1, [](DlOpReceiver& r) { r.drawPath(kTestPath2); }},
            {1, 24, 1, [](DlOpReceiver& r) { r.drawPath(kTestPath3); }},
-           // oval, rect and rrect paths are left as drawPath
+           // oval and rect paths are redirected to drawRect and drawOval
            {1, 24, 1, [](DlOpReceiver& r) { r.drawPath(kTestPathRect); }},
            {1, 24, 1, [](DlOpReceiver& r) { r.drawPath(kTestPathOval); }},
-           {1, 24, 1, [](DlOpReceiver& r) { r.drawPath(kTestPathRRect); }},
+           // rrect path is redirected to drawRRect
+           {1, 56, 1, [](DlOpReceiver& r) { r.drawPath(kTestPathRRect); }},
        }},
       {"DrawArc",
        {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/151849

Originally part of https://github.com/flutter/engine/pull/53622 which had to be reverted due to incompatible scuba changes. This part was split out as the likely culprit in the scuba failures and eventually an issue was found with the way the original code was written which failed to properly handle unclosed rectangles. This version fixes that bug.