### PR TITLE
[Impeller] Ignore opt-outs on iOS devices.

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -224,7 +224,12 @@ struct Settings {
   // Enable the Impeller renderer on supported platforms. Ignored if Impeller is
   // not supported on the platform.
 #if FML_OS_ANDROID || FML_OS_IOS || FML_OS_IOS_SIMULATOR
-  bool enable_impeller = true;
+  // On iOS devices, Impeller is the default with no opt-out and this field is
+  // const.
+#if FML_OS_IOS && !FML_OS_IOS_SIMULATOR
+  static constexpr const
+#endif  // FML_OS_IOS && !FML_OS_IOS_SIMULATOR
+      bool enable_impeller = true;
 #else
   bool enable_impeller = false;
 #endif

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -443,6 +443,10 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
   settings.use_asset_fonts =
       !command_line.HasOption(FlagForSwitch(Switch::DisableAssetFonts));
 
+#if FML_OS_IOS && !FML_OS_IOS_SIMULATOR
+// On these configurations, the Impeller flags are completely ignored with the
+// default taking hold.
+#else   // FML_OS_IOS && !FML_OS_IOS_SIMULATOR
   {
     std::string enable_impeller_value;
     if (command_line.GetOptionValue(FlagForSwitch(Switch::EnableImpeller),
@@ -451,6 +455,7 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
           enable_impeller_value.empty() || "true" == enable_impeller_value;
     }
   }
+#endif  // FML_OS_IOS && !FML_OS_IOS_SIMULATOR
 
   {
     std::string impeller_backend_value;

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -12,8 +12,9 @@
 #include <syslog.h>
 
 #include "flutter/common/constants.h"
+#include "flutter/fml/build_config.h"
 #include "flutter/shell/common/switches.h"
-#import "flutter/shell/platform/darwin/common/command_line.h"
+#include "flutter/shell/platform/darwin/common/command_line.h"
 
 FLUTTER_ASSERT_ARC
 
@@ -176,6 +177,7 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
   settings.enable_wide_gamut = enableWideGamut;
 #endif
 
+#if FML_OS_IOS_SIMULATOR
   if (!command_line.HasOption("enable-impeller")) {
     // Next, look in the app bundle.
     NSNumber* enableImpeller = [bundle objectForInfoDictionaryKey:@"FLTEnableImpeller"];
@@ -188,6 +190,7 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
       settings.enable_impeller = enableImpeller.boolValue;
     }
   }
+#endif  // FML_OS_IOS_SIMULATOR
 
   settings.warn_on_impeller_opt_out = true;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -239,17 +239,6 @@ FLUTTER_ASSERT_ARC
   XCTAssertEqual(renderingApi, flutter::IOSRenderingAPI::kMetal);
 }
 
-- (void)testPlatformViewsControllerRenderingSoftware {
-  auto settings = FLTDefaultSettingsForBundle();
-  settings.enable_software_rendering = true;
-  FlutterDartProject* project = [[FlutterDartProject alloc] initWithSettings:settings];
-  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar" project:project];
-  [engine run];
-  flutter::IOSRenderingAPI renderingApi = [engine platformViewsRenderingAPI];
-
-  XCTAssertEqual(renderingApi, flutter::IOSRenderingAPI::kSoftware);
-}
-
 - (void)testWaitForFirstFrameTimeout {
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar"];
   [engine run];

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -460,6 +460,7 @@ FLUTTER_ASSERT_ARC
 }
 
 - (void)testCanMergePlatformAndUIThread {
+#if defined(TARGET_IPHONE_SIMULATOR) && TARGET_IPHONE_SIMULATOR
   auto settings = FLTDefaultSettingsForBundle();
   settings.enable_impeller = true;
   FlutterDartProject* project = [[FlutterDartProject alloc] initWithSettings:settings];
@@ -468,9 +469,11 @@ FLUTTER_ASSERT_ARC
 
   XCTAssertEqual(engine.shell.GetTaskRunners().GetUITaskRunner(),
                  engine.shell.GetTaskRunners().GetPlatformTaskRunner());
+#endif  // defined(TARGET_IPHONE_SIMULATOR) && TARGET_IPHONE_SIMULATOR
 }
 
 - (void)testCanNotUnMergePlatformAndUIThread {
+#if defined(TARGET_IPHONE_SIMULATOR) && TARGET_IPHONE_SIMULATOR
   auto settings = FLTDefaultSettingsForBundle();
   settings.enable_impeller = true;
   FlutterDartProject* project = [[FlutterDartProject alloc] initWithSettings:settings];
@@ -479,6 +482,7 @@ FLUTTER_ASSERT_ARC
 
   XCTAssertEqual(engine.shell.GetTaskRunners().GetUITaskRunner(),
                  engine.shell.GetTaskRunners().GetPlatformTaskRunner());
+#endif  // defined(TARGET_IPHONE_SIMULATOR) && TARGET_IPHONE_SIMULATOR
 }
 
 @end


### PR DESCRIPTION
Addresses https://github.com/flutter/flutter/issues/155541

This does **not** remove Skia itself from the build. I'll stage that in a followup. Want to keep the scope of this patch small.

This is the new behavior:

* Impeller is the default on iOS devices **and** simulators.
* On iOS devices **only**, all flags and plist options are ignored.
* On iOS simulators **only**, Flutter will used Impeller's Metal backend by default and fallback to the Null backend if Metal device access is not available.
* On iOS simulators **only**, Flutter can pick Skia using the command line flags or plist flags. This is to allow users one more month to migrate as communicated by @zanderso.

The settings objects `enable_impeller` field is now `static constexpr` to avoid accidentally disabling the flag while it still exists.
