### PR TITLE
Prefix `gen_shapshot` build invocation with `time` based on the current platform.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -277,7 +277,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'f85c3be4bf808add6ba867b8ff7943fd235b7b5e',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '8e48d18e81f87e7fb1fe30c6bb14b67be92246a3',
 
   'src/flutter/third_party/depot_tools':
   Var('chromium_git') + '/chromium/tools/depot_tools.git' + '@' + '580b4ff3f5cd0dcaa2eacda28cefe0f45320e8f7',

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -63,6 +63,9 @@ group("generate_snapshot_bins") {
 # See: `bin_to_linkable` rules below that build these outputs into linkable form
 # See: https://github.com/flutter/flutter/wiki/Flutter-engine-operation-in-AOT-Mode
 compiled_action("generate_snapshot_bin") {
+  # TODO(https://github.com/flutter/flutter/issues/154437).
+  prefix_with_time_cmd = true
+
   if (target_cpu == "x86" && host_os == "linux") {
     # By default Dart will create a 32-bit gen_snapshot host binary if the target
     # platform is 32-bit.  Override this to create a 64-bit gen_snapshot for x86


### PR DESCRIPTION
Work on debugging https://github.com/flutter/flutter/issues/154437.