### PR TITLE
Fix npe during skia dispatch of drawAtlas

### DIFF
--- a/display_list/skia/dl_sk_dispatcher.cc
+++ b/display_list/skia/dl_sk_dispatcher.cc
@@ -260,8 +260,9 @@ void DlSkCanvasDispatcher::drawAtlas(const sk_sp<DlImage> atlas,
       sk_colors.push_back(colors[i].argb());
     }
   }
-  canvas_->drawAtlas(skia_atlas.get(), xform, ToSkRects(tex), sk_colors.data(),
-                     count, ToSk(mode), ToSk(sampling), ToSkRect(cullRect),
+  canvas_->drawAtlas(skia_atlas.get(), xform, ToSkRects(tex),
+                     colors == nullptr ? nullptr : sk_colors.data(), count,
+                     ToSk(mode), ToSk(sampling), ToSkRect(cullRect),
                      safe_paint(render_with_attributes));
 }
 void DlSkCanvasDispatcher::drawDisplayList(

--- a/display_list/skia/dl_sk_dispatcher.cc
+++ b/display_list/skia/dl_sk_dispatcher.cc
@@ -254,9 +254,11 @@ void DlSkCanvasDispatcher::drawAtlas(const sk_sp<DlImage> atlas,
     return;
   }
   std::vector<SkColor> sk_colors;
-  sk_colors.reserve(count);
-  for (int i = 0; i < count; ++i) {
-    sk_colors.push_back(colors[i].argb());
+  if (colors != nullptr) {
+    sk_colors.reserve(count);
+    for (int i = 0; i < count; ++i) {
+      sk_colors.push_back(colors[i].argb());
+    }
   }
   canvas_->drawAtlas(skia_atlas.get(), xform, ToSkRects(tex), sk_colors.data(),
                      count, ToSk(mode), ToSk(sampling), ToSkRect(cullRect),

--- a/display_list/skia/dl_sk_dispatcher.cc
+++ b/display_list/skia/dl_sk_dispatcher.cc
@@ -261,7 +261,7 @@ void DlSkCanvasDispatcher::drawAtlas(const sk_sp<DlImage> atlas,
     }
   }
   canvas_->drawAtlas(skia_atlas.get(), xform, ToSkRects(tex),
-                     colors == nullptr ? nullptr : sk_colors.data(), count,
+                     sk_colors.empty() ? nullptr : sk_colors.data(), count,
                      ToSk(mode), ToSk(sampling), ToSkRect(cullRect),
                      safe_paint(render_with_attributes));
 }

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -1364,6 +1364,38 @@ void main() async {
     final int rgba = data.buffer.asUint32List()[0];
     expect(rgba, 0xFF0000FF);
   });
+
+  test('DrawAtlas with no colors does not crash',
+      () async {
+    final Image testImage = await createTestImage();
+    final PictureRecorder recorder = PictureRecorder();
+    final Canvas canvas = Canvas(recorder);
+    // Make a drawAtlas call that should be solid red.
+    canvas.drawAtlas(
+      testImage,
+      [
+        RSTransform.fromComponents(
+          rotation: 0,
+          scale: 10,
+          anchorX: 0,
+          anchorY: 0,
+          translateX: 0,
+          translateY: 0,
+        ),
+      ],
+      [const Rect.fromLTWH(0, 0, 1, 1)],
+      [],
+      BlendMode.dst,
+      null,
+      Paint(),
+    );
+
+    final Image resultImage = await recorder.endRecording().toImage(1, 1);
+    final ByteData? data = await resultImage.toByteData();
+    if (data == null) {
+      fail('Expected non-null byte data');
+    }
+  });
 }
 
 Future<Image> createTestImage() async {

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -1392,9 +1392,7 @@ void main() async {
 
     final Image resultImage = await recorder.endRecording().toImage(1, 1);
     final ByteData? data = await resultImage.toByteData();
-    if (data == null) {
-      fail('Expected non-null byte data');
-    }
+    expect(data, isNotNull);
   });
 }
 


### PR DESCRIPTION
Colors are optionally provided, so make sure to null check the array.

Fixes https://github.com/flutter/flutter/issues/155783