### PR TITLE
cipd: add mobileprovision CIPD package

### DIFF
--- a/tools/cipd/mobileprovision/.gitignore
+++ b/tools/cipd/mobileprovision/.gitignore
@@ -1,0 +1,1 @@
+development.mobileprovision

--- a/tools/cipd/mobileprovision/README.md
+++ b/tools/cipd/mobileprovision/README.md
@@ -1,0 +1,63 @@
+# Updating mobile provisioning profile CIPD package
+
+Once per year, the iOS development signing certificate used by devicelab and
+chrome bots expires and a new one must be issued. Once the new certificate has
+been created, a new provisioning profile needs to be created that will allow
+apps signed with both the old and new certificate to run on physical test
+devices.
+
+These instructions cover one sub-step of the process of renewing our DeviceLab
+development signing certificates. For the full set of instructions, which are
+Google-internal, see
+[How to renew the DeviceLab development certificate][renew_dev_cert].
+
+[renew_dev_cert]: https://g3doc.corp.google.com/company/teams/flutter/infrastructure/devicelab/apple_cert_renewal.md
+
+
+## Steps
+
+1. Request write access via http://go/flutter-luci-cipd#requesting-write-read-access-to-cipd-packages.
+
+2. Wait about 5 minutes for access rights to sync.
+
+3. Copy the updated iOS provisioning profile to a file named `development.mobileprovision` in this directory.
+
+4. Run `cipd create --pkg-def mac-arm64.yaml`.
+
+5. Verify the package has been uploaded at: https://chrome-infra-packages.appspot.com/p/flutter_internal/mac/mobileprovision/mac-arm64
+
+6. Click on the latest upload and copy the `Instance_ID` value.
+
+7. Run `cipd create --pkg-def mac-amd64.yaml`.
+
+8. Verify the package has been uploaded at: https://chrome-infra-packages.appspot.com/p/flutter_internal/mac/mobileprovision/mac-amd64
+
+9. Click on the latest upload and copy the `Instance_ID` value.
+
+10. Set the `latest` ref to the latest arm64 upload via the following command, replacing with the instance ID copied above:
+
+   ```sh
+   cipd set-ref flutter_internal/mac/mobileprovision/mac-arm64 -ref latest -version ARM64_INSTANCE_ID
+   ```
+
+11. Set the `latest` ref to the latest amd64 upload via the following command, replacing with the instance ID copied above:
+
+   ```sh
+   cipd set-ref flutter_internal/mac/mobileprovision/mac-amd64 -ref latest -version AMD64_INSTANCE_ID
+   ```
+
+12. Set the `version:to_2025` (or appropriate year) tag on the latest arm64 upload via the following command:
+
+   ```sh
+   cipd set-tag flutter_internal/mac/mobileprovision/mac-arm64 -tag "version:to_2025" -version ARM64_INSTANCE_ID
+   ```
+
+13. Set the `version:to_2025` (or appropriate year) tag on the latest amd64 upload via the following command:
+
+   ```sh
+   cipd set-tag flutter_internal/mac/mobileprovision/mac-amd64 -tag "version:to_2025" -version AMD64_INSTANCE_ID
+   ```
+
+14. Update `.ci.yaml` and migrate `apple_signing` steps to the new version tag.  
+    Before: `{"dependency": "apple_signing", "version": "version:to_2024"}`  
+    After: `{"dependency": "apple_signing", "version": "version:to_2025"}`

--- a/tools/cipd/mobileprovision/mac-amd64.yaml
+++ b/tools/cipd/mobileprovision/mac-amd64.yaml
@@ -1,0 +1,29 @@
+# Comments are allowed.
+
+# The package name is required. Third-party chromium dependencies should
+# unsurprisingly all be prefixed with chromium/third_party/.
+package: flutter_internal/mac/mobileprovision/mac-amd64
+
+# The description is optional and is solely for the reader's benefit. It
+# isn't used in creating the CIPD package.
+description: iOS provisioning provide for "match Development" signing certificate
+
+# The root is optional and, if unspecified, defaults to ".". It specifies the
+# root directory of the files and directories specified below in "data".
+#
+# You won't typically need to specify this explicitly.
+root: "."
+
+# The install mode is optional. If provided, it specifies how CIPD should
+# install a package: "copy", which will copy the contents of the package
+# to the installation directory; and "symlink", which will create symlinks
+# to the contents of the package in the CIPD root inside the installation
+# directory.
+#
+# You won't typically need to specify this explicitly.
+install_mode: "copy"
+
+# The data is required and described what should be included in the CIPD
+# package.
+data:
+  - file: development.mobileprovision

--- a/tools/cipd/mobileprovision/mac-arm64.yaml
+++ b/tools/cipd/mobileprovision/mac-arm64.yaml
@@ -1,0 +1,29 @@
+# Comments are allowed.
+
+# The package name is required. Third-party chromium dependencies should
+# unsurprisingly all be prefixed with chromium/third_party/.
+package: flutter_internal/mac/mobileprovision/mac-arm64
+
+# The description is optional and is solely for the reader's benefit. It
+# isn't used in creating the CIPD package.
+description: iOS provisioning provide for "match Development" signing certificate
+
+# The root is optional and, if unspecified, defaults to ".". It specifies the
+# root directory of the files and directories specified below in "data".
+#
+# You won't typically need to specify this explicitly.
+root: "."
+
+# The install mode is optional. If provided, it specifies how CIPD should
+# install a package: "copy", which will copy the contents of the package
+# to the installation directory; and "symlink", which will create symlinks
+# to the contents of the package in the CIPD root inside the installation
+# directory.
+#
+# You won't typically need to specify this explicitly.
+install_mode: "copy"
+
+# The data is required and described what should be included in the CIPD
+# package.
+data:
+  - file: development.mobileprovision


### PR DESCRIPTION
Adds instructions for creating updated CIPD packages containing a new provisioning profile that goes with an updated signing certificate, for use on Chromium CI bots.

These are part of a broader set of steps required to renew our development signing certificate annually, as described in [cl/678826297](http://cl/678826297) (Google-internal).

Issue: https://github.com/flutter/flutter/issues/152888


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
