### PR TITLE
Shift --no-prebuilt-dart-sdk build to linux_unopt

### DIFF
--- a/ci/builders/linux_android_aot_engine.json
+++ b/ci/builders/linux_android_aot_engine.json
@@ -1,4 +1,12 @@
 {
+    "_comment": [
+        "The builds defined in this file should not contain tests, ",
+        "and the file should not contain builds that are essentially tests. ",
+        "The only builds in this file should be the builds necessary to produce ",
+        "release artifacts. ",
+        "Tests to run on linux hosts should go in one of the other linux_ build ",
+        "definition files."
+    ],
     "builds": [
         {
             "archives": [

--- a/ci/builders/linux_android_debug_engine.json
+++ b/ci/builders/linux_android_debug_engine.json
@@ -1,4 +1,12 @@
 {
+    "_comment": [
+        "The builds defined in this file should not contain tests, ",
+        "and the file should not contain builds that are essentially tests. ",
+        "The only builds in this file should be the builds necessary to produce ",
+        "release artifacts. ",
+        "Tests to run on linux hosts should go in one of the other linux_ build ",
+        "definition files."
+    ],
     "builds": [
         {
             "archives": [

--- a/ci/builders/linux_arm_host_engine.json
+++ b/ci/builders/linux_arm_host_engine.json
@@ -1,4 +1,12 @@
 {
+    "_comment": [
+        "The builds defined in this file should not contain tests, ",
+        "and the file should not contain builds that are essentially tests. ",
+        "The only builds in this file should be the builds necessary to produce ",
+        "release artifacts. ",
+        "Tests to run on linux hosts should go in one of the other linux_ build ",
+        "definition files."
+    ],
     "builds": [
         {
             "archives": [

--- a/ci/builders/linux_fuchsia.json
+++ b/ci/builders/linux_fuchsia.json
@@ -1,4 +1,12 @@
 {
+    "_comment": [
+        "The builds defined in this file should not contain tests, ",
+        "and the file should not contain builds that are essentially tests. ",
+        "The only builds in this file should be the builds necessary to produce ",
+        "release artifacts. ",
+        "Tests to run on linux hosts should go in one of the other linux_ build ",
+        "definition files."
+    ],
     "builds": [
         {
             "drone_dimensions": [

--- a/ci/builders/linux_host_desktop_engine.json
+++ b/ci/builders/linux_host_desktop_engine.json
@@ -1,4 +1,12 @@
 {
+    "_comment": [
+        "The builds defined in this file should not contain tests, ",
+        "and the file should not contain builds that are essentially tests. ",
+        "The only builds in this file should be the builds necessary to produce ",
+        "release artifacts. ",
+        "Tests to run on linux hosts should go in one of the other linux_ build ",
+        "definition files."
+    ],
     "builds": [
         {
             "archives": [

--- a/ci/builders/linux_host_engine.json
+++ b/ci/builders/linux_host_engine.json
@@ -1,4 +1,12 @@
 {
+    "_comment": [
+        "The builds defined in this file should not contain tests, ",
+        "and the file should not contain builds that are essentially tests. ",
+        "The only builds in this file should be the builds necessary to produce ",
+        "release artifacts. ",
+        "Tests to run on linux hosts should go in one of the other linux_ build ",
+        "definition files."
+    ],
     "builds": [
         {
             "archives": [
@@ -207,40 +215,6 @@
                         "--no-upload"
                     ]
                 }
-            ]
-        },
-        {
-            "archives": [
-            ],
-            "cas_archive": false,
-            "drone_dimensions": [
-                "device_type=none",
-                "os=Linux"
-            ],
-            "gclient_variables": {
-                "download_android_deps": false,
-                "download_jdk": false,
-                "use_rbe": true
-            },
-            "gn": [
-                "--target-dir",
-                "ci/host_debug",
-                "--runtime-mode",
-                "debug",
-                "--no-prebuilt-dart-sdk",
-                "--build-embedder-examples",
-                "--rbe",
-                "--no-goma"
-            ],
-            "name": "ci/host_debug_no_prebuilt_dart_sdk",
-            "description": "Produces debug mode Linux host-side tooling for Linux without use of prebuilt dart sdk artifacts.",
-            "ninja": {
-                "config": "ci/host_debug",
-                "targets": [
-                    "default"
-                ]
-            },
-            "tests": [
             ]
         }
     ],

--- a/ci/builders/linux_unopt.json
+++ b/ci/builders/linux_unopt.json
@@ -363,6 +363,36 @@
                     ]
                 }
             ]
+        },
+        {
+            "cas_archive": false,
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "download_jdk": false,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/host_debug",
+                "--runtime-mode",
+                "debug",
+                "--no-prebuilt-dart-sdk",
+                "--build-embedder-examples",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/host_debug_no_prebuilt_dart_sdk",
+            "description": "Produces debug mode Linux host-side tooling for Linux without use of prebuilt dart sdk artifacts.",
+            "ninja": {
+                "config": "ci/host_debug",
+                "targets": [
+                    "default"
+                ]
+            }
         }
     ]
 }

--- a/ci/builders/mac_android_aot_engine.json
+++ b/ci/builders/mac_android_aot_engine.json
@@ -1,4 +1,12 @@
 {
+    "_comment": [
+        "The builds defined in this file should not contain tests, ",
+        "and the file should not contain builds that are essentially tests. ",
+        "The only builds in this file should be the builds necessary to produce ",
+        "release artifacts. ",
+        "Tests to run on mac hosts should go in one of the other mac_ build ",
+        "definition files."
+    ],
     "builds": [
         {
             "archives": [

--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -1,4 +1,12 @@
 {
+    "_comment": [
+        "The builds defined in this file should not contain tests, ",
+        "and the file should not contain builds that are essentially tests. ",
+        "The only builds in this file should be the builds necessary to produce ",
+        "release artifacts. ",
+        "Tests to run on mac hosts should go in one of the other mac_ build ",
+        "definition files."
+    ],
     "builds": [
         {
             "drone_dimensions": [


### PR DESCRIPTION
This is my bad for not having this documented better/at-all, but since this build does not produce artifacts, it should not go under a builder that is marked as `release_build: "true"` in the .ci.yaml. This PR moves the build to `linux_unopt.json`.
