### PR TITLE
Allocate a view ID for secondary views

### DIFF
--- a/shell/platform/linux/fl_engine_private.h
+++ b/shell/platform/linux/fl_engine_private.h
@@ -115,15 +115,18 @@ FlutterEngineProcTable* fl_engine_get_embedder_api(FlEngine* engine);
  * added.
  * @user_data: (closure): user data to pass to @callback.
  *
- * Asynchronously add a new view.
+ * Asynchronously add a new view. The returned view ID should not be used until
+ * this function completes.
+ *
+ * Returns: the ID for the view.
  */
-void fl_engine_add_view(FlEngine* engine,
-                        size_t width,
-                        size_t height,
-                        double pixel_ratio,
-                        GCancellable* cancellable,
-                        GAsyncReadyCallback callback,
-                        gpointer user_data);
+FlutterViewId fl_engine_add_view(FlEngine* engine,
+                                 size_t width,
+                                 size_t height,
+                                 double pixel_ratio,
+                                 GCancellable* cancellable,
+                                 GAsyncReadyCallback callback,
+                                 gpointer user_data);
 
 /**
  * fl_engine_add_view_finish:
@@ -134,11 +137,11 @@ void fl_engine_add_view(FlEngine* engine,
  *
  * Completes request started with fl_engine_add_view().
  *
- * Returns: the newly added view ID or -1 on error.
+ * Returns: %TRUE on success.
  */
-FlutterViewId fl_engine_add_view_finish(FlEngine* engine,
-                                        GAsyncResult* result,
-                                        GError** error);
+gboolean fl_engine_add_view_finish(FlEngine* engine,
+                                   GAsyncResult* result,
+                                   GError** error);
 
 /**
  * fl_engine_remove_view:
@@ -166,7 +169,7 @@ void fl_engine_remove_view(FlEngine* engine,
  *
  * Completes request started with fl_engine_remove_view().
  *
- * Returns: TRUE on succcess.
+ * Returns: %TRUE on succcess.
  */
 gboolean fl_engine_remove_view_finish(FlEngine* engine,
                                       GAsyncResult* result,

--- a/shell/platform/linux/fl_engine_test.cc
+++ b/shell/platform/linux/fl_engine_test.cc
@@ -552,9 +552,8 @@ static void add_view_cb(GObject* object,
                         GAsyncResult* result,
                         gpointer user_data) {
   g_autoptr(GError) error = nullptr;
-  FlutterViewId view_id =
-      fl_engine_add_view_finish(FL_ENGINE(object), result, &error);
-  EXPECT_GT(view_id, 0);
+  gboolean r = fl_engine_add_view_finish(FL_ENGINE(object), result, &error);
+  EXPECT_TRUE(r);
   EXPECT_EQ(error, nullptr);
 
   g_main_loop_quit(static_cast<GMainLoop*>(user_data));
@@ -583,7 +582,9 @@ TEST(FlEngineTest, AddView) {
         return kSuccess;
       }));
 
-  fl_engine_add_view(engine, 123, 456, 2.0, nullptr, add_view_cb, loop);
+  FlutterViewId view_id =
+      fl_engine_add_view(engine, 123, 456, 2.0, nullptr, add_view_cb, loop);
+  EXPECT_GT(view_id, 0);
   EXPECT_TRUE(called);
 
   // Blocks here until add_view_cb is called.
@@ -594,9 +595,8 @@ static void add_view_error_cb(GObject* object,
                               GAsyncResult* result,
                               gpointer user_data) {
   g_autoptr(GError) error = nullptr;
-  FlutterViewId view_id =
-      fl_engine_add_view_finish(FL_ENGINE(object), result, &error);
-  EXPECT_EQ(view_id, -1);
+  gboolean r = fl_engine_add_view_finish(FL_ENGINE(object), result, &error);
+  EXPECT_FALSE(r);
   EXPECT_NE(error, nullptr);
 
   g_main_loop_quit(static_cast<GMainLoop*>(user_data));
@@ -619,7 +619,9 @@ TEST(FlEngineTest, AddViewError) {
         return kSuccess;
       }));
 
-  fl_engine_add_view(engine, 123, 456, 2.0, nullptr, add_view_error_cb, loop);
+  FlutterViewId view_id = fl_engine_add_view(engine, 123, 456, 2.0, nullptr,
+                                             add_view_error_cb, loop);
+  EXPECT_GT(view_id, 0);
 
   // Blocks here until add_view_error_cb is called.
   g_main_loop_run(loop);
@@ -629,9 +631,8 @@ static void add_view_engine_error_cb(GObject* object,
                                      GAsyncResult* result,
                                      gpointer user_data) {
   g_autoptr(GError) error = nullptr;
-  FlutterViewId view_id =
-      fl_engine_add_view_finish(FL_ENGINE(object), result, &error);
-  EXPECT_EQ(view_id, -1);
+  gboolean r = fl_engine_add_view_finish(FL_ENGINE(object), result, &error);
+  EXPECT_FALSE(r);
   EXPECT_NE(error, nullptr);
 
   g_main_loop_quit(static_cast<GMainLoop*>(user_data));
@@ -648,8 +649,9 @@ TEST(FlEngineTest, AddViewEngineError) {
         return kInvalidArguments;
       }));
 
-  fl_engine_add_view(engine, 123, 456, 2.0, nullptr, add_view_engine_error_cb,
-                     loop);
+  FlutterViewId view_id = fl_engine_add_view(engine, 123, 456, 2.0, nullptr,
+                                             add_view_engine_error_cb, loop);
+  EXPECT_GT(view_id, 0);
 
   // Blocks here until remove_view_engine_error_cb is called.
   g_main_loop_run(loop);

--- a/shell/platform/linux/public/flutter_linux/fl_view.h
+++ b/shell/platform/linux/public/flutter_linux/fl_view.h
@@ -70,6 +70,16 @@ FlView* fl_view_new_for_engine(FlEngine* engine);
 FlEngine* fl_view_get_engine(FlView* view);
 
 /**
+ * fl_view_get_id:
+ * @view: an #FlView.
+ *
+ * Gets the Flutter view ID used by this view.
+ *
+ * Returns: a view ID or -1 if now ID assigned.
+ */
+int64_t fl_view_get_id(FlView* view);
+
+/**
  * fl_view_set_background_color:
  * @view: an #FlView.
  * @color: a background color.

--- a/shell/platform/linux/testing/mock_engine.cc
+++ b/shell/platform/linux/testing/mock_engine.cc
@@ -521,6 +521,18 @@ FlutterEngineResult FlutterEngineNotifyDisplayUpdate(
   return kSuccess;
 }
 
+FlutterEngineResult FlutterEngineAddView(FLUTTER_API_SYMBOL(FlutterEngine)
+                                             engine,
+                                         const FlutterAddViewInfo* info) {
+  return kSuccess;
+}
+
+FlutterEngineResult FlutterEngineRemoveView(FLUTTER_API_SYMBOL(FlutterEngine)
+                                                engine,
+                                            const FlutterRemoveViewInfo* info) {
+  return kSuccess;
+}
+
 }  // namespace
 
 FlutterEngineResult FlutterEngineGetProcAddresses(
@@ -561,5 +573,7 @@ FlutterEngineResult FlutterEngineGetProcAddresses(
   table->UpdateAccessibilityFeatures =
       &FlutterEngineUpdateAccessibilityFeatures;
   table->NotifyDisplayUpdate = &FlutterEngineNotifyDisplayUpdate;
+  table->AddView = &FlutterEngineAddView;
+  table->RemoveView = &FlutterEngineRemoveView;
   return kSuccess;
 }


### PR DESCRIPTION
Allocate view IDs for secondary Flutter views - another step towards full multi-view support.