### PR TITLE
iOS: Fix IOSSurfaceNoopTest

### DIFF
--- a/shell/platform/darwin/ios/ios_surface_noop_unittests.mm
+++ b/shell/platform/darwin/ios/ios_surface_noop_unittests.mm
@@ -14,6 +14,7 @@
 #import "flutter/lib/ui/window/platform_message_response.h"
 #import "flutter/shell/common/thread_host.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
+#import "flutter/shell/platform/darwin/ios/ios_context_noop.h"
 
 FLUTTER_ASSERT_ARC
 
@@ -22,7 +23,8 @@ FLUTTER_ASSERT_ARC
 
 @implementation IOSSurfaceNoopTest
 - (void)testCreateSurface {
-  flutter::IOSSurfaceNoop noop(nullptr);
+  auto context = std::make_shared<flutter::IOSContextNoop>();
+  flutter::IOSSurfaceNoop noop(context);
 
   XCTAssertTrue(noop.IsValid());
   XCTAssertTrue(!!noop.CreateGPUSurface());


### PR DESCRIPTION
Previously, we were passing `nullptr` to the `IOSSurfaceNoop` constructor:
https://github.com/flutter/engine/blob/de1762dbc5cc3483631c5e511a3496998ec6cf65/shell/platform/darwin/ios/ios_surface_noop.mm#L23-L24

which calls the IOSSurface constructor:
https://github.com/flutter/engine/blob/de1762dbc5cc3483631c5e511a3496998ec6cf65/shell/platform/darwin/ios/ios_surface.mm#L55-L58

Which calls `FML_DCHECK(ios_context_)`, which really doesn't like it when `ios_context_` is null.

I will later follow up with the next question of... "what exactly is going on with our CI here?", but this unbreaks my local dev testing workflow for the moment :)

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
