### PR TITLE
[Impeller] null check surface transaction stats.

### DIFF
--- a/impeller/toolkit/android/surface_transaction_stats.cc
+++ b/impeller/toolkit/android/surface_transaction_stats.cc
@@ -10,6 +10,12 @@ namespace impeller::android {
 
 fml::UniqueFD CreatePreviousReleaseFence(const SurfaceControl& control,
                                          ASurfaceTransactionStats* stats) {
+  if (stats == nullptr) {
+    // For some reason we got a null surface transaction stats. Treat this
+    // as a completed buffer, as passing a null stats to the function
+    // below will crash.
+    return {};
+  }
   const auto fd =
       GetProcTable().ASurfaceTransactionStats_getPreviousReleaseFenceFd(
           stats, control.GetHandle());


### PR DESCRIPTION
Maybe fixes https://github.com/flutter/flutter/issues/155877

If the stats are null, assume completed.