### PR TITLE
[Impeller] libImpeller: Allow creating image color sources.

### DIFF
--- a/impeller/toolkit/interop/color_source.cc
+++ b/impeller/toolkit/interop/color_source.cc
@@ -102,6 +102,23 @@ ScopedObject<ColorSource> ColorSource::MakeSweepGradient(
   return Create<ColorSource>(std::move(dl_filter));
 }
 
+ScopedObject<ColorSource> ColorSource::MakeImage(
+    const Texture& image,
+    flutter::DlTileMode horizontal_tile_mode,
+    flutter::DlTileMode vertical_tile_mode,
+    flutter::DlImageSampling sampling,
+    const Matrix& transformation) {
+  const auto sk_transformation = ToSkMatrix(transformation);
+  auto dl_filter =
+      std::make_shared<flutter::DlImageColorSource>(image.MakeImage(),     //
+                                                    horizontal_tile_mode,  //
+                                                    vertical_tile_mode,    //
+                                                    sampling,              //
+                                                    &sk_transformation     //
+      );
+  return Create<ColorSource>(std::move(dl_filter));
+}
+
 ColorSource::ColorSource(std::shared_ptr<flutter::DlColorSource> source)
     : color_source_(std::move(source)) {}
 

--- a/impeller/toolkit/interop/color_source.h
+++ b/impeller/toolkit/interop/color_source.h
@@ -14,6 +14,7 @@
 #include "impeller/toolkit/interop/formats.h"
 #include "impeller/toolkit/interop/impeller.h"
 #include "impeller/toolkit/interop/object.h"
+#include "impeller/toolkit/interop/texture.h"
 
 namespace impeller::interop {
 
@@ -54,6 +55,13 @@ class ColorSource final
       const std::vector<flutter::DlColor>& colors,
       const std::vector<Scalar>& stops,
       flutter::DlTileMode tile_mode,
+      const Matrix& transformation);
+
+  static ScopedObject<ColorSource> MakeImage(
+      const Texture& image,
+      flutter::DlTileMode horizontal_tile_mode,
+      flutter::DlTileMode vertical_tile_mode,
+      flutter::DlImageSampling sampling,
       const Matrix& transformation);
 
   explicit ColorSource(std::shared_ptr<flutter::DlColorSource> source);

--- a/impeller/toolkit/interop/impeller.cc
+++ b/impeller/toolkit/interop/impeller.cc
@@ -779,6 +779,24 @@ ImpellerColorSource ImpellerColorSourceCreateSweepGradientNew(
 }
 
 IMPELLER_EXTERN_C
+ImpellerColorSource ImpellerColorSourceCreateImageNew(
+    ImpellerTexture image,
+    ImpellerTileMode horizontal_tile_mode,
+    ImpellerTileMode vertical_tile_mode,
+    ImpellerTextureSampling sampling,
+    const ImpellerMatrix* transformation) {
+  return ColorSource::MakeImage(
+             *GetPeer(image),                          //
+             ToDisplayListType(horizontal_tile_mode),  //
+             ToDisplayListType(vertical_tile_mode),    //
+             ToDisplayListType(sampling),              //
+             transformation == nullptr ? Matrix{}
+                                       : ToImpellerType(*transformation)  //
+             )
+      .Leak();
+}
+
+IMPELLER_EXTERN_C
 void ImpellerColorFilterRetain(ImpellerColorFilter color_filter) {
   ObjectBase::SafeRetain(color_filter);
 }

--- a/impeller/toolkit/interop/impeller.h
+++ b/impeller/toolkit/interop/impeller.h
@@ -552,6 +552,14 @@ ImpellerColorSourceCreateSweepGradientNew(
     ImpellerTileMode tile_mode,
     const ImpellerMatrix* IMPELLER_NULLABLE transformation);
 
+IMPELLER_EXPORT IMPELLER_NODISCARD ImpellerColorSource IMPELLER_NULLABLE
+ImpellerColorSourceCreateImageNew(
+    ImpellerTexture IMPELLER_NONNULL image,
+    ImpellerTileMode horizontal_tile_mode,
+    ImpellerTileMode vertical_tile_mode,
+    ImpellerTextureSampling sampling,
+    const ImpellerMatrix* IMPELLER_NULLABLE transformation);
+
 //------------------------------------------------------------------------------
 // Color Filters
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/156360

This was missed in the earlier bringup.

cc @lyceel I did not expose the solid color source since (as @jonahwilliams [pointed out](https://github.com/flutter/flutter/issues/156360#issuecomment-2398005436)) all it does it [clear the current color source and set the color on the paint](https://github.com/flutter/engine/blob/72dca1bca3abe9e74ff74b35404f5c0f0dffe3bb/display_list/dl_builder.cc#L206).