### PR TITLE
[web] Warn users when picking a deprecated renderer.

### DIFF
--- a/lib/web_ui/lib/src/engine/configuration.dart
+++ b/lib/web_ui/lib/src/engine/configuration.dart
@@ -167,7 +167,7 @@ class FlutterConfiguration {
 
   /// Auto detect which rendering backend to use.
   ///
-  /// Using flutter tools option "--web-render=auto" or not specifying one
+  /// Using flutter tools option "--web-renderer=auto" or not specifying one
   /// would set the value to true. Otherwise, it would be false.
   static const bool flutterWebAutoDetect =
       bool.fromEnvironment('FLUTTER_WEB_AUTO_DETECT', defaultValue: true);
@@ -177,10 +177,10 @@ class FlutterConfiguration {
 
   /// Enable the Skia-based rendering backend.
   ///
-  /// Using flutter tools option "--web-render=canvaskit" would set the value to
+  /// Using flutter tools option "--web-renderer=canvaskit" would set the value to
   /// true.
   ///
-  /// Using flutter tools option "--web-render=html" would set the value to false.
+  /// Using flutter tools option "--web-renderer=html" would set the value to false.
   static const bool useSkia = bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
 
   // Runtime parameters.

--- a/lib/web_ui/lib/src/engine/renderer.dart
+++ b/lib/web_ui/lib/src/engine/renderer.dart
@@ -38,6 +38,19 @@ abstract class Renderer {
         useCanvasKit = FlutterConfiguration.useSkia;
       }
 
+      // Warn users in development that anything other than canvaskit is deprecated.
+      assert(() {
+        if (!useCanvasKit) {
+          // The user requested 'html' or 'auto' either in the command-line or JS.
+          final String requested =
+            configuration.requestedRendererType ??
+            (FlutterConfiguration.flutterWebAutoDetect ? 'auto' : 'html');
+          printWarning(
+            'The HTML Renderer is being deprecated. Stop using the "$requested" renderer mode.'
+            '\nSee: https://docs.flutter.dev/go/web-html-renderer-deprecation');
+        }
+        return true;
+      }());
       return useCanvasKit ? CanvasKitRenderer() : HtmlRenderer();
     }
   }

--- a/lib/web_ui/lib/src/engine/renderer.dart
+++ b/lib/web_ui/lib/src/engine/renderer.dart
@@ -47,7 +47,7 @@ abstract class Renderer {
             (FlutterConfiguration.flutterWebAutoDetect ? 'auto' : 'html');
           printWarning(
             'The HTML Renderer is being deprecated. Stop using the "$requested" renderer mode.'
-            '\nSee: https://docs.flutter.dev/go/web-html-renderer-deprecation');
+            '\nSee: https://docs.flutter.dev/to/web-html-renderer-deprecation');
         }
         return true;
       }());

--- a/lib/web_ui/test/html/deprecation_test.dart
+++ b/lib/web_ui/test/html/deprecation_test.dart
@@ -1,0 +1,36 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  final List<String> warnings = <String>[];
+  late void Function(String) oldPrintWarning;
+
+  setUpAll(() async {
+    oldPrintWarning = printWarning;
+    printWarning = (String warning) {
+      warnings.add(warning);
+    };
+  });
+
+  tearDownAll(() {
+    printWarning = oldPrintWarning;
+  });
+
+  test('Emit a warning when the HTML Renderer was picked.', () {
+    final Renderer chosenRenderer = renderer;
+
+    expect(chosenRenderer, isA<HtmlRenderer>());
+    expect(warnings, contains(
+      contains('See: https://docs.flutter.dev/go/web-html-renderer-deprecation')
+    ));
+  });
+}

--- a/lib/web_ui/test/html/deprecation_test.dart
+++ b/lib/web_ui/test/html/deprecation_test.dart
@@ -30,7 +30,7 @@ void testMain() {
 
     expect(chosenRenderer, isA<HtmlRenderer>());
     expect(warnings, contains(
-      contains('See: https://docs.flutter.dev/go/web-html-renderer-deprecation')
+      contains('See: https://docs.flutter.dev/to/web-html-renderer-deprecation')
     ));
   });
 }


### PR DESCRIPTION
Warn users when they pick a deprecated renderer for the web, and point them to the appropriate /go/ link.

## Issues

* Part of https://github.com/flutter/flutter/issues/145954
* Fixes https://github.com/flutter/flutter/issues/154879

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
