### PR TITLE
[Impeller] generate mipmaps for toImage.

### DIFF
--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -1368,7 +1368,12 @@ std::shared_ptr<Texture> DisplayListToTexture(
     const sk_sp<flutter::DisplayList>& display_list,
     ISize size,
     AiksContext& context,
-    bool reset_host_buffer) {
+    bool reset_host_buffer,
+    bool generate_mips) {
+  int mip_count = 1;
+  if (generate_mips) {
+    mip_count = size.MipCount();
+  }
   // Do not use the render target cache as the lifecycle of this texture
   // will outlive a particular frame.
   impeller::RenderTargetAllocator render_target_allocator =
@@ -1379,7 +1384,7 @@ std::shared_ptr<Texture> DisplayListToTexture(
     target = render_target_allocator.CreateOffscreenMSAA(
         *context.GetContext(),  // context
         size,                   // size
-        /*mip_count=*/1,
+        /*mip_count=*/mip_count,
         "Picture Snapshot MSAA",  // label
         impeller::RenderTarget::
             kDefaultColorAttachmentConfigMSAA  // color_attachment_config
@@ -1388,7 +1393,7 @@ std::shared_ptr<Texture> DisplayListToTexture(
     target = render_target_allocator.CreateOffscreen(
         *context.GetContext(),  // context
         size,                   // size
-        /*mip_count=*/1,
+        /*mip_count=*/mip_count,
         "Picture Snapshot",  // label
         impeller::RenderTarget::
             kDefaultColorAttachmentConfig  // color_attachment_config

--- a/impeller/display_list/dl_dispatcher.h
+++ b/impeller/display_list/dl_dispatcher.h
@@ -370,7 +370,8 @@ std::shared_ptr<Texture> DisplayListToTexture(
     const sk_sp<flutter::DisplayList>& display_list,
     ISize size,
     AiksContext& context,
-    bool reset_host_buffer = true);
+    bool reset_host_buffer = true,
+    bool generate_mips = false);
 
 /// Render the provided display list to the render target.
 bool RenderToOnscreen(ContentContext& context, RenderTarget render_target,

--- a/shell/common/snapshot_controller_impeller.cc
+++ b/shell/common/snapshot_controller_impeller.cc
@@ -14,7 +14,6 @@
 #include "flutter/impeller/geometry/size.h"
 #include "flutter/shell/common/snapshot_controller.h"
 #include "impeller/entity/contents/runtime_effect_contents.h"
-#include "impeller/renderer/render_target.h"
 
 namespace flutter {
 
@@ -49,7 +48,8 @@ sk_sp<DlImage> DoMakeRasterSnapshot(
 
   return impeller::DlImageImpeller::Make(
       impeller::DisplayListToTexture(display_list, render_target_size, *context,
-                                     /*reset_host_buffer=*/false),
+                                     /*reset_host_buffer=*/false,
+                                     /*generate_mips=*/true),
       DlImage::OwningContext::kRaster);
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/156161

Mips must be eagerly generated for Picture.toImage and friends so that filter quality (mip sampling) works as expected.