### PR TITLE
LED: Prefix `generate_snapshot` with `time -l`

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -277,7 +277,8 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'f85c3be4bf808add6ba867b8ff7943fd235b7b5e',
+  # DO NOT SUBMIT
+  'src': 'https://github.com/matanlurey/buildroot.git' + '@' + 'gn-run-binary-time-l',
 
   'src/flutter/third_party/depot_tools':
   Var('chromium_git') + '/chromium/tools/depot_tools.git' + '@' + '580b4ff3f5cd0dcaa2eacda28cefe0f45320e8f7',

--- a/ci/builders/standalone/mac_ios_engine_generate_snapshot_repro.json
+++ b/ci/builders/standalone/mac_ios_engine_generate_snapshot_repro.json
@@ -1,0 +1,44 @@
+{
+  "_comment": [
+    "The builds defined in this file repeatedly build the gen_snapshot target ",
+    "to try and reproduce failures that occurr regularly (but rarely) on CI. ",
+    "",
+    "See https://github.com/flutter/flutter/issues/154437 for details."
+  ],
+  "builds": [
+    {
+      "drone_dimensions": ["device_type=none", "os=Mac-13|Mac-14", "cpu=arm64"],
+      "gclient_variables": {
+        "download_android_deps": false,
+        "download_jdk": false,
+        "use_rbe": true
+      },
+      "gn": [
+        "--target-dir",
+        "ci/ios_debug_sim_generate_snapshot_repro",
+        "--ios",
+        "--runtime-mode",
+        "debug",
+        "--simulator",
+        "--no-lto",
+        "--darwin-extension-safe",
+        "--rbe",
+        "--no-goma",
+        "--xcode-symlinks"
+      ],
+      "name": "ci/ios_debug_sim_generate_snapshot_repro",
+      "description": "Produces extension safe debug mode artifacts to target the x64 iOS simulator.",
+      "ninja": {
+        "config": "ci/ios_debug_sim_generate_snapshot_repro",
+        "target": "//flutter/lib/snapshot:generate_snapshot_bin"
+      },
+      "properties": {
+        "$flutter/osx_sdk": {
+          "sdk_version": "15a240d"
+        }
+      }
+    }
+  ],
+  "generators": {},
+  "archives": []
+}


### PR DESCRIPTION
Draft request to use for LED builds only.