### PR TITLE
[Impeller] Delete command pools held by the CommandPoolRecyclerVK after decoding an image on the IO thread

### DIFF
--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -608,6 +608,10 @@ void ContextVK::InitializeCommonlyUsedShadersIfNeeded() const {
   auto pass = builder.Build(GetDevice());
 }
 
+void ContextVK::DisposeThreadLocalCachedResources() {
+  command_pool_recycler_->Dispose();
+}
+
 const std::shared_ptr<YUVConversionLibraryVK>&
 ContextVK::GetYUVConversionLibrary() const {
   return yuv_conversion_library_;

--- a/impeller/renderer/backend/vulkan/context_vk.h
+++ b/impeller/renderer/backend/vulkan/context_vk.h
@@ -167,7 +167,11 @@ class ContextVK final : public Context,
 
   void RecordFrameEndTime() const;
 
+  // |Context|
   void InitializeCommonlyUsedShadersIfNeeded() const override;
+
+  // |Context|
+  void DisposeThreadLocalCachedResources() override;
 
   /// @brief Whether the Android Surface control based swapchain should be
   /// disabled, even if the device is capable of supporting it.

--- a/impeller/renderer/backend/vulkan/surface_context_vk.cc
+++ b/impeller/renderer/backend/vulkan/surface_context_vk.cc
@@ -103,6 +103,10 @@ void SurfaceContextVK::InitializeCommonlyUsedShadersIfNeeded() const {
   parent_->InitializeCommonlyUsedShadersIfNeeded();
 }
 
+void SurfaceContextVK::DisposeThreadLocalCachedResources() {
+  parent_->DisposeThreadLocalCachedResources();
+}
+
 const std::shared_ptr<ContextVK>& SurfaceContextVK::GetParent() const {
   return parent_;
 }

--- a/impeller/renderer/backend/vulkan/surface_context_vk.h
+++ b/impeller/renderer/backend/vulkan/surface_context_vk.h
@@ -80,7 +80,11 @@ class SurfaceContextVK : public Context,
   ///        recreated on the next frame.
   void UpdateSurfaceSize(const ISize& size) const;
 
+  // |Context|
   void InitializeCommonlyUsedShadersIfNeeded() const override;
+
+  // |Context|
+  void DisposeThreadLocalCachedResources() override;
 
   const vk::Device& GetDevice() const;
 

--- a/impeller/renderer/context.h
+++ b/impeller/renderer/context.h
@@ -196,6 +196,13 @@ class Context {
   /// shader variants, as well as forcing driver initialization.
   virtual void InitializeCommonlyUsedShadersIfNeeded() const {}
 
+  /// Dispose resources that are cached on behalf of the current thread.
+  ///
+  /// Some backends such as Vulkan may cache resources that can be reused while
+  /// executing a rendering operation.  This API can be called after the
+  /// operation completes in order to clear the cache.
+  virtual void DisposeThreadLocalCachedResources() {}
+
  protected:
   Context();
 

--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -382,6 +382,8 @@ ImageDecoderImpeller::UnsafeUploadTextureToPrivate(
     return std::make_pair(nullptr, decode_error);
   }
 
+  context->DisposeThreadLocalCachedResources();
+
   return std::make_pair(
       impeller::DlImageImpeller::Make(std::move(result_texture)),
       std::string());

--- a/lib/ui/painting/image_encoding_impeller.cc
+++ b/lib/ui/painting/image_encoding_impeller.cc
@@ -188,6 +188,8 @@ void ImageEncodingImpeller::ConvertDlImageToSkImage(
            .ok()) {
     FML_LOG(ERROR) << "Failed to submit commands.";
   }
+
+  impeller_context->DisposeThreadLocalCachedResources();
 }
 
 void ImageEncodingImpeller::ConvertImageToRaster(


### PR DESCRIPTION
In the Vulkan backend, the CommandPoolRecyclerVK stores command pools that can be reused while rendering a frame.  For each frame, SurfaceContextVK::AcquireNextSurface calls CommandPoolRecyclerVK::Dispose to clear the cached pools.

However, the CommandPoolRecyclerVK's cache of pools is placed in thread-local storage.  So command pools used on the IO thread will not be cleaned up if frame rendering calls Dispose on the raster thread.

This PR adds a Context API that the IO thread can call after using a command pool in order to ensure that cached resources are disposed.

Fixes https://github.com/flutter/flutter/issues/155519