### PR TITLE
[Impeller] A text layout and shaping API for the standalone library.

### DIFF
--- a/impeller/toolkit/interop/BUILD.gn
+++ b/impeller/toolkit/interop/BUILD.gn
@@ -4,6 +4,14 @@
 
 import("//flutter/impeller/tools/impeller.gni")
 
+embed_blob("embedded_icu_data") {
+  symbol_name = "embedded_icu_data"
+  blob = "//flutter/third_party/icu/flutter/icudtl.dat"
+  hdr = "$target_gen_dir/embedded_icu_data.h"
+  cc = "$target_gen_dir/embedded_icu_data.cc"
+  deps = []
+}
+
 impeller_component("interop") {
   sources = [
     "color_filter.cc",
@@ -29,6 +37,12 @@ impeller_component("interop") {
     "object.h",
     "paint.cc",
     "paint.h",
+    "paragraph.cc",
+    "paragraph.h",
+    "paragraph_builder.cc",
+    "paragraph_builder.h",
+    "paragraph_style.cc",
+    "paragraph_style.h",
     "path.cc",
     "path.h",
     "path_builder.cc",
@@ -37,16 +51,21 @@ impeller_component("interop") {
     "surface.h",
     "texture.cc",
     "texture.h",
+    "typography_context.cc",
+    "typography_context.h",
   ]
 
-  deps = [
+  public_deps = [
     "../../base",
     "../../display_list",
     "../../entity",
     "../../renderer/backend",
     "//flutter/display_list",
     "//flutter/fml",
+    "//flutter/third_party/txt",
   ]
+
+  deps = [ ":embedded_icu_data" ]
 }
 
 impeller_component("library") {

--- a/impeller/toolkit/interop/dl_builder.cc
+++ b/impeller/toolkit/interop/dl_builder.cc
@@ -176,4 +176,13 @@ void DisplayListBuilder::DrawTextureRect(const Texture& texture,
   );
 }
 
+void DisplayListBuilder::DrawParagraph(const Paragraph& paragraph,
+                                       Point point) {
+  const auto& handle = paragraph.GetHandle();
+  if (!handle) {
+    return;
+  }
+  handle->Paint(&builder_, point.x, point.y);
+}
+
 }  // namespace impeller::interop

--- a/impeller/toolkit/interop/dl_builder.h
+++ b/impeller/toolkit/interop/dl_builder.h
@@ -15,6 +15,7 @@
 #include "impeller/toolkit/interop/impeller.h"
 #include "impeller/toolkit/interop/object.h"
 #include "impeller/toolkit/interop/paint.h"
+#include "impeller/toolkit/interop/paragraph.h"
 #include "impeller/toolkit/interop/path.h"
 #include "impeller/toolkit/interop/texture.h"
 
@@ -105,6 +106,8 @@ class DisplayListBuilder final
                        const Paint* paint);
 
   void DrawDisplayList(const DisplayList& dl, Scalar opacity);
+
+  void DrawParagraph(const Paragraph& paragraph, Point point);
 
   ScopedObject<DisplayList> Build();
 

--- a/impeller/toolkit/interop/formats.h
+++ b/impeller/toolkit/interop/formats.h
@@ -9,6 +9,9 @@
 
 #include "flutter/display_list/dl_builder.h"
 #include "flutter/display_list/dl_color.h"
+#include "flutter/third_party/txt/src/txt/font_style.h"
+#include "flutter/third_party/txt/src/txt/font_weight.h"
+#include "flutter/third_party/txt/src/txt/paragraph_style.h"
 #include "impeller/entity/entity.h"
 #include "impeller/geometry/color.h"
 #include "impeller/geometry/matrix.h"
@@ -416,6 +419,68 @@ constexpr flutter::DlColor ToDisplayListType(ImpellerColor color) {
                           color.blue,                           //
                           ToDisplayListType(color.color_space)  //
   );
+}
+
+constexpr txt::FontWeight ToTxtType(ImpellerFontWeight weight) {
+  switch (weight) {
+    case ImpellerFontWeight100:
+      return txt::FontWeight::w100;
+    case ImpellerFontWeight200:
+      return txt::FontWeight::w200;
+    case ImpellerFontWeight300:
+      return txt::FontWeight::w300;
+    case ImpellerFontWeight400:
+      return txt::FontWeight::w400;
+    case ImpellerFontWeight500:
+      return txt::FontWeight::w500;
+    case ImpellerFontWeight600:
+      return txt::FontWeight::w600;
+    case ImpellerFontWeight700:
+      return txt::FontWeight::w700;
+    case ImpellerFontWeight800:
+      return txt::FontWeight::w800;
+    case ImpellerFontWeight900:
+      return txt::FontWeight::w900;
+  }
+  return txt::FontWeight::w400;
+}
+
+constexpr txt::FontStyle ToTxtType(ImpellerFontStyle style) {
+  switch (style) {
+    case ImpellerFontStyleNormal:
+      return txt::FontStyle::normal;
+    case ImpellerFontStyleItalic:
+      return txt::FontStyle::italic;
+  }
+  return txt::FontStyle::normal;
+}
+
+constexpr txt::TextAlign ToTxtType(ImpellerTextAlignment align) {
+  switch (align) {
+    case ImpellerTextAlignmentLeft:
+      return txt::TextAlign::left;
+    case ImpellerTextAlignmentRight:
+      return txt::TextAlign::right;
+    case ImpellerTextAlignmentCenter:
+      return txt::TextAlign::center;
+    case ImpellerTextAlignmentJustify:
+      return txt::TextAlign::justify;
+    case ImpellerTextAlignmentStart:
+      return txt::TextAlign::start;
+    case ImpellerTextAlignmentEnd:
+      return txt::TextAlign::end;
+  }
+  return txt::TextAlign::left;
+}
+
+constexpr txt::TextDirection ToTxtType(ImpellerTextDirection direction) {
+  switch (direction) {
+    case ImpellerTextDirectionRTL:
+      return txt::TextDirection::rtl;
+    case ImpellerTextDirectionLTR:
+      return txt::TextDirection::ltr;
+  }
+  return txt::TextDirection::ltr;
 }
 
 }  // namespace impeller::interop

--- a/impeller/toolkit/interop/formats.h
+++ b/impeller/toolkit/interop/formats.h
@@ -423,23 +423,23 @@ constexpr flutter::DlColor ToDisplayListType(ImpellerColor color) {
 
 constexpr txt::FontWeight ToTxtType(ImpellerFontWeight weight) {
   switch (weight) {
-    case ImpellerFontWeight100:
+    case kImpellerFontWeight100:
       return txt::FontWeight::w100;
-    case ImpellerFontWeight200:
+    case kImpellerFontWeight200:
       return txt::FontWeight::w200;
-    case ImpellerFontWeight300:
+    case kImpellerFontWeight300:
       return txt::FontWeight::w300;
-    case ImpellerFontWeight400:
+    case kImpellerFontWeight400:
       return txt::FontWeight::w400;
-    case ImpellerFontWeight500:
+    case kImpellerFontWeight500:
       return txt::FontWeight::w500;
-    case ImpellerFontWeight600:
+    case kImpellerFontWeight600:
       return txt::FontWeight::w600;
-    case ImpellerFontWeight700:
+    case kImpellerFontWeight700:
       return txt::FontWeight::w700;
-    case ImpellerFontWeight800:
+    case kImpellerFontWeight800:
       return txt::FontWeight::w800;
-    case ImpellerFontWeight900:
+    case kImpellerFontWeight900:
       return txt::FontWeight::w900;
   }
   return txt::FontWeight::w400;
@@ -447,9 +447,9 @@ constexpr txt::FontWeight ToTxtType(ImpellerFontWeight weight) {
 
 constexpr txt::FontStyle ToTxtType(ImpellerFontStyle style) {
   switch (style) {
-    case ImpellerFontStyleNormal:
+    case kImpellerFontStyleNormal:
       return txt::FontStyle::normal;
-    case ImpellerFontStyleItalic:
+    case kImpellerFontStyleItalic:
       return txt::FontStyle::italic;
   }
   return txt::FontStyle::normal;
@@ -457,17 +457,17 @@ constexpr txt::FontStyle ToTxtType(ImpellerFontStyle style) {
 
 constexpr txt::TextAlign ToTxtType(ImpellerTextAlignment align) {
   switch (align) {
-    case ImpellerTextAlignmentLeft:
+    case kImpellerTextAlignmentLeft:
       return txt::TextAlign::left;
-    case ImpellerTextAlignmentRight:
+    case kImpellerTextAlignmentRight:
       return txt::TextAlign::right;
-    case ImpellerTextAlignmentCenter:
+    case kImpellerTextAlignmentCenter:
       return txt::TextAlign::center;
-    case ImpellerTextAlignmentJustify:
+    case kImpellerTextAlignmentJustify:
       return txt::TextAlign::justify;
-    case ImpellerTextAlignmentStart:
+    case kImpellerTextAlignmentStart:
       return txt::TextAlign::start;
-    case ImpellerTextAlignmentEnd:
+    case kImpellerTextAlignmentEnd:
       return txt::TextAlign::end;
   }
   return txt::TextAlign::left;
@@ -475,9 +475,9 @@ constexpr txt::TextAlign ToTxtType(ImpellerTextAlignment align) {
 
 constexpr txt::TextDirection ToTxtType(ImpellerTextDirection direction) {
   switch (direction) {
-    case ImpellerTextDirectionRTL:
+    case kImpellerTextDirectionRTL:
       return txt::TextDirection::rtl;
-    case ImpellerTextDirectionLTR:
+    case kImpellerTextDirectionLTR:
       return txt::TextDirection::ltr;
   }
   return txt::TextDirection::ltr;

--- a/impeller/toolkit/interop/impeller.cc
+++ b/impeller/toolkit/interop/impeller.cc
@@ -7,6 +7,7 @@
 #include <sstream>
 
 #include "flutter/fml/mapping.h"
+#include "flutter/fml/string_conversion.h"
 #include "impeller/base/validation.h"
 #include "impeller/geometry/scalar.h"
 #include "impeller/toolkit/interop/color_filter.h"
@@ -18,10 +19,14 @@
 #include "impeller/toolkit/interop/mask_filter.h"
 #include "impeller/toolkit/interop/object.h"
 #include "impeller/toolkit/interop/paint.h"
+#include "impeller/toolkit/interop/paragraph.h"
+#include "impeller/toolkit/interop/paragraph_builder.h"
+#include "impeller/toolkit/interop/paragraph_style.h"
 #include "impeller/toolkit/interop/path.h"
 #include "impeller/toolkit/interop/path_builder.h"
 #include "impeller/toolkit/interop/surface.h"
 #include "impeller/toolkit/interop/texture.h"
+#include "impeller/toolkit/interop/typography_context.h"
 
 namespace impeller::interop {
 
@@ -38,10 +43,14 @@ DEFINE_PEER_GETTER(DisplayListBuilder, ImpellerDisplayListBuilder);
 DEFINE_PEER_GETTER(ImageFilter, ImpellerImageFilter);
 DEFINE_PEER_GETTER(MaskFilter, ImpellerMaskFilter);
 DEFINE_PEER_GETTER(Paint, ImpellerPaint);
+DEFINE_PEER_GETTER(Paragraph, ImpellerParagraph);
+DEFINE_PEER_GETTER(ParagraphBuilder, ImpellerParagraphBuilder);
+DEFINE_PEER_GETTER(ParagraphStyle, ImpellerParagraphStyle);
 DEFINE_PEER_GETTER(Path, ImpellerPath);
 DEFINE_PEER_GETTER(PathBuilder, ImpellerPathBuilder);
 DEFINE_PEER_GETTER(Surface, ImpellerSurface);
 DEFINE_PEER_GETTER(Texture, ImpellerTexture);
+DEFINE_PEER_GETTER(TypographyContext, ImpellerTypographyContext);
 
 static std::string GetVersionAsString(uint32_t version) {
   std::stringstream stream;
@@ -453,8 +462,8 @@ IMPELLER_EXTERN_C
 ImpellerTexture ImpellerTextureCreateWithContentsNew(
     ImpellerContext context,
     const ImpellerTextureDescriptor* descriptor,
-    const ImpellerMapping* IMPELLER_NONNULL contents,
-    void* IMPELLER_NULLABLE contents_on_release_user_data) {
+    const ImpellerMapping* contents,
+    void* contents_on_release_user_data) {
   TextureDescriptor desc;
   desc.storage_mode = StorageMode::kDevicePrivate;
   desc.type = TextureType::kTexture2D;
@@ -815,6 +824,227 @@ void ImpellerPaintSetImageFilter(ImpellerPaint paint,
 void ImpellerPaintSetMaskFilter(ImpellerPaint paint,
                                 ImpellerMaskFilter mask_filter) {
   GetPeer(paint)->SetMaskFilter(*GetPeer(mask_filter));
+}
+
+IMPELLER_EXTERN_C ImpellerParagraphStyle ImpellerParagraphStyleNew() {
+  return Create<ParagraphStyle>().Leak();
+}
+
+IMPELLER_EXTERN_C
+void ImpellerParagraphStyleRetain(ImpellerParagraphStyle paragraph_style) {
+  ObjectBase::SafeRetain(paragraph_style);
+}
+
+IMPELLER_EXTERN_C
+void ImpellerParagraphStyleRelease(ImpellerParagraphStyle paragraph_style) {
+  ObjectBase::SafeRelease(paragraph_style);
+}
+
+IMPELLER_EXTERN_C
+void ImpellerParagraphStyleSetForeground(ImpellerParagraphStyle paragraph_style,
+                                         ImpellerPaint paint) {
+  GetPeer(paragraph_style)->SetForeground(Ref(GetPeer(paint)));
+}
+
+IMPELLER_EXTERN_C void ImpellerParagraphStyleSetBackground(
+    ImpellerParagraphStyle paragraph_style,
+    ImpellerPaint paint) {
+  GetPeer(paragraph_style)->SetBackground(Ref(GetPeer(paint)));
+}
+
+IMPELLER_EXTERN_C
+void ImpellerParagraphStyleSetFontWeight(ImpellerParagraphStyle paragraph_style,
+                                         ImpellerFontWeight weight) {
+  GetPeer(paragraph_style)->SetFontWeight(ToTxtType(weight));
+}
+
+IMPELLER_EXTERN_C
+void ImpellerParagraphStyleSetFontStyle(ImpellerParagraphStyle paragraph_style,
+                                        ImpellerFontStyle style) {
+  GetPeer(paragraph_style)->SetFontStyle(ToTxtType(style));
+}
+
+static std::string ReadString(const char* string) {
+  if (string == nullptr) {
+    return "";
+  }
+  return std::string{string};
+}
+
+IMPELLER_EXTERN_C
+void ImpellerParagraphStyleSetFontFamily(ImpellerParagraphStyle paragraph_style,
+                                         const char* family_name) {
+  GetPeer(paragraph_style)->SetFontFamily(ReadString(family_name));
+}
+
+IMPELLER_EXTERN_C
+void ImpellerParagraphStyleSetFontSize(ImpellerParagraphStyle paragraph_style,
+                                       float size) {
+  GetPeer(paragraph_style)->SetFontSize(size);
+}
+
+IMPELLER_EXTERN_C
+void ImpellerParagraphStyleSetHeight(ImpellerParagraphStyle paragraph_style,
+                                     float height) {
+  GetPeer(paragraph_style)->SetHeight(height);
+}
+
+IMPELLER_EXTERN_C
+void ImpellerParagraphStyleSetTextAlignment(
+    ImpellerParagraphStyle paragraph_style,
+    ImpellerTextAlignment align) {
+  GetPeer(paragraph_style)->SetTextAlignment(ToTxtType(align));
+}
+
+IMPELLER_EXTERN_C
+void ImpellerParagraphStyleSetTextDirection(
+    ImpellerParagraphStyle paragraph_style,
+    ImpellerTextDirection direction) {
+  GetPeer(paragraph_style)->SetTextDirection(ToTxtType(direction));
+}
+
+IMPELLER_EXTERN_C
+void ImpellerParagraphStyleSetMaxLines(ImpellerParagraphStyle paragraph_style,
+                                       uint32_t max_lines) {
+  GetPeer(paragraph_style)->SetMaxLines(max_lines);
+}
+
+IMPELLER_EXTERN_C
+void ImpellerParagraphStyleSetLocale(ImpellerParagraphStyle paragraph_style,
+                                     const char* locale) {
+  GetPeer(paragraph_style)->SetLocale(ReadString(locale));
+}
+
+IMPELLER_EXTERN_C
+void ImpellerDisplayListBuilderDrawParagraph(ImpellerDisplayListBuilder builder,
+                                             ImpellerParagraph paragraph,
+                                             const ImpellerPoint* point) {
+  GetPeer(builder)->DrawParagraph(*GetPeer(paragraph), ToImpellerType(*point));
+}
+
+IMPELLER_EXTERN_C ImpellerParagraphBuilder ImpellerParagraphBuilderNew(
+    ImpellerTypographyContext context) {
+  auto builder = Create<ParagraphBuilder>(*GetPeer(context));
+  if (!builder->IsValid()) {
+    VALIDATION_LOG << "Could not create valid paragraph builder.";
+    return nullptr;
+  }
+  return builder.Leak();
+}
+
+IMPELLER_EXTERN_C
+void ImpellerParagraphBuilderRetain(
+    ImpellerParagraphBuilder paragraph_builder) {
+  ObjectBase::SafeRetain(paragraph_builder);
+}
+
+IMPELLER_EXTERN_C
+void ImpellerParagraphBuilderRelease(
+    ImpellerParagraphBuilder paragraph_builder) {
+  ObjectBase::SafeRelease(paragraph_builder);
+}
+
+IMPELLER_EXTERN_C
+void ImpellerParagraphBuilderPushStyle(
+    ImpellerParagraphBuilder paragraph_builder,
+    ImpellerParagraphStyle style) {
+  GetPeer(paragraph_builder)->PushStyle(*GetPeer(style));
+}
+
+IMPELLER_EXTERN_C
+void ImpellerParagraphBuilderPopStyle(
+    ImpellerParagraphBuilder paragraph_builder) {
+  GetPeer(paragraph_builder)->PopStyle();
+}
+
+IMPELLER_EXTERN_C
+void ImpellerParagraphBuilderAddText(ImpellerParagraphBuilder paragraph_builder,
+                                     const uint8_t* data,
+                                     uint32_t length) {
+  if (data == nullptr) {
+    length = 0;
+  }
+  if (length == 0) {
+    return;
+  }
+  GetPeer(paragraph_builder)
+      ->AddText(fml::Utf8ToUtf16(
+          std::string_view{reinterpret_cast<const char*>(data), length}));
+}
+
+IMPELLER_EXTERN_C ImpellerParagraph ImpellerParagraphBuilderBuildParagraphNew(
+    ImpellerParagraphBuilder paragraph_builder,
+    float width) {
+  return GetPeer(paragraph_builder)->Build(width).Leak();
+}
+
+IMPELLER_EXTERN_C
+void ImpellerParagraphRetain(ImpellerParagraph paragraph) {
+  ObjectBase::SafeRetain(paragraph);
+}
+
+IMPELLER_EXTERN_C
+void ImpellerParagraphRelease(ImpellerParagraph paragraph) {
+  ObjectBase::SafeRelease(paragraph);
+}
+
+IMPELLER_EXTERN_C
+float ImpellerParagraphGetMaxWidth(ImpellerParagraph paragraph) {
+  return GetPeer(paragraph)->GetMaxWidth();
+}
+
+IMPELLER_EXTERN_C
+float ImpellerParagraphGetHeight(ImpellerParagraph paragraph) {
+  return GetPeer(paragraph)->GetHeight();
+}
+
+IMPELLER_EXTERN_C
+float ImpellerParagraphGetLongestLineWidth(ImpellerParagraph paragraph) {
+  return GetPeer(paragraph)->GetLongestLineWidth();
+}
+
+IMPELLER_EXTERN_C
+float ImpellerParagraphGetMinInstrinsicWidth(ImpellerParagraph paragraph) {
+  return GetPeer(paragraph)->GetMinIntrinsicWidth();
+}
+
+IMPELLER_EXTERN_C
+float ImpellerParagraphGetMaxInstrinsicWidth(ImpellerParagraph paragraph) {
+  return GetPeer(paragraph)->GetMaxInstrinsicWidth();
+}
+
+IMPELLER_EXTERN_C
+float ImpellerParagraphGetIdeographicBaseline(ImpellerParagraph paragraph) {
+  return GetPeer(paragraph)->GetIdeographicBaseline();
+}
+
+IMPELLER_EXTERN_C
+float ImpellerParagraphGetAlphabeticBaseline(ImpellerParagraph paragraph) {
+  return GetPeer(paragraph)->GetAlphabeticBaseline();
+}
+
+IMPELLER_EXTERN_C
+uint32_t ImpellerParagraphGetLineCount(ImpellerParagraph paragraph) {
+  return GetPeer(paragraph)->GetLineCount();
+}
+
+IMPELLER_EXTERN_C ImpellerTypographyContext ImpellerTypographyContextNew() {
+  auto context = Create<TypographyContext>();
+  if (!context->IsValid()) {
+    VALIDATION_LOG << "Could not create typography context.";
+    return nullptr;
+  }
+  return Create<TypographyContext>().Leak();
+}
+
+IMPELLER_EXTERN_C
+void ImpellerTypographyContextRetain(ImpellerTypographyContext context) {
+  ObjectBase::SafeRetain(context);
+}
+
+IMPELLER_EXTERN_C
+void ImpellerTypographyContextRelease(ImpellerTypographyContext context) {
+  ObjectBase::SafeRelease(context);
 }
 
 }  // namespace impeller::interop

--- a/impeller/toolkit/interop/impeller.cc
+++ b/impeller/toolkit/interop/impeller.cc
@@ -7,7 +7,6 @@
 #include <sstream>
 
 #include "flutter/fml/mapping.h"
-#include "flutter/fml/string_conversion.h"
 #include "impeller/base/validation.h"
 #include "impeller/geometry/scalar.h"
 #include "impeller/toolkit/interop/color_filter.h"
@@ -967,9 +966,7 @@ void ImpellerParagraphBuilderAddText(ImpellerParagraphBuilder paragraph_builder,
   if (length == 0) {
     return;
   }
-  GetPeer(paragraph_builder)
-      ->AddText(fml::Utf8ToUtf16(
-          std::string_view{reinterpret_cast<const char*>(data), length}));
+  GetPeer(paragraph_builder)->AddText(data, length);
 }
 
 IMPELLER_EXTERN_C ImpellerParagraph ImpellerParagraphBuilderBuildParagraphNew(

--- a/impeller/toolkit/interop/impeller.h
+++ b/impeller/toolkit/interop/impeller.h
@@ -198,34 +198,34 @@ typedef enum ImpellerColorSpace {
 } ImpellerColorSpace;
 
 typedef enum ImpellerFontWeight {
-  ImpellerFontWeight100,  // Thin
-  ImpellerFontWeight200,  // Extra-Light
-  ImpellerFontWeight300,  // Light
-  ImpellerFontWeight400,  // Normal/Regular
-  ImpellerFontWeight500,  // Medium
-  ImpellerFontWeight600,  // Semi-bold
-  ImpellerFontWeight700,  // Bold
-  ImpellerFontWeight800,  // Extra-Bold
-  ImpellerFontWeight900,  // Black
+  kImpellerFontWeight100,  // Thin
+  kImpellerFontWeight200,  // Extra-Light
+  kImpellerFontWeight300,  // Light
+  kImpellerFontWeight400,  // Normal/Regular
+  kImpellerFontWeight500,  // Medium
+  kImpellerFontWeight600,  // Semi-bold
+  kImpellerFontWeight700,  // Bold
+  kImpellerFontWeight800,  // Extra-Bold
+  kImpellerFontWeight900,  // Black
 } ImpellerFontWeight;
 
 typedef enum ImpellerFontStyle {
-  ImpellerFontStyleNormal,
-  ImpellerFontStyleItalic,
+  kImpellerFontStyleNormal,
+  kImpellerFontStyleItalic,
 } ImpellerFontStyle;
 
 typedef enum ImpellerTextAlignment {
-  ImpellerTextAlignmentLeft,
-  ImpellerTextAlignmentRight,
-  ImpellerTextAlignmentCenter,
-  ImpellerTextAlignmentJustify,
-  ImpellerTextAlignmentStart,
-  ImpellerTextAlignmentEnd,
+  kImpellerTextAlignmentLeft,
+  kImpellerTextAlignmentRight,
+  kImpellerTextAlignmentCenter,
+  kImpellerTextAlignmentJustify,
+  kImpellerTextAlignmentStart,
+  kImpellerTextAlignmentEnd,
 } ImpellerTextAlignment;
 
 typedef enum ImpellerTextDirection {
-  ImpellerTextDirectionRTL,
-  ImpellerTextDirectionLTR,
+  kImpellerTextDirectionRTL,
+  kImpellerTextDirectionLTR,
 } ImpellerTextDirection;
 
 //------------------------------------------------------------------------------

--- a/impeller/toolkit/interop/impeller.h
+++ b/impeller/toolkit/interop/impeller.h
@@ -57,7 +57,7 @@ IMPELLER_EXTERN_C_BEGIN
 
 #define IMPELLER_VERSION_VARIANT 1
 #define IMPELLER_VERSION_MAJOR 1
-#define IMPELLER_VERSION_MINOR 0
+#define IMPELLER_VERSION_MINOR 1
 #define IMPELLER_VERSION_PATCH 0
 
 #define IMPELLER_VERSION                                                  \
@@ -87,10 +87,14 @@ IMPELLER_DEFINE_HANDLE(ImpellerDisplayListBuilder);
 IMPELLER_DEFINE_HANDLE(ImpellerImageFilter);
 IMPELLER_DEFINE_HANDLE(ImpellerMaskFilter);
 IMPELLER_DEFINE_HANDLE(ImpellerPaint);
+IMPELLER_DEFINE_HANDLE(ImpellerParagraph);
+IMPELLER_DEFINE_HANDLE(ImpellerParagraphBuilder);
+IMPELLER_DEFINE_HANDLE(ImpellerParagraphStyle);
 IMPELLER_DEFINE_HANDLE(ImpellerPath);
 IMPELLER_DEFINE_HANDLE(ImpellerPathBuilder);
 IMPELLER_DEFINE_HANDLE(ImpellerSurface);
 IMPELLER_DEFINE_HANDLE(ImpellerTexture);
+IMPELLER_DEFINE_HANDLE(ImpellerTypographyContext);
 
 //------------------------------------------------------------------------------
 // Signatures
@@ -192,6 +196,37 @@ typedef enum ImpellerColorSpace {
   kImpellerColorSpaceExtendedSRGB,
   kImpellerColorSpaceDisplayP3,
 } ImpellerColorSpace;
+
+typedef enum ImpellerFontWeight {
+  ImpellerFontWeight100,  // Thin
+  ImpellerFontWeight200,  // Extra-Light
+  ImpellerFontWeight300,  // Light
+  ImpellerFontWeight400,  // Normal/Regular
+  ImpellerFontWeight500,  // Medium
+  ImpellerFontWeight600,  // Semi-bold
+  ImpellerFontWeight700,  // Bold
+  ImpellerFontWeight800,  // Extra-Bold
+  ImpellerFontWeight900,  // Black
+} ImpellerFontWeight;
+
+typedef enum ImpellerFontStyle {
+  ImpellerFontStyleNormal,
+  ImpellerFontStyleItalic,
+} ImpellerFontStyle;
+
+typedef enum ImpellerTextAlignment {
+  ImpellerTextAlignmentLeft,
+  ImpellerTextAlignmentRight,
+  ImpellerTextAlignmentCenter,
+  ImpellerTextAlignmentJustify,
+  ImpellerTextAlignmentStart,
+  ImpellerTextAlignmentEnd,
+} ImpellerTextAlignment;
+
+typedef enum ImpellerTextDirection {
+  ImpellerTextDirectionRTL,
+  ImpellerTextDirectionLTR,
+} ImpellerTextDirection;
 
 //------------------------------------------------------------------------------
 // Non-opaque structs
@@ -755,6 +790,12 @@ void ImpellerDisplayListBuilderDrawDisplayList(
     ImpellerDisplayList IMPELLER_NONNULL display_list,
     float opacity);
 
+IMPELLER_EXPORT
+void ImpellerDisplayListBuilderDrawParagraph(
+    ImpellerDisplayListBuilder IMPELLER_NONNULL builder,
+    ImpellerParagraph IMPELLER_NONNULL paragraph,
+    const ImpellerPoint* IMPELLER_NONNULL point);
+
 //------------------------------------------------------------------------------
 // Display List Builder: Drawing Textures
 //------------------------------------------------------------------------------
@@ -775,6 +816,167 @@ void ImpellerDisplayListBuilderDrawTextureRect(
     const ImpellerRect* IMPELLER_NONNULL dst_rect,
     ImpellerTextureSampling sampling,
     ImpellerPaint IMPELLER_NULLABLE paint);
+
+//------------------------------------------------------------------------------
+// Typography Context
+//------------------------------------------------------------------------------
+
+IMPELLER_EXPORT IMPELLER_NODISCARD ImpellerTypographyContext IMPELLER_NULLABLE
+ImpellerTypographyContextNew();
+
+IMPELLER_EXPORT
+void ImpellerTypographyContextRetain(
+    ImpellerTypographyContext IMPELLER_NULLABLE context);
+
+IMPELLER_EXPORT
+void ImpellerTypographyContextRelease(
+    ImpellerTypographyContext IMPELLER_NULLABLE context);
+
+//------------------------------------------------------------------------------
+// Paragraph Style
+//------------------------------------------------------------------------------
+
+IMPELLER_EXPORT IMPELLER_NODISCARD ImpellerParagraphStyle IMPELLER_NULLABLE
+ImpellerParagraphStyleNew();
+
+IMPELLER_EXPORT
+void ImpellerParagraphStyleRetain(
+    ImpellerParagraphStyle IMPELLER_NULLABLE paragraph_style);
+
+IMPELLER_EXPORT
+void ImpellerParagraphStyleRelease(
+    ImpellerParagraphStyle IMPELLER_NULLABLE paragraph_style);
+
+IMPELLER_EXPORT
+void ImpellerParagraphStyleSetForeground(
+    ImpellerParagraphStyle IMPELLER_NONNULL paragraph_style,
+    ImpellerPaint IMPELLER_NONNULL paint);
+
+IMPELLER_EXPORT
+void ImpellerParagraphStyleSetBackground(
+    ImpellerParagraphStyle IMPELLER_NONNULL paragraph_style,
+    ImpellerPaint IMPELLER_NONNULL paint);
+
+IMPELLER_EXPORT
+void ImpellerParagraphStyleSetFontWeight(
+    ImpellerParagraphStyle IMPELLER_NONNULL paragraph_style,
+    ImpellerFontWeight weight);
+
+IMPELLER_EXPORT
+void ImpellerParagraphStyleSetFontStyle(
+    ImpellerParagraphStyle IMPELLER_NONNULL paragraph_style,
+    ImpellerFontStyle style);
+
+IMPELLER_EXPORT
+void ImpellerParagraphStyleSetFontFamily(
+    ImpellerParagraphStyle IMPELLER_NONNULL paragraph_style,
+    const char* IMPELLER_NONNULL family_name);
+
+IMPELLER_EXPORT
+void ImpellerParagraphStyleSetFontSize(
+    ImpellerParagraphStyle IMPELLER_NONNULL paragraph_style,
+    float size);
+
+IMPELLER_EXPORT
+void ImpellerParagraphStyleSetHeight(
+    ImpellerParagraphStyle IMPELLER_NONNULL paragraph_style,
+    float height);
+
+IMPELLER_EXPORT
+void ImpellerParagraphStyleSetTextAlignment(
+    ImpellerParagraphStyle IMPELLER_NONNULL paragraph_style,
+    ImpellerTextAlignment align);
+
+IMPELLER_EXPORT
+void ImpellerParagraphStyleSetTextDirection(
+    ImpellerParagraphStyle IMPELLER_NONNULL paragraph_style,
+    ImpellerTextDirection direction);
+
+IMPELLER_EXPORT
+void ImpellerParagraphStyleSetMaxLines(
+    ImpellerParagraphStyle IMPELLER_NONNULL paragraph_style,
+    uint32_t max_lines);
+
+IMPELLER_EXPORT
+void ImpellerParagraphStyleSetLocale(
+    ImpellerParagraphStyle IMPELLER_NONNULL paragraph_style,
+    const char* IMPELLER_NONNULL locale);
+
+//------------------------------------------------------------------------------
+// Paragraph Builder
+//------------------------------------------------------------------------------
+
+IMPELLER_EXPORT IMPELLER_NODISCARD ImpellerParagraphBuilder IMPELLER_NULLABLE
+ImpellerParagraphBuilderNew(ImpellerTypographyContext IMPELLER_NONNULL context);
+
+IMPELLER_EXPORT
+void ImpellerParagraphBuilderRetain(
+    ImpellerParagraphBuilder IMPELLER_NULLABLE paragraph_builder);
+
+IMPELLER_EXPORT
+void ImpellerParagraphBuilderRelease(
+    ImpellerParagraphBuilder IMPELLER_NULLABLE paragraph_builder);
+
+IMPELLER_EXPORT
+void ImpellerParagraphBuilderPushStyle(
+    ImpellerParagraphBuilder IMPELLER_NONNULL paragraph_builder,
+    ImpellerParagraphStyle IMPELLER_NONNULL style);
+
+IMPELLER_EXPORT
+void ImpellerParagraphBuilderPopStyle(
+    ImpellerParagraphBuilder IMPELLER_NONNULL paragraph_builder);
+
+IMPELLER_EXPORT
+void ImpellerParagraphBuilderAddText(
+    ImpellerParagraphBuilder IMPELLER_NONNULL paragraph_builder,
+    const uint8_t* IMPELLER_NULLABLE data,
+    uint32_t length);
+
+IMPELLER_EXPORT IMPELLER_NODISCARD ImpellerParagraph IMPELLER_NULLABLE
+ImpellerParagraphBuilderBuildParagraphNew(
+    ImpellerParagraphBuilder IMPELLER_NONNULL paragraph_builder,
+    float width);
+
+//------------------------------------------------------------------------------
+// Paragraph
+//------------------------------------------------------------------------------
+
+IMPELLER_EXPORT
+void ImpellerParagraphRetain(ImpellerParagraph IMPELLER_NULLABLE paragraph);
+
+IMPELLER_EXPORT
+void ImpellerParagraphRelease(ImpellerParagraph IMPELLER_NULLABLE paragraph);
+
+IMPELLER_EXPORT
+float ImpellerParagraphGetMaxWidth(
+    ImpellerParagraph IMPELLER_NONNULL paragraph);
+
+IMPELLER_EXPORT
+float ImpellerParagraphGetHeight(ImpellerParagraph IMPELLER_NONNULL paragraph);
+
+IMPELLER_EXPORT
+float ImpellerParagraphGetLongestLineWidth(
+    ImpellerParagraph IMPELLER_NONNULL paragraph);
+
+IMPELLER_EXPORT
+float ImpellerParagraphGetMinInstrinsicWidth(
+    ImpellerParagraph IMPELLER_NONNULL paragraph);
+
+IMPELLER_EXPORT
+float ImpellerParagraphGetMaxInstrinsicWidth(
+    ImpellerParagraph IMPELLER_NONNULL paragraph);
+
+IMPELLER_EXPORT
+float ImpellerParagraphGetIdeographicBaseline(
+    ImpellerParagraph IMPELLER_NONNULL paragraph);
+
+IMPELLER_EXPORT
+float ImpellerParagraphGetAlphabeticBaseline(
+    ImpellerParagraph IMPELLER_NONNULL paragraph);
+
+IMPELLER_EXPORT
+uint32_t ImpellerParagraphGetLineCount(
+    ImpellerParagraph IMPELLER_NONNULL paragraph);
 
 IMPELLER_EXTERN_C_END
 

--- a/impeller/toolkit/interop/paragraph.cc
+++ b/impeller/toolkit/interop/paragraph.cc
@@ -1,0 +1,50 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/toolkit/interop/paragraph.h"
+
+namespace impeller::interop {
+
+Paragraph::Paragraph(std::unique_ptr<txt::Paragraph> paragraph)
+    : paragraph_(std::move(paragraph)) {}
+
+Paragraph::~Paragraph() = default;
+
+Scalar Paragraph::GetMaxWidth() const {
+  return paragraph_->GetMaxWidth();
+}
+
+Scalar Paragraph::GetHeight() const {
+  return paragraph_->GetHeight();
+}
+
+Scalar Paragraph::GetLongestLineWidth() const {
+  return paragraph_->GetLongestLine();
+}
+
+Scalar Paragraph::GetMinIntrinsicWidth() const {
+  return paragraph_->GetMinIntrinsicWidth();
+}
+
+Scalar Paragraph::GetMaxInstrinsicWidth() const {
+  return paragraph_->GetMaxIntrinsicWidth();
+}
+
+Scalar Paragraph::GetIdeographicBaseline() const {
+  return paragraph_->GetIdeographicBaseline();
+}
+
+Scalar Paragraph::GetAlphabeticBaseline() const {
+  return paragraph_->GetAlphabeticBaseline();
+}
+
+uint32_t Paragraph::GetLineCount() const {
+  return paragraph_->GetNumberOfLines();
+}
+
+const std::unique_ptr<txt::Paragraph>& Paragraph::GetHandle() const {
+  return paragraph_;
+}
+
+}  // namespace impeller::interop

--- a/impeller/toolkit/interop/paragraph.h
+++ b/impeller/toolkit/interop/paragraph.h
@@ -1,0 +1,50 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_TOOLKIT_INTEROP_PARAGRAPH_H_
+#define FLUTTER_IMPELLER_TOOLKIT_INTEROP_PARAGRAPH_H_
+
+#include "flutter/third_party/txt/src/txt/paragraph.h"
+#include "impeller/toolkit/interop/impeller.h"
+#include "impeller/toolkit/interop/object.h"
+
+namespace impeller::interop {
+
+class Paragraph final
+    : public Object<Paragraph,
+                    IMPELLER_INTERNAL_HANDLE_NAME(ImpellerParagraph)> {
+ public:
+  explicit Paragraph(std::unique_ptr<txt::Paragraph> paragraph);
+
+  ~Paragraph() override;
+
+  Paragraph(const Paragraph&) = delete;
+
+  Paragraph& operator=(const Paragraph&) = delete;
+
+  Scalar GetMaxWidth() const;
+
+  Scalar GetHeight() const;
+
+  Scalar GetLongestLineWidth() const;
+
+  Scalar GetMinIntrinsicWidth() const;
+
+  Scalar GetMaxInstrinsicWidth() const;
+
+  Scalar GetIdeographicBaseline() const;
+
+  Scalar GetAlphabeticBaseline() const;
+
+  uint32_t GetLineCount() const;
+
+  const std::unique_ptr<txt::Paragraph>& GetHandle() const;
+
+ private:
+  std::unique_ptr<txt::Paragraph> paragraph_;
+};
+
+}  // namespace impeller::interop
+
+#endif  // FLUTTER_IMPELLER_TOOLKIT_INTEROP_PARAGRAPH_H_

--- a/impeller/toolkit/interop/paragraph_builder.cc
+++ b/impeller/toolkit/interop/paragraph_builder.cc
@@ -39,8 +39,8 @@ void ParagraphBuilder::PopStyle() {
   builder_->Pop();
 }
 
-void ParagraphBuilder::AddText(std::u16string string) {
-  builder_->AddText(std::move(string));
+void ParagraphBuilder::AddText(const uint8_t* data, size_t byte_length) {
+  builder_->AddText(data, byte_length);
 }
 
 ScopedObject<Paragraph> ParagraphBuilder::Build(Scalar width) const {

--- a/impeller/toolkit/interop/paragraph_builder.cc
+++ b/impeller/toolkit/interop/paragraph_builder.cc
@@ -1,0 +1,55 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/toolkit/interop/paragraph_builder.h"
+
+#include "flutter/third_party/txt/src/skia/paragraph_builder_skia.h"
+#include "impeller/base/validation.h"
+#include "impeller/toolkit/interop/paragraph.h"
+
+namespace impeller::interop {
+
+ParagraphBuilder::ParagraphBuilder(const TypographyContext& context) {
+  if (!context.IsValid()) {
+    VALIDATION_LOG << "Invalid typography context.";
+    return;
+  }
+
+  static txt::ParagraphStyle kBaseStyle;
+
+  builder_ = std::make_unique<txt::ParagraphBuilderSkia>(
+      kBaseStyle,                   //
+      context.GetFontCollection(),  //
+      true                          // is impeller enabled
+  );
+}
+
+ParagraphBuilder::~ParagraphBuilder() = default;
+
+bool ParagraphBuilder::IsValid() const {
+  return !!builder_;
+}
+
+void ParagraphBuilder::PushStyle(const ParagraphStyle& style) {
+  builder_->PushStyle(style.CreateTextStyle());
+}
+
+void ParagraphBuilder::PopStyle() {
+  builder_->Pop();
+}
+
+void ParagraphBuilder::AddText(std::u16string string) {
+  builder_->AddText(std::move(string));
+}
+
+ScopedObject<Paragraph> ParagraphBuilder::Build(Scalar width) const {
+  auto txt_paragraph = builder_->Build();
+  if (!txt_paragraph) {
+    return nullptr;
+  }
+  txt_paragraph->Layout(width);
+  return Create<Paragraph>(std::move(txt_paragraph));
+}
+
+}  // namespace impeller::interop

--- a/impeller/toolkit/interop/paragraph_builder.h
+++ b/impeller/toolkit/interop/paragraph_builder.h
@@ -1,0 +1,48 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_TOOLKIT_INTEROP_PARAGRAPH_BUILDER_H_
+#define FLUTTER_IMPELLER_TOOLKIT_INTEROP_PARAGRAPH_BUILDER_H_
+
+#include <memory>
+#include <string>
+
+#include "flutter/third_party/txt/src/txt/paragraph_builder.h"
+#include "impeller/toolkit/interop/impeller.h"
+#include "impeller/toolkit/interop/object.h"
+#include "impeller/toolkit/interop/paragraph.h"
+#include "impeller/toolkit/interop/paragraph_style.h"
+#include "impeller/toolkit/interop/typography_context.h"
+
+namespace impeller::interop {
+
+class ParagraphBuilder final
+    : public Object<ParagraphBuilder,
+                    IMPELLER_INTERNAL_HANDLE_NAME(ImpellerParagraphBuilder)> {
+ public:
+  explicit ParagraphBuilder(const TypographyContext& context);
+
+  ~ParagraphBuilder() override;
+
+  ParagraphBuilder(const ParagraphBuilder&) = delete;
+
+  ParagraphBuilder& operator=(const ParagraphBuilder&) = delete;
+
+  bool IsValid() const;
+
+  void PushStyle(const ParagraphStyle& style);
+
+  void PopStyle();
+
+  void AddText(std::u16string string);
+
+  ScopedObject<Paragraph> Build(Scalar width) const;
+
+ private:
+  std::unique_ptr<txt::ParagraphBuilder> builder_;
+};
+
+}  // namespace impeller::interop
+
+#endif  // FLUTTER_IMPELLER_TOOLKIT_INTEROP_PARAGRAPH_BUILDER_H_

--- a/impeller/toolkit/interop/paragraph_builder.h
+++ b/impeller/toolkit/interop/paragraph_builder.h
@@ -6,7 +6,6 @@
 #define FLUTTER_IMPELLER_TOOLKIT_INTEROP_PARAGRAPH_BUILDER_H_
 
 #include <memory>
-#include <string>
 
 #include "flutter/third_party/txt/src/txt/paragraph_builder.h"
 #include "impeller/toolkit/interop/impeller.h"
@@ -35,7 +34,7 @@ class ParagraphBuilder final
 
   void PopStyle();
 
-  void AddText(std::u16string string);
+  void AddText(const uint8_t* data, size_t byte_length);
 
   ScopedObject<Paragraph> Build(Scalar width) const;
 

--- a/impeller/toolkit/interop/paragraph_style.cc
+++ b/impeller/toolkit/interop/paragraph_style.cc
@@ -1,0 +1,68 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/toolkit/interop/paragraph_style.h"
+
+namespace impeller::interop {
+
+ParagraphStyle::ParagraphStyle() = default;
+
+ParagraphStyle::~ParagraphStyle() = default;
+
+void ParagraphStyle::SetFontWeight(txt::FontWeight weight) {
+  style_.font_weight = weight;
+}
+
+void ParagraphStyle::SetFontStyle(txt::FontStyle style) {
+  style_.font_style = style;
+}
+
+void ParagraphStyle::SetFontFamily(std::string family) {
+  style_.font_family = std::move(family);
+}
+
+void ParagraphStyle::SetFontSize(double size) {
+  style_.font_size = size;
+}
+
+void ParagraphStyle::SetHeight(double height) {
+  style_.height = height;
+}
+
+void ParagraphStyle::SetTextAlignment(txt::TextAlign alignment) {
+  style_.text_align = alignment;
+}
+
+void ParagraphStyle::SetTextDirection(txt::TextDirection direction) {
+  style_.text_direction = direction;
+}
+
+void ParagraphStyle::SetMaxLines(size_t max_lines) {
+  style_.max_lines = max_lines;
+}
+
+void ParagraphStyle::SetLocale(std::string locale) {
+  style_.locale = std::move(locale);
+}
+
+void ParagraphStyle::SetForeground(ScopedObject<Paint> paint) {
+  foreground_ = std::move(paint);
+}
+
+void ParagraphStyle::SetBackground(ScopedObject<Paint> paint) {
+  backgrond_ = std::move(paint);
+}
+
+txt::TextStyle ParagraphStyle::CreateTextStyle() const {
+  auto style = style_.GetTextStyle();
+  if (foreground_) {
+    style.foreground = foreground_->GetPaint();
+  }
+  if (backgrond_) {
+    style.background = backgrond_->GetPaint();
+  }
+  return style;
+}
+
+}  // namespace impeller::interop

--- a/impeller/toolkit/interop/paragraph_style.h
+++ b/impeller/toolkit/interop/paragraph_style.h
@@ -1,0 +1,59 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_TOOLKIT_INTEROP_PARAGRAPH_STYLE_H_
+#define FLUTTER_IMPELLER_TOOLKIT_INTEROP_PARAGRAPH_STYLE_H_
+
+#include "impeller/toolkit/interop/impeller.h"
+#include "impeller/toolkit/interop/object.h"
+#include "impeller/toolkit/interop/paint.h"
+#include "third_party/txt/src/txt/paragraph_style.h"
+
+namespace impeller::interop {
+
+class ParagraphStyle final
+    : public Object<ParagraphStyle,
+                    IMPELLER_INTERNAL_HANDLE_NAME(ImpellerParagraphStyle)> {
+ public:
+  explicit ParagraphStyle();
+
+  ~ParagraphStyle() override;
+
+  ParagraphStyle(const ParagraphStyle&) = delete;
+
+  ParagraphStyle& operator=(const ParagraphStyle&) = delete;
+
+  void SetForeground(ScopedObject<Paint> paint);
+
+  void SetBackground(ScopedObject<Paint> paint);
+
+  void SetFontWeight(txt::FontWeight weight);
+
+  void SetFontStyle(txt::FontStyle style);
+
+  void SetFontFamily(std::string family);
+
+  void SetFontSize(double size);
+
+  void SetHeight(double height);
+
+  void SetTextAlignment(txt::TextAlign alignment);
+
+  void SetTextDirection(txt::TextDirection direction);
+
+  void SetMaxLines(size_t max_lines);
+
+  void SetLocale(std::string locale);
+
+  txt::TextStyle CreateTextStyle() const;
+
+ private:
+  txt::ParagraphStyle style_;
+  ScopedObject<Paint> foreground_;
+  ScopedObject<Paint> backgrond_;
+};
+
+}  // namespace impeller::interop
+
+#endif  // FLUTTER_IMPELLER_TOOLKIT_INTEROP_PARAGRAPH_STYLE_H_

--- a/impeller/toolkit/interop/typography_context.cc
+++ b/impeller/toolkit/interop/typography_context.cc
@@ -1,0 +1,36 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/toolkit/interop/typography_context.h"
+
+#include <mutex>
+
+#include "flutter/fml/icu_util.h"
+#include "impeller/toolkit/interop/embedded_icu_data.h"
+
+namespace impeller::interop {
+
+TypographyContext::TypographyContext()
+    : collection_(std::make_shared<txt::FontCollection>()) {
+  static std::once_flag sICUInitOnceFlag;
+  std::call_once(sICUInitOnceFlag, []() {
+    auto icu_data = std::make_unique<fml::NonOwnedMapping>(
+        impeller_embedded_icu_data_data, impeller_embedded_icu_data_length);
+    fml::icu::InitializeICUFromMapping(std::move(icu_data));
+  });
+  collection_->SetupDefaultFontManager(0u);
+}
+
+TypographyContext::~TypographyContext() = default;
+
+bool TypographyContext::IsValid() const {
+  return !!collection_;
+}
+
+const std::shared_ptr<txt::FontCollection>&
+TypographyContext::GetFontCollection() const {
+  return collection_;
+}
+
+}  // namespace impeller::interop

--- a/impeller/toolkit/interop/typography_context.h
+++ b/impeller/toolkit/interop/typography_context.h
@@ -1,0 +1,38 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_TOOLKIT_INTEROP_TYPOGRAPHY_CONTEXT_H_
+#define FLUTTER_IMPELLER_TOOLKIT_INTEROP_TYPOGRAPHY_CONTEXT_H_
+
+#include <memory>
+
+#include "flutter/third_party/txt/src/txt/font_collection.h"
+#include "impeller/toolkit/interop/impeller.h"
+#include "impeller/toolkit/interop/object.h"
+
+namespace impeller::interop {
+
+class TypographyContext final
+    : public Object<TypographyContext,
+                    IMPELLER_INTERNAL_HANDLE_NAME(ImpellerTypographyContext)> {
+ public:
+  TypographyContext();
+
+  ~TypographyContext() override;
+
+  TypographyContext(const TypographyContext&) = delete;
+
+  TypographyContext& operator=(const TypographyContext&) = delete;
+
+  bool IsValid() const;
+
+  const std::shared_ptr<txt::FontCollection>& GetFontCollection() const;
+
+ private:
+  std::shared_ptr<txt::FontCollection> collection_;
+};
+
+}  // namespace impeller::interop
+
+#endif  // FLUTTER_IMPELLER_TOOLKIT_INTEROP_TYPOGRAPHY_CONTEXT_H_

--- a/third_party/txt/src/skia/paragraph_builder_skia.cc
+++ b/third_party/txt/src/skia/paragraph_builder_skia.cc
@@ -51,8 +51,7 @@ ParagraphBuilderSkia::ParagraphBuilderSkia(
     const bool impeller_enabled)
     : base_style_(style.GetTextStyle()), impeller_enabled_(impeller_enabled) {
   builder_ = skt::ParagraphBuilder::make(
-      TxtToSkia(style),
-      font_collection->CreateSktFontCollection(),
+      TxtToSkia(style), font_collection->CreateSktFontCollection(),
       SkUnicodes::ICU::Make());
 }
 
@@ -74,6 +73,11 @@ const TextStyle& ParagraphBuilderSkia::PeekStyle() {
 
 void ParagraphBuilderSkia::AddText(const std::u16string& text) {
   builder_->addText(text);
+}
+
+void ParagraphBuilderSkia::AddText(const uint8_t* utf8_data,
+                                   size_t byte_length) {
+  builder_->addText(reinterpret_cast<const char*>(utf8_data), byte_length);
 }
 
 void ParagraphBuilderSkia::AddPlaceholder(PlaceholderRun& span) {

--- a/third_party/txt/src/skia/paragraph_builder_skia.h
+++ b/third_party/txt/src/skia/paragraph_builder_skia.h
@@ -41,6 +41,7 @@ class ParagraphBuilderSkia : public ParagraphBuilder {
   virtual void Pop() override;
   virtual const TextStyle& PeekStyle() override;
   virtual void AddText(const std::u16string& text) override;
+  virtual void AddText(const uint8_t* utf8_data, size_t byte_length) override;
   virtual void AddPlaceholder(PlaceholderRun& span) override;
   virtual std::unique_ptr<Paragraph> Build() override;
 

--- a/third_party/txt/src/txt/paragraph_builder.h
+++ b/third_party/txt/src/txt/paragraph_builder.h
@@ -59,8 +59,14 @@ class ParagraphBuilder {
   virtual const TextStyle& PeekStyle() = 0;
 
   // Adds text to the builder. Forms the proper runs to use the upper-most style
-  // on the style_stack_;
+  // on the style stack.
   virtual void AddText(const std::u16string& text) = 0;
+
+  // Adds text to the builder. Forms the proper runs to use the upper-most style
+  // on the style stack.
+  //
+  // Data must be in UTF-8 encoding.
+  virtual void AddText(const uint8_t* utf8_data, size_t byte_length) = 0;
 
   // Pushes the information required to leave an open space, where Flutter may
   // draw a custom placeholder into.


### PR DESCRIPTION
This uses the same shaper as the rest of Flutter. The minimal ICU data configuration comes embedded in the dylib so there are no out-of-band packaging concerns.

<img width="1136" alt="Screenshot 2024-10-02 at 4 11 17 PM" src="https://github.com/user-attachments/assets/ce63dc99-7c3d-4b71-ac5d-926dffa5269b">

Fixes https://github.com/flutter/flutter/issues/156015