### PR TITLE
Rename `GetTargetRenderPassDescriptor` to `GetRenderTarget`.

### DIFF
--- a/impeller/playground/playground.cc
+++ b/impeller/playground/playground.cc
@@ -263,7 +263,7 @@ bool Playground::OpenPlaygroundHere(
     ImGui_ImplGlfw_NewFrame();
 
     auto surface = impl_->AcquireSurfaceFrame(context_);
-    RenderTarget render_target = surface->GetTargetRenderPassDescriptor();
+    RenderTarget render_target = surface->GetRenderTarget();
 
     ImGui::NewFrame();
     ImGui::DockSpaceOverViewport(ImGui::GetMainViewport(),

--- a/impeller/renderer/backend/vulkan/test/swapchain_unittests.cc
+++ b/impeller/renderer/backend/vulkan/test/swapchain_unittests.cc
@@ -72,7 +72,7 @@ TEST(SwapchainTest, CachesRenderPassOnSwapchainImage) {
   std::vector<std::shared_ptr<Texture>> depth_stencil_textures;
   for (auto i = 0u; i < 3u; i++) {
     auto drawable = swapchain->AcquireNextDrawable();
-    RenderTarget render_target = drawable->GetTargetRenderPassDescriptor();
+    RenderTarget render_target = drawable->GetRenderTarget();
 
     auto texture = render_target.GetRenderTargetTexture();
     auto& texture_vk = TextureVK::Cast(*texture);
@@ -102,7 +102,7 @@ TEST(SwapchainTest, CachesRenderPassOnSwapchainImage) {
   std::vector<SharedHandleVK<vk::RenderPass>> render_passes;
   for (auto i = 0u; i < 3u; i++) {
     auto drawable = swapchain->AcquireNextDrawable();
-    RenderTarget render_target = drawable->GetTargetRenderPassDescriptor();
+    RenderTarget render_target = drawable->GetRenderTarget();
 
     auto texture = render_target.GetRenderTargetTexture();
     auto& texture_vk = TextureVK::Cast(*texture);
@@ -117,7 +117,7 @@ TEST(SwapchainTest, CachesRenderPassOnSwapchainImage) {
   // unchanged.
   for (auto i = 0u; i < 3u; i++) {
     auto drawable = swapchain->AcquireNextDrawable();
-    RenderTarget render_target = drawable->GetTargetRenderPassDescriptor();
+    RenderTarget render_target = drawable->GetRenderTarget();
 
     auto texture = render_target.GetRenderTargetTexture();
     auto& texture_vk = TextureVK::Cast(*texture);

--- a/impeller/renderer/surface.cc
+++ b/impeller/renderer/surface.cc
@@ -30,7 +30,7 @@ bool Surface::IsValid() const {
   return is_valid_;
 }
 
-const RenderTarget& Surface::GetTargetRenderPassDescriptor() const {
+const RenderTarget& Surface::GetRenderTarget() const {
   return desc_;
 }
 

--- a/impeller/renderer/surface.h
+++ b/impeller/renderer/surface.h
@@ -21,7 +21,7 @@ class Surface {
 
   bool IsValid() const;
 
-  const RenderTarget& GetTargetRenderPassDescriptor() const;
+  const RenderTarget& GetRenderTarget() const;
 
   virtual bool Present() const;
 

--- a/impeller/toolkit/interop/surface.cc
+++ b/impeller/toolkit/interop/surface.cc
@@ -56,7 +56,7 @@ bool Surface::DrawDisplayList(const DisplayList& dl) const {
 
   auto display_list = dl.GetDisplayList();
   auto& content_context = context_->GetAiksContext().GetContentContext();
-  auto render_target = surface_->GetTargetRenderPassDescriptor();
+  auto render_target = surface_->GetRenderTarget();
 
   const auto cull_rect = IRect::MakeSize(surface_->GetSize());
   auto skia_cull_rect =

--- a/shell/gpu/gpu_surface_gl_impeller.cc
+++ b/shell/gpu/gpu_surface_gl_impeller.cc
@@ -98,8 +98,7 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceGLImpeller::AcquireFrame(
       impeller::ISize{size.width(), size.height()}  // fbo_size
   );
 
-  impeller::RenderTarget render_target =
-      surface->GetTargetRenderPassDescriptor();
+  impeller::RenderTarget render_target = surface->GetRenderTarget();
 
   SurfaceFrame::EncodeCallback encode_calback =
       [aiks_context = aiks_context_,  //

--- a/shell/gpu/gpu_surface_metal_impeller.mm
+++ b/shell/gpu/gpu_surface_metal_impeller.mm
@@ -169,13 +169,12 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromCAMetalLa
         surface->SetFrameBoundary(surface_frame.submit_info().frame_boundary);
 
         const bool reset_host_buffer = surface_frame.submit_info().frame_boundary;
-        auto render_result =
-            impeller::RenderToOnscreen(aiks_context->GetContentContext(),         //
-                                       surface->GetTargetRenderPassDescriptor(),  //
-                                       display_list,                              //
-                                       sk_cull_rect,                              //
-                                       /*reset_host_buffer=*/reset_host_buffer    //
-            );
+        auto render_result = impeller::RenderToOnscreen(aiks_context->GetContentContext(),       //
+                                                        surface->GetRenderTarget(),              //
+                                                        display_list,                            //
+                                                        sk_cull_rect,                            //
+                                                        /*reset_host_buffer=*/reset_host_buffer  //
+        );
         if (!render_result) {
           return false;
         }
@@ -282,13 +281,12 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetalImpeller::AcquireFrameFromMTLTextur
 
         impeller::IRect cull_rect = surface->coverage();
         SkIRect sk_cull_rect = SkIRect::MakeWH(cull_rect.GetWidth(), cull_rect.GetHeight());
-        auto render_result =
-            impeller::RenderToOnscreen(aiks_context->GetContentContext(),         //
-                                       surface->GetTargetRenderPassDescriptor(),  //
-                                       display_list,                              //
-                                       sk_cull_rect,                              //
-                                       /*reset_host_buffer=*/true                 //
-            );
+        auto render_result = impeller::RenderToOnscreen(aiks_context->GetContentContext(),  //
+                                                        surface->GetRenderTarget(),         //
+                                                        display_list,                       //
+                                                        sk_cull_rect,                       //
+                                                        /*reset_host_buffer=*/true          //
+        );
         if (!render_result) {
           FML_LOG(ERROR) << "Failed to render Impeller frame";
           return false;

--- a/shell/gpu/gpu_surface_vulkan_impeller.cc
+++ b/shell/gpu/gpu_surface_vulkan_impeller.cc
@@ -59,11 +59,9 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkanImpeller::AcquireFrame(
     return nullptr;
   }
 
-  auto cull_rect =
-      surface->GetTargetRenderPassDescriptor().GetRenderTargetSize();
+  auto cull_rect = surface->GetRenderTarget().GetRenderTargetSize();
 
-  impeller::RenderTarget render_target =
-      surface->GetTargetRenderPassDescriptor();
+  impeller::RenderTarget render_target = surface->GetRenderTarget();
 
   SurfaceFrame::EncodeCallback encode_callback = [aiks_context =
                                                       aiks_context_,  //


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/154799.