### PR TITLE
Speculative fix for memory issues related to retrying image decompression

### DIFF
--- a/impeller/renderer/backend/metal/context_mtl.mm
+++ b/impeller/renderer/backend/metal/context_mtl.mm
@@ -383,7 +383,7 @@ void ContextMTL::StoreTaskForGPU(const fml::closure& task,
                                  const fml::closure& failure) {
   tasks_awaiting_gpu_.push_back(PendingTasks{task, failure});
   while (tasks_awaiting_gpu_.size() > kMaxTasksAwaitingGPU) {
-    PendingTasks front = std::move(tasks_awaiting_gpu_.front());
+    const PendingTasks& front = tasks_awaiting_gpu_.front();
     if (front.failure) {
       front.failure();
     }

--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -418,22 +418,21 @@ void ImageDecoderImpeller::UploadTextureToPrivate(
             result(image, decode_error);
           })
           .SetIfTrue([&result, context, buffer, image_info, resize_info] {
-            // The `result` function must be copied in the capture list for each
-            // closure or the stack allocated callback will be cleared by the
-            // time to closure is executed later.
+            auto result_ptr = std::make_shared<ImageResult>(std::move(result));
             context->StoreTaskForGPU(
-                [result, context, buffer, image_info, resize_info]() {
+                [result_ptr, context, buffer, image_info, resize_info]() {
                   sk_sp<DlImage> image;
                   std::string decode_error;
                   std::tie(image, decode_error) =
                       std::tie(image, decode_error) =
                           UnsafeUploadTextureToPrivate(context, buffer,
                                                        image_info, resize_info);
-                  result(image, decode_error);
+                  (*result_ptr)(image, decode_error);
                 },
-                [result]() {
-                  result(nullptr,
-                         "Image upload failed due to loss of GPU access.");
+                [result_ptr]() {
+                  (*result_ptr)(
+                      nullptr,
+                      "Image upload failed due to loss of GPU access.");
                 });
           }));
 }

--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -423,10 +423,8 @@ void ImageDecoderImpeller::UploadTextureToPrivate(
                 [result_ptr, context, buffer, image_info, resize_info]() {
                   sk_sp<DlImage> image;
                   std::string decode_error;
-                  std::tie(image, decode_error) =
-                      std::tie(image, decode_error) =
-                          UnsafeUploadTextureToPrivate(context, buffer,
-                                                       image_info, resize_info);
+                  std::tie(image, decode_error) = UnsafeUploadTextureToPrivate(
+                      context, buffer, image_info, resize_info);
                   (*result_ptr)(image, decode_error);
                 },
                 [result_ptr]() {

--- a/lib/ui/painting/image_encoding_unittests.cc
+++ b/lib/ui/painting/image_encoding_unittests.cc
@@ -328,7 +328,6 @@ TEST_F(ShellTest, EncodeImageRetryOverflows) {
   DestroyShell(std::move(shell), task_runners);
 }
 
-
 TEST_F(ShellTest, ToImageRetries) {
 #ifndef FML_OS_MACOSX
   GTEST_SKIP() << "Only works on macos currently.";

--- a/lib/ui/painting/image_encoding_unittests.cc
+++ b/lib/ui/painting/image_encoding_unittests.cc
@@ -375,6 +375,53 @@ TEST_F(ShellTest, ToImageRetries) {
   message_latch.Wait();
   DestroyShell(std::move(shell), task_runners);
 }
+TEST_F(ShellTest, ToImageRetryOverflow) {
+#ifndef FML_OS_MACOSX
+  GTEST_SKIP() << "Only works on macos currently.";
+#endif
+  Settings settings = CreateSettingsForFixture();
+  settings.enable_impeller = true;
+  TaskRunners task_runners("test",                  // label
+                           GetCurrentTaskRunner(),  // platform
+                           CreateNewThread(),       // raster
+                           CreateNewThread(),       // ui
+                           CreateNewThread()        // io
+  );
+
+  std::unique_ptr<Shell> shell = CreateShell({
+      .settings = settings,
+      .task_runners = task_runners,
+  });
+
+  auto turn_off_gpu = [&](Dart_NativeArguments args) {
+    auto handle = Dart_GetNativeArgument(args, 0);
+    bool value = true;
+    ASSERT_TRUE(Dart_IsBoolean(handle));
+    Dart_BooleanValue(handle, &value);
+    TurnOffGPU(shell.get(), value);
+  };
+
+  AddNativeCallback("TurnOffGPU", CREATE_NATIVE_ENTRY(turn_off_gpu));
+
+  auto validate_not_null = [&](Dart_NativeArguments args) {
+    auto handle = Dart_GetNativeArgument(args, 0);
+    EXPECT_FALSE(Dart_IsNull(handle));
+    message_latch.Signal();
+  };
+
+  AddNativeCallback("ValidateNotNull", CREATE_NATIVE_ENTRY(validate_not_null));
+
+  ASSERT_TRUE(shell->IsSetup());
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("toImageRetryOverflows");
+
+  shell->RunEngine(std::move(configuration), [&](auto result) {
+    ASSERT_EQ(result, Engine::RunStatus::Success);
+  });
+
+  message_latch.Wait();
+  DestroyShell(std::move(shell), task_runners);
+}
 
 TEST_F(ShellTest, EncodeImageFailsWithoutGPUImpeller) {
 #ifndef FML_OS_MACOSX

--- a/lib/ui/painting/image_encoding_unittests.cc
+++ b/lib/ui/painting/image_encoding_unittests.cc
@@ -280,6 +280,55 @@ TEST_F(ShellTest, EncodeImageRetries) {
   DestroyShell(std::move(shell), task_runners);
 }
 
+TEST_F(ShellTest, EncodeImageRetryOverflows) {
+#ifndef FML_OS_MACOSX
+  GTEST_SKIP() << "Only works on macos currently.";
+#endif
+  Settings settings = CreateSettingsForFixture();
+  settings.enable_impeller = true;
+  TaskRunners task_runners("test",                  // label
+                           GetCurrentTaskRunner(),  // platform
+                           CreateNewThread(),       // raster
+                           CreateNewThread(),       // ui
+                           CreateNewThread()        // io
+  );
+
+  std::unique_ptr<Shell> shell = CreateShell({
+      .settings = settings,
+      .task_runners = task_runners,
+  });
+
+  auto turn_off_gpu = [&](Dart_NativeArguments args) {
+    auto handle = Dart_GetNativeArgument(args, 0);
+    bool value = true;
+    ASSERT_TRUE(Dart_IsBoolean(handle));
+    Dart_BooleanValue(handle, &value);
+    TurnOffGPU(shell.get(), value);
+  };
+
+  AddNativeCallback("TurnOffGPU", CREATE_NATIVE_ENTRY(turn_off_gpu));
+
+  auto validate_not_null = [&](Dart_NativeArguments args) {
+    auto handle = Dart_GetNativeArgument(args, 0);
+    EXPECT_FALSE(Dart_IsNull(handle));
+    message_latch.Signal();
+  };
+
+  AddNativeCallback("ValidateNotNull", CREATE_NATIVE_ENTRY(validate_not_null));
+
+  ASSERT_TRUE(shell->IsSetup());
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("toByteDataRetryOverflows");
+
+  shell->RunEngine(std::move(configuration), [&](auto result) {
+    ASSERT_EQ(result, Engine::RunStatus::Success);
+  });
+
+  message_latch.Wait();
+  DestroyShell(std::move(shell), task_runners);
+}
+
+
 TEST_F(ShellTest, ToImageRetries) {
 #ifndef FML_OS_MACOSX
   GTEST_SKIP() << "Only works on macos currently.";


### PR DESCRIPTION
b/371512414

This issue had no reproduction but the stacktrace was provided.  The theory of this fix is that the `ImageResult` type is capturing something that doesn't handle being copied and deallocated twice so instead of copying it, we std::move it into a shared_ptr so that it will only be deallocated once.

Also, I just avoid using a `std::move` when overflowing.  The idea here is maybe sometimes deleting the std::move'd item isn't kosher.  We know from the stacktrace that it has something to do with overflowing because that would be the only case where something is being deleted.

I've added 2 integration tests that exercises the code where the crash appears to be happening.  This is good coverage to have but neither of them reproduced the issue, even with MallocScribble enabled.  That's the best we can do without a reproduction.

```
Thread 7  (id: 0x0000a103)crashed
0x000000010a48ae8c(Flutter -function.h)std::_fl::allocator<impeller::ContextMTL::PendingTasks>::destroy[abi:v15000](impeller::ContextMTL::PendingTasks*)
0x000000010a48b9fc(Flutter -allocator_traits.h:309)impeller::ContextMTL::StoreTaskForGPU(std::_fl::function<void ()> const&, std::_fl::function<void ()> const&)
0x000000010a48b9fc(Flutter -allocator_traits.h:309)impeller::ContextMTL::StoreTaskForGPU(std::_fl::function<void ()> const&, std::_fl::function<void ()> const&)
0x000000010a4d49e4(Flutter -image_decoder_impeller.cc:422)std::_fl::__function::__func<flutter::ImageDecoderImpeller::UploadTextureToPrivate(std::_fl::function<void (sk_sp<flutter::DlImage>, std::_fl::basic_string<char, std::_fl::char_traits<char>, std::_fl::allocator<char>>)>, std::_fl::shared_ptr<impeller::Context> const&, std::_fl::shared_ptr<impeller::DeviceBuffer> const&, SkImageInfo const&, std::_fl::shared_ptr<SkBitmap> const&, std::_fl::optional<SkImageInfo> const&, std::_fl::shared_ptr<fml::SyncSwitch> const&)::$_1, std::_fl::allocator<flutter::ImageDecoderImpeller::UploadTextureToPrivate(std::_fl::function<void (sk_sp<flutter::DlImage>, std::_fl::basic_string<char, std::_fl::char_traits<char>, std::_fl::allocator<char>>)>, std::_fl::shared_ptr<impeller::Context> const&, std::_fl::shared_ptr<impeller::DeviceBuffer> const&, SkImageInfo const&, std::_fl::shared_ptr<SkBitmap> const&, std::_fl::optional<SkImageInfo> const&, std::_fl::shared_ptr<fml::SyncSwitch> const&)::$_1>, void ()>::operator()()
0x000000010a06c234(Flutter -function.h:512)fml::SyncSwitch::Execute(fml::SyncSwitch::Handlers const&) const
0x000000010a4d42f8(Flutter -image_decoder_impeller.cc:408)flutter::ImageDecoderImpeller::UploadTextureToPrivate(std::_fl::function<void (sk_sp<flutter::DlImage>, std::_fl::basic_string<char, std::_fl::char_traits<char>, std::_fl::allocator<char>>)>, std::_fl::shared_ptr<impeller::Context> const&, std::_fl::shared_ptr<impeller::DeviceBuffer> const&, SkImageInfo const&, std::_fl::shared_ptr<SkBitmap> const&, std::_fl::optional<SkImageInfo> const&, std::_fl::shared_ptr<fml::SyncSwitch> const&)
0x000000010a4d3838(Flutter -image_decoder_impeller.cc:538)std::_fl::__function::__func<flutter::ImageDecoderImpeller::Decode(fml::RefPtr<flutter::ImageDescriptor>, unsigned int, unsigned int, std::_fl::function<void (sk_sp<flutter::DlImage>, std::_fl::basic_string<char, std::_fl::char_traits<char>, std::_fl::allocator<char>>)> const&)::$_1, std::_fl::allocator<flutter::ImageDecoderImpeller::Decode(fml::RefPtr<flutter::ImageDescriptor>, unsigned int, unsigned int, std::_fl::function<void (sk_sp<flutter::DlImage>, std::_fl::basic_string<char, std::_fl::char_traits<char>, std::_fl::allocator<char>>)> const&)::$_1>, void ()>::operator()()
0x000000010a06dd1c(Flutter -function.h:512)fml::ConcurrentMessageLoopDarwin::ExecuteTask(std::_fl::function<void ()> const&)
0x000000010a06737c(Flutter -concurrent_message_loop.cc:101)void* std::_fl::__thread_proxy[abi:v15000]<std::_fl::tuple<std::_fl::unique_ptr<std::_fl::__thread_struct, std::_fl::default_delete<std::_fl::__thread_struct>>, fml::ConcurrentMessageLoop::ConcurrentMessageLoop(unsigned long)::$_0>>(void*)
0x000000021d4ff378(libsystem_pthread.dylib + 0x00006378)_pthread_start
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
