### PR TITLE
Honor blur tile mode in BackdropFilter widget on Skia backend

### DIFF
--- a/display_list/skia/dl_sk_canvas.cc
+++ b/display_list/skia/dl_sk_canvas.cc
@@ -58,8 +58,11 @@ void DlSkCanvasAdapter::SaveLayer(const SkRect* bounds,
   sk_sp<SkImageFilter> sk_backdrop = ToSk(backdrop);
   SkOptionalPaint sk_paint(paint);
   TRACE_EVENT0("flutter", "Canvas::saveLayer");
-  delegate_->saveLayer(
-      SkCanvas::SaveLayerRec{bounds, sk_paint(), sk_backdrop.get(), 0});
+  const SkTileMode tile_mode = backdrop && backdrop->asBlur()
+                                   ? ToSk(backdrop->asBlur()->tile_mode())
+                                   : SkTileMode::kClamp;
+  delegate_->saveLayer(SkCanvas::SaveLayerRec{
+      bounds, sk_paint(), sk_backdrop.get(), tile_mode, nullptr, 0});
 }
 
 void DlSkCanvasAdapter::Restore() {

--- a/display_list/skia/dl_sk_canvas.cc
+++ b/display_list/skia/dl_sk_canvas.cc
@@ -58,11 +58,11 @@ void DlSkCanvasAdapter::SaveLayer(const SkRect* bounds,
   sk_sp<SkImageFilter> sk_backdrop = ToSk(backdrop);
   SkOptionalPaint sk_paint(paint);
   TRACE_EVENT0("flutter", "Canvas::saveLayer");
-  const SkTileMode tile_mode = backdrop && backdrop->asBlur()
-                                   ? ToSk(backdrop->asBlur()->tile_mode())
-                                   : SkTileMode::kClamp;
-  delegate_->saveLayer(SkCanvas::SaveLayerRec{
-      bounds, sk_paint(), sk_backdrop.get(), tile_mode, nullptr, 0});
+  SkCanvas::SaveLayerRec params(bounds, sk_paint(), sk_backdrop.get(), 0);
+  if (sk_backdrop && backdrop->asBlur()) {
+    params.fBackdropTileMode = ToSk(backdrop->asBlur()->tile_mode());
+  }
+  delegate_->saveLayer(params);
 }
 
 void DlSkCanvasAdapter::Restore() {

--- a/display_list/skia/dl_sk_dispatcher.cc
+++ b/display_list/skia/dl_sk_dispatcher.cc
@@ -70,8 +70,11 @@ void DlSkCanvasDispatcher::saveLayer(const DlRect& bounds,
     const sk_sp<SkImageFilter> sk_backdrop = ToSk(backdrop);
     const SkRect* sl_bounds =
         options.bounds_from_caller() ? &ToSkRect(bounds) : nullptr;
-    canvas_->saveLayer(
-        SkCanvas::SaveLayerRec(sl_bounds, paint, sk_backdrop.get(), 0));
+    const SkTileMode tile_mode = backdrop && backdrop->asBlur()
+                                     ? ToSk(backdrop->asBlur()->tile_mode())
+                                     : SkTileMode::kClamp;
+    canvas_->saveLayer(SkCanvas::SaveLayerRec(
+        sl_bounds, paint, sk_backdrop.get(), tile_mode, nullptr, 0));
     // saveLayer will apply the current opacity on behalf of the children
     // so they will inherit an opaque opacity.
     save_opacity(SK_Scalar1);

--- a/display_list/skia/dl_sk_dispatcher.cc
+++ b/display_list/skia/dl_sk_dispatcher.cc
@@ -70,11 +70,11 @@ void DlSkCanvasDispatcher::saveLayer(const DlRect& bounds,
     const sk_sp<SkImageFilter> sk_backdrop = ToSk(backdrop);
     const SkRect* sl_bounds =
         options.bounds_from_caller() ? &ToSkRect(bounds) : nullptr;
-    const SkTileMode tile_mode = backdrop && backdrop->asBlur()
-                                     ? ToSk(backdrop->asBlur()->tile_mode())
-                                     : SkTileMode::kClamp;
-    canvas_->saveLayer(SkCanvas::SaveLayerRec(
-        sl_bounds, paint, sk_backdrop.get(), tile_mode, nullptr, 0));
+    SkCanvas::SaveLayerRec params(sl_bounds, paint, sk_backdrop.get(), 0);
+    if (sk_backdrop && backdrop->asBlur()) {
+      params.fBackdropTileMode = ToSk(backdrop->asBlur()->tile_mode());
+    }
+    canvas_->saveLayer(params);
     // saveLayer will apply the current opacity on behalf of the children
     // so they will inherit an opaque opacity.
     save_opacity(SK_Scalar1);

--- a/display_list/testing/dl_rendering_unittests.cc
+++ b/display_list/testing/dl_rendering_unittests.cc
@@ -1330,7 +1330,8 @@ class CanvasCompareTester {
                      [=](const SkSetupContext& ctx) {
                        sk_backdrop_setup(ctx);
                        ctx.canvas->saveLayer(SkCanvas::SaveLayerRec(
-                           nullptr, nullptr, sk_backdrop.get(), 0));
+                           nullptr, nullptr, sk_backdrop.get(),
+                           SkTileMode::kDecal, nullptr, 0));
                        sk_content_setup(ctx);
                      },
                      [=](const DlSetupContext& ctx) {
@@ -1345,7 +1346,8 @@ class CanvasCompareTester {
                      [=](const SkSetupContext& ctx) {
                        sk_backdrop_setup(ctx);
                        ctx.canvas->saveLayer(SkCanvas::SaveLayerRec(
-                           &layer_bounds, nullptr, sk_backdrop.get(), 0));
+                           &layer_bounds, nullptr, sk_backdrop.get(),
+                           SkTileMode::kDecal, nullptr, 0));
                        sk_content_setup(ctx);
                      },
                      [=](const DlSetupContext& ctx) {
@@ -1362,7 +1364,8 @@ class CanvasCompareTester {
                        sk_backdrop_setup(ctx);
                        ctx.canvas->clipRect(layer_bounds);
                        ctx.canvas->saveLayer(SkCanvas::SaveLayerRec(
-                           nullptr, nullptr, sk_backdrop.get(), 0));
+                           nullptr, nullptr, sk_backdrop.get(),
+                           SkTileMode::kDecal, nullptr, 0));
                        sk_content_setup(ctx);
                      },
                      [=](const DlSetupContext& ctx) {

--- a/testing/dart/painting_test.dart
+++ b/testing/dart/painting_test.dart
@@ -116,25 +116,41 @@ void main() {
       callback(canvas);
       return recorder.endRecording();
     }
-    final SceneBuilder sceneBuilder = SceneBuilder();
+
+    const double rectSize = 10;
+    const int count = 50;
+    const double imgSize = rectSize * count;
 
     final Picture blueGreenGridPicture = makePicture((Canvas canvas) {
       const Color white = Color(0xFFFFFFFF);
+      const Color purple = Color(0xFFFF00FF);
       const Color blue = Color(0xFF0000FF);
       const Color green = Color(0xFF00FF00);
+      const Color yellow = Color(0xFFFFFF00);
+      const Color red = Color(0xFFFF0000);
       canvas.drawColor(white, BlendMode.src);
-      for (int i = 0; i < 100; i++) {
-        canvas.drawRect(Rect.fromLTWH(i * 5, 0, 1, 1000),
-                        Paint()..color = (i & 1) == 0 ? green : blue);
-        canvas.drawRect(Rect.fromLTWH(0, i * 5, 1000, 1),
-                        Paint()..color = (i & 1) == 0 ? blue : green);
+      for (int i = 0; i < count; i++) {
+        for (int j = 0; j < count; j++) {
+          final bool rectOdd = (i + j) & 1 == 0;
+          final Color fg = (i < count / 2)
+            ? ((j < count / 2) ? green : blue)
+            : ((j < count / 2) ? yellow : red);
+          canvas.drawRect(Rect.fromLTWH(i * rectSize, j * rectSize, rectSize, rectSize),
+                          Paint()..color = rectOdd ? fg : white);
+        }
       }
+      canvas.drawRect(const Rect.fromLTWH(0, 0, imgSize, 1), Paint()..color = purple);
+      canvas.drawRect(const Rect.fromLTWH(0, 0, 1, imgSize), Paint()..color = purple);
+      canvas.drawRect(const Rect.fromLTWH(0, imgSize - 1, imgSize, 1), Paint()..color = purple);
+      canvas.drawRect(const Rect.fromLTWH(imgSize - 1, 0, 1, imgSize), Paint()..color = purple);
     });
+
+    final SceneBuilder sceneBuilder = SceneBuilder();
     sceneBuilder.addPicture(Offset.zero, blueGreenGridPicture);
-    sceneBuilder.pushBackdropFilter(ImageFilter.blur(sigmaX: 10, sigmaY: 10, tileMode: tileMode));
+    sceneBuilder.pushBackdropFilter(ImageFilter.blur(sigmaX: 20, sigmaY: 20, tileMode: tileMode));
 
     final Scene scene = sceneBuilder.build();
-    final Image image = scene.toImageSync(501, 501);
+    final Image image = scene.toImageSync(imgSize.round(), imgSize.round());
 
     scene.dispose();
     blueGreenGridPicture.dispose();

--- a/testing/dart/painting_test.dart
+++ b/testing/dart/painting_test.dart
@@ -109,7 +109,7 @@ void main() {
     redClippedPicture.dispose();
   });
 
-  Image BackdropBlurWithTileMode(TileMode tileMode) {
+  Image backdropBlurWithTileMode(TileMode tileMode) {
     Picture makePicture(CanvasCallback callback) {
       final PictureRecorder recorder = PictureRecorder();
       final Canvas canvas = Canvas(recorder);
@@ -119,14 +119,14 @@ void main() {
     final SceneBuilder sceneBuilder = SceneBuilder();
 
     final Picture blueGreenGridPicture = makePicture((Canvas canvas) {
-      const Color white = const Color(0xFFFFFFFF);
-      const Color blue = const Color(0xFF0000FF);
-      const Color green = const Color(0xFF00FF00);
+      const Color white = Color(0xFFFFFFFF);
+      const Color blue = Color(0xFF0000FF);
+      const Color green = Color(0xFF00FF00);
       canvas.drawColor(white, BlendMode.src);
       for (int i = 0; i < 100; i++) {
-        canvas.drawRect(Rect.fromLTRB(i * 5, 0, i * 5, 1000),
+        canvas.drawRect(Rect.fromLTWH(i * 5, 0, 1, 1000),
                         Paint()..color = (i & 1) == 0 ? green : blue);
-        canvas.drawRect(Rect.fromLTRB(0, i * 5, 1000, i * 5),
+        canvas.drawRect(Rect.fromLTWH(0, i * 5, 1000, 1),
                         Paint()..color = (i & 1) == 0 ? blue : green);
       }
     });
@@ -143,7 +143,7 @@ void main() {
   }
 
   test('BackdropFilter with Blur honors TileMode.decal', () async {
-    Image image = BackdropBlurWithTileMode(TileMode.decal);
+    final Image image = backdropBlurWithTileMode(TileMode.decal);
 
     final ImageComparer comparer = await ImageComparer.create();
     await comparer.addGoldenImage(image, 'dart_ui_backdrop_filter_blur_decal_tile_mode.png');
@@ -152,7 +152,7 @@ void main() {
   });
 
   test('BackdropFilter with Blur honors TileMode.clamp', () async {
-    Image image = BackdropBlurWithTileMode(TileMode.clamp);
+    final Image image = backdropBlurWithTileMode(TileMode.clamp);
 
     final ImageComparer comparer = await ImageComparer.create();
     await comparer.addGoldenImage(image, 'dart_ui_backdrop_filter_blur_clamp_tile_mode.png');
@@ -161,7 +161,7 @@ void main() {
   });
 
   test('BackdropFilter with Blur honors TileMode.mirror', () async {
-    Image image = BackdropBlurWithTileMode(TileMode.mirror);
+    final Image image = backdropBlurWithTileMode(TileMode.mirror);
 
     final ImageComparer comparer = await ImageComparer.create();
     await comparer.addGoldenImage(image, 'dart_ui_backdrop_filter_blur_mirror_tile_mode.png');
@@ -170,7 +170,7 @@ void main() {
   });
 
   test('BackdropFilter with Blur honors TileMode.repeated', () async {
-    Image image = BackdropBlurWithTileMode(TileMode.repeated);
+    final Image image = backdropBlurWithTileMode(TileMode.repeated);
 
     final ImageComparer comparer = await ImageComparer.create();
     await comparer.addGoldenImage(image, 'dart_ui_backdrop_filter_blur_repeated_tile_mode.png');

--- a/testing/dart/painting_test.dart
+++ b/testing/dart/painting_test.dart
@@ -8,6 +8,8 @@ import 'dart:ui';
 import 'package:test/test.dart';
 import 'package:vector_math/vector_math_64.dart';
 
+import 'goldens.dart';
+
 typedef CanvasCallback = void Function(Canvas canvas);
 
 void main() {
@@ -105,6 +107,75 @@ void main() {
     image.dispose();
     whitePicture.dispose();
     redClippedPicture.dispose();
+  });
+
+  Image BackdropBlurWithTileMode(TileMode tileMode) {
+    Picture makePicture(CanvasCallback callback) {
+      final PictureRecorder recorder = PictureRecorder();
+      final Canvas canvas = Canvas(recorder);
+      callback(canvas);
+      return recorder.endRecording();
+    }
+    final SceneBuilder sceneBuilder = SceneBuilder();
+
+    final Picture blueGreenGridPicture = makePicture((Canvas canvas) {
+      const Color white = const Color(0xFFFFFFFF);
+      const Color blue = const Color(0xFF0000FF);
+      const Color green = const Color(0xFF00FF00);
+      canvas.drawColor(white, BlendMode.src);
+      for (int i = 0; i < 100; i++) {
+        canvas.drawRect(Rect.fromLTRB(i * 5, 0, i * 5, 1000),
+                        Paint()..color = (i & 1) == 0 ? green : blue);
+        canvas.drawRect(Rect.fromLTRB(0, i * 5, 1000, i * 5),
+                        Paint()..color = (i & 1) == 0 ? blue : green);
+      }
+    });
+    sceneBuilder.addPicture(Offset.zero, blueGreenGridPicture);
+    sceneBuilder.pushBackdropFilter(ImageFilter.blur(sigmaX: 10, sigmaY: 10, tileMode: tileMode));
+
+    final Scene scene = sceneBuilder.build();
+    final Image image = scene.toImageSync(501, 501);
+
+    scene.dispose();
+    blueGreenGridPicture.dispose();
+
+    return image;
+  }
+
+  test('BackdropFilter with Blur honors TileMode.decal', () async {
+    Image image = BackdropBlurWithTileMode(TileMode.decal);
+
+    final ImageComparer comparer = await ImageComparer.create();
+    await comparer.addGoldenImage(image, 'dart_ui_backdrop_filter_blur_decal_tile_mode.png');
+
+    image.dispose();
+  });
+
+  test('BackdropFilter with Blur honors TileMode.clamp', () async {
+    Image image = BackdropBlurWithTileMode(TileMode.clamp);
+
+    final ImageComparer comparer = await ImageComparer.create();
+    await comparer.addGoldenImage(image, 'dart_ui_backdrop_filter_blur_clamp_tile_mode.png');
+
+    image.dispose();
+  });
+
+  test('BackdropFilter with Blur honors TileMode.mirror', () async {
+    Image image = BackdropBlurWithTileMode(TileMode.mirror);
+
+    final ImageComparer comparer = await ImageComparer.create();
+    await comparer.addGoldenImage(image, 'dart_ui_backdrop_filter_blur_mirror_tile_mode.png');
+
+    image.dispose();
+  });
+
+  test('BackdropFilter with Blur honors TileMode.repeated', () async {
+    Image image = BackdropBlurWithTileMode(TileMode.repeated);
+
+    final ImageComparer comparer = await ImageComparer.create();
+    await comparer.addGoldenImage(image, 'dart_ui_backdrop_filter_blur_repeated_tile_mode.png');
+
+    image.dispose();
   });
 
   test('ImageFilter.matrix defaults to FilterQuality.medium', () {


### PR DESCRIPTION
The blur ImageFilter has a tile mode that describes how to sample pixels near the edge of the source. When used as a BackdropFilter this behavior is important as the wrong tile mode can cause distracting flashing as app content is scrolled under foreground widgets that blur their background. Unfortunately the Skia backend used to default the tile mode for all backdrop filters to `clamp` mode with no way to update it and that mode was the one that produced the most distracting flashing.

Recently Skia opened up control over the tile mode used for backdrop filters and we now take advantage of that capability so that app developers can now set the tile mode to a nicer value.