### PR TITLE
[Flutter GPU] Get the GLES backend/Windows working.

### DIFF
--- a/lib/gpu/command_buffer.h
+++ b/lib/gpu/command_buffer.h
@@ -9,6 +9,7 @@
 #include "flutter/lib/gpu/export.h"
 #include "flutter/lib/ui/dart_wrapper.h"
 #include "impeller/renderer/command_buffer.h"
+#include "impeller/renderer/context.h"
 
 namespace flutter {
 namespace gpu {

--- a/lib/gpu/render_pass.cc
+++ b/lib/gpu/render_pass.cc
@@ -3,10 +3,13 @@
 // found in the LICENSE file.
 
 #include "flutter/lib/gpu/render_pass.h"
+#include <future>
+#include <memory>
 
 #include "flutter/lib/gpu/formats.h"
 #include "flutter/lib/gpu/render_pipeline.h"
 #include "flutter/lib/gpu/shader.h"
+#include "fml/make_copyable.h"
 #include "fml/memory/ref_ptr.h"
 #include "impeller/core/buffer_view.h"
 #include "impeller/core/formats.h"
@@ -14,7 +17,10 @@
 #include "impeller/core/shader_types.h"
 #include "impeller/core/vertex_buffer.h"
 #include "impeller/geometry/color.h"
+#include "impeller/renderer/pipeline.h"
+#include "impeller/renderer/pipeline_descriptor.h"
 #include "impeller/renderer/pipeline_library.h"
+#include "lib/ui/ui_dart_state.h"
 #include "tonic/converter/dart_converter.h"
 
 namespace flutter {
@@ -134,8 +140,27 @@ RenderPass::GetOrCreatePipeline() {
   render_pipeline_->BindToPipelineDescriptor(*context.GetShaderLibrary(),
                                              pipeline_desc);
 
-  auto pipeline =
-      context.GetPipelineLibrary()->GetPipeline(pipeline_desc).Get();
+  std::shared_ptr<impeller::Pipeline<impeller::PipelineDescriptor>> pipeline;
+
+  if (context.GetBackendType() == impeller::Context::BackendType::kOpenGLES) {
+    // Get the pipeline on the raster thread.
+    auto dart_state = flutter::UIDartState::Current();
+    std::promise<
+        std::shared_ptr<impeller::Pipeline<impeller::PipelineDescriptor>>>
+        pipeline_promise;
+    auto pipeline_future = pipeline_promise.get_future();
+    fml::TaskRunner::RunNowOrPostTask(
+        dart_state->GetTaskRunners().GetRasterTaskRunner(),
+        fml::MakeCopyable([promise = std::move(pipeline_promise),
+                           context = GetContext(), pipeline_desc]() mutable {
+          promise.set_value(
+              context->GetPipelineLibrary()->GetPipeline(pipeline_desc).Get());
+        }));
+    pipeline = pipeline_future.get();
+  } else {
+    pipeline = context.GetPipelineLibrary()->GetPipeline(pipeline_desc).Get();
+  }
+
   FML_DCHECK(pipeline) << "Couldn't resolve render pipeline";
   return pipeline;
 }
@@ -443,11 +468,11 @@ bool InternalFlutterGpu_RenderPass_BindTexture(
   auto& command = wrapper->GetCommand();
 
   auto uniform_name = tonic::StdStringFromDart(uniform_name_handle);
-  const impeller::SampledImageSlot* image_slot =
+  const flutter::gpu::Shader::TextureBinding* texture_binding =
       shader->GetUniformTexture(uniform_name);
   // TODO(bdero): Return an error string stating that no uniform texture with
   //              this name exists and throw an exception.
-  if (!image_slot) {
+  if (!texture_binding) {
     return false;
   }
 
@@ -461,10 +486,10 @@ bool InternalFlutterGpu_RenderPass_BindTexture(
       flutter::gpu::ToImpellerSamplerAddressMode(height_address_mode);
   const std::unique_ptr<const impeller::Sampler>& sampler =
       wrapper->GetContext()->GetSamplerLibrary()->GetSampler(sampler_desc);
-
-  return command.BindResource(
-      shader->GetShaderStage(), impeller::DescriptorType::kSampledImage,
-      *image_slot, impeller::ShaderMetadata{}, texture->GetTexture(), sampler);
+  return command.BindResource(shader->GetShaderStage(),
+                              impeller::DescriptorType::kSampledImage,
+                              texture_binding->slot, texture_binding->metadata,
+                              texture->GetTexture(), sampler);
 }
 
 void InternalFlutterGpu_RenderPass_ClearBindings(

--- a/lib/gpu/shader.cc
+++ b/lib/gpu/shader.cc
@@ -42,8 +42,7 @@ fml::RefPtr<Shader> Shader::Make(
     std::vector<impeller::ShaderStageIOSlot> inputs,
     std::vector<impeller::ShaderStageBufferLayout> layouts,
     std::unordered_map<std::string, UniformBinding> uniform_structs,
-    std::unordered_map<std::string, impeller::SampledImageSlot>
-        uniform_textures,
+    std::unordered_map<std::string, TextureBinding> uniform_textures,
     std::vector<impeller::DescriptorSetLayout> descriptor_set_layouts) {
   auto shader = fml::MakeRefCounted<Shader>();
   shader->entrypoint_ = std::move(entrypoint);
@@ -112,7 +111,7 @@ const Shader::UniformBinding* Shader::GetUniformStruct(
   return &uniform->second;
 }
 
-const impeller::SampledImageSlot* Shader::GetUniformTexture(
+const Shader::TextureBinding* Shader::GetUniformTexture(
     const std::string& name) const {
   auto uniform = uniform_textures_.find(name);
   if (uniform == uniform_textures_.end()) {

--- a/lib/gpu/shader.h
+++ b/lib/gpu/shader.h
@@ -34,6 +34,11 @@ class Shader : public RefCountedDartWrappable<Shader> {
         const std::string& name) const;
   };
 
+  struct TextureBinding {
+    impeller::SampledImageSlot slot;
+    impeller::ShaderMetadata metadata;
+  };
+
   ~Shader() override;
 
   static fml::RefPtr<Shader> Make(
@@ -43,8 +48,7 @@ class Shader : public RefCountedDartWrappable<Shader> {
       std::vector<impeller::ShaderStageIOSlot> inputs,
       std::vector<impeller::ShaderStageBufferLayout> layouts,
       std::unordered_map<std::string, UniformBinding> uniform_structs,
-      std::unordered_map<std::string, impeller::SampledImageSlot>
-          uniform_textures,
+      std::unordered_map<std::string, TextureBinding> uniform_textures,
       std::vector<impeller::DescriptorSetLayout> descriptor_set_layouts);
 
   std::shared_ptr<const impeller::ShaderFunction> GetFunctionFromLibrary(
@@ -63,7 +67,7 @@ class Shader : public RefCountedDartWrappable<Shader> {
 
   const Shader::UniformBinding* GetUniformStruct(const std::string& name) const;
 
-  const impeller::SampledImageSlot* GetUniformTexture(
+  const Shader::TextureBinding* GetUniformTexture(
       const std::string& name) const;
 
  private:
@@ -75,7 +79,7 @@ class Shader : public RefCountedDartWrappable<Shader> {
   std::vector<impeller::ShaderStageIOSlot> inputs_;
   std::vector<impeller::ShaderStageBufferLayout> layouts_;
   std::unordered_map<std::string, UniformBinding> uniform_structs_;
-  std::unordered_map<std::string, impeller::SampledImageSlot> uniform_textures_;
+  std::unordered_map<std::string, TextureBinding> uniform_textures_;
   std::vector<impeller::DescriptorSetLayout> descriptor_set_layouts_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(Shader);


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/156305.

* Resolve pipelines and submit command buffers on the raster thread.
* Don't use desktop GL shader variation on Windows.
* Fix interpretation of `array_elements`.
* Fix texture binding metadata.

Gets Flutter GPU working on Windows!
![image](https://github.com/user-attachments/assets/9eecb67f-a980-4556-8060-b0c947713534)
![image](https://github.com/user-attachments/assets/c8e2071f-e7c0-411c-8f37-e1f3037916f4)
