### PR TITLE
Add support for `et test //flutter/path/to/dart_test`

### DIFF
--- a/build/dart/internal/dart_test.gni
+++ b/build/dart/internal/dart_test.gni
@@ -27,6 +27,9 @@ template("dart_test") {
       invoker.main_dart,
     ]
     cwd = rebase_path(cwd)
+    metadata = {
+      action_type = [ "dart_test" ]
+    }
     testonly = true
     forward_variables_from(invoker,
                            [

--- a/build/dart/internal/gen_dartcli_call.gni
+++ b/build/dart/internal/gen_dartcli_call.gni
@@ -46,6 +46,7 @@ template("gen_dartcli_call") {
                            [
                              "cwd",
                              "output",
+                             "metadata",
                              "testonly",
                              "visibility",
                            ])

--- a/build/dart/internal/gen_executable_call.gni
+++ b/build/dart/internal/gen_executable_call.gni
@@ -60,6 +60,7 @@ template("gen_executable_call") {
     args = call_args
     forward_variables_from(invoker,
                            [
+                             "metadata",
                              "testonly",
                              "visibility",
                            ])

--- a/tools/engine_tool/lib/src/gn.dart
+++ b/tools/engine_tool/lib/src/gn.dart
@@ -123,6 +123,34 @@ sealed class BuildTarget {
     required this.testOnly,
   });
 
+  factory BuildTarget._parseFromAction(
+    String label, {
+    required bool testOnly,
+    required JsonObject json,
+  }) {
+    final metadata = json.objectOrNull('metadata');
+    if (metadata != null) {
+      final actionTypes = metadata.stringListOrNull('action_type');
+      if (actionTypes != null && actionTypes.contains('dart_test')) {
+        final String executable;
+        final outputs = json.stringListOrNull('outputs');
+        if (outputs != null && outputs.isNotEmpty) {
+          // Remove the leading // from the path.
+          executable = outputs.first.substring(2);
+        } else {
+          throw StateError('Expected at least one output for $label');
+        }
+        print(executable);
+        return ExecutableBuildTarget(
+          label: Label.parseGn(label),
+          testOnly: testOnly,
+          executable: executable,
+        );
+      }
+    }
+    return ActionBuildTarget(label: Label.parseGn(label), testOnly: testOnly);
+  }
+
   /// Returns a build target from JSON originating from `gn desc --format=json`.
   ///
   /// If the JSON is not a supported build target, returns `null`.
@@ -145,8 +173,11 @@ sealed class BuildTarget {
           label: Label.parseGn(label),
           testOnly: testOnly,
         ),
-      'action' =>
-        ActionBuildTarget(label: Label.parseGn(label), testOnly: testOnly),
+      'action' => BuildTarget._parseFromAction(
+          label,
+          testOnly: testOnly,
+          json: json,
+        ),
       _ => null,
     };
   }

--- a/tools/engine_tool/lib/src/gn.dart
+++ b/tools/engine_tool/lib/src/gn.dart
@@ -134,13 +134,12 @@ sealed class BuildTarget {
       if (actionTypes != null && actionTypes.contains('dart_test')) {
         final String executable;
         final outputs = json.stringListOrNull('outputs');
-        if (outputs != null && outputs.isNotEmpty) {
-          // Remove the leading // from the path.
-          executable = outputs.first.substring(2);
-        } else {
+        if (outputs == null || outputs.isEmpty) {
           throw StateError('Expected at least one output for $label');
         }
-        print(executable);
+
+        // Remove the leading // from the path.
+        executable = outputs.first.substring(2);
         return ExecutableBuildTarget(
           label: Label.parseGn(label),
           testOnly: testOnly,
@@ -148,7 +147,10 @@ sealed class BuildTarget {
         );
       }
     }
-    return ActionBuildTarget(label: Label.parseGn(label), testOnly: testOnly);
+    return ActionBuildTarget(
+      label: Label.parseGn(label),
+      testOnly: testOnly,
+    );
   }
 
   /// Returns a build target from JSON originating from `gn desc --format=json`.

--- a/tools/engine_tool/lib/src/typed_json.dart
+++ b/tools/engine_tool/lib/src/typed_json.dart
@@ -226,6 +226,44 @@ extension type const JsonObject(Map<String, Object?> _object) {
     throw e;
   }
 
+  JsonObject? _getObjectOrNull(String key) {
+    final Object? value = _object[key];
+    if (value == null && !_object.containsKey(key)) {
+      return null;
+    } else if (value is! Map<String, Object?>) {
+      _error(InvalidTypeJsonReadException(
+        this,
+        key,
+        expected: Map<String, Object?>,
+        actual: value.runtimeType,
+      ));
+      return const JsonObject({});
+    } else {
+      return JsonObject(value);
+    }
+  }
+
+  JsonObject _getObject(String key) {
+    final JsonObject? result = _getObjectOrNull(key);
+    if (result == null) {
+      _error(MissingKeyJsonReadException(this, key));
+      return const JsonObject({});
+    }
+    return result;
+  }
+
+  /// Returns the value at the given [key] as a [JsonObject].
+  ///
+  /// Throws a [JsonReadException] if the value is not found or cannot be cast.
+  JsonObject object(String key) => _getObject(key);
+
+  /// Returns the value at the given [key] as a [JsonObject].
+  ///
+  /// If the value is not found, returns `null`.
+  ///
+  /// Throws a [JsonReadException] if the value cannot be cast.
+  JsonObject? objectOrNull(String key) => _getObjectOrNull(key);
+
   /// Returns the result of applying the given [mapper] to this JSON object.
   ///
   /// Any exception that otherwise would be thrown by the mapper is caught

--- a/tools/engine_tool/test/typed_json_test.dart
+++ b/tools/engine_tool/test/typed_json_test.dart
@@ -188,6 +188,33 @@ void main() {
     });
   });
 
+  group('JsonObject.objectOrNull', () {
+    test('returns object value', () {
+      const jsonObject = JsonObject({
+        'key': {'nestedKey': 'nestedValue'}
+      });
+      expect(
+        jsonObject.objectOrNull('key'),
+        const JsonObject({'nestedKey': 'nestedValue'}),
+      );
+    });
+
+    test('returns null due to missing key', () {
+      const jsonObject = JsonObject({
+        'key': {'nestedKey': 'nestedValue'}
+      });
+      expect(jsonObject.objectOrNull('missing'), isNull);
+    });
+
+    test('throws due to wrong type', () {
+      const jsonObject = JsonObject({'key': 'value'});
+      expect(
+        () => jsonObject.objectOrNull('key'),
+        throwsA(const isInstanceOf<InvalidTypeJsonReadException>()),
+      );
+    });
+  });
+
   group('JsonObject.map', () {
     test('returns multiple fields', () {
       final (String name, int age, bool isStudent) =


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/147013.
Closes https://github.com/flutter/flutter/issues/147071.

/cc @reidbaker who I know wants to do this for the Java rules soon TM.
/cc @jtmcdole, @zanderso for visibility.