### PR TITLE
[ci] make opengles impeller scenario app non-bringup

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -95,7 +95,6 @@ targets:
       - testing/skia_gold_client/**
 
   - name: Linux linux_android_emulator_opengles_tests_34
-    bringup: true
     enabled_branches:
       - main
     recipe: engine_v2/engine_v2


### PR DESCRIPTION
This is passing consistently now.