### PR TITLE
Add and use a `dart_test` rule.

### DIFF
--- a/build/dart/internal/dart_test.gni
+++ b/build/dart/internal/dart_test.gni
@@ -1,0 +1,37 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//flutter/build/dart/internal/gen_dartcli_call.gni")
+
+# Generates an executable that runs `dart test` on a single test program.
+#
+# Parameters:
+#   main_dart (required):
+#     The entrypoint to the Dart test program.
+#
+#   output (optional):
+#     Overrides the full output path.
+#     Defaults to $root_out_dir/gen/$target_path/$target_name; for example
+#     //flutter/foo/bar emits a binary at out/{variant}/gen/flutter/foo/bar.
+template("dart_test") {
+  assert(defined(invoker.main_dart), "Must specify 'main_dart'")
+
+  # Generate the CWD based on the directory of the invoking GN file.
+  parent_dir = get_label_info(target_name, "dir")
+  cwd = get_path_info(parent_dir, "dir")
+
+  gen_dartcli_call(target_name) {
+    args = [
+      "test",
+      invoker.main_dart,
+    ]
+    cwd = rebase_path(cwd)
+    testonly = true
+    forward_variables_from(invoker,
+                           [
+                             "output",
+                             "visibility",
+                           ])
+  }
+}

--- a/build/dart/internal/gen_dartcli_call.gni
+++ b/build/dart/internal/gen_dartcli_call.gni
@@ -32,11 +32,11 @@ template("gen_dartcli_call") {
   }
 
   # Add default arguments to the Dart CLI.
+  # TODO(https://github.com/flutter/flutter/issues/156171): --suppress-analytics
   dart_args = []
   if (defined(invoker.args)) {
     dart_args += invoker.args
   }
-  dart_args += [ "--suppress-analytics" ]
 
   # Actually generate the shell script.
   gen_executable_call(target_name) {
@@ -46,6 +46,8 @@ template("gen_dartcli_call") {
                            [
                              "cwd",
                              "output",
+                             "testonly",
+                             "visibility",
                            ])
   }
 }

--- a/build/dart/internal/gen_executable_call.gni
+++ b/build/dart/internal/gen_executable_call.gni
@@ -58,5 +58,10 @@ template("gen_executable_call") {
     script = "//flutter/build/dart/internal/gen_executable_call.py"
     outputs = [ output ]
     args = call_args
+    forward_variables_from(invoker,
+                           [
+                             "testonly",
+                             "visibility",
+                           ])
   }
 }

--- a/build/dart/rules.gni
+++ b/build/dart/rules.gni
@@ -5,5 +5,6 @@
 # This file has rules for making Dart packages and snapshots.
 
 import("//flutter/build/dart/internal/application_snapshot.gni")
+import("//flutter/build/dart/internal/dart_test.gni")
 import("//flutter/build/dart/internal/flutter_frontend_server.gni")
 import("//flutter/build/dart/internal/flutter_snapshot.gni")

--- a/tools/engine_tool/BUILD.gn
+++ b/tools/engine_tool/BUILD.gn
@@ -2,14 +2,100 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//flutter/build/dart/internal/gen_dartcli_call.gni")
+import("//flutter/build/dart/rules.gni")
 
-# TODO(matanl): WIP in https://github.com/flutter/flutter/issues/155769.
-#
-# Example usage:
-#   ninja -C ../out/host_debug flutter/tools/engine_tool:tests
-#   ../out/host_debug/gen/flutter/tools/engine_tool/tests
-gen_dartcli_call("tests") {
-  args = [ "test" ]
-  cwd = "//flutter/tools/engine_tool"
+group("tests") {
+  testonly = true
+  public_deps = [
+    ":build_command_test",
+    ":entry_point_test",
+    ":fetch_command_test",
+    ":flutter_tools_test",
+    ":format_command_test",
+    ":gn_test",
+    ":label_test",
+    ":lint_command_test",
+    ":logger_test",
+    ":phone_home_test",
+    ":proc_utils_test",
+    ":query_command_test",
+    ":run_command_test",
+    ":run_target_test",
+    ":test_command_test",
+    ":typed_json_test",
+    ":utils_test",
+    ":worker_pool_test",
+  ]
+}
+
+dart_test("flutter_tools_test") {
+  main_dart = "test/external_tools/flutter_tools_test.dart"
+}
+
+dart_test("gn_test") {
+  main_dart = "test/external_tools/gn_test.dart"
+}
+
+dart_test("build_command_test") {
+  main_dart = "test/build_command_test.dart"
+}
+
+dart_test("entry_point_test") {
+  main_dart = "test/entry_point_test.dart"
+}
+
+dart_test("fetch_command_test") {
+  main_dart = "test/fetch_command_test.dart"
+}
+
+dart_test("format_command_test") {
+  main_dart = "test/format_command_test.dart"
+}
+
+dart_test("label_test") {
+  main_dart = "test/label_test.dart"
+}
+
+dart_test("lint_command_test") {
+  main_dart = "test/lint_command_test.dart"
+}
+
+dart_test("logger_test") {
+  main_dart = "test/logger_test.dart"
+}
+
+dart_test("phone_home_test") {
+  main_dart = "test/phone_home_test.dart"
+}
+
+dart_test("proc_utils_test") {
+  main_dart = "test/proc_utils_test.dart"
+}
+
+dart_test("query_command_test") {
+  main_dart = "test/query_command_test.dart"
+}
+
+dart_test("run_command_test") {
+  main_dart = "test/run_command_test.dart"
+}
+
+dart_test("run_target_test") {
+  main_dart = "test/run_target_test.dart"
+}
+
+dart_test("test_command_test") {
+  main_dart = "test/test_command_test.dart"
+}
+
+dart_test("typed_json_test") {
+  main_dart = "test/typed_json_test.dart"
+}
+
+dart_test("utils_test") {
+  main_dart = "test/utils_test.dart"
+}
+
+dart_test("worker_pool_test") {
+  main_dart = "test/worker_pool_test.dart"
 }


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/147013.

I think I still need applicable metadata about the output, and then make sure `et test` understands everything:

```sh
% et test //flutter/tools/engine_tool/...
[2024-10-03 13:26:42.657137] ERROR: No test targets found
```