### PR TITLE
iOS: Migrate FlutterEngine to ARC

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -70,7 +70,9 @@ source_set("flutter_framework_source_arc") {
     "framework/Source/FlutterDartVMServicePublisher.mm",
     "framework/Source/FlutterEmbedderKeyResponder.h",
     "framework/Source/FlutterEmbedderKeyResponder.mm",
+    "framework/Source/FlutterEngine.mm",
     "framework/Source/FlutterEngineGroup.mm",
+    "framework/Source/FlutterEngine_Internal.h",
     "framework/Source/FlutterHeadlessDartRunner.mm",
     "framework/Source/FlutterKeyPrimaryResponder.h",
     "framework/Source/FlutterKeySecondaryResponder.h",
@@ -186,8 +188,6 @@ source_set("flutter_framework_source") {
     # iOS embedder is migrating to ARC.
     # New files are highly encouraged to be in ARC.
     # To add new files in ARC, add them to the `flutter_framework_source_arc` target.
-    "framework/Source/FlutterEngine.mm",
-    "framework/Source/FlutterEngine_Internal.h",
     "framework/Source/FlutterViewController.mm",
     "framework/Source/FlutterViewController_Internal.h",
     "platform_view_ios.h",

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -125,6 +125,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 @property(nonatomic, strong) FlutterMethodChannel* platformViewsChannel;
 @property(nonatomic, strong) FlutterMethodChannel* textInputChannel;
 @property(nonatomic, strong) FlutterMethodChannel* undoManagerChannel;
+@property(nonatomic, strong) FlutterMethodChannel* scribbleChannel;
 
 #pragma mark - Embedder API properties
 
@@ -146,7 +147,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   std::shared_ptr<flutter::SamplingProfiler> _profiler;
 
   // Channels
-  fml::scoped_nsobject<FlutterMethodChannel> _scribbleChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _spellCheckChannel;
   fml::scoped_nsobject<FlutterBasicMessageChannel> _lifecycleChannel;
   fml::scoped_nsobject<FlutterBasicMessageChannel> _systemChannel;
@@ -472,9 +472,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 - (std::shared_ptr<flutter::PlatformViewsController>&)platformViewsController {
   return _platformViewsController;
 }
-- (FlutterMethodChannel*)scribbleChannel {
-  return _scribbleChannel.get();
-}
 - (FlutterMethodChannel*)spellCheckChannel {
   return _spellCheckChannel.get();
 }
@@ -507,7 +504,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   self.platformViewsChannel = nil;
   self.textInputChannel = nil;
   self.undoManagerChannel = nil;
-  _scribbleChannel.reset();
+  self.scribbleChannel = nil;
   _lifecycleChannel.reset();
   _systemChannel.reset();
   _settingsChannel.reset();
@@ -586,10 +583,10 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
                                  binaryMessenger:self.binaryMessenger
                                            codec:[FlutterJSONMethodCodec sharedInstance]];
 
-  _scribbleChannel.reset([[FlutterMethodChannel alloc]
+  self.scribbleChannel = [[FlutterMethodChannel alloc]
          initWithName:@"flutter/scribble"
       binaryMessenger:self.binaryMessenger
-                codec:[FlutterJSONMethodCodec sharedInstance]]);
+                codec:[FlutterJSONMethodCodec sharedInstance]];
 
   _spellCheckChannel.reset([[FlutterMethodChannel alloc]
          initWithName:@"flutter/spellcheck"

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -100,6 +100,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
                              FlutterBinaryMessenger,
                              FlutterTextureRegistry>
 @property(nonatomic, readonly) FlutterDartProject* dartProject;
+@property(nonatomic, readonly, copy) NSString* labelPrefix;
 
 // Maintains a dictionary of plugin names that have registered with the engine.  Used by
 // FlutterEngineRegistrar to implement a FlutterPluginRegistrar.
@@ -120,7 +121,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 @implementation FlutterEngine {
   std::shared_ptr<flutter::ThreadHost> _threadHost;
   std::unique_ptr<flutter::Shell> _shell;
-  NSString* _labelPrefix;
 
   fml::WeakNSObject<FlutterViewController> _viewController;
   fml::scoped_nsobject<FlutterDartVMServicePublisher> _publisher;
@@ -191,8 +191,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 
   _restorationEnabled = restorationEnabled;
   _allowHeadlessExecution = allowHeadlessExecution;
-  _labelPrefix = [labelPrefix copy];
-
+  _labelPrefix = labelPrefix;
   _dartProject = project ?: [[FlutterDartProject alloc] init];
 
   _enableEmbedderAPI = _dartProject.settings.enable_embedder_api;
@@ -838,7 +837,7 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
 
   SetEntryPoint(&settings, entrypoint, libraryURI);
 
-  NSString* threadLabel = [FlutterEngine generateThreadLabel:_labelPrefix];
+  NSString* threadLabel = [FlutterEngine generateThreadLabel:self.labelPrefix];
   _threadHost = std::make_shared<flutter::ThreadHost>();
   *_threadHost = MakeThreadHost(threadLabel, settings);
 
@@ -1426,7 +1425,7 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
                          initialRoute:(/*nullable*/ NSString*)initialRoute
                        entrypointArgs:(/*nullable*/ NSArray<NSString*>*)entrypointArgs {
   NSAssert(_shell, @"Spawning from an engine without a shell (possibly not run).");
-  FlutterEngine* result = [[FlutterEngine alloc] initWithName:_labelPrefix
+  FlutterEngine* result = [[FlutterEngine alloc] initWithName:self.labelPrefix
                                                       project:self.dartProject
                                        allowHeadlessExecution:_allowHeadlessExecution];
   flutter::RunConfiguration configuration =

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -126,6 +126,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 @property(nonatomic, strong) FlutterMethodChannel* textInputChannel;
 @property(nonatomic, strong) FlutterMethodChannel* undoManagerChannel;
 @property(nonatomic, strong) FlutterMethodChannel* scribbleChannel;
+@property(nonatomic, strong) FlutterMethodChannel* spellCheckChannel;
 
 #pragma mark - Embedder API properties
 
@@ -147,7 +148,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   std::shared_ptr<flutter::SamplingProfiler> _profiler;
 
   // Channels
-  fml::scoped_nsobject<FlutterMethodChannel> _spellCheckChannel;
   fml::scoped_nsobject<FlutterBasicMessageChannel> _lifecycleChannel;
   fml::scoped_nsobject<FlutterBasicMessageChannel> _systemChannel;
   fml::scoped_nsobject<FlutterBasicMessageChannel> _settingsChannel;
@@ -472,9 +472,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 - (std::shared_ptr<flutter::PlatformViewsController>&)platformViewsController {
   return _platformViewsController;
 }
-- (FlutterMethodChannel*)spellCheckChannel {
-  return _spellCheckChannel.get();
-}
 - (FlutterBasicMessageChannel*)lifecycleChannel {
   return _lifecycleChannel.get();
 }
@@ -509,7 +506,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   _systemChannel.reset();
   _settingsChannel.reset();
   _keyEventChannel.reset();
-  _spellCheckChannel.reset();
+  self.spellCheckChannel = nil;
 }
 
 - (void)startProfiler {
@@ -583,15 +580,15 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
                                  binaryMessenger:self.binaryMessenger
                                            codec:[FlutterJSONMethodCodec sharedInstance]];
 
-  self.scribbleChannel = [[FlutterMethodChannel alloc]
-         initWithName:@"flutter/scribble"
-      binaryMessenger:self.binaryMessenger
-                codec:[FlutterJSONMethodCodec sharedInstance]];
+  self.scribbleChannel =
+      [[FlutterMethodChannel alloc] initWithName:@"flutter/scribble"
+                                 binaryMessenger:self.binaryMessenger
+                                           codec:[FlutterJSONMethodCodec sharedInstance]];
 
-  _spellCheckChannel.reset([[FlutterMethodChannel alloc]
+  self.spellCheckChannel = [[FlutterMethodChannel alloc]
          initWithName:@"flutter/spellcheck"
       binaryMessenger:self.binaryMessenger
-                codec:[FlutterStandardMethodCodec sharedInstance]]);
+                codec:[FlutterStandardMethodCodec sharedInstance]];
 
   _lifecycleChannel.reset([[FlutterBasicMessageChannel alloc]
          initWithName:@"flutter/lifecycle"
@@ -682,8 +679,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
     }];
 
     FlutterSpellCheckPlugin* spellCheckPlugin = self.spellCheckPlugin;
-    [_spellCheckChannel.get()
-        setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
+    [self.spellCheckChannel setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
           [spellCheckPlugin handleMethodCall:call result:result];
         }];
   }

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -129,6 +129,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 @property(nonatomic, strong) FlutterMethodChannel* spellCheckChannel;
 @property(nonatomic, strong) FlutterBasicMessageChannel* lifecycleChannel;
 @property(nonatomic, strong) FlutterBasicMessageChannel* systemChannel;
+@property(nonatomic, strong) FlutterBasicMessageChannel* settingsChannel;
 
 #pragma mark - Embedder API properties
 
@@ -150,7 +151,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   std::shared_ptr<flutter::SamplingProfiler> _profiler;
 
   // Channels
-  fml::scoped_nsobject<FlutterBasicMessageChannel> _settingsChannel;
   fml::scoped_nsobject<FlutterBasicMessageChannel> _keyEventChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _screenshotChannel;
 
@@ -472,9 +472,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 - (std::shared_ptr<flutter::PlatformViewsController>&)platformViewsController {
   return _platformViewsController;
 }
-- (FlutterBasicMessageChannel*)settingsChannel {
-  return _settingsChannel.get();
-}
 - (FlutterBasicMessageChannel*)keyEventChannel {
   return _keyEventChannel.get();
 }
@@ -498,7 +495,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   self.scribbleChannel = nil;
   self.lifecycleChannel = nil;
   self.systemChannel = nil;
-  _settingsChannel.reset();
+  self.settingsChannel = nil;
   _keyEventChannel.reset();
   self.spellCheckChannel = nil;
 }
@@ -594,10 +591,10 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
                                        binaryMessenger:self.binaryMessenger
                                                  codec:[FlutterJSONMessageCodec sharedInstance]];
 
-  _settingsChannel.reset([[FlutterBasicMessageChannel alloc]
-         initWithName:@"flutter/settings"
-      binaryMessenger:self.binaryMessenger
-                codec:[FlutterJSONMessageCodec sharedInstance]]);
+  self.settingsChannel =
+      [[FlutterBasicMessageChannel alloc] initWithName:@"flutter/settings"
+                                       binaryMessenger:self.binaryMessenger
+                                                 codec:[FlutterJSONMessageCodec sharedInstance]];
 
   _keyEventChannel.reset([[FlutterBasicMessageChannel alloc]
          initWithName:@"flutter/keyevent"

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -682,6 +682,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 
 - (void)maybeSetupPlatformViewChannels {
   if (_shell && self.shell.IsSetup()) {
+    // TODO(cbracken): Use weakSelf for these.
     FlutterPlatformPlugin* platformPlugin = self.platformPlugin;
     [_platformChannel.get() setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
       [platformPlugin handleMethodCall:call result:result];

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -131,6 +131,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 @property(nonatomic, strong) FlutterBasicMessageChannel* systemChannel;
 @property(nonatomic, strong) FlutterBasicMessageChannel* settingsChannel;
 @property(nonatomic, strong) FlutterBasicMessageChannel* keyEventChannel;
+@property(nonatomic, strong) FlutterMethodChannel* screenshotChannel;
 
 #pragma mark - Embedder API properties
 
@@ -150,9 +151,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   flutter::IOSRenderingAPI _renderingApi;
   std::shared_ptr<flutter::ProfilerMetricsIOS> _profiler_metrics;
   std::shared_ptr<flutter::SamplingProfiler> _profiler;
-
-  // Channels
-  fml::scoped_nsobject<FlutterMethodChannel> _screenshotChannel;
 
   int64_t _nextTextureId;
 
@@ -609,12 +607,12 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
                                                           restorationEnabled:_restorationEnabled];
   self.spellCheckPlugin = [[FlutterSpellCheckPlugin alloc] init];
 
-  _screenshotChannel.reset([[FlutterMethodChannel alloc]
-         initWithName:@"flutter/screenshot"
-      binaryMessenger:self.binaryMessenger
-                codec:[FlutterStandardMethodCodec sharedInstance]]);
+  self.screenshotChannel =
+      [[FlutterMethodChannel alloc] initWithName:@"flutter/screenshot"
+                                 binaryMessenger:self.binaryMessenger
+                                           codec:[FlutterStandardMethodCodec sharedInstance]];
 
-  [_screenshotChannel.get()
+  [self.screenshotChannel
       setMethodCallHandler:^(FlutterMethodCall* _Nonnull call, FlutterResult _Nonnull result) {
         FlutterEngine* strongSelf = weakSelf;
         if (!(strongSelf && strongSelf->_shell && strongSelf->_shell->IsSetup())) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -120,6 +120,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 @property(nonatomic, strong) FlutterRestorationPlugin* restorationPlugin;
 @property(nonatomic, strong) FlutterMethodChannel* localizationChannel;
 @property(nonatomic, strong) FlutterMethodChannel* navigationChannel;
+@property(nonatomic, strong) FlutterMethodChannel* restorationChannel;
 
 #pragma mark - Embedder API properties
 
@@ -141,7 +142,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   std::shared_ptr<flutter::SamplingProfiler> _profiler;
 
   // Channels
-  fml::scoped_nsobject<FlutterMethodChannel> _restorationChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _platformChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _platformViewsChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _textInputChannel;
@@ -472,9 +472,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 - (std::shared_ptr<flutter::PlatformViewsController>&)platformViewsController {
   return _platformViewsController;
 }
-- (FlutterMethodChannel*)restorationChannel {
-  return _restorationChannel.get();
-}
 - (FlutterMethodChannel*)platformChannel {
   return _platformChannel.get();
 }
@@ -514,7 +511,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 - (void)resetChannels {
   self.localizationChannel = nil;
   self.navigationChannel = nil;
-  _restorationChannel.reset();
+  self.restorationChannel = nil;
   _platformChannel.reset();
   _platformViewsChannel.reset();
   _textInputChannel.reset();
@@ -573,10 +570,10 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
     _initialRoute = nil;
   }
 
-  _restorationChannel.reset([[FlutterMethodChannel alloc]
-         initWithName:@"flutter/restoration"
-      binaryMessenger:self.binaryMessenger
-                codec:[FlutterStandardMethodCodec sharedInstance]]);
+  self.restorationChannel =
+      [[FlutterMethodChannel alloc] initWithName:@"flutter/restoration"
+                                 binaryMessenger:self.binaryMessenger
+                                           codec:[FlutterStandardMethodCodec sharedInstance]];
 
   _platformChannel.reset([[FlutterMethodChannel alloc]
          initWithName:@"flutter/platform"
@@ -636,7 +633,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   self.platformPlugin = [[FlutterPlatformPlugin alloc] initWithEngine:self];
 
   self.restorationPlugin =
-      [[FlutterRestorationPlugin alloc] initWithChannel:_restorationChannel.get()
+      [[FlutterRestorationPlugin alloc] initWithChannel:self.restorationChannel
                                      restorationEnabled:_restorationEnabled];
   self.spellCheckPlugin = [[FlutterSpellCheckPlugin alloc] init];
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -111,6 +111,10 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 @property(nonatomic, copy) NSString* initialRoute;
 @property(nonatomic, strong) id<NSObject> flutterViewControllerWillDeallocObserver;
 
+#pragma mark - Channel properties
+
+@property(nonatomic, strong) FlutterPlatformPlugin* platformPlugin;
+
 #pragma mark - Embedder API properties
 
 @property(nonatomic, assign) BOOL enableEmbedderAPI;
@@ -131,7 +135,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   std::shared_ptr<flutter::SamplingProfiler> _profiler;
 
   // Channels
-  fml::scoped_nsobject<FlutterPlatformPlugin> _platformPlugin;
   fml::scoped_nsobject<FlutterTextInputPlugin> _textInputPlugin;
   fml::scoped_nsobject<FlutterUndoManagerPlugin> _undoManagerPlugin;
   fml::scoped_nsobject<FlutterSpellCheckPlugin> _spellCheckPlugin;
@@ -466,9 +469,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   return _viewController.get();
 }
 
-- (FlutterPlatformPlugin*)platformPlugin {
-  return _platformPlugin.get();
-}
 - (std::shared_ptr<flutter::PlatformViewsController>&)platformViewsController {
   return _platformViewsController;
 }
@@ -652,7 +652,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
       [[FlutterUndoManagerPlugin alloc] initWithDelegate:self];
   _undoManagerPlugin.reset(undoManagerPlugin);
 
-  _platformPlugin.reset([[FlutterPlatformPlugin alloc] initWithEngine:self]);
+  self.platformPlugin = [[FlutterPlatformPlugin alloc] initWithEngine:self];
 
   _restorationPlugin.reset([[FlutterRestorationPlugin alloc]
          initWithChannel:_restorationChannel.get()
@@ -692,7 +692,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 
 - (void)maybeSetupPlatformViewChannels {
   if (_shell && self.shell.IsSetup()) {
-    FlutterPlatformPlugin* platformPlugin = _platformPlugin.get();
+    FlutterPlatformPlugin* platformPlugin = self.platformPlugin;
     [_platformChannel.get() setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
       [platformPlugin handleMethodCall:call result:result];
     }];

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -116,6 +116,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 @property(nonatomic, strong) FlutterPlatformPlugin* platformPlugin;
 @property(nonatomic, strong) FlutterTextInputPlugin* textInputPlugin;
 @property(nonatomic, strong) FlutterUndoManagerPlugin* undoManagerPlugin;
+@property(nonatomic, strong) FlutterSpellCheckPlugin* spellCheckPlugin;
 
 #pragma mark - Embedder API properties
 
@@ -137,7 +138,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   std::shared_ptr<flutter::SamplingProfiler> _profiler;
 
   // Channels
-  fml::scoped_nsobject<FlutterSpellCheckPlugin> _spellCheckPlugin;
   fml::scoped_nsobject<FlutterRestorationPlugin> _restorationPlugin;
   fml::scoped_nsobject<FlutterMethodChannel> _localizationChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _navigationChannel;
@@ -647,7 +647,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   _restorationPlugin.reset([[FlutterRestorationPlugin alloc]
          initWithChannel:_restorationChannel.get()
       restorationEnabled:_restorationEnabled]);
-  _spellCheckPlugin.reset([[FlutterSpellCheckPlugin alloc] init]);
+  self.spellCheckPlugin = [[FlutterSpellCheckPlugin alloc] init];
 
   _screenshotChannel.reset([[FlutterMethodChannel alloc]
          initWithName:@"flutter/screenshot"
@@ -707,7 +707,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
           [undoManagerPlugin handleMethodCall:call result:result];
         }];
 
-    FlutterSpellCheckPlugin* spellCheckPlugin = _spellCheckPlugin.get();
+    FlutterSpellCheckPlugin* spellCheckPlugin = self.spellCheckPlugin;
     [_spellCheckChannel.get()
         setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
           [spellCheckPlugin handleMethodCall:call result:result];

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -608,8 +608,9 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   self.undoManagerPlugin = [[FlutterUndoManagerPlugin alloc] initWithDelegate:self];
   self.platformPlugin = [[FlutterPlatformPlugin alloc] initWithEngine:self];
 
-  self.restorationPlugin = [[FlutterRestorationPlugin alloc] initWithChannel:self.restorationChannel
-                                                          restorationEnabled:self.restorationEnabled];
+  self.restorationPlugin =
+      [[FlutterRestorationPlugin alloc] initWithChannel:self.restorationChannel
+                                     restorationEnabled:self.restorationEnabled];
   self.spellCheckPlugin = [[FlutterSpellCheckPlugin alloc] init];
 
   self.screenshotChannel =

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -646,13 +646,12 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 
 - (void)maybeSetupPlatformViewChannels {
   if (_shell && self.shell.IsSetup()) {
-    // TODO(cbracken): Use weakSelf for these.
-    FlutterPlatformPlugin* platformPlugin = self.platformPlugin;
+    __weak FlutterEngine* weakSelf = self;
+
     [self.platformChannel setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
-      [platformPlugin handleMethodCall:call result:result];
+      [weakSelf.platformPlugin handleMethodCall:call result:result];
     }];
 
-    __weak FlutterEngine* weakSelf = self;
     [self.platformViewsChannel
         setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
           if (weakSelf) {
@@ -660,19 +659,16 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
           }
         }];
 
-    FlutterTextInputPlugin* textInputPlugin = self.textInputPlugin;
     [self.textInputChannel setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
-      [textInputPlugin handleMethodCall:call result:result];
+      [weakSelf.textInputPlugin handleMethodCall:call result:result];
     }];
 
-    FlutterUndoManagerPlugin* undoManagerPlugin = self.undoManagerPlugin;
     [self.undoManagerChannel setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
-      [undoManagerPlugin handleMethodCall:call result:result];
+      [weakSelf.undoManagerPlugin handleMethodCall:call result:result];
     }];
 
-    FlutterSpellCheckPlugin* spellCheckPlugin = self.spellCheckPlugin;
     [self.spellCheckChannel setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
-      [spellCheckPlugin handleMethodCall:call result:result];
+      [weakSelf.spellCheckPlugin handleMethodCall:call result:result];
     }];
   }
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -118,6 +118,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 @property(nonatomic, strong) FlutterUndoManagerPlugin* undoManagerPlugin;
 @property(nonatomic, strong) FlutterSpellCheckPlugin* spellCheckPlugin;
 @property(nonatomic, strong) FlutterRestorationPlugin* restorationPlugin;
+@property(nonatomic, strong) FlutterMethodChannel* localizationChannel;
 
 #pragma mark - Embedder API properties
 
@@ -139,7 +140,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   std::shared_ptr<flutter::SamplingProfiler> _profiler;
 
   // Channels
-  fml::scoped_nsobject<FlutterMethodChannel> _localizationChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _navigationChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _restorationChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _platformChannel;
@@ -472,9 +472,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 - (std::shared_ptr<flutter::PlatformViewsController>&)platformViewsController {
   return _platformViewsController;
 }
-- (FlutterMethodChannel*)localizationChannel {
-  return _localizationChannel.get();
-}
 - (FlutterMethodChannel*)navigationChannel {
   return _navigationChannel.get();
 }
@@ -518,7 +515,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 }
 
 - (void)resetChannels {
-  _localizationChannel.reset();
+  self.localizationChannel = nil;
   _navigationChannel.reset();
   _restorationChannel.reset();
   _platformChannel.reset();
@@ -563,10 +560,10 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
                             }
                           }];
 
-  _localizationChannel.reset([[FlutterMethodChannel alloc]
-         initWithName:@"flutter/localization"
-      binaryMessenger:self.binaryMessenger
-                codec:[FlutterJSONMethodCodec sharedInstance]]);
+  self.localizationChannel =
+      [[FlutterMethodChannel alloc] initWithName:@"flutter/localization"
+                                 binaryMessenger:self.binaryMessenger
+                                           codec:[FlutterJSONMethodCodec sharedInstance]];
 
   _navigationChannel.reset([[FlutterMethodChannel alloc]
          initWithName:@"flutter/navigation"

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -115,6 +115,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 
 @property(nonatomic, strong) FlutterPlatformPlugin* platformPlugin;
 @property(nonatomic, strong) FlutterTextInputPlugin* textInputPlugin;
+@property(nonatomic, strong) FlutterUndoManagerPlugin* undoManagerPlugin;
 
 #pragma mark - Embedder API properties
 
@@ -136,7 +137,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   std::shared_ptr<flutter::SamplingProfiler> _profiler;
 
   // Channels
-  fml::scoped_nsobject<FlutterUndoManagerPlugin> _undoManagerPlugin;
   fml::scoped_nsobject<FlutterSpellCheckPlugin> _spellCheckPlugin;
   fml::scoped_nsobject<FlutterRestorationPlugin> _restorationPlugin;
   fml::scoped_nsobject<FlutterMethodChannel> _localizationChannel;
@@ -472,9 +472,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 - (std::shared_ptr<flutter::PlatformViewsController>&)platformViewsController {
   return _platformViewsController;
 }
-- (FlutterUndoManagerPlugin*)undoManagerPlugin {
-  return _undoManagerPlugin.get();
-}
 - (FlutterRestorationPlugin*)restorationPlugin {
   return _restorationPlugin.get();
 }
@@ -644,10 +641,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   self.textInputPlugin.indirectScribbleDelegate = self;
   [self.textInputPlugin setUpIndirectScribbleInteraction:self.viewController];
 
-  FlutterUndoManagerPlugin* undoManagerPlugin =
-      [[FlutterUndoManagerPlugin alloc] initWithDelegate:self];
-  _undoManagerPlugin.reset(undoManagerPlugin);
-
+  self.undoManagerPlugin = [[FlutterUndoManagerPlugin alloc] initWithDelegate:self];
   self.platformPlugin = [[FlutterPlatformPlugin alloc] initWithEngine:self];
 
   _restorationPlugin.reset([[FlutterRestorationPlugin alloc]
@@ -706,7 +700,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
       [textInputPlugin handleMethodCall:call result:result];
     }];
 
-    FlutterUndoManagerPlugin* undoManagerPlugin = _undoManagerPlugin.get();
+    FlutterUndoManagerPlugin* undoManagerPlugin = self.undoManagerPlugin;
     [_undoManagerChannel.get()
         setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
           [undoManagerPlugin handleMethodCall:call result:result];

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -110,6 +110,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 @property(nonatomic, readwrite, copy) NSString* isolateId;
 @property(nonatomic, copy) NSString* initialRoute;
 @property(nonatomic, strong) id<NSObject> flutterViewControllerWillDeallocObserver;
+@property(nonatomic, strong) FlutterDartVMServicePublisher* publisher;
 
 #pragma mark - Channel properties
 
@@ -145,7 +146,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   std::unique_ptr<flutter::Shell> _shell;
 
   fml::WeakNSObject<FlutterViewController> _viewController;
-  fml::scoped_nsobject<FlutterDartVMServicePublisher> _publisher;
 
   std::shared_ptr<flutter::PlatformViewsController> _platformViewsController;
   flutter::IOSRenderingAPI _renderingApi;
@@ -472,11 +472,11 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 }
 
 - (NSURL*)observatoryUrl {
-  return [_publisher.get() url];
+  return [self.publisher url];
 }
 
 - (NSURL*)vmServiceUrl {
-  return [_publisher.get() url];
+  return [self.publisher url];
 }
 
 - (void)resetChannels {
@@ -691,8 +691,8 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   [self setUpChannels];
   [self onLocaleUpdated:nil];
   [self updateDisplays];
-  _publisher.reset([[FlutterDartVMServicePublisher alloc]
-      initWithEnableVMServicePublication:doesVMServicePublication]);
+  self.publisher = [[FlutterDartVMServicePublisher alloc]
+      initWithEnableVMServicePublication:doesVMServicePublication];
   [self maybeSetupPlatformViewChannels];
   _shell->SetGpuAvailability(_isGpuDisabled ? flutter::GpuAvailability::kUnavailable
                                             : flutter::GpuAvailability::kAvailable);

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -620,30 +620,30 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
                                  binaryMessenger:self.binaryMessenger
                                            codec:[FlutterStandardMethodCodec sharedInstance]];
 
-  [self.screenshotChannel
-      setMethodCallHandler:^(FlutterMethodCall* _Nonnull call, FlutterResult _Nonnull result) {
-        FlutterEngine* strongSelf = weakSelf;
-        if (!(strongSelf && strongSelf->_shell && strongSelf->_shell->IsSetup())) {
-          return result([FlutterError
-              errorWithCode:@"invalid_state"
-                    message:@"Requesting screenshot while engine is not running."
-                    details:nil]);
-        }
-        flutter::Rasterizer::Screenshot screenshot =
-            [strongSelf screenshot:flutter::Rasterizer::ScreenshotType::SurfaceData base64Encode:NO];
-        if (!screenshot.data) {
-          return result([FlutterError errorWithCode:@"failure"
-                                            message:@"Unable to get screenshot."
-                                            details:nil]);
-        }
-        // TODO(gaaclarke): Find way to eliminate this data copy.
-        NSData* data = [NSData dataWithBytes:screenshot.data->writable_data()
-                                      length:screenshot.data->size()];
-        NSString* format = [NSString stringWithUTF8String:screenshot.format.c_str()];
-        NSNumber* width = @(screenshot.frame_size.fWidth);
-        NSNumber* height = @(screenshot.frame_size.fHeight);
-        return result(@[ width, height, format ?: [NSNull null], data ]);
-      }];
+  [self.screenshotChannel setMethodCallHandler:^(FlutterMethodCall* _Nonnull call,
+                                                 FlutterResult _Nonnull result) {
+    FlutterEngine* strongSelf = weakSelf;
+    if (!(strongSelf && strongSelf->_shell && strongSelf->_shell->IsSetup())) {
+      return result([FlutterError
+          errorWithCode:@"invalid_state"
+                message:@"Requesting screenshot while engine is not running."
+                details:nil]);
+    }
+    flutter::Rasterizer::Screenshot screenshot =
+        [strongSelf screenshot:flutter::Rasterizer::ScreenshotType::SurfaceData base64Encode:NO];
+    if (!screenshot.data) {
+      return result([FlutterError errorWithCode:@"failure"
+                                        message:@"Unable to get screenshot."
+                                        details:nil]);
+    }
+    // TODO(gaaclarke): Find way to eliminate this data copy.
+    NSData* data = [NSData dataWithBytes:screenshot.data->writable_data()
+                                  length:screenshot.data->size()];
+    NSString* format = [NSString stringWithUTF8String:screenshot.format.c_str()];
+    NSNumber* width = @(screenshot.frame_size.fWidth);
+    NSNumber* height = @(screenshot.frame_size.fHeight);
+    return result(@[ width, height, format ?: [NSNull null], data ]);
+  }];
 }
 
 - (void)maybeSetupPlatformViewChannels {

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -122,6 +122,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 @property(nonatomic, strong) FlutterMethodChannel* navigationChannel;
 @property(nonatomic, strong) FlutterMethodChannel* restorationChannel;
 @property(nonatomic, strong) FlutterMethodChannel* platformChannel;
+@property(nonatomic, strong) FlutterMethodChannel* platformViewsChannel;
 
 #pragma mark - Embedder API properties
 
@@ -143,7 +144,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   std::shared_ptr<flutter::SamplingProfiler> _profiler;
 
   // Channels
-  fml::scoped_nsobject<FlutterMethodChannel> _platformViewsChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _textInputChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _undoManagerChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _scribbleChannel;
@@ -510,7 +510,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   self.navigationChannel = nil;
   self.restorationChannel = nil;
   self.platformChannel = nil;
-  _platformViewsChannel.reset();
+  self.platformViewsChannel = nil;
   _textInputChannel.reset();
   _undoManagerChannel.reset();
   _scribbleChannel.reset();
@@ -577,10 +577,10 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
                                  binaryMessenger:self.binaryMessenger
                                            codec:[FlutterJSONMethodCodec sharedInstance]];
 
-  _platformViewsChannel.reset([[FlutterMethodChannel alloc]
-         initWithName:@"flutter/platform_views"
-      binaryMessenger:self.binaryMessenger
-                codec:[FlutterStandardMethodCodec sharedInstance]]);
+  self.platformViewsChannel =
+      [[FlutterMethodChannel alloc] initWithName:@"flutter/platform_views"
+                                 binaryMessenger:self.binaryMessenger
+                                           codec:[FlutterStandardMethodCodec sharedInstance]];
 
   _textInputChannel.reset([[FlutterMethodChannel alloc]
          initWithName:@"flutter/textinput"
@@ -673,7 +673,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
     }];
 
     __weak FlutterEngine* weakSelf = self;
-    [_platformViewsChannel.get()
+    [self.platformViewsChannel
         setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
           if (weakSelf) {
             weakSelf.platformViewsController->OnMethodCall(call, result);
@@ -1152,7 +1152,7 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
       return;
     }
 
-    [_platformViewsChannel.get() invokeMethod:@"viewFocused" arguments:@(platform_view_id)];
+    [self.platformViewsChannel invokeMethod:@"viewFocused" arguments:@(platform_view_id)];
   });
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -130,6 +130,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 @property(nonatomic, strong) FlutterBasicMessageChannel* lifecycleChannel;
 @property(nonatomic, strong) FlutterBasicMessageChannel* systemChannel;
 @property(nonatomic, strong) FlutterBasicMessageChannel* settingsChannel;
+@property(nonatomic, strong) FlutterBasicMessageChannel* keyEventChannel;
 
 #pragma mark - Embedder API properties
 
@@ -151,7 +152,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   std::shared_ptr<flutter::SamplingProfiler> _profiler;
 
   // Channels
-  fml::scoped_nsobject<FlutterBasicMessageChannel> _keyEventChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _screenshotChannel;
 
   int64_t _nextTextureId;
@@ -472,9 +472,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 - (std::shared_ptr<flutter::PlatformViewsController>&)platformViewsController {
   return _platformViewsController;
 }
-- (FlutterBasicMessageChannel*)keyEventChannel {
-  return _keyEventChannel.get();
-}
 
 - (NSURL*)observatoryUrl {
   return [_publisher.get() url];
@@ -496,7 +493,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   self.lifecycleChannel = nil;
   self.systemChannel = nil;
   self.settingsChannel = nil;
-  _keyEventChannel.reset();
+  self.keyEventChannel = nil;
   self.spellCheckChannel = nil;
 }
 
@@ -596,10 +593,10 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
                                        binaryMessenger:self.binaryMessenger
                                                  codec:[FlutterJSONMessageCodec sharedInstance]];
 
-  _keyEventChannel.reset([[FlutterBasicMessageChannel alloc]
-         initWithName:@"flutter/keyevent"
-      binaryMessenger:self.binaryMessenger
-                codec:[FlutterJSONMessageCodec sharedInstance]]);
+  self.keyEventChannel =
+      [[FlutterBasicMessageChannel alloc] initWithName:@"flutter/keyevent"
+                                       binaryMessenger:self.binaryMessenger
+                                                 codec:[FlutterJSONMessageCodec sharedInstance]];
 
   self.textInputPlugin = [[FlutterTextInputPlugin alloc] initWithDelegate:self];
   self.textInputPlugin.indirectScribbleDelegate = self;

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -117,6 +117,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 @property(nonatomic, strong) FlutterTextInputPlugin* textInputPlugin;
 @property(nonatomic, strong) FlutterUndoManagerPlugin* undoManagerPlugin;
 @property(nonatomic, strong) FlutterSpellCheckPlugin* spellCheckPlugin;
+@property(nonatomic, strong) FlutterRestorationPlugin* restorationPlugin;
 
 #pragma mark - Embedder API properties
 
@@ -138,7 +139,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   std::shared_ptr<flutter::SamplingProfiler> _profiler;
 
   // Channels
-  fml::scoped_nsobject<FlutterRestorationPlugin> _restorationPlugin;
   fml::scoped_nsobject<FlutterMethodChannel> _localizationChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _navigationChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _restorationChannel;
@@ -472,9 +472,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 - (std::shared_ptr<flutter::PlatformViewsController>&)platformViewsController {
   return _platformViewsController;
 }
-- (FlutterRestorationPlugin*)restorationPlugin {
-  return _restorationPlugin.get();
-}
 - (FlutterMethodChannel*)localizationChannel {
   return _localizationChannel.get();
 }
@@ -644,9 +641,9 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   self.undoManagerPlugin = [[FlutterUndoManagerPlugin alloc] initWithDelegate:self];
   self.platformPlugin = [[FlutterPlatformPlugin alloc] initWithEngine:self];
 
-  _restorationPlugin.reset([[FlutterRestorationPlugin alloc]
-         initWithChannel:_restorationChannel.get()
-      restorationEnabled:_restorationEnabled]);
+  self.restorationPlugin =
+      [[FlutterRestorationPlugin alloc] initWithChannel:_restorationChannel.get()
+                                     restorationEnabled:_restorationEnabled];
   self.spellCheckPlugin = [[FlutterSpellCheckPlugin alloc] init];
 
   _screenshotChannel.reset([[FlutterMethodChannel alloc]

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -197,7 +197,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 
   _restorationEnabled = restorationEnabled;
   _allowHeadlessExecution = allowHeadlessExecution;
-  _labelPrefix = labelPrefix;
+  _labelPrefix = [labelPrefix copy];
   _dartProject = project ?: [[FlutterDartProject alloc] init];
 
   _enableEmbedderAPI = _dartProject.settings.enable_embedder_api;

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -152,6 +152,8 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   std::shared_ptr<flutter::ThreadHost> _threadHost;
   std::unique_ptr<flutter::Shell> _shell;
 
+  // TODO(cbracken): https://github.com/flutter/flutter/issues/155943
+  // Migrate to @property(nonatomic, weak).
   fml::WeakNSObject<FlutterViewController> _viewController;
 
   std::shared_ptr<flutter::PlatformViewsController> _platformViewsController;

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -119,6 +119,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 @property(nonatomic, strong) FlutterSpellCheckPlugin* spellCheckPlugin;
 @property(nonatomic, strong) FlutterRestorationPlugin* restorationPlugin;
 @property(nonatomic, strong) FlutterMethodChannel* localizationChannel;
+@property(nonatomic, strong) FlutterMethodChannel* navigationChannel;
 
 #pragma mark - Embedder API properties
 
@@ -140,7 +141,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   std::shared_ptr<flutter::SamplingProfiler> _profiler;
 
   // Channels
-  fml::scoped_nsobject<FlutterMethodChannel> _navigationChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _restorationChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _platformChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _platformViewsChannel;
@@ -472,9 +472,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 - (std::shared_ptr<flutter::PlatformViewsController>&)platformViewsController {
   return _platformViewsController;
 }
-- (FlutterMethodChannel*)navigationChannel {
-  return _navigationChannel.get();
-}
 - (FlutterMethodChannel*)restorationChannel {
   return _restorationChannel.get();
 }
@@ -516,7 +513,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 
 - (void)resetChannels {
   self.localizationChannel = nil;
-  _navigationChannel.reset();
+  self.navigationChannel = nil;
   _restorationChannel.reset();
   _platformChannel.reset();
   _platformViewsChannel.reset();
@@ -565,14 +562,14 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
                                  binaryMessenger:self.binaryMessenger
                                            codec:[FlutterJSONMethodCodec sharedInstance]];
 
-  _navigationChannel.reset([[FlutterMethodChannel alloc]
-         initWithName:@"flutter/navigation"
-      binaryMessenger:self.binaryMessenger
-                codec:[FlutterJSONMethodCodec sharedInstance]]);
+  self.navigationChannel =
+      [[FlutterMethodChannel alloc] initWithName:@"flutter/navigation"
+                                 binaryMessenger:self.binaryMessenger
+                                           codec:[FlutterJSONMethodCodec sharedInstance]];
 
   if ([_initialRoute length] > 0) {
     // Flutter isn't ready to receive this method call yet but the channel buffer will cache this.
-    [_navigationChannel invokeMethod:@"setInitialRoute" arguments:_initialRoute];
+    [self.navigationChannel invokeMethod:@"setInitialRoute" arguments:_initialRoute];
     _initialRoute = nil;
   }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -128,6 +128,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 @property(nonatomic, strong) FlutterMethodChannel* scribbleChannel;
 @property(nonatomic, strong) FlutterMethodChannel* spellCheckChannel;
 @property(nonatomic, strong) FlutterBasicMessageChannel* lifecycleChannel;
+@property(nonatomic, strong) FlutterBasicMessageChannel* systemChannel;
 
 #pragma mark - Embedder API properties
 
@@ -149,7 +150,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   std::shared_ptr<flutter::SamplingProfiler> _profiler;
 
   // Channels
-  fml::scoped_nsobject<FlutterBasicMessageChannel> _systemChannel;
   fml::scoped_nsobject<FlutterBasicMessageChannel> _settingsChannel;
   fml::scoped_nsobject<FlutterBasicMessageChannel> _keyEventChannel;
   fml::scoped_nsobject<FlutterMethodChannel> _screenshotChannel;
@@ -472,9 +472,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 - (std::shared_ptr<flutter::PlatformViewsController>&)platformViewsController {
   return _platformViewsController;
 }
-- (FlutterBasicMessageChannel*)systemChannel {
-  return _systemChannel.get();
-}
 - (FlutterBasicMessageChannel*)settingsChannel {
   return _settingsChannel.get();
 }
@@ -500,7 +497,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   self.undoManagerChannel = nil;
   self.scribbleChannel = nil;
   self.lifecycleChannel = nil;
-  _systemChannel.reset();
+  self.systemChannel = nil;
   _settingsChannel.reset();
   _keyEventChannel.reset();
   self.spellCheckChannel = nil;
@@ -592,10 +589,10 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
                                        binaryMessenger:self.binaryMessenger
                                                  codec:[FlutterStringCodec sharedInstance]];
 
-  _systemChannel.reset([[FlutterBasicMessageChannel alloc]
-         initWithName:@"flutter/system"
-      binaryMessenger:self.binaryMessenger
-                codec:[FlutterJSONMessageCodec sharedInstance]]);
+  self.systemChannel =
+      [[FlutterBasicMessageChannel alloc] initWithName:@"flutter/system"
+                                       binaryMessenger:self.binaryMessenger
+                                                 codec:[FlutterJSONMessageCodec sharedInstance]];
 
   _settingsChannel.reset([[FlutterBasicMessageChannel alloc]
          initWithName:@"flutter/settings"
@@ -926,7 +923,7 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
   if (_shell) {
     _shell->NotifyLowMemoryWarning();
   }
-  [_systemChannel sendMessage:@{@"type" : @"memoryPressure"}];
+  [self.systemChannel sendMessage:@{@"type" : @"memoryPressure"}];
 }
 
 #pragma mark - Text input delegate

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h
@@ -12,7 +12,7 @@
 @interface FlutterPlatformPlugin : NSObject
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-- (instancetype)initWithEngine:(fml::WeakNSObject<FlutterEngine>)engine NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithEngine:(FlutterEngine*)engine NS_DESIGNATED_INITIALIZER;
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result;
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -82,7 +82,7 @@ static void SetStatusBarStyleForSharedApplication(UIStatusBarStyle style) {
 
 @implementation FlutterPlatformPlugin
 
-- (instancetype)initWithEngine:(fml::WeakNSObject<FlutterEngine>)engine {
+- (instancetype)initWithEngine:(FlutterEngine*)engine {
   FML_DCHECK(engine) << "engine must be set";
   self = [super init];
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPluginTest.mm
@@ -37,15 +37,12 @@ FLUTTER_ASSERT_ARC
   OCMStub([mockApplication sharedApplication]).andReturn(mockApplication);
 
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
-  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
-      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
   [engine runWithEntrypoint:nil];
 
   XCTestExpectation* invokeExpectation =
       [self expectationWithDescription:@"Web search launched with escaped search term"];
 
-  FlutterPlatformPlugin* plugin =
-      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
+  FlutterPlatformPlugin* plugin = [[FlutterPlatformPlugin alloc] initWithEngine:engine];
   FlutterPlatformPlugin* mockPlugin = OCMPartialMock(plugin);
 
   FlutterMethodCall* methodCall = [FlutterMethodCall methodCallWithMethodName:@"SearchWeb.invoke"
@@ -71,15 +68,12 @@ FLUTTER_ASSERT_ARC
   OCMStub([mockApplication sharedApplication]).andReturn(mockApplication);
 
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
-  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
-      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
   [engine runWithEntrypoint:nil];
 
   XCTestExpectation* invokeExpectation =
       [self expectationWithDescription:@"Web search launched with non escaped search term"];
 
-  FlutterPlatformPlugin* plugin =
-      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
+  FlutterPlatformPlugin* plugin = [[FlutterPlatformPlugin alloc] initWithEngine:engine];
   FlutterPlatformPlugin* mockPlugin = OCMPartialMock(plugin);
 
   FlutterMethodCall* methodCall = [FlutterMethodCall methodCallWithMethodName:@"SearchWeb.invoke"
@@ -103,8 +97,6 @@ FLUTTER_ASSERT_ARC
 - (void)testLookUpCallInitiated {
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
   [engine runWithEntrypoint:nil];
-  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
-      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
 
   XCTestExpectation* presentExpectation =
       [self expectationWithDescription:@"Look Up view controller presented"];
@@ -114,8 +106,7 @@ FLUTTER_ASSERT_ARC
                                                                                        bundle:nil];
   FlutterViewController* mockEngineViewController = OCMPartialMock(engineViewController);
 
-  FlutterPlatformPlugin* plugin =
-      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
+  FlutterPlatformPlugin* plugin = [[FlutterPlatformPlugin alloc] initWithEngine:engine];
   FlutterPlatformPlugin* mockPlugin = OCMPartialMock(plugin);
 
   FlutterMethodCall* methodCall = [FlutterMethodCall methodCallWithMethodName:@"LookUp.invoke"
@@ -134,8 +125,6 @@ FLUTTER_ASSERT_ARC
 - (void)testShareScreenInvoked {
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
   [engine runWithEntrypoint:nil];
-  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
-      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
 
   XCTestExpectation* presentExpectation =
       [self expectationWithDescription:@"Share view controller presented"];
@@ -149,8 +138,7 @@ FLUTTER_ASSERT_ARC
                    animated:YES
                  completion:nil]);
 
-  FlutterPlatformPlugin* plugin =
-      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
+  FlutterPlatformPlugin* plugin = [[FlutterPlatformPlugin alloc] initWithEngine:engine];
   FlutterPlatformPlugin* mockPlugin = OCMPartialMock(plugin);
 
   FlutterMethodCall* methodCall = [FlutterMethodCall methodCallWithMethodName:@"Share.invoke"
@@ -169,8 +157,6 @@ FLUTTER_ASSERT_ARC
 - (void)testShareScreenInvokedOnIPad {
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
   [engine runWithEntrypoint:nil];
-  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
-      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
 
   XCTestExpectation* presentExpectation =
       [self expectationWithDescription:@"Share view controller presented on iPad"];
@@ -187,8 +173,7 @@ FLUTTER_ASSERT_ARC
   id mockTraitCollection = OCMClassMock([UITraitCollection class]);
   OCMStub([mockTraitCollection userInterfaceIdiom]).andReturn(UIUserInterfaceIdiomPad);
 
-  FlutterPlatformPlugin* plugin =
-      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
+  FlutterPlatformPlugin* plugin = [[FlutterPlatformPlugin alloc] initWithEngine:engine];
   FlutterPlatformPlugin* mockPlugin = OCMPartialMock(plugin);
 
   FlutterMethodCall* methodCall = [FlutterMethodCall methodCallWithMethodName:@"Share.invoke"
@@ -207,10 +192,7 @@ FLUTTER_ASSERT_ARC
 - (void)testClipboardHasCorrectStrings {
   [UIPasteboard generalPasteboard].string = nil;
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
-  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
-      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
-  FlutterPlatformPlugin* plugin =
-      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
+  FlutterPlatformPlugin* plugin = [[FlutterPlatformPlugin alloc] initWithEngine:engine];
 
   XCTestExpectation* setStringExpectation = [self expectationWithDescription:@"setString"];
   FlutterResult resultSet = ^(id result) {
@@ -246,10 +228,7 @@ FLUTTER_ASSERT_ARC
 - (void)testClipboardSetDataToNullDoNotCrash {
   [UIPasteboard generalPasteboard].string = nil;
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
-  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
-      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
-  FlutterPlatformPlugin* plugin =
-      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
+  FlutterPlatformPlugin* plugin = [[FlutterPlatformPlugin alloc] initWithEngine:engine];
 
   XCTestExpectation* setStringExpectation = [self expectationWithDescription:@"setData"];
   FlutterResult resultSet = ^(id result) {
@@ -280,10 +259,7 @@ FLUTTER_ASSERT_ARC
       [[UINavigationController alloc] initWithRootViewController:flutterViewController];
   UITabBarController* tabBarController = [[UITabBarController alloc] init];
   tabBarController.viewControllers = @[ navigationController ];
-  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
-      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
-  FlutterPlatformPlugin* plugin =
-      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
+  FlutterPlatformPlugin* plugin = [[FlutterPlatformPlugin alloc] initWithEngine:engine];
 
   id navigationControllerMock = OCMPartialMock(navigationController);
   OCMStub([navigationControllerMock popViewControllerAnimated:YES]);
@@ -303,12 +279,9 @@ FLUTTER_ASSERT_ARC
 
 - (void)testWhetherDeviceHasLiveTextInputInvokeCorrectly {
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
-  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
-      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
   XCTestExpectation* invokeExpectation =
       [self expectationWithDescription:@"isLiveTextInputAvailableInvoke"];
-  FlutterPlatformPlugin* plugin =
-      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
+  FlutterPlatformPlugin* plugin = [[FlutterPlatformPlugin alloc] initWithEngine:engine];
   FlutterPlatformPlugin* mockPlugin = OCMPartialMock(plugin);
   FlutterMethodCall* methodCall =
       [FlutterMethodCall methodCallWithMethodName:@"LiveText.isLiveTextInputAvailable"
@@ -331,8 +304,6 @@ FLUTTER_ASSERT_ARC
     [engine runWithEntrypoint:nil];
     FlutterViewController* flutterViewController =
         [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
-    std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
-        std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
     XCTAssertFalse(flutterViewController.prefersStatusBarHidden);
 
     // Update to hidden.
@@ -371,8 +342,6 @@ FLUTTER_ASSERT_ARC
     [engine runWithEntrypoint:nil];
     FlutterViewController* flutterViewController =
         [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
-    std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
-        std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
     XCTAssertFalse(flutterViewController.prefersStatusBarHidden);
 
     // Update to hidden.
@@ -420,8 +389,6 @@ FLUTTER_ASSERT_ARC
   [engine runWithEntrypoint:nil];
   FlutterViewController* flutterViewController =
       [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
-  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
-      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
 
   // Update to hidden.
   FlutterPlatformPlugin* plugin = [engine platformPlugin];
@@ -471,8 +438,6 @@ FLUTTER_ASSERT_ARC
   [engine runWithEntrypoint:nil];
   FlutterViewController* flutterViewController =
       [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
-  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
-      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
   XCTAssertFalse(flutterViewController.prefersStatusBarHidden);
 
   FlutterPlatformPlugin* plugin = [engine platformPlugin];


### PR DESCRIPTION
Migrates `FlutterEnging` from manual reference counting to ARC. Migrates properties from `retain` to strong and `assign` to `weak` (where referencing an Obj-C object).

No semantic changes, therefore no changes to tests.

Issue: https://github.com/flutter/flutter/issues/137801

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] There weren't as many ARCane memory management gotchas in this patch as I'd have expected.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
