### PR TITLE
Migrate FlutterViewController to ARC

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -105,6 +105,8 @@ source_set("flutter_framework_source_arc") {
     "framework/Source/FlutterUndoManagerPlugin.mm",
     "framework/Source/FlutterView.h",
     "framework/Source/FlutterView.mm",
+    "framework/Source/FlutterViewController.mm",
+    "framework/Source/FlutterViewController_Internal.h",
     "framework/Source/FlutterViewResponder.h",
     "framework/Source/KeyCodeMap.g.mm",
     "framework/Source/KeyCodeMap_Internal.h",
@@ -175,6 +177,7 @@ source_set("flutter_framework_source_arc") {
     "//flutter/shell/platform/darwin/graphics",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//flutter/shell/profiling:profiling",
+    "//flutter/third_party/spring_animation",
   ]
 }
 
@@ -189,8 +192,6 @@ source_set("flutter_framework_source") {
     # iOS embedder is migrating to ARC.
     # New files are highly encouraged to be in ARC.
     # To add new files in ARC, add them to the `flutter_framework_source_arc` target.
-    "framework/Source/FlutterViewController.mm",
-    "framework/Source/FlutterViewController_Internal.h",
     "platform_view_ios.h",
     "platform_view_ios.mm",
   ]
@@ -210,7 +211,6 @@ source_set("flutter_framework_source") {
     "//flutter/shell/platform/darwin/common:framework_common",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//flutter/shell/profiling:profiling",
-    "//flutter/third_party/spring_animation",
   ]
 
   public_configs = [

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -831,8 +831,8 @@ static void SendFakeTouchEvent(UIScreen* screen,
     if (_viewportMetrics.physical_width) {
       [self surfaceUpdated:YES];
     }
-    [[self.engine lifecycleChannel] sendMessage:@"AppLifecycleState.inactive"];
-    [[self.engine restorationPlugin] markRestorationComplete];
+    [self.engine.lifecycleChannel sendMessage:@"AppLifecycleState.inactive"];
+    [self.engine.restorationPlugin markRestorationComplete];
   }
 
   [super viewWillAppear:animated];

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -908,7 +908,7 @@ static void SendFakeTouchEvent(UIScreen* screen,
                  dispatch_get_main_queue(), ^{
                    // `viewWillTransitionToSize` is only called after the previous rotation is
                    // complete. So there won't be race condition for this flag.
-                   _shouldIgnoreViewportMetricsUpdatesDuringRotation = NO;
+                   weakSelf.shouldIgnoreViewportMetricsUpdatesDuringRotation = NO;
                    [weakSelf updateViewportMetricsIfNeeded];
                  });
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1,4 +1,4 @@
-// Copyright 2013 The Flutter Authors. All rights reservedj；えr
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -13,7 +13,6 @@
 #include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/fml/message_loop.h"
 #include "flutter/fml/platform/darwin/platform_version.h"
-#include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/runtime/ptrace_check.h"
 #include "flutter/shell/common/thread_host.h"
 #import "flutter/shell/platform/darwin/common/framework/Source/FlutterBinaryMessengerRelay.h"
@@ -245,22 +244,20 @@ typedef struct MouseState {
   }
   FlutterView.forceSoftwareRendering = project.settings.enable_software_rendering;
   _weakFactory = std::make_unique<fml::WeakNSObjectFactory<FlutterViewController>>(self);
-  auto engine = fml::scoped_nsobject<FlutterEngine>{[[FlutterEngine alloc]
-                initWithName:@"io.flutter"
-                     project:project
-      allowHeadlessExecution:self.engineAllowHeadlessExecution
-          restorationEnabled:self.restorationIdentifier != nil]};
-
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"io.flutter"
+                                                      project:project
+                                       allowHeadlessExecution:self.engineAllowHeadlessExecution
+                                           restorationEnabled:self.restorationIdentifier != nil];
   if (!engine) {
     return;
   }
 
   _viewOpaque = YES;
   _engine = engine;
-  _flutterView = [[FlutterView alloc] initWithDelegate:self.engine
-                                                opaque:self.isViewOpaque
+  _flutterView = [[FlutterView alloc] initWithDelegate:_engine
+                                                opaque:_viewOpaque
                                        enableWideGamut:project.isWideGamutEnabled];
-  [self.engine createShell:nil libraryURI:nil initialRoute:initialRoute];
+  [_engine createShell:nil libraryURI:nil initialRoute:initialRoute];
   _engineNeedsLaunch = YES;
   _ongoingTouches = [[NSMutableSet alloc] init];
   [self loadDefaultSplashScreenView];

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -526,7 +526,7 @@ static UIView* GetViewOrPlaceholder(UIView* existing_view) {
   // This is an arbitrary offset that is not CGPointZero.
   scrollView.contentOffset = CGPointMake(kScrollViewContentSize, kScrollViewContentSize);
 
-  [self.view addSubview:self.scrollView];
+  [self.view addSubview:scrollView];
   self.scrollView = scrollView;
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -156,6 +156,7 @@ typedef struct MouseState {
   // TODO(cbracken): https://github.com/flutter/flutter/issues/137801
   // Eliminate once we can use weak pointers in platform_view_ios.h.
   std::unique_ptr<fml::WeakNSObjectFactory<FlutterViewController>> _weakFactory;
+  FlutterEngine* _engine;
 
   flutter::ViewportMetrics _viewportMetrics;
   MouseState _mouseState;
@@ -305,6 +306,10 @@ typedef struct MouseState {
   // TODO(cbracken): https://github.com/flutter/flutter/issues/157140
   // Eliminate method calls in initializers and dealloc.
   [self setUpNotificationCenterObservers];
+}
+
+- (FlutterEngine*)engine {
+  return _engine;
 }
 
 - (fml::WeakNSObject<FlutterViewController>)getWeakNSObject {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1317,7 +1317,6 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
     return;
   }
 
-  NSAssert(self.engine, @"engine must not be nil");
   flutter::Shell& shell = self.engine.shell;
   auto callback = [](std::unique_ptr<flutter::FrameTimingsRecorder> recorder) {
     // Do nothing in this block. Just trigger system to callback touch events with correct rate.
@@ -1402,7 +1401,6 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   if (firstViewBoundsUpdate && applicationOrSceneIsActive && self.engine) {
     [self surfaceUpdated:YES];
 
-    NSAssert(self.engine, @"engine must not be nil");
     flutter::Shell& shell = self.engine.shell;
     fml::TimeDelta waitTime =
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -696,13 +696,13 @@ static void SendFakeTouchEvent(UIScreen* screen,
 }
 
 - (void)setSplashScreenView:(UIView*)view {
-  if (view == self.splashScreenView) {
+  if (view == _splashScreenView) {
     return;
   }
 
   // Special case: user wants to remove the splash screen view.
   if (!view) {
-    if (self.splashScreenView) {
+    if (_splashScreenView) {
       [self removeSplashScreenView:nil];
     }
     return;

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -2159,7 +2159,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 - (void)onUserSettingsChanged:(NSNotification*)notification {
   [self.engine.settingsChannel sendMessage:@{
     @"textScaleFactor" : @(self.textScaleFactor),
-    @"alwaysUse24HourFormat" : @([FlutterHourFormat isAlwaysUse24HourFormat]),
+    @"alwaysUse24HourFormat" : @(FlutterHourFormat.isAlwaysUse24HourFormat),
     @"platformBrightness" : self.brightnessMode,
     @"platformContrast" : self.contrastMode,
     @"nativeSpellCheckServiceDefined" : @true,

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -2092,8 +2092,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   if (!self.engine) {
     return;
   }
-  // XXX: Explicit type here.
-  auto platformView = self.engine.platformView;
+  fml::WeakPtr<flutter::PlatformView> platformView = self.engine.platformView;
   int32_t flags = self.accessibilityFlags;
 #if TARGET_OS_SIMULATOR
   // There doesn't appear to be any way to determine whether the accessibility

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1,4 +1,4 @@
-// Copyright 2013 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reservedj；えr
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -1885,11 +1885,30 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 // the wild, however, so I suspect that the API is built for a tvOS remote or
 // something, and perhaps only one ever appears in the set on iOS from a
 // keyboard.
+//
+// We define separate superPresses* overrides to avoid implicitly capturing self in the blocks
+// passed to the presses* methods below.
+
+- (void)superPressesBegan:(NSSet<UIPress*>*)presses withEvent:(UIPressesEvent*)event {
+  [super pressesBegan:presses withEvent:event];
+}
+
+- (void)superPressesChanged:(NSSet<UIPress*>*)presses withEvent:(UIPressesEvent*)event {
+  [super pressesChanged:presses withEvent:event];
+}
+
+- (void)superPressesEnded:(NSSet<UIPress*>*)presses withEvent:(UIPressesEvent*)event {
+  [super pressesEnded:presses withEvent:event];
+}
+
+- (void)superPressesCancelled:(NSSet<UIPress*>*)presses withEvent:(UIPressesEvent*)event {
+  [super pressesCancelled:presses withEvent:event];
+}
 
 // If you substantially change these presses overrides, consider also changing
 // the similar ones in FlutterTextInputPlugin. They need to be overridden in
 // both places to capture keys both inside and outside of a text field, but have
-// slightly different implmentations.
+// slightly different implementations.
 
 - (void)pressesBegan:(NSSet<UIPress*>*)presses
            withEvent:(UIPressesEvent*)event API_AVAILABLE(ios(9.0)) {
@@ -1898,7 +1917,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
     for (UIPress* press in presses) {
       [self handlePressEvent:[[FlutterUIPressProxy alloc] initWithPress:press withEvent:event]
                   nextAction:^() {
-                    [weakSelf->super pressesBegan:[NSSet setWithObject:press] withEvent:event];
+                    [weakSelf superPressesBegan:[NSSet setWithObject:press] withEvent:event];
                   }];
     }
   } else {
@@ -1913,7 +1932,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
     for (UIPress* press in presses) {
       [self handlePressEvent:[[FlutterUIPressProxy alloc] initWithPress:press withEvent:event]
                   nextAction:^() {
-                    [weakSelf->super pressesChanged:[NSSet setWithObject:press] withEvent:event];
+                    [weakSelf superPressesChanged:[NSSet setWithObject:press] withEvent:event];
                   }];
     }
   } else {
@@ -1928,7 +1947,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
     for (UIPress* press in presses) {
       [self handlePressEvent:[[FlutterUIPressProxy alloc] initWithPress:press withEvent:event]
                   nextAction:^() {
-                    [weakSelf->super pressesEnded:[NSSet setWithObject:press] withEvent:event];
+                    [weakSelf superPressesEnded:[NSSet setWithObject:press] withEvent:event];
                   }];
     }
   } else {
@@ -1943,7 +1962,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
     for (UIPress* press in presses) {
       [self handlePressEvent:[[FlutterUIPressProxy alloc] initWithPress:press withEvent:event]
                   nextAction:^() {
-                    [weakSelf->super pressesCancelled:[NSSet setWithObject:press] withEvent:event];
+                    [weakSelf superPressesCancelled:[NSSet setWithObject:press] withEvent:event];
                   }];
     }
   } else {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1311,7 +1311,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
     return;
   }
 
-  // XXX: Errr, shouldn't we be ensuring self.engine isn't nil here?
+  NSAssert(self.engine, @"engine must not be nil");
   flutter::Shell& shell = self.engine.shell;
   auto callback = [](std::unique_ptr<flutter::FrameTimingsRecorder> recorder) {
     // Do nothing in this block. Just trigger system to callback touch events with correct rate.
@@ -1396,7 +1396,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   if (firstViewBoundsUpdate && applicationOrSceneIsActive && self.engine) {
     [self surfaceUpdated:YES];
 
-    // XXX: Check self.engine isn't nil...
+    NSAssert(self.engine, @"engine must not be nil");
     flutter::Shell& shell = self.engine.shell;
     fml::TimeDelta waitTime =
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -187,6 +187,8 @@ typedef struct MouseState {
     _weakFactory = std::make_unique<fml::WeakNSObjectFactory<FlutterViewController>>(self);
     _ongoingTouches = [[NSMutableSet alloc] init];
 
+    // TODO(cbracken): https://github.com/flutter/flutter/issues/157140
+    // Eliminate method calls in initializers and dealloc.
     [self performCommonViewControllerInitialization];
     [engine setViewController:self];
   }
@@ -199,6 +201,8 @@ typedef struct MouseState {
                          bundle:(NSBundle*)nibBundle {
   self = [super initWithNibName:nibName bundle:nibBundle];
   if (self) {
+    // TODO(cbracken): https://github.com/flutter/flutter/issues/157140
+    // Eliminate method calls in initializers and dealloc.
     [self sharedSetupWithProject:project initialRoute:nil];
   }
 
@@ -211,6 +215,8 @@ typedef struct MouseState {
                          bundle:(NSBundle*)nibBundle {
   self = [super initWithNibName:nibName bundle:nibBundle];
   if (self) {
+    // TODO(cbracken): https://github.com/flutter/flutter/issues/157140
+    // Eliminate method calls in initializers and dealloc.
     [self sharedSetupWithProject:project initialRoute:initialRoute];
   }
 
@@ -262,6 +268,9 @@ typedef struct MouseState {
   [_engine createShell:nil libraryURI:nil initialRoute:initialRoute];
   _engineNeedsLaunch = YES;
   _ongoingTouches = [[NSMutableSet alloc] init];
+
+  // TODO(cbracken): https://github.com/flutter/flutter/issues/157140
+  // Eliminate method calls in initializers and dealloc.
   [self loadDefaultSplashScreenView];
   [self performCommonViewControllerInitialization];
 }
@@ -289,6 +298,8 @@ typedef struct MouseState {
   _orientationPreferences = UIInterfaceOrientationMaskAll;
   _statusBarStyle = UIStatusBarStyleDefault;
 
+  // TODO(cbracken): https://github.com/flutter/flutter/issues/157140
+  // Eliminate method calls in initializers and dealloc.
   [self setUpNotificationCenterObservers];
 }
 
@@ -601,6 +612,7 @@ static void SendFakeTouchEvent(UIScreen* screen,
 - (void)removeSplashScreenView:(dispatch_block_t _Nullable)onComplete {
   NSAssert(self.splashScreenView, @"The splash screen view must not be nil");
   UIView* splashScreen = self.splashScreenView;
+  // setSplashScreenView calls this method. Assign directly to ivar to avoid an infinite loop.
   _splashScreenView = nil;
   [UIView animateWithDuration:0.2
       animations:^{
@@ -960,6 +972,8 @@ static void SendFakeTouchEvent(UIScreen* screen,
   // before any other members are destroyed.
   _weakFactory.reset();
 
+  // TODO(cbracken): https://github.com/flutter/flutter/issues/157140
+  // Eliminate method calls in initializers and dealloc.
   [self removeInternalPlugins];
   [self deregisterNotifications];
 
@@ -1572,8 +1586,6 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   if (isLocal && ![isLocal boolValue]) {
     return YES;
   }
-
-  // Engine’s viewController is not current viewController.
   return self.engine.viewController != self;
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -499,16 +499,20 @@ static UIView* GetViewOrPlaceholder(UIView* existing_view) {
   self.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 
   [self installSplashScreenViewIfNecessary];
-  self.scrollView = [[UIScrollView alloc] init];
-  self.scrollView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+
+  // Create and set up the scroll view.
+  UIScrollView* scrollView = [[UIScrollView alloc] init];
+  scrollView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
   // The color shouldn't matter since it is offscreen.
-  self.scrollView.backgroundColor = UIColor.whiteColor;
-  self.scrollView.delegate = self;
+  scrollView.backgroundColor = UIColor.whiteColor;
+  scrollView.delegate = self;
   // This is an arbitrary small size.
-  self.scrollView.contentSize = CGSizeMake(kScrollViewContentSize, kScrollViewContentSize);
+  scrollView.contentSize = CGSizeMake(kScrollViewContentSize, kScrollViewContentSize);
   // This is an arbitrary offset that is not CGPointZero.
-  self.scrollView.contentOffset = CGPointMake(kScrollViewContentSize, kScrollViewContentSize);
+  scrollView.contentOffset = CGPointMake(kScrollViewContentSize, kScrollViewContentSize);
+
   [self.view addSubview:self.scrollView];
+  self.scrollView = scrollView;
 }
 
 - (flutter::PointerData)generatePointerDataForFake {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -149,7 +149,7 @@ typedef struct MouseState {
 - (void)onFirstFrameRendered;
 
 /// Handles updating viewport metrics on keyboard animation.
-- (void)handleKeyboardAnimationCallback:(fml::TimePoint)targetTime;
+- (void)handleKeyboardAnimationCallbackWithTargetTime:(fml::TimePoint)targetTime;
 @end
 
 @implementation FlutterViewController {
@@ -1722,7 +1722,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 
   __weak FlutterViewController* weakSelf = self;
   [self setUpKeyboardAnimationVsyncClient:^(fml::TimePoint targetTime) {
-    [weakSelf handleKeyboardAnimationCallback:targetTime];
+    [weakSelf handleKeyboardAnimationCallbackWithTargetTime:targetTime];
   }];
   VSyncClient* currentVsyncClient = _keyboardAnimationVSyncClient;
 
@@ -1776,7 +1776,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
                                          toValue:self.targetViewInsetBottom];
 }
 
-- (void)handleKeyboardAnimationCallback:(fml::TimePoint)targetTime {
+- (void)handleKeyboardAnimationCallbackWithTargetTime:(fml::TimePoint)targetTime {
   // If the view controller's view is not loaded, bail out.
   if (!self.isViewLoaded) {
     return;

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -147,7 +147,7 @@ typedef struct MouseState {
 @end
 
 @implementation FlutterViewController {
-  // TODO(cbracken): https://github.com/flutter/flutter/issues/155943
+  // TODO(cbracken): https://github.com/flutter/flutter/issues/137801
   // Eliminate once we can use weak pointers in platform_view_ios.h.
   std::unique_ptr<fml::WeakNSObjectFactory<FlutterViewController>> _weakFactory;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -2162,7 +2162,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
     @"alwaysUse24HourFormat" : @(FlutterHourFormat.isAlwaysUse24HourFormat),
     @"platformBrightness" : self.brightnessMode,
     @"platformContrast" : self.contrastMode,
-    @"nativeSpellCheckServiceDefined" : @true,
+    @"nativeSpellCheckServiceDefined" : @YES,
     @"supportsShowingSystemContextMenu" : @(self.supportsShowingSystemContextMenu)
   }];
 }
@@ -2583,7 +2583,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
       break;
     default:
       // continuousScrollEvent: should only ever be triggered with the above phases
-      NSAssert(false, @"Trackpad pan event occured with unexpected phase 0x%lx",
+      NSAssert(NO, @"Trackpad pan event occured with unexpected phase 0x%lx",
                (long)recognizer.state);
       break;
   }
@@ -2613,7 +2613,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
       break;
     default:
       // pinchEvent: should only ever be triggered with the above phases
-      NSAssert(false, @"Trackpad pinch event occured with unexpected phase 0x%lx",
+      NSAssert(NO, @"Trackpad pinch event occured with unexpected phase 0x%lx",
                (long)recognizer.state);
       break;
   }

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -33,6 +33,8 @@
 #import "flutter/shell/platform/embedder/embedder.h"
 #import "flutter/third_party/spring_animation/spring_animation.h"
 
+FLUTTER_ASSERT_ARC
+
 static constexpr int kMicrosecondsPerSecond = 1000 * 1000;
 static constexpr CGFloat kScrollViewContentSize = 2.0;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -71,6 +71,8 @@ typedef struct MouseState {
 
 @property(nonatomic, assign) UIInterfaceOrientationMask orientationPreferences;
 @property(nonatomic, assign) UIStatusBarStyle statusBarStyle;
+@property(nonatomic, assign) BOOL initialized;
+@property(nonatomic, assign) BOOL engineNeedsLaunch;
 
 @property(nonatomic, readwrite, getter=isDisplayingFlutterUI) BOOL displayingFlutterUI;
 @property(nonatomic, assign) BOOL isHomeIndicatorHidden;
@@ -131,9 +133,6 @@ typedef struct MouseState {
   std::unique_ptr<fml::WeakNSObjectFactory<FlutterViewController>> _weakFactory;
 
   flutter::ViewportMetrics _viewportMetrics;
-  BOOL _initialized;
-  BOOL _viewOpaque;
-  BOOL _engineNeedsLaunch;
   fml::scoped_nsobject<NSMutableSet<NSNumber*>> _ongoingTouches;
   // This scroll view is a workaround to accommodate iOS 13 and higher.  There isn't a way to get
   // touches on the status bar to trigger scrolling to the top of a scroll view.  We place a
@@ -154,6 +153,7 @@ typedef struct MouseState {
   NSTimeInterval _scrollInertiaEventAppKitDeadline;
 }
 
+@synthesize viewOpaque = _viewOpaque;
 @synthesize displayingFlutterUI = _displayingFlutterUI;
 @synthesize prefersStatusBarHidden = _flutterPrefersStatusBarHidden;
 @dynamic viewIdentifier;
@@ -284,7 +284,6 @@ typedef struct MouseState {
   }
 
   _initialized = YES;
-
   _orientationPreferences = UIInterfaceOrientationMaskAll;
   _statusBarStyle = UIStatusBarStyleDefault;
 
@@ -754,10 +753,10 @@ static void SendFakeTouchEvent(UIScreen* screen,
 - (void)viewDidLoad {
   TRACE_EVENT0("flutter", "viewDidLoad");
 
-  if (self.engine && _engineNeedsLaunch) {
+  if (self.engine && self.engineNeedsLaunch) {
     [self.engine launchEngine:nil libraryURI:nil entrypointArgs:nil];
     [self.engine setViewController:self];
-    _engineNeedsLaunch = NO;
+    self.engineNeedsLaunch = NO;
   } else if (self.engine.viewController == self) {
     [self.engine attachView];
   }

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -922,10 +922,15 @@ static void SendFakeTouchEvent(UIScreen* screen,
   dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
                                static_cast<int64_t>(transitionDuration / 2.0 * NSEC_PER_SEC)),
                  dispatch_get_main_queue(), ^{
+                   FlutterViewController* strongSelf = weakSelf;
+                   if (!strongSelf) {
+                     return;
+                   }
+
                    // `viewWillTransitionToSize` is only called after the previous rotation is
                    // complete. So there won't be race condition for this flag.
-                   weakSelf.shouldIgnoreViewportMetricsUpdatesDuringRotation = NO;
-                   [weakSelf updateViewportMetricsIfNeeded];
+                   strongSelf.shouldIgnoreViewportMetricsUpdatesDuringRotation = NO;
+                   [strongSelf updateViewportMetricsIfNeeded];
                  });
 }
 
@@ -2293,6 +2298,11 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   // Notifications may not be on the iOS UI thread
   __weak FlutterViewController* weakSelf = self;
   dispatch_async(dispatch_get_main_queue(), ^{
+    FlutterViewController* strongSelf = weakSelf;
+    if (!strongSelf) {
+      return;
+    }
+
     NSDictionary* info = notification.userInfo;
     NSNumber* update = info[@(flutter::kOverlayStyleUpdateNotificationKey)];
     if (update == nil) {
@@ -2300,9 +2310,9 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
     }
 
     UIStatusBarStyle style = static_cast<UIStatusBarStyle>(update.integerValue);
-    if (style != weakSelf.statusBarStyle) {
-      weakSelf.statusBarStyle = style;
-      [weakSelf setNeedsStatusBarAppearanceUpdate];
+    if (style != strongSelf.statusBarStyle) {
+      strongSelf.statusBarStyle = style;
+      [strongSelf setNeedsStatusBarAppearanceUpdate];
     }
   });
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1804,13 +1804,12 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
            @"_keyboardAnimationVSyncClient must be nil when setting up.");
 
   // Make sure the new viewport metrics get sent after the begin frame event has processed.
-  fml::scoped_nsprotocol<FlutterKeyboardAnimationCallback> animationCallback(
-      [keyboardAnimationCallback copy]);
+  FlutterKeyboardAnimationCallback animationCallback = [keyboardAnimationCallback copy];
   auto uiCallback = [animationCallback](std::unique_ptr<flutter::FrameTimingsRecorder> recorder) {
     fml::TimeDelta frameInterval = recorder->GetVsyncTargetTime() - recorder->GetVsyncStartTime();
     fml::TimePoint keyboardAnimationTargetTime = recorder->GetVsyncTargetTime() + frameInterval;
     dispatch_async(dispatch_get_main_queue(), ^(void) {
-      animationCallback.get()(keyboardAnimationTargetTime);
+      animationCallback(keyboardAnimationTargetTime);
     });
   };
 
@@ -1895,10 +1894,11 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 - (void)pressesBegan:(NSSet<UIPress*>*)presses
            withEvent:(UIPressesEvent*)event API_AVAILABLE(ios(9.0)) {
   if (@available(iOS 13.4, *)) {
+    __weak FlutterViewController* weakSelf = self;
     for (UIPress* press in presses) {
       [self handlePressEvent:[[FlutterUIPressProxy alloc] initWithPress:press withEvent:event]
                   nextAction:^() {
-                    [super pressesBegan:[NSSet setWithObject:press] withEvent:event];
+                    [weakSelf->super pressesBegan:[NSSet setWithObject:press] withEvent:event];
                   }];
     }
   } else {
@@ -1909,10 +1909,11 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 - (void)pressesChanged:(NSSet<UIPress*>*)presses
              withEvent:(UIPressesEvent*)event API_AVAILABLE(ios(9.0)) {
   if (@available(iOS 13.4, *)) {
+    __weak FlutterViewController* weakSelf = self;
     for (UIPress* press in presses) {
       [self handlePressEvent:[[FlutterUIPressProxy alloc] initWithPress:press withEvent:event]
                   nextAction:^() {
-                    [super pressesChanged:[NSSet setWithObject:press] withEvent:event];
+                    [weakSelf->super pressesChanged:[NSSet setWithObject:press] withEvent:event];
                   }];
     }
   } else {
@@ -1923,10 +1924,11 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 - (void)pressesEnded:(NSSet<UIPress*>*)presses
            withEvent:(UIPressesEvent*)event API_AVAILABLE(ios(9.0)) {
   if (@available(iOS 13.4, *)) {
+    __weak FlutterViewController* weakSelf = self;
     for (UIPress* press in presses) {
       [self handlePressEvent:[[FlutterUIPressProxy alloc] initWithPress:press withEvent:event]
                   nextAction:^() {
-                    [super pressesEnded:[NSSet setWithObject:press] withEvent:event];
+                    [weakSelf->super pressesEnded:[NSSet setWithObject:press] withEvent:event];
                   }];
     }
   } else {
@@ -1937,10 +1939,11 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 - (void)pressesCancelled:(NSSet<UIPress*>*)presses
                withEvent:(UIPressesEvent*)event API_AVAILABLE(ios(9.0)) {
   if (@available(iOS 13.4, *)) {
+    __weak FlutterViewController* weakSelf = self;
     for (UIPress* press in presses) {
       [self handlePressEvent:[[FlutterUIPressProxy alloc] initWithPress:press withEvent:event]
                   nextAction:^() {
-                    [super pressesCancelled:[NSSet setWithObject:press] withEvent:event];
+                    [weakSelf->super pressesCancelled:[NSSet setWithObject:press] withEvent:event];
                   }];
     }
   } else {
@@ -2266,8 +2269,8 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
     }
 
     UIStatusBarStyle style = static_cast<UIStatusBarStyle>(update.integerValue);
-    if (style != self.statusBarStyle) {
-      self.statusBarStyle = style;
+    if (style != weakSelf.statusBarStyle) {
+      weakSelf.statusBarStyle = style;
       [weakSelf setNeedsStatusBarAppearanceUpdate];
     }
   });

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -658,9 +658,7 @@ static void SendFakeTouchEvent(UIScreen* screen,
                                           rasterTaskRunner = self.engine.rasterTaskRunner]() {
     FML_DCHECK(rasterTaskRunner->RunsTasksOnCurrentThread());
     // Get callback on raster thread and jump back to platform thread.
-    platformTaskRunner->PostTask([weakSelf]() {
-      [weakSelf onFirstFrameRendered];
-    });
+    platformTaskRunner->PostTask([weakSelf]() { [weakSelf onFirstFrameRendered]; });
   });
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
@@ -46,7 +46,7 @@ typedef void (^FlutterKeyboardAnimationCallback)(fml::TimePoint);
 @property(class, nonatomic, readonly) BOOL accessibilityIsOnOffSwitchLabelsEnabled;
 @property(nonatomic, readonly) BOOL isPresentingViewController;
 @property(nonatomic, readonly) BOOL isVoiceOverRunning;
-@property(nonatomic, retain) FlutterKeyboardManager* keyboardManager;
+@property(nonatomic, strong) FlutterKeyboardManager* keyboardManager;
 
 /**
  * @brief Whether the status bar is preferred hidden.


### PR DESCRIPTION
Migrates `FlutterViewController` from manual reference counting to ARC. Eliminates use of scoped_nsobject and scoped_nsprotocol, and migrates ivars to property syntax where possible.

No semantic changes, therefore no changes to tests.

Issue: https://github.com/flutter/flutter/issues/137801

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] We're about one patch away from vanquishing our ARCh enemy... MRC.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
