### PR TITLE
[Impeller] delete expensive trace event.

### DIFF
--- a/impeller/renderer/backend/gles/blit_command_gles.cc
+++ b/impeller/renderer/backend/gles/blit_command_gles.cc
@@ -283,8 +283,6 @@ bool BlitCopyBufferToTextureCommandGLES::Encode(
   }
 
   {
-    TRACE_EVENT1("impeller", "TexImage2DUpload", "Bytes",
-                 std::to_string(data.buffer_view.range.length).c_str());
     gl.PixelStorei(GL_UNPACK_ALIGNMENT, 1);
     gl.TexSubImage2D(texture_target,                  // target
                      0u,                              // LOD level


### PR DESCRIPTION
The trace event in the blit pass is firing potentially hundreds of times per frame when we incremental update the glyph atlas. This takes significantly more time than the blit itself.