### PR TITLE
[Flutter GPU] Add CullMode.

### DIFF
--- a/lib/gpu/formats.h
+++ b/lib/gpu/formats.h
@@ -501,6 +501,27 @@ constexpr impeller::StencilOperation ToImpellerStencilOperation(int value) {
       static_cast<FlutterGPUStencilOperation>(value));
 }
 
+enum class FlutterGPUCullMode {
+  kNone,
+  kFrontFace,
+  kBackFace,
+};
+
+constexpr impeller::CullMode ToImpellerCullMode(FlutterGPUCullMode value) {
+  switch (value) {
+    case FlutterGPUCullMode::kNone:
+      return impeller::CullMode::kNone;
+    case FlutterGPUCullMode::kFrontFace:
+      return impeller::CullMode::kFrontFace;
+    case FlutterGPUCullMode::kBackFace:
+      return impeller::CullMode::kBackFace;
+  }
+}
+
+constexpr impeller::CullMode ToImpellerCullMode(int value) {
+  return ToImpellerCullMode(static_cast<FlutterGPUCullMode>(value));
+}
+
 }  // namespace gpu
 }  // namespace flutter
 

--- a/lib/gpu/lib/src/formats.dart
+++ b/lib/gpu/lib/src/formats.dart
@@ -135,6 +135,12 @@ enum PrimitiveType {
   point,
 }
 
+enum CullMode {
+  none,
+  frontFace,
+  backFace,
+}
+
 enum CompareFunction {
   /// Comparison test never passes.
   never,

--- a/lib/gpu/lib/src/render_pass.dart
+++ b/lib/gpu/lib/src/render_pass.dart
@@ -264,6 +264,10 @@ base class RenderPass extends NativeFieldWrapperClass1 {
         targetFace.index);
   }
 
+  void setCullMode(CullMode cullMode) {
+    _setCullMode(cullMode.index);
+  }
+
   void draw() {
     if (!_draw()) {
       throw Exception("Failed to append draw");
@@ -401,6 +405,10 @@ base class RenderPass extends NativeFieldWrapperClass1 {
       int readMask,
       int writeMask,
       int target_face);
+
+  @Native<Void Function(Pointer<Void>, Int)>(
+      symbol: 'InternalFlutterGpu_RenderPass_SetCullMode')
+  external void _setCullMode(int cullMode);
 
   @Native<Bool Function(Pointer<Void>)>(
       symbol: 'InternalFlutterGpu_RenderPass_Draw')

--- a/lib/gpu/render_pass.cc
+++ b/lib/gpu/render_pass.cc
@@ -76,6 +76,10 @@ impeller::VertexBuffer& RenderPass::GetVertexBuffer() {
   return vertex_buffer_;
 }
 
+impeller::PipelineDescriptor& RenderPass::GetPipelineDescriptor() {
+  return pipeline_descriptor_;
+}
+
 bool RenderPass::Begin(flutter::gpu::CommandBuffer& command_buffer) {
   render_pass_ =
       command_buffer.GetCommandBuffer()->CreateRenderPass(render_target_);
@@ -556,6 +560,14 @@ void InternalFlutterGpu_RenderPass_SetStencilConfig(
   if (target_face != 1 /* both or back */) {
     wrapper->GetStencilBackAttachmentDescriptor() = desc;
   }
+}
+
+void InternalFlutterGpu_RenderPass_SetCullMode(
+    flutter::gpu::RenderPass* wrapper,
+    int cull_mode) {
+  impeller::PipelineDescriptor& pipeline_descriptor =
+      wrapper->GetPipelineDescriptor();
+  pipeline_descriptor.SetCullMode(flutter::gpu::ToImpellerCullMode(cull_mode));
 }
 
 bool InternalFlutterGpu_RenderPass_Draw(flutter::gpu::RenderPass* wrapper) {

--- a/lib/gpu/render_pass.h
+++ b/lib/gpu/render_pass.h
@@ -52,6 +52,8 @@ class RenderPass : public RefCountedDartWrappable<RenderPass> {
 
   impeller::VertexBuffer& GetVertexBuffer();
 
+  impeller::PipelineDescriptor& GetPipelineDescriptor();
+
   bool Begin(flutter::gpu::CommandBuffer& command_buffer);
 
   void SetPipeline(fml::RefPtr<RenderPipeline> pipeline);
@@ -240,6 +242,11 @@ extern void InternalFlutterGpu_RenderPass_SetStencilConfig(
     int read_mask,
     int write_mask,
     int target);
+
+FLUTTER_GPU_EXPORT
+extern void InternalFlutterGpu_RenderPass_SetCullMode(
+    flutter::gpu::RenderPass* wrapper,
+    int cull_mode);
 
 FLUTTER_GPU_EXPORT
 extern bool InternalFlutterGpu_RenderPass_Draw(


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/155636.

New golden `flutter_gpu_test_cull_mode` will draw a red triangle if the CullMode isn't working:
![flutter_gpu_test_cull_mode](https://github.com/user-attachments/assets/cbdf804e-1608-4352-9aa1-d5d9223f3c1a)
