### PR TITLE
Migrate off a global test fixture for `build` and `lint`.

### DIFF
--- a/tools/engine_tool/test/lint_command_test.dart
+++ b/tools/engine_tool/test/lint_command_test.dart
@@ -2,11 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:convert' as convert;
 import 'dart:ffi' as ffi show Abi;
 import 'dart:io' as io;
 
-import 'package:engine_build_configs/engine_build_configs.dart';
 import 'package:engine_repo_tools/engine_repo_tools.dart';
 import 'package:engine_tool/src/commands/command_runner.dart';
 import 'package:engine_tool/src/environment.dart';
@@ -16,56 +14,25 @@ import 'package:process_fakes/process_fakes.dart';
 import 'package:process_runner/process_runner.dart';
 import 'package:test/test.dart';
 
-import 'fixtures.dart' as fixtures;
-
 void main() {
-  final Engine engine;
-  try {
-    engine = Engine.findWithin();
-  } catch (e) {
-    io.stderr.writeln(e);
-    io.exitCode = 1;
-    return;
-  }
-  final BuilderConfig linuxTestConfig = BuilderConfig.fromJson(
-    path: 'ci/builders/linux_test_config.json',
-    map: convert.jsonDecode(fixtures.testConfig('Linux', Platform.linux))
-        as Map<String, Object?>,
-  );
-
-  final BuilderConfig macTestConfig = BuilderConfig.fromJson(
-    path: 'ci/builders/mac_test_config.json',
-    map: convert.jsonDecode(fixtures.testConfig('Mac-12', Platform.macOS))
-        as Map<String, Object?>,
-  );
-
-  final BuilderConfig winTestConfig = BuilderConfig.fromJson(
-    path: 'ci/builders/win_test_config.json',
-    map: convert.jsonDecode(fixtures.testConfig('Windows-11', Platform.windows))
-        as Map<String, Object?>,
-  );
-
-  final Map<String, BuilderConfig> configs = <String, BuilderConfig>{
-    'linux_test_config': linuxTestConfig,
-    'mac_test_config': macTestConfig,
-    'win_test_config': winTestConfig,
-  };
+  final engine = Engine.findWithin();
 
   (Environment, List<List<String>>) macEnv(Logger logger) {
-    final List<List<String>> runHistory = <List<String>>[];
+    final runHistory = <List<String>>[];
     return (
       Environment(
         abi: ffi.Abi.macosArm64,
         engine: engine,
         platform: FakePlatform(
-            operatingSystem: Platform.macOS,
-            resolvedExecutable: io.Platform.resolvedExecutable,
-            pathSeparator: '/'),
+          operatingSystem: Platform.macOS,
+          resolvedExecutable: io.Platform.resolvedExecutable,
+          pathSeparator: '/',
+        ),
         processRunner: ProcessRunner(
-            processManager: FakeProcessManager(onStart: (List<String> command) {
+            processManager: FakeProcessManager(onStart: (command) {
           runHistory.add(command);
           return FakeProcess();
-        }, onRun: (List<String> command) {
+        }, onRun: (command) {
           // Should not be executed.
           assert(false);
           return io.ProcessResult(81, 1, '', '');
@@ -81,7 +48,7 @@ void main() {
     final (Environment env, List<List<String>> runHistory) = macEnv(logger);
     final ToolCommandRunner runner = ToolCommandRunner(
       environment: env,
-      configs: configs,
+      configs: {},
     );
     final int result = await runner.run(<String>['lint']);
     expect(result, equals(0));

--- a/tools/engine_tool/test/src/test_build_configs.dart
+++ b/tools/engine_tool/test/src/test_build_configs.dart
@@ -1,0 +1,138 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:engine_build_configs/engine_build_configs.dart';
+
+/// Builds a test [BuilderConfig].
+///
+/// Many tests will involve exactly one build configuration, or a small number
+/// of build configurations. Instead of constructing these configurations ahead
+/// of time, this builder is used to create them on-the-fly, with convenient
+/// methods for setting up and cloning configurations.
+///
+/// This builder exists in order to avoid global fixtures in tests that do not
+/// isolate elements of the test environment relevant to their test. Prior to
+/// the builder, 100s of lines of static configuration were used to setup and
+/// instrument tests across multiple files; instead, this builder is used to
+/// precisely configure the test environment for each test.
+///
+/// See <https://github.com/flutter/flutter/issues/148420> for more information.
+final class TestBuilderConfig {
+  final _builds = <Map<String, Object?>>[];
+
+  /// Appends a build to the configuration.
+  void addBuild({
+    required String name,
+    required TestDroneDimension dimension,
+    bool enableRbe = false,
+    String description = 'A default description.',
+    String? targetDir,
+    (String, List<String>)? generatorTask,
+    (String, List<String>)? testTask,
+  }) {
+    _builds.add({
+      'archives': [],
+      'drone_dimensions': [
+        dimension._dimension,
+      ],
+      'gclient_variables': <String, Object?>{},
+      'gn': [
+        if (enableRbe) '--rbe',
+      ],
+      'name': name,
+      'description': description,
+      'ninja': <String, Object?>{
+        if (targetDir case final targetDir?) ...{
+          'config': targetDir,
+          'targets': ['ninja_target'],
+        }
+      },
+      'tests': _testTask(testTask),
+      'generators': _generatorTask(generatorTask),
+    });
+  }
+
+  static List<Object?> _testTask((String, List<String>)? task) {
+    if (task == null) {
+      return [];
+    }
+    final (script, args) = task;
+    return [
+      {
+        'name': 'test_task',
+        'language': 'python',
+        'scripts': [script],
+        'parameters': args,
+        'contexts': ['context'],
+      },
+    ];
+  }
+
+  static Map<String, Object?> _generatorTask((String, List<String>)? task) {
+    if (task == null) {
+      return {};
+    }
+    final (script, args) = task;
+    return {
+      'tasks': [
+        {
+          'name': 'generator_task',
+          'language': 'python',
+          'scripts': [script],
+          'parameters': args,
+        },
+      ],
+    };
+  }
+
+  /// Copies the state of `this` as a new [TestBuilderConfig].
+  TestBuilderConfig clone() {
+    final clone = TestBuilderConfig();
+    clone._builds.addAll(_builds);
+    return clone;
+  }
+
+  /// Creates and returns a [BuilderConfig] capturing the current builder state.
+  ///
+  /// [path] is the path to the configuration file that would be read from disk.
+  ///
+  /// After creation, the builder state remains, and changes can be made to the
+  /// builder to create a new configuration without affecting the previous one
+  /// created.
+  BuilderConfig buildConfig({
+    required String path,
+  }) {
+    final config = BuilderConfig.fromJson(map: buildJson(), path: path);
+    if (config.check(path) case final errors when errors.isNotEmpty) {
+      throw StateError('Invalid configuration:\n${errors.join('\n')}');
+    }
+    return config;
+  }
+
+  /// Creates and returns the JSON serialized format of a [BuilderConfig].
+  ///
+  /// Most of the time, use [build] instead of this method.
+  ///
+  /// It is undefined behavior to mutate the returned map.
+  Map<String, Object?> buildJson() {
+    return {
+      'builds': _builds,
+    };
+  }
+}
+
+/// Fixed set of dimensions for [TestBuilderConfig.addBuild].
+enum TestDroneDimension {
+  /// Runs on Linux.
+  linux('os=Linux'),
+
+  /// Runs on macOS.
+  mac('os=Mac-12'),
+
+  /// Runs on Windows.
+  win('os=Windows-11');
+
+  const TestDroneDimension(this._dimension);
+  final String _dimension;
+}

--- a/tools/engine_tool/test/utils.dart
+++ b/tools/engine_tool/test/utils.dart
@@ -69,10 +69,10 @@ class TestEnvironment {
       abi: abi,
       engine: engine,
       platform: FakePlatform(
-          operatingSystem: _operatingSystemForAbi(abi),
-          resolvedExecutable: io.Platform.resolvedExecutable,
-          pathSeparator: _pathSeparatorForAbi(abi),
-          numberOfProcessors: 32,
+        operatingSystem: _operatingSystemForAbi(abi),
+        resolvedExecutable: io.Platform.resolvedExecutable,
+        pathSeparator: _pathSeparatorForAbi(abi),
+        numberOfProcessors: 32,
       ),
       processRunner: ProcessRunner(
           processManager: FakeProcessManager(onStart: (List<String> command) {
@@ -84,7 +84,8 @@ class TestEnvironment {
         return processResult;
       }, onRun: (List<String> command) {
         final io.ProcessResult result = _getCannedProcessResult(
-          command, cannedProcesses,
+          command,
+          cannedProcesses,
         );
         processHistory.add(ExecutedProcess(
           command,


### PR DESCRIPTION
Partial work towards https://github.com/flutter/flutter/issues/148420, unblocks https://github.com/flutter/engine/pull/55537.

These tests can now be more precise, and changing the fixtures no longer has side-effects on tests across the entire repository. There are about 11 other usages (there were ~50 in these) after this PR that I'll get to, as well as the hard-coded `gn desc` output, before retiring `fixtures.dart`