### PR TITLE
Added metal validation for `impeller_unittests

### DIFF
--- a/engine.code-workspace
+++ b/engine.code-workspace
@@ -145,6 +145,12 @@
           "prependTestRunningArgs": [
             "--enable_playground"
           ]
+        },
+        "env": {
+          "MTL_DEBUG_LAYER": "1",
+          "MTL_DEBUG_LAYER_ERROR_MODE": "assert",
+          "MTL_DEBUG_LAYER_WARNING_MODE": "nslog",
+          "MTL_SHADER_VALIDATION": "1"
         }
       },
       {

--- a/tools/vscode_workspace/engine-workspace.yaml
+++ b/tools/vscode_workspace/engine-workspace.yaml
@@ -133,6 +133,11 @@ settings:
       gtest:
         prependTestRunningArgs:
           - --enable_playground
+      env:
+        MTL_DEBUG_LAYER: "1"
+        MTL_DEBUG_LAYER_ERROR_MODE: assert
+        MTL_DEBUG_LAYER_WARNING_MODE: nslog
+        MTL_SHADER_VALIDATION: "1"
     - name: display_list_unittests_arm64
       pattern: ../out/host_debug_unopt_arm64/display_list_unittests
       runTask:


### PR DESCRIPTION
This turns on Metal validation for launching impeller_unittests from the tests panel.  This matches the default behavior of launching tests from XCode.  Without these assertions errors in Metal are completely silent.  In my case I just got a black screen until I tried running the tests through xcode.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
