### PR TITLE
web ui: fix autofill email input type for detection by proton pass

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -512,6 +512,8 @@ class AutofillInfo {
         element.id = autofillHint;
         if (autofillHint.contains('password')) {
           element.type = 'password';
+        } else if (autofillHint.contains('email')) {
+          element.type = 'email';
         } else {
           element.type = 'text';
         }

--- a/lib/web_ui/test/engine/text_editing_test.dart
+++ b/lib/web_ui/test/engine/text_editing_test.dart
@@ -3068,6 +3068,8 @@ Future<void> testMain() async {
     const String testHint = 'streetAddressLine2';
     const String testId = 'EditableText-659836579';
     const String testPasswordHint = 'password';
+    const String testEmailHint = 'email';
+    const String testUsernameHint = 'username';
 
     test('autofill has correct value', () {
       final AutofillInfo autofillInfo = AutofillInfo.fromFrameworkMessage(
@@ -3136,6 +3138,42 @@ Future<void> testMain() async {
       expect(testInputElement.type, 'password');
       expect(testInputElement.getAttribute('autocomplete'),
           BrowserAutofillHints.instance.flutterToEngine(testPasswordHint));
+    });
+
+    test('email autofill hint', () {
+      final AutofillInfo autofillInfo = AutofillInfo.fromFrameworkMessage(
+          createAutofillInfo(testEmailHint, testId));
+
+      final DomHTMLInputElement testInputElement = createDomHTMLInputElement();
+      autofillInfo.applyToDomElement(testInputElement);
+
+      // Hint sent from the framework is converted to the hint compatible with
+      // browsers.
+      expect(testInputElement.name,
+          BrowserAutofillHints.instance.flutterToEngine(testEmailHint));
+      expect(testInputElement.id,
+          BrowserAutofillHints.instance.flutterToEngine(testEmailHint));
+      expect(testInputElement.type, 'email');
+      expect(testInputElement.getAttribute('autocomplete'),
+          BrowserAutofillHints.instance.flutterToEngine(testEmailHint));
+    });
+
+    test('username autofill hint', () {
+      final AutofillInfo autofillInfo = AutofillInfo.fromFrameworkMessage(
+          createAutofillInfo(testUsernameHint, testId));
+
+      final DomHTMLInputElement testInputElement = createDomHTMLInputElement();
+      autofillInfo.applyToDomElement(testInputElement);
+
+      // Hint sent from the framework is converted to the hint compatible with
+      // browsers.
+      expect(testInputElement.name,
+          BrowserAutofillHints.instance.flutterToEngine(testUsernameHint));
+      expect(testInputElement.id,
+          BrowserAutofillHints.instance.flutterToEngine(testUsernameHint));
+      expect(testInputElement.type, 'text');
+      expect(testInputElement.getAttribute('autocomplete'),
+          BrowserAutofillHints.instance.flutterToEngine(testUsernameHint));
     });
 
     test('autofill with no hints', () {


### PR DESCRIPTION
This pull request enhances the autofill functionality in the text editing engine by adding support for email and username hints. It also includes corresponding unit tests to verify the new functionality.

### Enhancements to Autofill Functionality:

* Updated the `AutofillInfo` class to handle email hints by setting the input element type to 'email' when the autofill hint contains 'email'.

### Unit Tests:

* Added constants for email and username hints in the `testMain` function. 
* Introduced tests to verify the correct behavior of email and username autofill hints, ensuring that the input element's type, name, id, and autocomplete attributes are set appropriately.

Fixes Issue [#156235](https://github.com/flutter/flutter/issues/156235)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
