### PR TITLE
Make arm64 iOS simulator local engine build unopt

### DIFF
--- a/ci/builders/local_engine.json
+++ b/ci/builders/local_engine.json
@@ -184,16 +184,17 @@
         "--simulator-cpu=arm64",
         "--runtime-mode",
         "debug",
+        "--unoptimized",
         "--no-stripped",
         "--no-lto",
         "--xcode-symlinks",
         "--rbe",
         "--no-goma"
       ],
-      "name": "macos/ios_debug_sim_arm64",
+      "name": "macos/ios_debug_sim_unopt_arm64",
       "description": "Builds a debug mode engine that targets the arm64 iOS simulator from a macOS host.",
       "ninja": {
-        "config": "ios_debug_sim_arm64",
+        "config": "ios_debug_sim_unopt_arm64",
         "targets": []
       },
       "properties": {


### PR DESCRIPTION
Most iOS embedder developers rely on two simulator builds:
* ios_debug_sim_unopt (for simulators on x64 hosts)
* ios_debug_sim_unopt_arm64 (for simulators on arm64 hosts)

We specify these two builds, for example, in our iOS unit test Xcode project `testing/ios/IosUnitTests/Tests/FlutterEngineConfig.xcconfig`.

Currently `local_engine.json` specifies two simulator builds:
* ios_debug_sim_unopt (for simulators on x64 hosts)
* ios_debug_sim_arm64 (for simulators on arm64 hosts)

While the x64 build specifies the `--unoptimized` flag, the arm64 build does not, which is problematic for those wanting to use both `et` and run the iOS unit tests.

This adds the `--unoptimized` flag for consistency with prevailing practice among iOS embedder developers.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
