### PR TITLE
Remove and inline dependencies on `build_root` for a constant.

### DIFF
--- a/build/dart/internal/application_snapshot.gni
+++ b/build/dart/internal/application_snapshot.gni
@@ -3,7 +3,6 @@
 # found in the LICENSE file.
 
 import("//build/compiled_action.gni")
-import("//build/module_args/dart.gni")
 import("//flutter/build/dart/dart.gni")
 import("//flutter/common/config.gni")
 

--- a/build/dart/rules.gni
+++ b/build/dart/rules.gni
@@ -4,14 +4,6 @@
 
 # This file has rules for making Dart packages and snapshots.
 
-import("//build/compiled_action.gni")
-import("//build/module_args/dart.gni")
-import("//flutter/build/dart/dart.gni")
-import("//flutter/common/config.gni")
-
-import("$dart_src/build/dart/dart_action.gni")
-import("$dart_src/sdk_args.gni")
-
 import("//flutter/build/dart/internal/application_snapshot.gni")
 import("//flutter/build/dart/internal/flutter_frontend_server.gni")
 import("//flutter/build/dart/internal/flutter_snapshot.gni")

--- a/sky/packages/sky_engine/BUILD.gn
+++ b/sky/packages/sky_engine/BUILD.gn
@@ -41,6 +41,9 @@ if (is_fuchsia) {
 
 dart_sdk_lib_path = rebase_path("$dart_src/sdk/lib")
 
+# This variable should point to the Dart SDK.
+dart_sdk_root = "//third_party/dart-sdk/dart-sdk"
+
 copy("async") {
   lib_path = rebase_path("async", "", dart_sdk_lib_path)
   sources = rebase_path(async_sdk_sources, "", lib_path)


### PR DESCRIPTION
Removes imports unused after https://github.com/flutter/engine/pull/55404, inlines a constant unused elsewhere.