### PR TITLE
Use localized config data for `et test` tests.

### DIFF
--- a/tools/engine_tool/test/test_command_test.dart
+++ b/tools/engine_tool/test/test_command_test.dart
@@ -2,46 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:convert' as convert;
-
-import 'package:engine_build_configs/engine_build_configs.dart';
 import 'package:engine_tool/src/commands/command_runner.dart';
-import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
-import 'fixtures.dart' as fixtures;
+import 'src/test_build_configs.dart';
 import 'utils.dart';
 
 void main() {
-  final linuxTestConfig = BuilderConfig.fromJson(
-    path: 'ci/builders/linux_test_config.json',
-    map: convert.jsonDecode(fixtures.testConfig('Linux', Platform.linux))
-        as Map<String, Object?>,
-  );
-
-  final macTestConfig = BuilderConfig.fromJson(
-    path: 'ci/builders/mac_test_config.json',
-    map: convert.jsonDecode(fixtures.testConfig('Mac-12', Platform.macOS))
-        as Map<String, Object?>,
-  );
-
-  final winTestConfig = BuilderConfig.fromJson(
-    path: 'ci/builders/win_test_config.json',
-    map: convert.jsonDecode(fixtures.testConfig('Windows-11', Platform.windows))
-        as Map<String, Object?>,
-  );
-
-  final configs = <String, BuilderConfig>{
-    'linux_test_config': linuxTestConfig,
-    'mac_test_config': macTestConfig,
-    'win_test_config': winTestConfig,
-  };
-
-  test('test command executes test', () async {
+  test('test implicitly picks a configuration and executes tests', () async {
     final testEnvironment = TestEnvironment.withTestEngine(
-      // This test needs specific instrumentation. Ideally all tests should
-      // use per-test environments and not rely on global state, but that is a
-      // larger change (https://github.com/flutter/flutter/issues/148420).
       cannedProcesses: [
         CannedProcess(
           (command) => command.contains('desc'),
@@ -59,28 +28,43 @@ void main() {
     );
     addTearDown(testEnvironment.cleanup);
 
+    final builders = TestBuilderConfig();
+    builders.addBuild(
+      name: 'linux/host_debug',
+      dimension: TestDroneDimension.linux,
+      targetDir: 'host_debug',
+    );
+
     final runner = ToolCommandRunner(
       environment: testEnvironment.environment,
-      configs: configs,
+      configs: {
+        'linux_test_config': builders.buildConfig(
+          path: 'ci/builders/linux_test_config.json',
+        )
+      },
     );
-    final result = await runner.run(<String>[
+    final result = await runner.run([
       'test',
       '//flutter/display_list:display_list_unittests',
     ]);
+
+    printOnFailure(testEnvironment.testLogs.map((t) => t.message).join('\n'));
     expect(result, equals(0));
-    expect(testEnvironment.processHistory.length, greaterThan(3));
-    final offset = testEnvironment.processHistory.length - 1;
+
     expect(
-      testEnvironment.processHistory[offset].command[0],
-      endsWith('display_list_unittests'),
+      testEnvironment.processHistory,
+      contains(
+        isA<ExecutedProcess>().having(
+          (e) => e.command,
+          'command',
+          contains(endsWith('display_list_unittests')),
+        ),
+      ),
     );
   });
 
   test('test command skips non-testonly executables', () async {
     final testEnvironment = TestEnvironment.withTestEngine(
-      // This test needs specific instrumentation. Ideally all tests should
-      // use per-test environments and not rely on global state, but that is a
-      // larger change (https://github.com/flutter/flutter/issues/148420).
       cannedProcesses: [
         CannedProcess(
           (command) => command.contains('desc'),
@@ -103,18 +87,53 @@ void main() {
     );
     addTearDown(testEnvironment.cleanup);
 
-    final env = testEnvironment.environment;
+    final builders = TestBuilderConfig();
+    builders.addBuild(
+      name: 'linux/host_debug',
+      dimension: TestDroneDimension.linux,
+      targetDir: 'host_debug',
+    );
+
     final runner = ToolCommandRunner(
-      environment: env,
-      configs: configs,
+      environment: testEnvironment.environment,
+      configs: {
+        'linux_test_config': builders.buildConfig(
+          path: 'ci/builders/linux_test_config.json',
+        )
+      },
     );
     final result = await runner.run(<String>[
       'test',
       '//...',
     ]);
+
+    printOnFailure(testEnvironment.testLogs.map((t) => t.message).join('\n'));
     expect(result, equals(0));
-    expect(testEnvironment.processHistory.where((ExecutedProcess process) {
-      return process.command[0].contains('protoc');
-    }), isEmpty);
+
+    expect(
+      testEnvironment.processHistory,
+      contains(
+        isA<ExecutedProcess>().having(
+          (e) => e.command,
+          'command',
+          contains(endsWith('display_list_unittests')),
+        ),
+      ),
+      reason: 'display_list_unittests is marked as testonly',
+    );
+
+    expect(
+      testEnvironment.processHistory,
+      isNot(
+        contains(
+          isA<ExecutedProcess>().having(
+            (e) => e.command,
+            'command',
+            contains(endsWith('protoc')),
+          ),
+        ),
+      ),
+      reason: 'protoc is not marked as testonly',
+    );
   });
 }


### PR DESCRIPTION
The logical "part 2.5" of the work started in https://github.com/flutter/engine/pull/55540.

Test output does not change, the tests just no longer rely on the global `fixtures.dart` data.