### PR TITLE
Release`onTrimMemoryListener` after `ImageReaderSurfaceProducer` released.

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -705,6 +705,7 @@ public class FlutterRenderer implements TextureRegistry {
     private void releaseInternal() {
       cleanup();
       released = true;
+      removeOnTrimMemoryListener(this);
       imageReaderProducers.remove(this);
     }
 

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -776,7 +776,6 @@ public class FlutterRendererTest {
     verify(callback).onSurfaceDestroyed();
   }
 
-
   @Test
   public void ImageReaderSurfaceProducerUnsubscribesWhenReleased() {
     // Regression test for https://github.com/flutter/flutter/issues/156434.
@@ -785,7 +784,7 @@ public class FlutterRendererTest {
 
     // Create and set a mock callback.
     TextureRegistry.SurfaceProducer.Callback callback =
-            mock(TextureRegistry.SurfaceProducer.Callback.class);
+        mock(TextureRegistry.SurfaceProducer.Callback.class);
     producer.setCallback(callback);
 
     // Release the surface.

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -4,6 +4,7 @@
 
 package io.flutter.embedding.engine.renderer;
 
+import static android.content.ComponentCallbacks2.TRIM_MEMORY_BACKGROUND;
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_COMPLETE;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -671,7 +672,7 @@ public class FlutterRendererTest {
 
     // Invoke the onTrimMemory callback with level 40.
     // This should result in a trim.
-    texture.onTrimMemory(40);
+    texture.onTrimMemory(TRIM_MEMORY_BACKGROUND);
     shadowOf(Looper.getMainLooper()).idle();
 
     assertEquals(0, texture.numImageReaders());
@@ -769,10 +770,32 @@ public class FlutterRendererTest {
     producer.setCallback(callback);
 
     // Trim memory.
-    ((FlutterRenderer.ImageReaderSurfaceProducer) producer).onTrimMemory(40);
+    flutterRenderer.onTrimMemory(TRIM_MEMORY_BACKGROUND);
 
     // Verify.
     verify(callback).onSurfaceDestroyed();
+  }
+
+
+  @Test
+  public void ImageReaderSurfaceProducerUnsubscribesWhenReleased() {
+    // Regression test for https://github.com/flutter/flutter/issues/156434.
+    FlutterRenderer flutterRenderer = engineRule.getFlutterEngine().getRenderer();
+    TextureRegistry.SurfaceProducer producer = flutterRenderer.createSurfaceProducer();
+
+    // Create and set a mock callback.
+    TextureRegistry.SurfaceProducer.Callback callback =
+            mock(TextureRegistry.SurfaceProducer.Callback.class);
+    producer.setCallback(callback);
+
+    // Release the surface.
+    producer.release();
+
+    // Call trim memory.
+    flutterRenderer.onTrimMemory(TRIM_MEMORY_BACKGROUND);
+
+    // Verify was not called.
+    verify(callback, never()).onSurfaceDestroyed();
   }
 
   @Test
@@ -795,7 +818,7 @@ public class FlutterRendererTest {
     producer.setCallback(callback);
 
     // Trim memory.
-    ((FlutterRenderer.ImageReaderSurfaceProducer) producer).onTrimMemory(40);
+    flutterRenderer.onTrimMemory(TRIM_MEMORY_BACKGROUND);
 
     // Trigger a resume.
     ((LifecycleRegistry) ProcessLifecycleOwner.get().getLifecycle())


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/156434.

A better fix for the workaround in https://github.com/flutter/flutter/issues/156158.

This should likely be cherrypicked, as it's a memory leak, safe, and avoids workaround code in plugins.