### PR TITLE
[DisplayList] Create DlFoo type variants to start moving away from Skia types in API

### DIFF
--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -273,7 +273,7 @@ TEST_F(DisplayListTest, GeneralReceiverInitialValues) {
 
 TEST_F(DisplayListTest, Iteration) {
   DisplayListBuilder builder;
-  builder.DrawRect({10, 10, 20, 20}, DlPaint());
+  builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
   auto dl = builder.Build();
   for (DlIndex i : *dl) {
     EXPECT_EQ(dl->GetOpType(i), DisplayListOpType::kDrawRect)  //
@@ -421,7 +421,7 @@ TEST_F(DisplayListTest, SaveRestoreRestoresClip) {
   DisplayListBuilder builder(cull_rect);
 
   builder.Save();
-  builder.ClipRect({0.0f, 0.0f, 10.0f, 10.0f});
+  builder.ClipRect(SkRect{0.0f, 0.0f, 10.0f, 10.0f});
   builder.Restore();
   check_defaults(builder, cull_rect);
 
@@ -440,7 +440,7 @@ TEST_F(DisplayListTest, BuildRestoresClip) {
   SkRect cull_rect = SkRect::MakeLTRB(-10.0f, -10.0f, 500.0f, 500.0f);
   DisplayListBuilder builder(cull_rect);
 
-  builder.ClipRect({0.0f, 0.0f, 10.0f, 10.0f});
+  builder.ClipRect(SkRect{0.0f, 0.0f, 10.0f, 10.0f});
   builder.Build();
   check_defaults(builder, cull_rect);
 
@@ -1228,25 +1228,27 @@ TEST_F(DisplayListTest, SingleOpsMightSupportGroupOpacityBlendMode) {
   RUN_TESTS2(canvas.DrawColor(DlColor(SK_ColorRED), DlBlendMode::kSrcOver);
              , true);
   RUN_TESTS2(canvas.DrawColor(DlColor(SK_ColorRED), DlBlendMode::kSrc);, false);
-  RUN_TESTS(canvas.DrawLine({0, 0}, {10, 10}, paint););
-  RUN_TESTS(canvas.DrawRect({0, 0, 10, 10}, paint););
-  RUN_TESTS(canvas.DrawOval({0, 0, 10, 10}, paint););
-  RUN_TESTS(canvas.DrawCircle({10, 10}, 5, paint););
+  RUN_TESTS(canvas.DrawLine(SkPoint{0, 0}, SkPoint{10, 10}, paint););
+  RUN_TESTS(canvas.DrawRect(SkRect{0, 0, 10, 10}, paint););
+  RUN_TESTS(canvas.DrawOval(SkRect{0, 0, 10, 10}, paint););
+  RUN_TESTS(canvas.DrawCircle(SkPoint{10, 10}, 5, paint););
   RUN_TESTS(
       canvas.DrawRRect(SkRRect::MakeRectXY({0, 0, 10, 10}, 2, 2), paint););
   RUN_TESTS(canvas.DrawDRRect(SkRRect::MakeRectXY({0, 0, 10, 10}, 2, 2),
                               SkRRect::MakeRectXY({2, 2, 8, 8}, 2, 2), paint););
   RUN_TESTS(canvas.DrawPath(
       SkPath().addOval({0, 0, 10, 10}).addOval({5, 5, 15, 15}), paint););
-  RUN_TESTS(canvas.DrawArc({0, 0, 10, 10}, 0, math::kPi, true, paint););
+  RUN_TESTS(canvas.DrawArc(SkRect{0, 0, 10, 10}, 0, math::kPi, true, paint););
   RUN_TESTS2(
       canvas.DrawPoints(PointMode::kPoints, TestPointCount, kTestPoints, paint);
       , false);
   RUN_TESTS2(canvas.DrawVertices(kTestVertices1, DlBlendMode::kSrc, paint);
              , false);
-  RUN_TESTS(canvas.DrawImage(TestImage1, {0, 0}, kLinearSampling, &paint););
-  RUN_TESTS2(canvas.DrawImage(TestImage1, {0, 0}, kLinearSampling, nullptr);
-             , true);
+  RUN_TESTS(
+      canvas.DrawImage(TestImage1, SkPoint{0, 0}, kLinearSampling, &paint););
+  RUN_TESTS2(
+      canvas.DrawImage(TestImage1, SkPoint{0, 0}, kLinearSampling, nullptr);
+      , true);
   RUN_TESTS(canvas.DrawImageRect(TestImage1, SkIRect{10, 10, 20, 20},
                                  {0, 0, 10, 10}, kNearestSampling, &paint,
                                  DlCanvas::SrcRectConstraint::kFast););
@@ -1254,10 +1256,12 @@ TEST_F(DisplayListTest, SingleOpsMightSupportGroupOpacityBlendMode) {
                                   {0, 0, 10, 10}, kNearestSampling, nullptr,
                                   DlCanvas::SrcRectConstraint::kFast);
              , true);
-  RUN_TESTS(canvas.DrawImageNine(TestImage2, {20, 20, 30, 30}, {0, 0, 20, 20},
-                                 DlFilterMode::kLinear, &paint););
-  RUN_TESTS2(canvas.DrawImageNine(TestImage2, {20, 20, 30, 30}, {0, 0, 20, 20},
-                                  DlFilterMode::kLinear, nullptr);
+  RUN_TESTS(canvas.DrawImageNine(TestImage2, SkIRect{20, 20, 30, 30},
+                                 SkRect{0, 0, 20, 20}, DlFilterMode::kLinear,
+                                 &paint););
+  RUN_TESTS2(canvas.DrawImageNine(TestImage2, SkIRect{20, 20, 30, 30},
+                                  SkRect{0, 0, 20, 20}, DlFilterMode::kLinear,
+                                  nullptr);
              , true);
   static SkRSXform xforms[] = {{1, 0, 0, 0}, {0, 1, 0, 0}};
   static SkRect texs[] = {{10, 10, 20, 20}, {20, 20, 30, 30}};
@@ -1273,8 +1277,8 @@ TEST_F(DisplayListTest, SingleOpsMightSupportGroupOpacityBlendMode) {
   RUN_TESTS2(canvas.DrawDisplayList(TestDisplayList1);, true);
   {
     static DisplayListBuilder builder;
-    builder.DrawRect({0, 0, 10, 10}, DlPaint());
-    builder.DrawRect({5, 5, 15, 15}, DlPaint());
+    builder.DrawRect(SkRect{0, 0, 10, 10}, DlPaint());
+    builder.DrawRect(SkRect{5, 5, 15, 15}, DlPaint());
     static auto display_list = builder.Build();
     RUN_TESTS2(canvas.DrawDisplayList(display_list);, false);
   }
@@ -1346,9 +1350,10 @@ TEST_F(DisplayListTest, SaveLayerFalseWithSrcBlendSupportsGroupOpacity) {
   // saveLayer following it should not use that attribute to base its
   // decisions about group opacity and the draw rect after that comes
   // with its own compatible blend mode.
-  builder.DrawRect({0, 0, 0, 0}, DlPaint().setBlendMode(DlBlendMode::kSrc));
+  builder.DrawRect(SkRect{0, 0, 0, 0},
+                   DlPaint().setBlendMode(DlBlendMode::kSrc));
   builder.SaveLayer(nullptr, nullptr);
-  builder.DrawRect({0, 0, 10, 10}, DlPaint());
+  builder.DrawRect(SkRect{0, 0, 10, 10}, DlPaint());
   builder.Restore();
   auto display_list = builder.Build();
   EXPECT_TRUE(display_list->can_apply_group_opacity());
@@ -1359,7 +1364,7 @@ TEST_F(DisplayListTest, SaveLayerTrueWithSrcBlendDoesNotSupportGroupOpacity) {
   DlPaint save_paint;
   save_paint.setBlendMode(DlBlendMode::kSrc);
   builder.SaveLayer(nullptr, &save_paint);
-  builder.DrawRect({0, 0, 10, 10}, DlPaint());
+  builder.DrawRect(SkRect{0, 0, 10, 10}, DlPaint());
   builder.Restore();
   auto display_list = builder.Build();
   EXPECT_FALSE(display_list->can_apply_group_opacity());
@@ -1368,7 +1373,8 @@ TEST_F(DisplayListTest, SaveLayerTrueWithSrcBlendDoesNotSupportGroupOpacity) {
 TEST_F(DisplayListTest, SaveLayerFalseSupportsGroupOpacityWithChildSrcBlend) {
   DisplayListBuilder builder;
   builder.SaveLayer(nullptr, nullptr);
-  builder.DrawRect({0, 0, 10, 10}, DlPaint().setBlendMode(DlBlendMode::kSrc));
+  builder.DrawRect(SkRect{0, 0, 10, 10},
+                   DlPaint().setBlendMode(DlBlendMode::kSrc));
   builder.Restore();
   auto display_list = builder.Build();
   EXPECT_TRUE(display_list->can_apply_group_opacity());
@@ -1378,7 +1384,8 @@ TEST_F(DisplayListTest, SaveLayerTrueSupportsGroupOpacityWithChildSrcBlend) {
   DisplayListBuilder builder;
   DlPaint save_paint;
   builder.SaveLayer(nullptr, &save_paint);
-  builder.DrawRect({0, 0, 10, 10}, DlPaint().setBlendMode(DlBlendMode::kSrc));
+  builder.DrawRect(SkRect{0, 0, 10, 10},
+                   DlPaint().setBlendMode(DlBlendMode::kSrc));
   builder.Restore();
   auto display_list = builder.Build();
   EXPECT_TRUE(display_list->can_apply_group_opacity());
@@ -1388,12 +1395,12 @@ TEST_F(DisplayListTest, SaveLayerBoundsSnapshotsImageFilter) {
   DisplayListBuilder builder;
   DlPaint save_paint;
   builder.SaveLayer(nullptr, &save_paint);
-  builder.DrawRect({50, 50, 100, 100}, DlPaint());
+  builder.DrawRect(SkRect{50, 50, 100, 100}, DlPaint());
   // This image filter should be ignored since it was not set before saveLayer
   // And the rect drawn with it will not contribute any more area to the bounds
   DlPaint draw_paint;
   draw_paint.setImageFilter(&kTestBlurImageFilter1);
-  builder.DrawRect({70, 70, 80, 80}, draw_paint);
+  builder.DrawRect(SkRect{70, 70, 80, 80}, draw_paint);
   builder.Restore();
   SkRect bounds = builder.Build()->bounds();
   EXPECT_EQ(bounds, SkRect::MakeLTRB(50, 50, 100, 100));
@@ -1533,7 +1540,7 @@ TEST_F(DisplayListTest, SaveLayerOneSimpleOpInheritsOpacity) {
   DlPaint save_paint;
   save_paint.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
   builder.SaveLayer(nullptr, &save_paint);
-  builder.DrawRect({10, 10, 20, 20}, DlPaint());
+  builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
   builder.Restore();
 
   builder.Build()->Dispatch(expector);
@@ -1547,7 +1554,7 @@ TEST_F(DisplayListTest, SaveLayerNoAttributesInheritsOpacity) {
 
   DisplayListBuilder builder;
   builder.SaveLayer(nullptr, nullptr);
-  builder.DrawRect({10, 10, 20, 20}, DlPaint());
+  builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
   builder.Restore();
 
   builder.Build()->Dispatch(expector);
@@ -1562,8 +1569,8 @@ TEST_F(DisplayListTest, SaveLayerTwoOverlappingOpsDoesNotInheritOpacity) {
   DlPaint save_paint;
   save_paint.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
   builder.SaveLayer(nullptr, &save_paint);
-  builder.DrawRect({10, 10, 20, 20}, DlPaint());
-  builder.DrawRect({15, 15, 25, 25}, DlPaint());
+  builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
+  builder.DrawRect(SkRect{15, 15, 25, 25}, DlPaint());
   builder.Restore();
 
   builder.Build()->Dispatch(expector);
@@ -1584,9 +1591,9 @@ TEST_F(DisplayListTest, NestedSaveLayersMightInheritOpacity) {
   save_paint.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
   builder.SaveLayer(nullptr, &save_paint);
   builder.SaveLayer(nullptr, &save_paint);
-  builder.DrawRect({10, 10, 20, 20}, DlPaint());
+  builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
   builder.SaveLayer(nullptr, &save_paint);
-  builder.DrawRect({15, 15, 25, 25}, DlPaint());
+  builder.DrawRect(SkRect{15, 15, 25, 25}, DlPaint());
   builder.Restore();
   builder.Restore();
   builder.Restore();
@@ -1608,7 +1615,7 @@ TEST_F(DisplayListTest, NestedSaveLayersCanBothSupportOpacityOptimization) {
   save_paint.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
   builder.SaveLayer(nullptr, &save_paint);
   builder.SaveLayer(nullptr, nullptr);
-  builder.DrawRect({10, 10, 20, 20}, DlPaint());
+  builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
   builder.Restore();
   builder.Restore();
 
@@ -1625,7 +1632,7 @@ TEST_F(DisplayListTest, SaveLayerImageFilterDoesNotInheritOpacity) {
   save_paint.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
   save_paint.setImageFilter(&kTestBlurImageFilter1);
   builder.SaveLayer(nullptr, &save_paint);
-  builder.DrawRect({10, 10, 20, 20}, DlPaint());
+  builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
   builder.Restore();
 
   builder.Build()->Dispatch(expector);
@@ -1641,7 +1648,7 @@ TEST_F(DisplayListTest, SaveLayerColorFilterDoesNotInheritOpacity) {
   save_paint.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
   save_paint.setColorFilter(&kTestMatrixColorFilter1);
   builder.SaveLayer(nullptr, &save_paint);
-  builder.DrawRect({10, 10, 20, 20}, DlPaint());
+  builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
   builder.Restore();
 
   builder.Build()->Dispatch(expector);
@@ -1657,7 +1664,7 @@ TEST_F(DisplayListTest, SaveLayerSrcBlendDoesNotInheritOpacity) {
   save_paint.setColor(DlColor(SkColorSetARGB(127, 255, 255, 255)));
   save_paint.setBlendMode(DlBlendMode::kSrc);
   builder.SaveLayer(nullptr, &save_paint);
-  builder.DrawRect({10, 10, 20, 20}, DlPaint());
+  builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
   builder.Restore();
 
   builder.Build()->Dispatch(expector);
@@ -1675,7 +1682,7 @@ TEST_F(DisplayListTest, SaveLayerImageFilterOnChildInheritsOpacity) {
   builder.SaveLayer(nullptr, &save_paint);
   DlPaint draw_paint = save_paint;
   draw_paint.setImageFilter(&kTestBlurImageFilter1);
-  builder.DrawRect({10, 10, 20, 20}, draw_paint);
+  builder.DrawRect(SkRect{10, 10, 20, 20}, draw_paint);
   builder.Restore();
 
   builder.Build()->Dispatch(expector);
@@ -1692,7 +1699,7 @@ TEST_F(DisplayListTest, SaveLayerColorFilterOnChildDoesNotInheritOpacity) {
   builder.SaveLayer(nullptr, &save_paint);
   DlPaint draw_paint = save_paint;
   draw_paint.setColorFilter(&kTestMatrixColorFilter1);
-  builder.DrawRect({10, 10, 20, 20}, draw_paint);
+  builder.DrawRect(SkRect{10, 10, 20, 20}, draw_paint);
   builder.Restore();
 
   builder.Build()->Dispatch(expector);
@@ -1709,7 +1716,7 @@ TEST_F(DisplayListTest, SaveLayerSrcBlendOnChildDoesNotInheritOpacity) {
   builder.SaveLayer(nullptr, &save_paint);
   DlPaint draw_paint = save_paint;
   draw_paint.setBlendMode(DlBlendMode::kSrc);
-  builder.DrawRect({10, 10, 20, 20}, draw_paint);
+  builder.DrawRect(SkRect{10, 10, 20, 20}, draw_paint);
   builder.Restore();
 
   builder.Build()->Dispatch(expector);
@@ -1790,14 +1797,15 @@ TEST_F(DisplayListTest, FlutterSvgIssue661BoundsWereEmpty) {
   DlPaint paint = DlPaint(DlColor::kWhite()).setAntiAlias(true);
   {
     builder.Save();
-    builder.ClipRect({0, 0, 100, 100}, ClipOp::kIntersect, true);
+    builder.ClipRect(SkRect{0, 0, 100, 100}, ClipOp::kIntersect, true);
     {
       builder.Save();
       builder.Transform2DAffine(2.17391, 0, -2547.83,  //
                                 0, 2.04082, -500);
       {
         builder.Save();
-        builder.ClipRect({1172, 245, 1218, 294}, ClipOp::kIntersect, true);
+        builder.ClipRect(SkRect{1172, 245, 1218, 294}, ClipOp::kIntersect,
+                         true);
         {
           builder.SaveLayer(nullptr, nullptr, nullptr);
           {
@@ -1974,7 +1982,7 @@ TEST_F(DisplayListTest, ClipRectAffectsClipBounds) {
   ASSERT_EQ(initial_destination_bounds, clip_bounds);
 
   builder.Save();
-  builder.ClipRect({0, 0, 15, 15}, ClipOp::kIntersect, false);
+  builder.ClipRect(SkRect{0, 0, 15, 15}, ClipOp::kIntersect, false);
   // Both clip bounds have changed
   ASSERT_NE(builder.GetLocalClipBounds(), clip_bounds);
   ASSERT_NE(builder.GetDestinationClipBounds(), clip_bounds);
@@ -2013,7 +2021,7 @@ TEST_F(DisplayListTest, ClipRectDoAAAffectsClipBounds) {
   ASSERT_EQ(initial_destination_bounds, clip_expanded_bounds);
 
   builder.Save();
-  builder.ClipRect({0, 0, 15, 15}, ClipOp::kIntersect, true);
+  builder.ClipRect(SkRect{0, 0, 15, 15}, ClipOp::kIntersect, true);
   // Both clip bounds have changed
   ASSERT_NE(builder.GetLocalClipBounds(), clip_expanded_bounds);
   ASSERT_NE(builder.GetDestinationClipBounds(), clip_expanded_bounds);
@@ -2071,7 +2079,7 @@ TEST_F(DisplayListTest, ClipRRectAffectsClipBounds) {
   ASSERT_EQ(initial_destination_bounds, clip_bounds);
 
   builder.Save();
-  builder.ClipRect({0, 0, 15, 15}, ClipOp::kIntersect, false);
+  builder.ClipRect(SkRect{0, 0, 15, 15}, ClipOp::kIntersect, false);
   // Both clip bounds have changed
   ASSERT_NE(builder.GetLocalClipBounds(), clip_bounds);
   ASSERT_NE(builder.GetDestinationClipBounds(), clip_bounds);
@@ -2111,7 +2119,7 @@ TEST_F(DisplayListTest, ClipRRectDoAAAffectsClipBounds) {
   ASSERT_EQ(initial_destination_bounds, clip_expanded_bounds);
 
   builder.Save();
-  builder.ClipRect({0, 0, 15, 15}, ClipOp::kIntersect, true);
+  builder.ClipRect(SkRect{0, 0, 15, 15}, ClipOp::kIntersect, true);
   // Both clip bounds have changed
   ASSERT_NE(builder.GetLocalClipBounds(), clip_expanded_bounds);
   ASSERT_NE(builder.GetDestinationClipBounds(), clip_expanded_bounds);
@@ -2172,7 +2180,7 @@ TEST_F(DisplayListTest, ClipPathAffectsClipBounds) {
   ASSERT_EQ(initial_destination_bounds, clip_bounds);
 
   builder.Save();
-  builder.ClipRect({0, 0, 15, 15}, ClipOp::kIntersect, false);
+  builder.ClipRect(SkRect{0, 0, 15, 15}, ClipOp::kIntersect, false);
   // Both clip bounds have changed
   ASSERT_NE(builder.GetLocalClipBounds(), clip_bounds);
   ASSERT_NE(builder.GetDestinationClipBounds(), clip_bounds);
@@ -2211,7 +2219,7 @@ TEST_F(DisplayListTest, ClipPathDoAAAffectsClipBounds) {
   ASSERT_EQ(initial_destination_bounds, clip_expanded_bounds);
 
   builder.Save();
-  builder.ClipRect({0, 0, 15, 15}, ClipOp::kIntersect, true);
+  builder.ClipRect(SkRect{0, 0, 15, 15}, ClipOp::kIntersect, true);
   // Both clip bounds have changed
   ASSERT_NE(builder.GetLocalClipBounds(), clip_expanded_bounds);
   ASSERT_NE(builder.GetDestinationClipBounds(), clip_expanded_bounds);
@@ -2443,9 +2451,9 @@ TEST_F(DisplayListTest, RTreeOfSimpleScene) {
 
 TEST_F(DisplayListTest, RTreeOfSaveRestoreScene) {
   DisplayListBuilder builder(/*prepare_rtree=*/true);
-  builder.DrawRect({10, 10, 20, 20}, DlPaint());
+  builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
   builder.Save();
-  builder.DrawRect({50, 50, 60, 60}, DlPaint());
+  builder.DrawRect(SkRect{50, 50, 60, 60}, DlPaint());
   builder.Restore();
   auto display_list = builder.Build();
   auto rtree = display_list->rtree();
@@ -2477,11 +2485,11 @@ TEST_F(DisplayListTest, RTreeOfSaveLayerFilterScene) {
   auto filter = DlBlurImageFilter(1.0, 1.0, DlTileMode::kClamp);
   DlPaint default_paint = DlPaint();
   DlPaint filter_paint = DlPaint().setImageFilter(&filter);
-  builder.DrawRect({10, 10, 20, 20}, default_paint);
+  builder.DrawRect(SkRect{10, 10, 20, 20}, default_paint);
   builder.SaveLayer(nullptr, &filter_paint);
   // the following rectangle will be expanded to 50,50,60,60
   // by the saveLayer filter during the restore operation
-  builder.DrawRect({53, 53, 57, 57}, default_paint);
+  builder.DrawRect(SkRect{53, 53, 57, 57}, default_paint);
   builder.Restore();
   auto display_list = builder.Build();
   auto rtree = display_list->rtree();
@@ -2509,8 +2517,8 @@ TEST_F(DisplayListTest, RTreeOfSaveLayerFilterScene) {
 
 TEST_F(DisplayListTest, NestedDisplayListRTreesAreSparse) {
   DisplayListBuilder nested_dl_builder(/**prepare_rtree=*/true);
-  nested_dl_builder.DrawRect({10, 10, 20, 20}, DlPaint());
-  nested_dl_builder.DrawRect({50, 50, 60, 60}, DlPaint());
+  nested_dl_builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
+  nested_dl_builder.DrawRect(SkRect{50, 50, 60, 60}, DlPaint());
   auto nested_display_list = nested_dl_builder.Build();
 
   DisplayListBuilder builder(/**prepare_rtree=*/true);
@@ -2531,38 +2539,38 @@ TEST_F(DisplayListTest, NestedDisplayListRTreesAreSparse) {
 TEST_F(DisplayListTest, RemoveUnnecessarySaveRestorePairs) {
   {
     DisplayListBuilder builder;
-    builder.DrawRect({10, 10, 20, 20}, DlPaint());
+    builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
     builder.Save();  // This save op is unnecessary
-    builder.DrawRect({50, 50, 60, 60}, DlPaint());
+    builder.DrawRect(SkRect{50, 50, 60, 60}, DlPaint());
     builder.Restore();
 
     DisplayListBuilder builder2;
-    builder2.DrawRect({10, 10, 20, 20}, DlPaint());
-    builder2.DrawRect({50, 50, 60, 60}, DlPaint());
+    builder2.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
+    builder2.DrawRect(SkRect{50, 50, 60, 60}, DlPaint());
     ASSERT_TRUE(DisplayListsEQ_Verbose(builder.Build(), builder2.Build()));
   }
 
   {
     DisplayListBuilder builder;
-    builder.DrawRect({10, 10, 20, 20}, DlPaint());
+    builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
     builder.Save();
     {
       builder.Translate(1.0, 1.0);
       builder.Save();
       {  //
-        builder.DrawRect({50, 50, 60, 60}, DlPaint());
+        builder.DrawRect(SkRect{50, 50, 60, 60}, DlPaint());
       }
       builder.Restore();
     }
     builder.Restore();
 
     DisplayListBuilder builder2;
-    builder2.DrawRect({10, 10, 20, 20}, DlPaint());
+    builder2.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
     builder2.Save();
     {  //
       builder2.Translate(1.0, 1.0);
       {  //
-        builder2.DrawRect({50, 50, 60, 60}, DlPaint());
+        builder2.DrawRect(SkRect{50, 50, 60, 60}, DlPaint());
       }
     }
     builder2.Restore();
@@ -2580,8 +2588,8 @@ TEST_F(DisplayListTest, CollapseMultipleNestedSaveRestore) {
       {
         builder1.Translate(10, 10);
         builder1.Scale(2, 2);
-        builder1.ClipRect({10, 10, 20, 20}, ClipOp::kIntersect, false);
-        builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+        builder1.ClipRect(SkRect{10, 10, 20, 20}, ClipOp::kIntersect, false);
+        builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
       }
       builder1.Restore();
     }
@@ -2595,8 +2603,8 @@ TEST_F(DisplayListTest, CollapseMultipleNestedSaveRestore) {
   {
     builder2.Translate(10, 10);
     builder2.Scale(2, 2);
-    builder2.ClipRect({10, 10, 20, 20}, ClipOp::kIntersect, false);
-    builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder2.ClipRect(SkRect{10, 10, 20, 20}, ClipOp::kIntersect, false);
+    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   }
   builder2.Restore();
   auto display_list2 = builder2.Build();
@@ -2610,7 +2618,7 @@ TEST_F(DisplayListTest, CollapseNestedSaveAndSaveLayerRestore) {
   {
     builder1.SaveLayer(nullptr, nullptr);
     {
-      builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
       builder1.Scale(2, 2);
     }
     builder1.Restore();
@@ -2621,7 +2629,7 @@ TEST_F(DisplayListTest, CollapseNestedSaveAndSaveLayerRestore) {
   DisplayListBuilder builder2;
   builder2.SaveLayer(nullptr, nullptr);
   {
-    builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
     builder2.Scale(2, 2);
   }
   builder2.Restore();
@@ -2695,14 +2703,14 @@ TEST_F(DisplayListTest, TransformTriggersDeferredSave) {
                                         0, 1, 0, 100,  //
                                         0, 0, 1, 0,    //
                                         0, 0, 0, 1);
-      builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
     }
     builder1.Restore();
     builder1.TransformFullPerspective(1, 0, 0, 10,   //
                                       0, 1, 0, 100,  //
                                       0, 0, 1, 0,    //
                                       0, 0, 0, 1);
-    builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   }
   builder1.Restore();
   auto display_list1 = builder1.Build();
@@ -2714,7 +2722,7 @@ TEST_F(DisplayListTest, TransformTriggersDeferredSave) {
                                       0, 1, 0, 100,  //
                                       0, 0, 1, 0,    //
                                       0, 0, 0, 1);
-    builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   }
   builder2.Restore();
   builder2.Save();
@@ -2723,7 +2731,7 @@ TEST_F(DisplayListTest, TransformTriggersDeferredSave) {
                                       0, 1, 0, 100,  //
                                       0, 0, 1, 0,    //
                                       0, 0, 0, 1);
-    builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   }
   builder2.Restore();
   auto display_list2 = builder2.Build();
@@ -2738,7 +2746,7 @@ TEST_F(DisplayListTest, Transform2DTriggersDeferredSave) {
     builder1.Save();
     {
       builder1.Transform2DAffine(0, 1, 12, 1, 0, 33);
-      builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
     }
     builder1.Restore();
   }
@@ -2749,7 +2757,7 @@ TEST_F(DisplayListTest, Transform2DTriggersDeferredSave) {
   builder2.Save();
   {
     builder2.Transform2DAffine(0, 1, 12, 1, 0, 33);
-    builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   }
   builder2.Restore();
   auto display_list2 = builder2.Build();
@@ -2767,7 +2775,7 @@ TEST_F(DisplayListTest, TransformPerspectiveTriggersDeferredSave) {
                                         1, 0, 0, 33,  //
                                         3, 2, 5, 29,  //
                                         0, 0, 0, 12);
-      builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
     }
     builder1.Restore();
   }
@@ -2781,7 +2789,7 @@ TEST_F(DisplayListTest, TransformPerspectiveTriggersDeferredSave) {
                                       1, 0, 0, 33,  //
                                       3, 2, 5, 29,  //
                                       0, 0, 0, 12);
-    builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   }
   builder2.Restore();
   auto display_list2 = builder2.Build();
@@ -2796,7 +2804,7 @@ TEST_F(DisplayListTest, ResetTransformTriggersDeferredSave) {
     builder1.Save();
     {
       builder1.TransformReset();
-      builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
     }
     builder1.Restore();
   }
@@ -2807,7 +2815,7 @@ TEST_F(DisplayListTest, ResetTransformTriggersDeferredSave) {
   builder2.Save();
   {
     builder2.TransformReset();
-    builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   }
   builder2.Restore();
   auto display_list2 = builder2.Build();
@@ -2822,7 +2830,7 @@ TEST_F(DisplayListTest, SkewTriggersDeferredSave) {
     builder1.Save();
     {
       builder1.Skew(10, 10);
-      builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
     }
     builder1.Restore();
   }
@@ -2833,7 +2841,7 @@ TEST_F(DisplayListTest, SkewTriggersDeferredSave) {
   builder2.Save();
   {
     builder2.Skew(10, 10);
-    builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   }
   builder2.Restore();
   auto display_list2 = builder2.Build();
@@ -2848,7 +2856,7 @@ TEST_F(DisplayListTest, TranslateTriggersDeferredSave) {
     builder1.Save();
     {
       builder1.Translate(10, 10);
-      builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
     }
     builder1.Restore();
   }
@@ -2859,7 +2867,7 @@ TEST_F(DisplayListTest, TranslateTriggersDeferredSave) {
   builder2.Save();
   {
     builder2.Translate(10, 10);
-    builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   }
   builder2.Restore();
   auto display_list2 = builder2.Build();
@@ -2874,7 +2882,7 @@ TEST_F(DisplayListTest, ScaleTriggersDeferredSave) {
     builder1.Save();
     {
       builder1.Scale(0.5, 0.5);
-      builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
     }
     builder1.Restore();
   }
@@ -2885,7 +2893,7 @@ TEST_F(DisplayListTest, ScaleTriggersDeferredSave) {
   builder2.Save();
   {
     builder2.Scale(0.5, 0.5);
-    builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   }
   builder2.Restore();
   auto display_list2 = builder2.Build();
@@ -2901,14 +2909,14 @@ TEST_F(DisplayListTest, ClipRectTriggersDeferredSave) {
     {
       builder1.ClipRect(SkRect::MakeLTRB(0, 0, 100, 100), ClipOp::kIntersect,
                         true);
-      builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
     }
     builder1.Restore();
     builder1.TransformFullPerspective(1, 0, 0, 0,  //
                                       0, 1, 0, 0,  //
                                       0, 0, 1, 0,  //
                                       0, 0, 0, 1);
-    builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   }
   builder1.Restore();
   auto display_list1 = builder1.Build();
@@ -2918,14 +2926,14 @@ TEST_F(DisplayListTest, ClipRectTriggersDeferredSave) {
   {
     builder2.ClipRect(SkRect::MakeLTRB(0, 0, 100, 100), ClipOp::kIntersect,
                       true);
-    builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   }
   builder2.Restore();
   builder2.TransformFullPerspective(1, 0, 0, 0,  //
                                     0, 1, 0, 0,  //
                                     0, 0, 1, 0,  //
                                     0, 0, 0, 1);
-  builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   auto display_list2 = builder2.Build();
 
   ASSERT_TRUE(DisplayListsEQ_Verbose(display_list1, display_list2));
@@ -2939,14 +2947,14 @@ TEST_F(DisplayListTest, ClipRRectTriggersDeferredSave) {
     {
       builder1.ClipRRect(kTestRRect, ClipOp::kIntersect, true);
 
-      builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
     }
     builder1.Restore();
     builder1.TransformFullPerspective(1, 0, 0, 0,  //
                                       0, 1, 0, 0,  //
                                       0, 0, 1, 0,  //
                                       0, 0, 0, 1);
-    builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   }
   builder1.Restore();
   auto display_list1 = builder1.Build();
@@ -2955,13 +2963,13 @@ TEST_F(DisplayListTest, ClipRRectTriggersDeferredSave) {
   builder2.Save();
   builder2.ClipRRect(kTestRRect, ClipOp::kIntersect, true);
 
-  builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   builder2.Restore();
   builder2.TransformFullPerspective(1, 0, 0, 0,  //
                                     0, 1, 0, 0,  //
                                     0, 0, 1, 0,  //
                                     0, 0, 0, 1);
-  builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   auto display_list2 = builder2.Build();
 
   ASSERT_TRUE(DisplayListsEQ_Verbose(display_list1, display_list2));
@@ -2974,14 +2982,14 @@ TEST_F(DisplayListTest, ClipPathTriggersDeferredSave) {
     builder1.Save();
     {
       builder1.ClipPath(kTestPath1, ClipOp::kIntersect, true);
-      builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
     }
     builder1.Restore();
     builder1.TransformFullPerspective(1, 0, 0, 0,  //
                                       0, 1, 0, 0,  //
                                       0, 0, 1, 0,  //
                                       0, 0, 0, 1);
-    builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   }
   builder1.Restore();
   auto display_list1 = builder1.Build();
@@ -2990,14 +2998,14 @@ TEST_F(DisplayListTest, ClipPathTriggersDeferredSave) {
   builder2.Save();
   {
     builder2.ClipPath(kTestPath1, ClipOp::kIntersect, true);
-    builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   }
   builder2.Restore();
   builder2.TransformFullPerspective(1, 0, 0, 0,  //
                                     0, 1, 0, 0,  //
                                     0, 0, 1, 0,  //
                                     0, 0, 0, 1);
-  builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   auto display_list2 = builder2.Build();
 
   ASSERT_TRUE(DisplayListsEQ_Verbose(display_list1, display_list2));
@@ -3010,17 +3018,17 @@ TEST_F(DisplayListTest, NOPTranslateDoesNotTriggerDeferredSave) {
     builder1.Save();
     {
       builder1.Translate(0, 0);
-      builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
     }
     builder1.Restore();
-    builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   }
   builder1.Restore();
   auto display_list1 = builder1.Build();
 
   DisplayListBuilder builder2;
-  builder2.DrawRect({0, 0, 100, 100}, DlPaint());
-  builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   auto display_list2 = builder2.Build();
 
   ASSERT_TRUE(DisplayListsEQ_Verbose(display_list1, display_list2));
@@ -3033,17 +3041,17 @@ TEST_F(DisplayListTest, NOPScaleDoesNotTriggerDeferredSave) {
     builder1.Save();
     {
       builder1.Scale(1.0, 1.0);
-      builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
     }
     builder1.Restore();
-    builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   }
   builder1.Restore();
   auto display_list1 = builder1.Build();
 
   DisplayListBuilder builder2;
-  builder2.DrawRect({0, 0, 100, 100}, DlPaint());
-  builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   auto display_list2 = builder2.Build();
 
   ASSERT_TRUE(DisplayListsEQ_Verbose(display_list1, display_list2));
@@ -3056,17 +3064,17 @@ TEST_F(DisplayListTest, NOPRotationDoesNotTriggerDeferredSave) {
     builder1.Save();
     {
       builder1.Rotate(360);
-      builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
     }
     builder1.Restore();
-    builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   }
   builder1.Restore();
   auto display_list1 = builder1.Build();
 
   DisplayListBuilder builder2;
-  builder2.DrawRect({0, 0, 100, 100}, DlPaint());
-  builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   auto display_list2 = builder2.Build();
 
   ASSERT_TRUE(DisplayListsEQ_Verbose(display_list1, display_list2));
@@ -3079,17 +3087,17 @@ TEST_F(DisplayListTest, NOPSkewDoesNotTriggerDeferredSave) {
     builder1.Save();
     {
       builder1.Skew(0, 0);
-      builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
     }
     builder1.Restore();
-    builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   }
   builder1.Restore();
   auto display_list1 = builder1.Build();
 
   DisplayListBuilder builder2;
-  builder2.DrawRect({0, 0, 100, 100}, DlPaint());
-  builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   auto display_list2 = builder2.Build();
 
   ASSERT_TRUE(DisplayListsEQ_Verbose(display_list1, display_list2));
@@ -3105,21 +3113,21 @@ TEST_F(DisplayListTest, NOPTransformDoesNotTriggerDeferredSave) {
                                         0, 1, 0, 0,  //
                                         0, 0, 1, 0,  //
                                         0, 0, 0, 1);
-      builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
     }
     builder1.Restore();
     builder1.TransformFullPerspective(1, 0, 0, 0,  //
                                       0, 1, 0, 0,  //
                                       0, 0, 1, 0,  //
                                       0, 0, 0, 1);
-    builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   }
   builder1.Restore();
   auto display_list1 = builder1.Build();
 
   DisplayListBuilder builder2;
-  builder2.DrawRect({0, 0, 100, 100}, DlPaint());
-  builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   auto display_list2 = builder2.Build();
 
   ASSERT_TRUE(DisplayListsEQ_Verbose(display_list1, display_list2));
@@ -3132,17 +3140,17 @@ TEST_F(DisplayListTest, NOPTransform2DDoesNotTriggerDeferredSave) {
     builder1.Save();
     {
       builder1.Transform2DAffine(1, 0, 0, 0, 1, 0);
-      builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
     }
     builder1.Restore();
-    builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   }
   builder1.Restore();
   auto display_list1 = builder1.Build();
 
   DisplayListBuilder builder2;
-  builder2.DrawRect({0, 0, 100, 100}, DlPaint());
-  builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   auto display_list2 = builder2.Build();
 
   ASSERT_TRUE(DisplayListsEQ_Verbose(display_list1, display_list2));
@@ -3159,17 +3167,17 @@ TEST_F(DisplayListTest, NOPTransformFullPerspectiveDoesNotTriggerDeferredSave) {
                                           0, 1, 0, 0,  //
                                           0, 0, 1, 0,  //
                                           0, 0, 0, 1);
-        builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+        builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
       }
       builder1.Restore();
-      builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
     }
     builder1.Restore();
     auto display_list1 = builder1.Build();
 
     DisplayListBuilder builder2;
-    builder2.DrawRect({0, 0, 100, 100}, DlPaint());
-    builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
     auto display_list2 = builder2.Build();
 
     ASSERT_TRUE(DisplayListsEQ_Verbose(display_list1, display_list2));
@@ -3186,10 +3194,10 @@ TEST_F(DisplayListTest, NOPTransformFullPerspectiveDoesNotTriggerDeferredSave) {
                                           0, 0, 1, 0,  //
                                           0, 0, 0, 1);
         builder1.TransformReset();
-        builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+        builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
       }
       builder1.Restore();
-      builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
     }
     builder1.Restore();
     auto display_list1 = builder1.Build();
@@ -3198,10 +3206,10 @@ TEST_F(DisplayListTest, NOPTransformFullPerspectiveDoesNotTriggerDeferredSave) {
     builder2.Save();
     {
       builder2.TransformReset();
-      builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+      builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
     }
     builder2.Restore();
-    builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
     auto display_list2 = builder2.Build();
 
     ASSERT_TRUE(DisplayListsEQ_Verbose(display_list1, display_list2));
@@ -3216,17 +3224,17 @@ TEST_F(DisplayListTest, NOPClipDoesNotTriggerDeferredSave) {
     {
       builder1.ClipRect(SkRect::MakeLTRB(0, SK_ScalarNaN, SK_ScalarNaN, 0),
                         ClipOp::kIntersect, true);
-      builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+      builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
     }
     builder1.Restore();
-    builder1.DrawRect({0, 0, 100, 100}, DlPaint());
+    builder1.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   }
   builder1.Restore();
   auto display_list1 = builder1.Build();
 
   DisplayListBuilder builder2;
-  builder2.DrawRect({0, 0, 100, 100}, DlPaint());
-  builder2.DrawRect({0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+  builder2.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
   auto display_list2 = builder2.Build();
 
   ASSERT_TRUE(DisplayListsEQ_Verbose(display_list1, display_list2));
@@ -3238,13 +3246,13 @@ TEST_F(DisplayListTest, RTreeOfClippedSaveLayerFilterScene) {
   auto filter = DlBlurImageFilter(10.0, 10.0, DlTileMode::kClamp);
   DlPaint default_paint = DlPaint();
   DlPaint filter_paint = DlPaint().setImageFilter(&filter);
-  builder.DrawRect({10, 10, 20, 20}, default_paint);
-  builder.ClipRect({50, 50, 60, 60}, ClipOp::kIntersect, false);
+  builder.DrawRect(SkRect{10, 10, 20, 20}, default_paint);
+  builder.ClipRect(SkRect{50, 50, 60, 60}, ClipOp::kIntersect, false);
   builder.SaveLayer(nullptr, &filter_paint);
   // the following rectangle will be expanded to 23,23,87,87
   // by the saveLayer filter during the restore operation
   // but it will then be clipped to 50,50,60,60
-  builder.DrawRect({53, 53, 57, 57}, default_paint);
+  builder.DrawRect(SkRect{53, 53, 57, 57}, default_paint);
   builder.Restore();
   auto display_list = builder.Build();
   auto rtree = display_list->rtree();
@@ -3393,10 +3401,10 @@ TEST_F(DisplayListTest, RTreeRenderCulling) {
 
 TEST_F(DisplayListTest, DrawSaveDrawCannotInheritOpacity) {
   DisplayListBuilder builder;
-  builder.DrawCircle({10, 10}, 5, DlPaint());
+  builder.DrawCircle(SkPoint{10, 10}, 5, DlPaint());
   builder.Save();
-  builder.ClipRect({0, 0, 20, 20}, DlCanvas::ClipOp::kIntersect, false);
-  builder.DrawRect({5, 5, 15, 15}, DlPaint());
+  builder.ClipRect(SkRect{0, 0, 20, 20}, DlCanvas::ClipOp::kIntersect, false);
+  builder.DrawRect(SkRect{5, 5, 15, 15}, DlPaint());
   builder.Restore();
   auto display_list = builder.Build();
 
@@ -3493,31 +3501,31 @@ TEST_F(DisplayListTest, NopOperationsOmittedFromRecords) {
     run_one_test(
         name + " DrawRect",
         [](DisplayListBuilder& builder, DlPaint& paint) {
-          builder.DrawRect({10, 10, 20, 20}, paint);
+          builder.DrawRect(SkRect{10, 10, 20, 20}, paint);
         },
         expected_op_count, expected_total_depth);
     run_one_test(
         name + " Other Draw Ops",
         [](DisplayListBuilder& builder, DlPaint& paint) {
-          builder.DrawLine({10, 10}, {20, 20}, paint);
-          builder.DrawOval({10, 10, 20, 20}, paint);
-          builder.DrawCircle({50, 50}, 20, paint);
+          builder.DrawLine(SkPoint{10, 10}, SkPoint{20, 20}, paint);
+          builder.DrawOval(SkRect{10, 10, 20, 20}, paint);
+          builder.DrawCircle(SkPoint{50, 50}, 20, paint);
           builder.DrawRRect(SkRRect::MakeRectXY({10, 10, 20, 20}, 5, 5), paint);
           builder.DrawDRRect(SkRRect::MakeRectXY({5, 5, 100, 100}, 5, 5),
                              SkRRect::MakeRectXY({10, 10, 20, 20}, 5, 5),
                              paint);
           builder.DrawPath(kTestPath1, paint);
-          builder.DrawArc({10, 10, 20, 20}, 45, 90, true, paint);
+          builder.DrawArc(SkRect{10, 10, 20, 20}, 45, 90, true, paint);
           SkPoint pts[] = {{10, 10}, {20, 20}};
           builder.DrawPoints(PointMode::kLines, 2, pts, paint);
           builder.DrawVertices(kTestVertices1, DlBlendMode::kSrcOver, paint);
-          builder.DrawImage(TestImage1, {10, 10}, DlImageSampling::kLinear,
-                            &paint);
+          builder.DrawImage(TestImage1, SkPoint{10, 10},
+                            DlImageSampling::kLinear, &paint);
           builder.DrawImageRect(TestImage1, SkRect{0.0f, 0.0f, 10.0f, 10.0f},
                                 SkRect{10.0f, 10.0f, 25.0f, 25.0f},
                                 DlImageSampling::kLinear, &paint);
-          builder.DrawImageNine(TestImage1, {10, 10, 20, 20},
-                                {10, 10, 100, 100}, DlFilterMode::kLinear,
+          builder.DrawImageNine(TestImage1, SkIRect{10, 10, 20, 20},
+                                SkRect{10, 10, 100, 100}, DlFilterMode::kLinear,
                                 &paint);
           SkRSXform xforms[] = {{1, 0, 10, 10}, {0, 1, 10, 10}};
           SkRect rects[] = {{10, 10, 20, 20}, {10, 20, 30, 20}};
@@ -3538,7 +3546,7 @@ TEST_F(DisplayListTest, NopOperationsOmittedFromRecords) {
         name + " SaveLayer",
         [](DisplayListBuilder& builder, DlPaint& paint) {
           builder.SaveLayer(nullptr, &paint, nullptr);
-          builder.DrawRect({10, 10, 20, 20}, DlPaint());
+          builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
           builder.Restore();
         },
         expected_op_count, expected_total_depth);
@@ -3546,7 +3554,7 @@ TEST_F(DisplayListTest, NopOperationsOmittedFromRecords) {
         name + " inside Save",
         [](DisplayListBuilder& builder, DlPaint& paint) {
           builder.Save();
-          builder.DrawRect({10, 10, 20, 20}, paint);
+          builder.DrawRect(SkRect{10, 10, 20, 20}, paint);
           builder.Restore();
         },
         expected_op_count, expected_total_depth);
@@ -3614,7 +3622,8 @@ TEST_F(DisplayListTest, NopOperationsOmittedFromRecords) {
               DlPaint save_paint;
               save_paint.setColor(DlColor::kTransparent());
               builder.SaveLayer(nullptr, &save_paint);
-              builder.DrawImage(TestImage1, {10, 10}, DlImageSampling::kLinear);
+              builder.DrawImage(TestImage1, SkPoint{10, 10},
+                                DlImageSampling::kLinear);
             });
 }
 
@@ -4150,33 +4159,33 @@ class DepthExpector : public virtual DlOpReceiver,
 
 TEST_F(DisplayListTest, SaveContentDepthTest) {
   DisplayListBuilder child_builder;
-  child_builder.DrawRect({10, 10, 20, 20}, DlPaint());  // depth 1
+  child_builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());  // depth 1
   auto child = child_builder.Build();
 
   DisplayListBuilder builder;
-  builder.DrawRect({10, 10, 20, 20}, DlPaint());  // depth 1
+  builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());  // depth 1
 
   builder.Save();  // covers depth 1->9
   {
     builder.Translate(5, 5);  // triggers deferred save at depth 1
-    builder.DrawRect({10, 10, 20, 20}, DlPaint());  // depth 2
+    builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());  // depth 2
 
     builder.DrawDisplayList(child, 1.0f);  // depth 3 (content) + 4 (self)
 
     builder.SaveLayer(nullptr, nullptr);  // covers depth 5->6
     {
-      builder.DrawRect({12, 12, 22, 22}, DlPaint());  // depth 5
-      builder.DrawRect({14, 14, 24, 24}, DlPaint());  // depth 6
+      builder.DrawRect(SkRect{12, 12, 22, 22}, DlPaint());  // depth 5
+      builder.DrawRect(SkRect{14, 14, 24, 24}, DlPaint());  // depth 6
     }
     builder.Restore();  // layer is restored with depth 6
 
-    builder.DrawRect({16, 16, 26, 26}, DlPaint());  // depth 8
-    builder.DrawRect({18, 18, 28, 28}, DlPaint());  // depth 9
+    builder.DrawRect(SkRect{16, 16, 26, 26}, DlPaint());  // depth 8
+    builder.DrawRect(SkRect{18, 18, 28, 28}, DlPaint());  // depth 9
   }
   builder.Restore();  // save is restored with depth 9
 
-  builder.DrawRect({16, 16, 26, 26}, DlPaint());  // depth 10
-  builder.DrawRect({18, 18, 28, 28}, DlPaint());  // depth 11
+  builder.DrawRect(SkRect{16, 16, 26, 26}, DlPaint());  // depth 10
+  builder.DrawRect(SkRect{18, 18, 28, 28}, DlPaint());  // depth 11
   auto display_list = builder.Build();
 
   EXPECT_EQ(display_list->total_depth(), 11u);
@@ -5420,12 +5429,12 @@ TEST_F(DisplayListTest, BoundedRenderOpsDoNotReportUnbounded) {
 
   test_bounded("DrawLine", [](DlCanvas& builder) {
     builder.DrawLine(
-        {draw_rect.left() + 1.0f, draw_rect.top() + 1.0f},
-        {draw_rect.right() - 1.0f, draw_rect.top() + 1.0f},
+        SkPoint{draw_rect.left() + 1.0f, draw_rect.top() + 1.0f},
+        SkPoint{draw_rect.right() - 1.0f, draw_rect.top() + 1.0f},
         DlPaint().setStrokeWidth(2.0f).setStrokeCap(DlStrokeCap::kSquare));
     builder.DrawLine(
-        {draw_rect.left() + 1.0f, draw_rect.bottom() - 1.0f},
-        {draw_rect.right() - 1.0f, draw_rect.bottom() - 1.0f},
+        SkPoint{draw_rect.left() + 1.0f, draw_rect.bottom() - 1.0f},
+        SkPoint{draw_rect.right() - 1.0f, draw_rect.bottom() - 1.0f},
         DlPaint().setStrokeWidth(2.0f).setStrokeCap(DlStrokeCap::kSquare));
   });
 
@@ -5559,7 +5568,7 @@ TEST_F(DisplayListTest, BoundedRenderOpsDoNotReportUnbounded) {
 
   test_bounded("DrawImage", [](DlCanvas& builder) {
     auto image = MakeTestImage(draw_rect.width(), draw_rect.height(), 5);
-    builder.DrawImage(image, {draw_rect.left(), draw_rect.top()},
+    builder.DrawImage(image, SkPoint{draw_rect.left(), draw_rect.top()},
                       DlImageSampling::kLinear);
   });
 

--- a/display_list/dl_builder.cc
+++ b/display_list/dl_builder.cc
@@ -147,8 +147,8 @@ DisplayListBuilder::~DisplayListBuilder() {
   }
 }
 
-SkISize DisplayListBuilder::GetBaseLayerSize() const {
-  return ToSkISize(DlIRect::RoundOut(original_cull_rect_).GetSize());
+DlISize DisplayListBuilder::GetBaseLayerDimensions() const {
+  return DlIRect::RoundOut(original_cull_rect_).GetSize();
 }
 
 SkImageInfo DisplayListBuilder::GetImageInfo() const {
@@ -540,14 +540,14 @@ void DisplayListBuilder::saveLayer(const DlRect& bounds,
     }
   }
 }
-void DisplayListBuilder::SaveLayer(const SkRect* bounds,
+void DisplayListBuilder::SaveLayer(std::optional<const DlRect>& bounds,
                                    const DlPaint* paint,
                                    const DlImageFilter* backdrop) {
   SaveLayerOptions options;
   DlRect temp_bounds;
-  if (bounds) {
+  if (bounds.has_value()) {
     options = options.with_bounds_from_caller();
-    temp_bounds = ToDlRect(*bounds);
+    temp_bounds = *bounds;
   } else {
     FML_DCHECK(temp_bounds.IsEmpty());
   }
@@ -867,7 +867,7 @@ void DisplayListBuilder::TransformFullPerspective(
                               myz == 0 &&
       mzx == 0 && mzy == 0 && mzz == 1 && mzt == 0 &&
       mwx == 0 && mwy == 0 && mwz == 0 && mwt == 1) {
-    Transform2DAffine(mxx, mxy, mxt,
+    transform2DAffine(mxx, mxy, mxt,
                       myx, myy, myt);
   } else if (std::isfinite(mxx) && std::isfinite(mxy) &&
              std::isfinite(mxz) && std::isfinite(mxt) &&
@@ -920,25 +920,18 @@ void DisplayListBuilder::TransformReset() {
 
   global_state().setIdentity();
 }
-void DisplayListBuilder::Transform(const SkMatrix* matrix) {
-  if (matrix != nullptr) {
-    Transform(SkM44(*matrix));
-  }
-}
-void DisplayListBuilder::Transform(const SkM44* m44) {
-  if (m44 != nullptr) {
-    transformFullPerspective(
-        m44->rc(0, 0), m44->rc(0, 1), m44->rc(0, 2), m44->rc(0, 3),
-        m44->rc(1, 0), m44->rc(1, 1), m44->rc(1, 2), m44->rc(1, 3),
-        m44->rc(2, 0), m44->rc(2, 1), m44->rc(2, 2), m44->rc(2, 3),
-        m44->rc(3, 0), m44->rc(3, 1), m44->rc(3, 2), m44->rc(3, 3));
-  }
+void DisplayListBuilder::Transform(const DlMatrix& matrix) {
+  TransformFullPerspective(
+      matrix.e[0][0], matrix.e[1][0], matrix.e[2][0], matrix.e[3][0],
+      matrix.e[0][1], matrix.e[1][1], matrix.e[2][1], matrix.e[3][1],
+      matrix.e[0][2], matrix.e[1][2], matrix.e[2][2], matrix.e[3][2],
+      matrix.e[0][3], matrix.e[1][3], matrix.e[2][3], matrix.e[3][3]);
 }
 
-void DisplayListBuilder::ClipRect(const SkRect& rect,
+void DisplayListBuilder::ClipRect(const DlRect& rect,
                                   ClipOp clip_op,
                                   bool is_aa) {
-  if (!rect.isFinite()) {
+  if (!rect.IsFinite()) {
     return;
   }
   if (current_info().is_nop) {
@@ -960,17 +953,17 @@ void DisplayListBuilder::ClipRect(const SkRect& rect,
   checkForDeferredSave();
   switch (clip_op) {
     case ClipOp::kIntersect:
-      Push<ClipIntersectRectOp>(0, ToDlRect(rect), is_aa);
+      Push<ClipIntersectRectOp>(0, rect, is_aa);
       break;
     case ClipOp::kDifference:
-      Push<ClipDifferenceRectOp>(0, ToDlRect(rect), is_aa);
+      Push<ClipDifferenceRectOp>(0, rect, is_aa);
       break;
   }
 }
-void DisplayListBuilder::ClipOval(const SkRect& bounds,
+void DisplayListBuilder::ClipOval(const DlRect& bounds,
                                   ClipOp clip_op,
                                   bool is_aa) {
-  if (!bounds.isFinite()) {
+  if (!bounds.IsFinite()) {
     return;
   }
   if (current_info().is_nop) {
@@ -992,10 +985,10 @@ void DisplayListBuilder::ClipOval(const SkRect& bounds,
   checkForDeferredSave();
   switch (clip_op) {
     case ClipOp::kIntersect:
-      Push<ClipIntersectOvalOp>(0, ToDlRect(bounds), is_aa);
+      Push<ClipIntersectOvalOp>(0, bounds, is_aa);
       break;
     case ClipOp::kDifference:
-      Push<ClipDifferenceOvalOp>(0, ToDlRect(bounds), is_aa);
+      Push<ClipDifferenceOvalOp>(0, bounds, is_aa);
       break;
   }
 }
@@ -1003,11 +996,11 @@ void DisplayListBuilder::ClipRRect(const SkRRect& rrect,
                                    ClipOp clip_op,
                                    bool is_aa) {
   if (rrect.isRect()) {
-    ClipRect(rrect.rect(), clip_op, is_aa);
+    ClipRect(ToDlRect(rrect.rect()), clip_op, is_aa);
     return;
   }
   if (rrect.isOval()) {
-    ClipOval(rrect.rect(), clip_op, is_aa);
+    ClipOval(ToDlRect(rrect.rect()), clip_op, is_aa);
     return;
   }
   if (current_info().is_nop) {
@@ -1043,12 +1036,12 @@ void DisplayListBuilder::ClipPath(const DlPath& path,
     return;
   }
   if (!path.IsInverseFillType()) {
-    SkRect rect;
-    if (path.IsSkRect(&rect)) {
+    DlRect rect;
+    if (path.IsRect(&rect)) {
       ClipRect(rect, clip_op, is_aa);
       return;
     }
-    if (path.IsSkOval(&rect)) {
+    if (path.IsOval(&rect)) {
       ClipOval(rect, clip_op, is_aa);
       return;
     }
@@ -1077,7 +1070,7 @@ void DisplayListBuilder::ClipPath(const DlPath& path,
   }
 }
 
-bool DisplayListBuilder::QuickReject(const SkRect& bounds) const {
+bool DisplayListBuilder::QuickReject(const DlRect& bounds) const {
   return global_state().content_culled(bounds);
 }
 
@@ -1113,11 +1106,11 @@ void DisplayListBuilder::drawLine(const DlPoint& p0, const DlPoint& p1) {
     UpdateLayerResult(result);
   }
 }
-void DisplayListBuilder::DrawLine(const SkPoint& p0,
-                                  const SkPoint& p1,
+void DisplayListBuilder::DrawLine(const DlPoint& p0,
+                                  const DlPoint& p1,
                                   const DlPaint& paint) {
   SetAttributesFromPaint(paint, DisplayListOpFlags::kDrawLineFlags);
-  drawLine(ToDlPoint(p0), ToDlPoint(p1));
+  drawLine(p0, p1);
 }
 void DisplayListBuilder::drawDashedLine(const DlPoint& p0,
                                         const DlPoint& p1,
@@ -1152,9 +1145,9 @@ void DisplayListBuilder::drawRect(const DlRect& rect) {
     UpdateLayerResult(result);
   }
 }
-void DisplayListBuilder::DrawRect(const SkRect& rect, const DlPaint& paint) {
+void DisplayListBuilder::DrawRect(const DlRect& rect, const DlPaint& paint) {
   SetAttributesFromPaint(paint, DisplayListOpFlags::kDrawRectFlags);
-  drawRect(ToDlRect(rect));
+  drawRect(rect);
 }
 void DisplayListBuilder::drawOval(const DlRect& bounds) {
   DisplayListAttributeFlags flags = kDrawOvalFlags;
@@ -1166,9 +1159,9 @@ void DisplayListBuilder::drawOval(const DlRect& bounds) {
     UpdateLayerResult(result);
   }
 }
-void DisplayListBuilder::DrawOval(const SkRect& bounds, const DlPaint& paint) {
+void DisplayListBuilder::DrawOval(const DlRect& bounds, const DlPaint& paint) {
   SetAttributesFromPaint(paint, DisplayListOpFlags::kDrawOvalFlags);
-  drawOval(ToDlRect(bounds));
+  drawOval(bounds);
 }
 void DisplayListBuilder::drawCircle(const DlPoint& center, DlScalar radius) {
   DisplayListAttributeFlags flags = kDrawCircleFlags;
@@ -1183,11 +1176,11 @@ void DisplayListBuilder::drawCircle(const DlPoint& center, DlScalar radius) {
     }
   }
 }
-void DisplayListBuilder::DrawCircle(const SkPoint& center,
+void DisplayListBuilder::DrawCircle(const DlPoint& center,
                                     DlScalar radius,
                                     const DlPaint& paint) {
   SetAttributesFromPaint(paint, DisplayListOpFlags::kDrawCircleFlags);
-  drawCircle(ToDlPoint(center), radius);
+  drawCircle(center, radius);
 }
 void DisplayListBuilder::drawRRect(const SkRRect& rrect) {
   if (rrect.isRect()) {
@@ -1241,11 +1234,6 @@ void DisplayListBuilder::drawPath(const DlPath& path) {
     }
   }
 }
-void DisplayListBuilder::DrawPath(const SkPath& path, const DlPaint& paint) {
-  SetAttributesFromPaint(paint, DisplayListOpFlags::kDrawPathFlags);
-  DlPath dl_path(path);
-  drawPath(dl_path);
-}
 void DisplayListBuilder::DrawPath(const DlPath& path, const DlPaint& paint) {
   SetAttributesFromPaint(paint, DisplayListOpFlags::kDrawPathFlags);
   drawPath(path);
@@ -1274,14 +1262,14 @@ void DisplayListBuilder::drawArc(const DlRect& bounds,
     UpdateLayerResult(result);
   }
 }
-void DisplayListBuilder::DrawArc(const SkRect& bounds,
+void DisplayListBuilder::DrawArc(const DlRect& bounds,
                                  DlScalar start,
                                  DlScalar sweep,
                                  bool useCenter,
                                  const DlPaint& paint) {
   SetAttributesFromPaint(
       paint, useCenter ? kDrawArcWithCenterFlags : kDrawArcNoCenterFlags);
-  drawArc(ToDlRect(bounds), start, sweep, useCenter);
+  drawArc(bounds, start, sweep, useCenter);
 }
 
 DisplayListAttributeFlags DisplayListBuilder::FlagsForPointMode(
@@ -1350,10 +1338,10 @@ void DisplayListBuilder::drawPoints(PointMode mode,
 }
 void DisplayListBuilder::DrawPoints(PointMode mode,
                                     uint32_t count,
-                                    const SkPoint pts[],
+                                    const DlPoint pts[],
                                     const DlPaint& paint) {
   SetAttributesFromPaint(paint, FlagsForPointMode(mode));
-  drawPoints(mode, count, ToDlPoints(pts));
+  drawPoints(mode, count, pts);
 }
 void DisplayListBuilder::drawVertices(
     const std::shared_ptr<DlVertices>& vertices,
@@ -1411,15 +1399,15 @@ void DisplayListBuilder::drawImage(const sk_sp<DlImage> image,
   }
 }
 void DisplayListBuilder::DrawImage(const sk_sp<DlImage>& image,
-                                   const SkPoint& point,
+                                   const DlPoint& point,
                                    DlImageSampling sampling,
                                    const DlPaint* paint) {
   if (paint != nullptr) {
     SetAttributesFromPaint(*paint,
                            DisplayListOpFlags::kDrawImageWithPaintFlags);
-    drawImage(image, ToDlPoint(point), sampling, true);
+    drawImage(image, point, sampling, true);
   } else {
-    drawImage(image, ToDlPoint(point), sampling, false);
+    drawImage(image, point, sampling, false);
   }
 }
 void DisplayListBuilder::drawImageRect(const sk_sp<DlImage> image,
@@ -1442,19 +1430,17 @@ void DisplayListBuilder::drawImageRect(const sk_sp<DlImage> image,
   }
 }
 void DisplayListBuilder::DrawImageRect(const sk_sp<DlImage>& image,
-                                       const SkRect& src,
-                                       const SkRect& dst,
+                                       const DlRect& src,
+                                       const DlRect& dst,
                                        DlImageSampling sampling,
                                        const DlPaint* paint,
                                        SrcRectConstraint constraint) {
   if (paint != nullptr) {
     SetAttributesFromPaint(*paint,
                            DisplayListOpFlags::kDrawImageRectWithPaintFlags);
-    drawImageRect(image, ToDlRect(src), ToDlRect(dst), sampling, true,
-                  constraint);
+    drawImageRect(image, src, dst, sampling, true, constraint);
   } else {
-    drawImageRect(image, ToDlRect(src), ToDlRect(dst), sampling, false,
-                  constraint);
+    drawImageRect(image, src, dst, sampling, false, constraint);
   }
 }
 void DisplayListBuilder::drawImageNine(const sk_sp<DlImage> image,
@@ -1477,16 +1463,16 @@ void DisplayListBuilder::drawImageNine(const sk_sp<DlImage> image,
   }
 }
 void DisplayListBuilder::DrawImageNine(const sk_sp<DlImage>& image,
-                                       const SkIRect& center,
-                                       const SkRect& dst,
+                                       const DlIRect& center,
+                                       const DlRect& dst,
                                        DlFilterMode filter,
                                        const DlPaint* paint) {
   if (paint != nullptr) {
     SetAttributesFromPaint(*paint,
                            DisplayListOpFlags::kDrawImageNineWithPaintFlags);
-    drawImageNine(image, ToDlIRect(center), ToDlRect(dst), filter, true);
+    drawImageNine(image, center, dst, filter, true);
   } else {
-    drawImageNine(image, ToDlIRect(center), ToDlRect(dst), filter, false);
+    drawImageNine(image, center, dst, filter, false);
   }
 }
 void DisplayListBuilder::drawAtlas(const sk_sp<DlImage> atlas,
@@ -1565,21 +1551,21 @@ void DisplayListBuilder::drawAtlas(const sk_sp<DlImage> atlas,
 }
 void DisplayListBuilder::DrawAtlas(const sk_sp<DlImage>& atlas,
                                    const SkRSXform xform[],
-                                   const SkRect tex[],
+                                   const DlRect tex[],
                                    const DlColor colors[],
                                    int count,
                                    DlBlendMode mode,
                                    DlImageSampling sampling,
-                                   const SkRect* cull_rect,
+                                   const DlRect* cull_rect,
                                    const DlPaint* paint) {
   if (paint != nullptr) {
     SetAttributesFromPaint(*paint,
                            DisplayListOpFlags::kDrawAtlasWithPaintFlags);
-    drawAtlas(atlas, xform, ToDlRects(tex), colors, count, mode, sampling,
-              ToDlRect(cull_rect), true);
+    drawAtlas(atlas, xform, tex, colors, count, mode, sampling, cull_rect,
+              true);
   } else {
-    drawAtlas(atlas, xform, ToDlRects(tex), colors, count, mode, sampling,
-              ToDlRect(cull_rect), false);
+    drawAtlas(atlas, xform, tex, colors, count, mode, sampling, cull_rect,
+              false);
   }
 }
 

--- a/display_list/dl_builder.h
+++ b/display_list/dl_builder.h
@@ -41,7 +41,7 @@ class DisplayListBuilder final : public virtual DlCanvas,
   ~DisplayListBuilder();
 
   // |DlCanvas|
-  SkISize GetBaseLayerSize() const override;
+  DlISize GetBaseLayerDimensions() const override;
   // |DlCanvas|
   SkImageInfo GetImageInfo() const override;
 
@@ -49,7 +49,7 @@ class DisplayListBuilder final : public virtual DlCanvas,
   void Save() override;
 
   // |DlCanvas|
-  void SaveLayer(const SkRect* bounds,
+  void SaveLayer(std::optional<const DlRect>& bounds,
                  const DlPaint* paint = nullptr,
                  const DlImageFilter* backdrop = nullptr) override;
   // |DlCanvas|
@@ -84,52 +84,31 @@ class DisplayListBuilder final : public virtual DlCanvas,
   // |DlCanvas|
   void TransformReset() override;
   // |DlCanvas|
-  void Transform(const SkMatrix* matrix) override;
+  void Transform(const DlMatrix& matrix) override;
   // |DlCanvas|
-  void Transform(const SkM44* matrix44) override;
-  // |DlCanvas|
-  void SetTransform(const SkMatrix* matrix) override {
+  void SetTransform(const DlMatrix& matrix) override {
     TransformReset();
     Transform(matrix);
   }
-  // |DlCanvas|
-  void SetTransform(const SkM44* matrix44) override {
-    TransformReset();
-    Transform(matrix44);
-  }
-  using DlCanvas::Transform;
 
   /// Returns the 4x4 full perspective transform representing all transform
   /// operations executed so far in this DisplayList within the enclosing
   /// save stack.
   // |DlCanvas|
-  SkM44 GetTransformFullPerspective() const override {
-    return global_state().matrix_4x4();
-  }
-  /// Returns the 3x3 partial perspective transform representing all transform
-  /// operations executed so far in this DisplayList within the enclosing
-  /// save stack.
-  // |DlCanvas|
-  SkMatrix GetTransform() const override { return global_state().matrix_3x3(); }
+  DlMatrix GetMatrix() const override { return global_state().matrix(); }
 
   // |DlCanvas|
-  void ClipRect(const SkRect& rect,
+  void ClipRect(const DlRect& rect,
                 ClipOp clip_op = ClipOp::kIntersect,
                 bool is_aa = false) override;
   // |DlCanvas|
-  void ClipOval(const SkRect& bounds,
+  void ClipOval(const DlRect& bounds,
                 ClipOp clip_op = ClipOp::kIntersect,
                 bool is_aa = false) override;
   // |DlCanvas|
   void ClipRRect(const SkRRect& rrect,
                  ClipOp clip_op = ClipOp::kIntersect,
                  bool is_aa = false) override;
-  // |DlCanvas|
-  void ClipPath(const SkPath& path,
-                ClipOp clip_op = ClipOp::kIntersect,
-                bool is_aa = false) override {
-    ClipPath(DlPath(path), clip_op, is_aa);
-  }
   // |DlCanvas|
   void ClipPath(const DlPath& path,
                 ClipOp clip_op = ClipOp::kIntersect,
@@ -139,30 +118,30 @@ class DisplayListBuilder final : public virtual DlCanvas,
   /// measured in the coordinate space within which this DisplayList will
   /// be rendered.
   // |DlCanvas|
-  SkRect GetDestinationClipBounds() const override {
-    return global_state().device_cull_rect();
+  DlRect GetDestinationClipCoverage() const override {
+    return global_state().GetDeviceCullCoverage();
   }
   /// Conservative estimate of the bounds of all outstanding clip operations
   /// transformed into the local coordinate space in which currently
   /// recorded rendering operations are interpreted.
   // |DlCanvas|
-  SkRect GetLocalClipBounds() const override {
-    return global_state().local_cull_rect();
+  DlRect GetLocalClipCoverage() const override {
+    return global_state().GetLocalCullCoverage();
   }
 
   /// Return true iff the supplied bounds are easily shown to be outside
   /// of the current clip bounds. This method may conservatively return
   /// false if it cannot make the determination.
   // |DlCanvas|
-  bool QuickReject(const SkRect& bounds) const override;
+  bool QuickReject(const DlRect& bounds) const override;
 
   // |DlCanvas|
   void DrawPaint(const DlPaint& paint) override;
   // |DlCanvas|
   void DrawColor(DlColor color, DlBlendMode mode) override;
   // |DlCanvas|
-  void DrawLine(const SkPoint& p0,
-                const SkPoint& p1,
+  void DrawLine(const DlPoint& p0,
+                const DlPoint& p1,
                 const DlPaint& paint) override;
   // |DlCanvas|
   void DrawDashedLine(const DlPoint& p0,
@@ -171,11 +150,11 @@ class DisplayListBuilder final : public virtual DlCanvas,
                       DlScalar off_length,
                       const DlPaint& paint) override;
   // |DlCanvas|
-  void DrawRect(const SkRect& rect, const DlPaint& paint) override;
+  void DrawRect(const DlRect& rect, const DlPaint& paint) override;
   // |DlCanvas|
-  void DrawOval(const SkRect& bounds, const DlPaint& paint) override;
+  void DrawOval(const DlRect& bounds, const DlPaint& paint) override;
   // |DlCanvas|
-  void DrawCircle(const SkPoint& center,
+  void DrawCircle(const DlPoint& center,
                   DlScalar radius,
                   const DlPaint& paint) override;
   // |DlCanvas|
@@ -185,11 +164,9 @@ class DisplayListBuilder final : public virtual DlCanvas,
                   const SkRRect& inner,
                   const DlPaint& paint) override;
   // |DlCanvas|
-  void DrawPath(const SkPath& path, const DlPaint& paint) override;
-  // |DlCanvas|
   void DrawPath(const DlPath& path, const DlPaint& paint) override;
   // |DlCanvas|
-  void DrawArc(const SkRect& bounds,
+  void DrawArc(const DlRect& bounds,
                DlScalar start,
                DlScalar sweep,
                bool useCenter,
@@ -197,7 +174,7 @@ class DisplayListBuilder final : public virtual DlCanvas,
   // |DlCanvas|
   void DrawPoints(PointMode mode,
                   uint32_t count,
-                  const SkPoint pts[],
+                  const DlPoint pts[],
                   const DlPaint& paint) override;
   // |DlCanvas|
   void DrawVertices(const std::shared_ptr<DlVertices>& vertices,
@@ -205,33 +182,32 @@ class DisplayListBuilder final : public virtual DlCanvas,
                     const DlPaint& paint) override;
   // |DlCanvas|
   void DrawImage(const sk_sp<DlImage>& image,
-                 const SkPoint& point,
+                 const DlPoint& point,
                  DlImageSampling sampling,
                  const DlPaint* paint = nullptr) override;
   // |DlCanvas|
   void DrawImageRect(
       const sk_sp<DlImage>& image,
-      const SkRect& src,
-      const SkRect& dst,
+      const DlRect& src,
+      const DlRect& dst,
       DlImageSampling sampling,
       const DlPaint* paint = nullptr,
       SrcRectConstraint constraint = SrcRectConstraint::kFast) override;
-  using DlCanvas::DrawImageRect;
   // |DlCanvas|
   void DrawImageNine(const sk_sp<DlImage>& image,
-                     const SkIRect& center,
-                     const SkRect& dst,
+                     const DlIRect& center,
+                     const DlRect& dst,
                      DlFilterMode filter,
                      const DlPaint* paint = nullptr) override;
   // |DlCanvas|
   void DrawAtlas(const sk_sp<DlImage>& atlas,
                  const SkRSXform xform[],
-                 const SkRect tex[],
+                 const DlRect tex[],
                  const DlColor colors[],
                  int count,
                  DlBlendMode mode,
                  DlImageSampling sampling,
-                 const SkRect* cullRect,
+                 const DlRect* cullRect,
                  const DlPaint* paint = nullptr) override;
   // |DlCanvas|
   void DrawDisplayList(const sk_sp<DisplayList> display_list,
@@ -252,14 +228,6 @@ class DisplayListBuilder final : public virtual DlCanvas,
                      const DlPaint& paint) override;
 
   // |DlCanvas|
-  void DrawShadow(const SkPath& path,
-                  const DlColor color,
-                  const DlScalar elevation,
-                  bool transparent_occluder,
-                  DlScalar dpr) override {
-    DrawShadow(DlPath(path), color, elevation, transparent_occluder, dpr);
-  }
-  // |DlCanvas|
   void DrawShadow(const DlPath& path,
                   const DlColor color,
                   const DlScalar elevation,
@@ -270,6 +238,8 @@ class DisplayListBuilder final : public virtual DlCanvas,
   void Flush() override {}
 
   sk_sp<DisplayList> Build();
+
+  ENABLE_DL_CANVAS_BACKWARDS_COMPATIBILITY
 
  private:
   void Init(bool prepare_rtree);
@@ -417,11 +387,11 @@ class DisplayListBuilder final : public virtual DlCanvas,
 
   // |DlOpReceiver|
   void clipRect(const DlRect& rect, ClipOp clip_op, bool is_aa) override {
-    ClipRect(ToSkRect(rect), clip_op, is_aa);
+    ClipRect(rect, clip_op, is_aa);
   }
   // |DlOpReceiver|
   void clipOval(const DlRect& bounds, ClipOp clip_op, bool is_aa) override {
-    ClipOval(ToSkRect(bounds), clip_op, is_aa);
+    ClipOval(bounds, clip_op, is_aa);
   }
   // |DlOpReceiver|
   void clipRRect(const SkRRect& rrect, ClipOp clip_op, bool is_aa) override {

--- a/display_list/dl_canvas.cc
+++ b/display_list/dl_canvas.cc
@@ -11,7 +11,7 @@ namespace flutter {
 
 DlRect DlCanvas::ComputeShadowBounds(const DlPath& path,
                                      float elevation,
-                                     SkScalar dpr,
+                                     DlScalar dpr,
                                      const DlMatrix& ctm) {
   SkRect shadow_bounds(path.GetSkBounds());
   SkShadowUtils::GetLocalBounds(

--- a/display_list/dl_canvas.cc
+++ b/display_list/dl_canvas.cc
@@ -9,16 +9,16 @@
 
 namespace flutter {
 
-SkRect DlCanvas::ComputeShadowBounds(const SkPath& path,
+DlRect DlCanvas::ComputeShadowBounds(const DlPath& path,
                                      float elevation,
                                      SkScalar dpr,
-                                     const SkMatrix& ctm) {
-  SkRect shadow_bounds(path.getBounds());
+                                     const DlMatrix& ctm) {
+  SkRect shadow_bounds(path.GetSkBounds());
   SkShadowUtils::GetLocalBounds(
-      ctm, path, SkPoint3::Make(0, 0, dpr * elevation),
+      ToSkMatrix(ctm), path.GetSkPath(), SkPoint3::Make(0, 0, dpr * elevation),
       SkPoint3::Make(0, -1, 1), kShadowLightRadius / kShadowLightHeight,
       SkShadowFlags::kDirectionalLight_ShadowFlag, &shadow_bounds);
-  return shadow_bounds;
+  return ToDlRect(shadow_bounds);
 }
 
 }  // namespace flutter

--- a/display_list/dl_canvas.h
+++ b/display_list/dl_canvas.h
@@ -56,11 +56,11 @@ class DlCanvas {
 
   virtual ~DlCanvas() = default;
 
-  virtual SkISize GetBaseLayerSize() const = 0;
+  virtual DlISize GetBaseLayerDimensions() const = 0;
   virtual SkImageInfo GetImageInfo() const = 0;
 
   virtual void Save() = 0;
-  virtual void SaveLayer(const SkRect* bounds,
+  virtual void SaveLayer(std::optional<const DlRect>& bounds,
                          const DlPaint* paint = nullptr,
                          const DlImageFilter* backdrop = nullptr) = 0;
   virtual void Restore() = 0;
@@ -85,133 +85,114 @@ class DlCanvas {
       DlScalar mwx, DlScalar mwy, DlScalar mwz, DlScalar mwt) = 0;
   // clang-format on
   virtual void TransformReset() = 0;
-  virtual void Transform(const SkMatrix* matrix) = 0;
-  virtual void Transform(const SkM44* matrix44) = 0;
-  void Transform(const SkMatrix& matrix) { Transform(&matrix); }
-  void Transform(const SkM44& matrix44) { Transform(&matrix44); }
-  virtual void SetTransform(const SkMatrix* matrix) = 0;
-  virtual void SetTransform(const SkM44* matrix44) = 0;
-  virtual void SetTransform(const SkMatrix& matrix) { SetTransform(&matrix); }
-  virtual void SetTransform(const SkM44& matrix44) { SetTransform(&matrix44); }
+  virtual void Transform(const DlMatrix& matrix) = 0;
+  virtual void SetTransform(const DlMatrix& matrix) = 0;
 
-  /// Returns the 4x4 full perspective transform representing all transform
-  /// operations executed so far in this DisplayList within the enclosing
-  /// save stack.
-  virtual SkM44 GetTransformFullPerspective() const = 0;
-  /// Returns the 3x3 partial perspective transform representing all transform
-  /// operations executed so far in this DisplayList within the enclosing
-  /// save stack.
-  virtual SkMatrix GetTransform() const = 0;
+  virtual DlMatrix GetMatrix() const = 0;
 
-  virtual void ClipRect(const SkRect& rect,
+  virtual void ClipRect(const DlRect& rect,
                         ClipOp clip_op = ClipOp::kIntersect,
                         bool is_aa = false) = 0;
-  virtual void ClipOval(const SkRect& bounds,
+  virtual void ClipOval(const DlRect& bounds,
                         ClipOp clip_op = ClipOp::kIntersect,
                         bool is_aa = false) = 0;
   virtual void ClipRRect(const SkRRect& rrect,
                          ClipOp clip_op = ClipOp::kIntersect,
                          bool is_aa = false) = 0;
-  virtual void ClipPath(const SkPath& path,
-                        ClipOp clip_op = ClipOp::kIntersect,
-                        bool is_aa = false) = 0;
   virtual void ClipPath(const DlPath& path,
                         ClipOp clip_op = ClipOp::kIntersect,
-                        bool is_aa = false) {
-    ClipPath(path.GetSkPath(), clip_op, is_aa);
-  }
+                        bool is_aa = false) = 0;
 
   /// Conservative estimate of the bounds of all outstanding clip operations
   /// measured in the coordinate space within which this DisplayList will
   /// be rendered.
-  virtual SkRect GetDestinationClipBounds() const = 0;
+  virtual DlRect GetDestinationClipCoverage() const = 0;
   /// Conservative estimate of the bounds of all outstanding clip operations
   /// transformed into the local coordinate space in which currently
   /// recorded rendering operations are interpreted.
-  virtual SkRect GetLocalClipBounds() const = 0;
+  virtual DlRect GetLocalClipCoverage() const = 0;
 
   /// Return true iff the supplied bounds are easily shown to be outside
   /// of the current clip bounds. This method may conservatively return
   /// false if it cannot make the determination.
-  virtual bool QuickReject(const SkRect& bounds) const = 0;
+  virtual bool QuickReject(const DlRect& bounds) const = 0;
 
   virtual void DrawPaint(const DlPaint& paint) = 0;
   virtual void DrawColor(DlColor color,
                          DlBlendMode mode = DlBlendMode::kSrcOver) = 0;
   void Clear(DlColor color) { DrawColor(color, DlBlendMode::kSrc); }
-  virtual void DrawLine(const SkPoint& p0,
-                        const SkPoint& p1,
+  virtual void DrawLine(const DlPoint& p0,
+                        const DlPoint& p1,
                         const DlPaint& paint) = 0;
   virtual void DrawDashedLine(const DlPoint& p0,
                               const DlPoint& p1,
                               DlScalar on_length,
                               DlScalar off_length,
                               const DlPaint& paint) = 0;
-  virtual void DrawRect(const SkRect& rect, const DlPaint& paint) = 0;
-  virtual void DrawOval(const SkRect& bounds, const DlPaint& paint) = 0;
-  virtual void DrawCircle(const SkPoint& center,
+  virtual void DrawRect(const DlRect& rect, const DlPaint& paint) = 0;
+  virtual void DrawOval(const DlRect& bounds, const DlPaint& paint) = 0;
+  virtual void DrawCircle(const DlPoint& center,
                           DlScalar radius,
                           const DlPaint& paint) = 0;
   virtual void DrawRRect(const SkRRect& rrect, const DlPaint& paint) = 0;
   virtual void DrawDRRect(const SkRRect& outer,
                           const SkRRect& inner,
                           const DlPaint& paint) = 0;
-  virtual void DrawPath(const SkPath& path, const DlPaint& paint) = 0;
-  virtual void DrawPath(const DlPath& path, const DlPaint& paint) {
-    DrawPath(path.GetSkPath(), paint);
-  }
-  virtual void DrawArc(const SkRect& bounds,
+  virtual void DrawPath(const DlPath& path, const DlPaint& paint) = 0;
+  virtual void DrawArc(const DlRect& bounds,
                        DlScalar start,
                        DlScalar sweep,
                        bool useCenter,
                        const DlPaint& paint) = 0;
   virtual void DrawPoints(PointMode mode,
                           uint32_t count,
-                          const SkPoint pts[],
+                          const DlPoint pts[],
                           const DlPaint& paint) = 0;
   virtual void DrawVertices(const std::shared_ptr<DlVertices>& vertices,
                             DlBlendMode mode,
                             const DlPaint& paint) = 0;
   virtual void DrawImage(const sk_sp<DlImage>& image,
-                         const SkPoint& point,
+                         const DlPoint& point,
                          DlImageSampling sampling,
                          const DlPaint* paint = nullptr) = 0;
   virtual void DrawImageRect(
       const sk_sp<DlImage>& image,
-      const SkRect& src,
-      const SkRect& dst,
+      const DlRect& src,
+      const DlRect& dst,
       DlImageSampling sampling,
       const DlPaint* paint = nullptr,
       SrcRectConstraint constraint = SrcRectConstraint::kFast) = 0;
   virtual void DrawImageRect(
       const sk_sp<DlImage>& image,
-      const SkIRect& src,
-      const SkRect& dst,
+      const DlIRect& src,
+      const DlRect& dst,
       DlImageSampling sampling,
       const DlPaint* paint = nullptr,
       SrcRectConstraint constraint = SrcRectConstraint::kFast) {
-    DrawImageRect(image, SkRect::Make(src), dst, sampling, paint, constraint);
+    auto float_src = DlRect::MakeLTRB(src.GetLeft(), src.GetTop(),
+                                      src.GetRight(), src.GetBottom());
+    DrawImageRect(image, float_src, dst, sampling, paint, constraint);
   }
   void DrawImageRect(const sk_sp<DlImage>& image,
-                     const SkRect& dst,
+                     const DlRect& dst,
                      DlImageSampling sampling,
                      const DlPaint* paint = nullptr,
                      SrcRectConstraint constraint = SrcRectConstraint::kFast) {
-    DrawImageRect(image, image->bounds(), dst, sampling, paint, constraint);
+    DrawImageRect(image, image->GetBounds(), dst, sampling, paint, constraint);
   }
   virtual void DrawImageNine(const sk_sp<DlImage>& image,
-                             const SkIRect& center,
-                             const SkRect& dst,
+                             const DlIRect& center,
+                             const DlRect& dst,
                              DlFilterMode filter,
                              const DlPaint* paint = nullptr) = 0;
   virtual void DrawAtlas(const sk_sp<DlImage>& atlas,
                          const SkRSXform xform[],
-                         const SkRect tex[],
+                         const DlRect tex[],
                          const DlColor colors[],
                          int count,
                          DlBlendMode mode,
                          DlImageSampling sampling,
-                         const SkRect* cullRect,
+                         const DlRect* cullRect,
                          const DlPaint* paint = nullptr) = 0;
   virtual void DrawDisplayList(const sk_sp<DisplayList> display_list,
                                DlScalar opacity = SK_Scalar1) = 0;
@@ -226,28 +207,225 @@ class DlCanvas {
                             DlScalar x,
                             DlScalar y,
                             const DlPaint& paint) = 0;
-  virtual void DrawShadow(const SkPath& path,
-                          const DlColor color,
-                          const DlScalar elevation,
-                          bool transparent_occluder,
-                          DlScalar dpr) = 0;
   virtual void DrawShadow(const DlPath& path,
                           const DlColor color,
                           const DlScalar elevation,
                           bool transparent_occluder,
-                          DlScalar dpr) {
-    DrawShadow(path.GetSkPath(), color, elevation, transparent_occluder, dpr);
-  }
+                          DlScalar dpr) = 0;
 
   virtual void Flush() = 0;
 
   static constexpr DlScalar kShadowLightHeight = 600;
   static constexpr DlScalar kShadowLightRadius = 800;
 
+  static DlRect ComputeShadowBounds(const DlPath& path,
+                                    float elevation,
+                                    DlScalar dpr,
+                                    const DlMatrix& ctm);
+
+  // -----------------------------------------------------------------
+  // SkObject Compatibility section - deprecated...
+  // -----------------------------------------------------------------
+
+  SkISize GetBaseLayerSize() const {
+    return ToSkISize(GetBaseLayerDimensions());
+  }
+
+  void SaveLayer(const SkRect* bounds,
+                 const DlPaint* paint = nullptr,
+                 const DlImageFilter* backdrop = nullptr) {
+    auto optional_bounds = ToOptDlRect(bounds);
+    SaveLayer(optional_bounds, paint, backdrop);
+  }
+
+  void Transform(const SkMatrix* matrix) {
+    if (matrix) {
+      Transform(*matrix);
+    }
+  }
+  void Transform(const SkM44* matrix44) {
+    if (matrix44) {
+      Transform(*matrix44);
+    }
+  }
+  void Transform(const SkMatrix& matrix) { Transform(ToDlMatrix(matrix)); }
+  void Transform(const SkM44& m44) { Transform(ToDlMatrix(m44)); }
+  void SetTransform(const SkMatrix* matrix) {
+    if (matrix) {
+      SetTransform(*matrix);
+    }
+  }
+  void SetTransform(const SkM44* matrix44) {
+    if (matrix44) {
+      SetTransform(*matrix44);
+    }
+  }
+  void SetTransform(const SkMatrix& matrix) {
+    SetTransform(ToDlMatrix(matrix));
+  }
+  void SetTransform(const SkM44& m44) { SetTransform(ToDlMatrix(m44)); }
+
+  /// Returns the 4x4 full perspective transform representing all transform
+  /// operations executed so far in this DisplayList within the enclosing
+  /// save stack.
+  SkM44 GetTransformFullPerspective() const { return ToSkM44(GetMatrix()); }
+  /// Returns the 3x3 partial perspective transform representing all transform
+  /// operations executed so far in this DisplayList within the enclosing
+  /// save stack.
+  SkMatrix GetTransform() const { return ToSkMatrix(GetMatrix()); }
+
+  void ClipRect(const SkRect& rect,
+                ClipOp clip_op = ClipOp::kIntersect,
+                bool is_aa = false) {
+    ClipRect(ToDlRect(rect), clip_op, is_aa);
+  }
+
+  void ClipOval(const SkRect& bounds,
+                ClipOp clip_op = ClipOp::kIntersect,
+                bool is_aa = false) {
+    ClipOval(ToDlRect(bounds), clip_op, is_aa);
+  }
+  void ClipPath(const SkPath& path,
+                ClipOp clip_op = ClipOp::kIntersect,
+                bool is_aa = false) {
+    ClipPath(DlPath(path), clip_op, is_aa);
+  }
+
+  SkRect GetDestinationClipBounds() const {
+    return ToSkRect(GetDestinationClipCoverage());
+  }
+  SkRect GetLocalClipBounds() const { return ToSkRect(GetLocalClipCoverage()); }
+  bool QuickReject(const SkRect& bounds) const {
+    return QuickReject(ToDlRect(bounds));
+  }
+
+  void DrawLine(const SkPoint& p0, const SkPoint& p1, const DlPaint& paint) {
+    DrawLine(ToDlPoint(p0), ToDlPoint(p1), paint);
+  }
+  void DrawRect(const SkRect& rect, const DlPaint& paint) {
+    DrawRect(ToDlRect(rect), paint);
+  }
+  void DrawOval(const SkRect& bounds, const DlPaint& paint) {
+    DrawOval(ToDlRect(bounds), paint);
+  }
+  void DrawCircle(const SkPoint& center,
+                  DlScalar radius,
+                  const DlPaint& paint) {
+    DrawCircle(ToDlPoint(center), radius, paint);
+  }
+  void DrawPath(const SkPath& path, const DlPaint& paint) {
+    DrawPath(DlPath(path), paint);
+  }
+  void DrawArc(const SkRect& bounds,
+               DlScalar start,
+               DlScalar sweep,
+               bool useCenter,
+               const DlPaint& paint) {
+    DrawArc(ToDlRect(bounds), start, sweep, useCenter, paint);
+  }
+  void DrawPoints(PointMode mode,
+                  uint32_t count,
+                  const SkPoint pts[],
+                  const DlPaint& paint) {
+    DrawPoints(mode, count, ToDlPoints(pts), paint);
+  }
+  void DrawImage(const sk_sp<DlImage>& image,
+                 const SkPoint& point,
+                 DlImageSampling sampling,
+                 const DlPaint* paint = nullptr) {
+    DrawImage(image, ToDlPoint(point), sampling, paint);
+  }
+  void DrawImageRect(const sk_sp<DlImage>& image,
+                     const SkRect& src,
+                     const SkRect& dst,
+                     DlImageSampling sampling,
+                     const DlPaint* paint = nullptr,
+                     SrcRectConstraint constraint = SrcRectConstraint::kFast) {
+    DrawImageRect(image, ToDlRect(src), ToDlRect(dst), sampling, paint,
+                  constraint);
+  }
+  void DrawImageRect(const sk_sp<DlImage>& image,
+                     const SkIRect& src,
+                     const SkRect& dst,
+                     DlImageSampling sampling,
+                     const DlPaint* paint = nullptr,
+                     SrcRectConstraint constraint = SrcRectConstraint::kFast) {
+    DrawImageRect(image, ToDlRect(src), ToDlRect(dst), sampling, paint,
+                  constraint);
+  }
+  void DrawImageRect(const sk_sp<DlImage>& image,
+                     const SkRect& dst,
+                     DlImageSampling sampling,
+                     const DlPaint* paint = nullptr,
+                     SrcRectConstraint constraint = SrcRectConstraint::kFast) {
+    DrawImageRect(image, image->GetBounds(), ToDlRect(dst), sampling, paint,
+                  constraint);
+  }
+  void DrawImageNine(const sk_sp<DlImage>& image,
+                     const SkIRect& center,
+                     const SkRect& dst,
+                     DlFilterMode filter,
+                     const DlPaint* paint = nullptr) {
+    DrawImageNine(image, ToDlIRect(center), ToDlRect(dst), filter, paint);
+  }
+  void DrawAtlas(const sk_sp<DlImage>& atlas,
+                 const SkRSXform xform[],
+                 const SkRect tex[],
+                 const DlColor colors[],
+                 int count,
+                 DlBlendMode mode,
+                 DlImageSampling sampling,
+                 const SkRect* cullRect,
+                 const DlPaint* paint = nullptr) {
+    DrawAtlas(atlas, xform, ToDlRects(tex), colors, count, mode, sampling,
+              ToDlRect(cullRect), paint);
+  }
+  void DrawShadow(const SkPath& path,
+                  const DlColor color,
+                  const DlScalar elevation,
+                  bool transparent_occluder,
+                  DlScalar dpr) {
+    DrawShadow(DlPath(path), color, elevation, transparent_occluder, dpr);
+  }
+
   static SkRect ComputeShadowBounds(const SkPath& path,
                                     float elevation,
                                     DlScalar dpr,
-                                    const SkMatrix& ctm);
+                                    const SkMatrix& ctm) {
+    return ToSkRect(
+        ComputeShadowBounds(DlPath(path), elevation, dpr, ToDlMatrix(ctm)));
+  }
+
+#define ENABLE_DL_CANVAS_BACKWARDS_COMPATIBILITY \
+  using DlCanvas::GetBaseLayerSize;              \
+                                                 \
+  using DlCanvas::SaveLayer;                     \
+                                                 \
+  using DlCanvas::Transform;                     \
+  using DlCanvas::SetTransform;                  \
+  using DlCanvas::GetTransformFullPerspective;   \
+  using DlCanvas::GetTransform;                  \
+                                                 \
+  using DlCanvas::ClipRect;                      \
+  using DlCanvas::ClipOval;                      \
+  using DlCanvas::ClipPath;                      \
+                                                 \
+  using DlCanvas::GetDestinationClipBounds;      \
+  using DlCanvas::GetLocalClipBounds;            \
+  using DlCanvas::QuickReject;                   \
+                                                 \
+  using DlCanvas::DrawLine;                      \
+  using DlCanvas::DrawRect;                      \
+  using DlCanvas::DrawOval;                      \
+  using DlCanvas::DrawCircle;                    \
+  using DlCanvas::DrawPath;                      \
+  using DlCanvas::DrawArc;                       \
+  using DlCanvas::DrawPoints;                    \
+  using DlCanvas::DrawImage;                     \
+  using DlCanvas::DrawImageRect;                 \
+  using DlCanvas::DrawImageNine;                 \
+  using DlCanvas::DrawAtlas;                     \
+  using DlCanvas::DrawShadow;
 };
 
 class DlAutoCanvasRestore {

--- a/display_list/geometry/dl_geometry_types.h
+++ b/display_list/geometry/dl_geometry_types.h
@@ -47,6 +47,10 @@ inline const DlRect& ToDlRect(const SkRect& rect) {
   return *reinterpret_cast<const DlRect*>(&rect);
 }
 
+inline const DlRect ToDlRect(const SkIRect& rect) {
+  return DlRect::MakeLTRB(rect.fLeft, rect.fTop, rect.fRight, rect.fBottom);
+}
+
 inline const DlIRect& ToDlIRect(const SkIRect& rect) {
   return *reinterpret_cast<const DlIRect*>(&rect);
 }
@@ -57,6 +61,10 @@ inline DlRect* ToDlRect(SkRect* rect) {
 
 inline const DlRect* ToDlRect(const SkRect* rect) {
   return rect == nullptr ? nullptr : reinterpret_cast<const DlRect*>(rect);
+}
+
+inline std::optional<const DlRect> ToOptDlRect(const SkRect* rect) {
+  return rect == nullptr ? std::nullopt : std::optional(ToDlRect(*rect));
 }
 
 inline const DlRect* ToDlRects(const SkRect* rects) {
@@ -102,6 +110,10 @@ inline const SkIRect& ToSkIRect(const DlIRect& rect) {
 
 inline const SkRect* ToSkRect(const DlRect* rect) {
   return rect == nullptr ? nullptr : reinterpret_cast<const SkRect*>(rect);
+}
+
+inline const SkRect* ToSkRect(std::optional<const DlRect>& rect) {
+  return rect.has_value() ? &ToSkRect(rect.value()) : nullptr;
 }
 
 inline SkRect* ToSkRect(DlRect* rect) {

--- a/display_list/skia/dl_sk_canvas.h
+++ b/display_list/skia/dl_sk_canvas.h
@@ -26,160 +26,138 @@ class DlSkCanvasAdapter final : public virtual DlCanvas {
   void set_canvas(SkCanvas* canvas);
   SkCanvas* canvas() { return delegate_; }
 
-  SkISize GetBaseLayerSize() const override;
+  DlISize GetBaseLayerDimensions() const override;
   SkImageInfo GetImageInfo() const override;
 
   void Save() override;
-  void SaveLayer(const SkRect* bounds,
+  void SaveLayer(std::optional<const DlRect>& bounds,
                  const DlPaint* paint = nullptr,
                  const DlImageFilter* backdrop = nullptr) override;
   void Restore() override;
   int GetSaveCount() const override;
   void RestoreToCount(int restore_count) override;
 
-  void Translate(SkScalar tx, SkScalar ty) override;
-  void Scale(SkScalar sx, SkScalar sy) override;
-  void Rotate(SkScalar degrees) override;
-  void Skew(SkScalar sx, SkScalar sy) override;
+  void Translate(DlScalar tx, DlScalar ty) override;
+  void Scale(DlScalar sx, DlScalar sy) override;
+  void Rotate(DlScalar degrees) override;
+  void Skew(DlScalar sx, DlScalar sy) override;
 
   // clang-format off
 
   // 2x3 2D affine subset of a 4x4 transform in row major order
-  void Transform2DAffine(SkScalar mxx, SkScalar mxy, SkScalar mxt,
-                         SkScalar myx, SkScalar myy, SkScalar myt) override;
+  void Transform2DAffine(DlScalar mxx, DlScalar mxy, DlScalar mxt,
+                         DlScalar myx, DlScalar myy, DlScalar myt) override;
   // full 4x4 transform in row major order
   void TransformFullPerspective(
-      SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
-      SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
-      SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
-      SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) override;
+      DlScalar mxx, DlScalar mxy, DlScalar mxz, DlScalar mxt,
+      DlScalar myx, DlScalar myy, DlScalar myz, DlScalar myt,
+      DlScalar mzx, DlScalar mzy, DlScalar mzz, DlScalar mzt,
+      DlScalar mwx, DlScalar mwy, DlScalar mwz, DlScalar mwt) override;
   // clang-format on
   void TransformReset() override;
-  void Transform(const SkMatrix* matrix) override;
-  void Transform(const SkM44* matrix44) override;
-  void SetTransform(const SkMatrix* matrix) override;
-  void SetTransform(const SkM44* matrix44) override;
-  using DlCanvas::SetTransform;
-  using DlCanvas::Transform;
+  void Transform(const DlMatrix& matrix) override;
+  void SetTransform(const DlMatrix& matrix) override;
 
   /// Returns the 4x4 full perspective transform representing all transform
   /// operations executed so far in this DisplayList within the enclosing
   /// save stack.
-  SkM44 GetTransformFullPerspective() const override;
-  /// Returns the 3x3 partial perspective transform representing all transform
-  /// operations executed so far in this DisplayList within the enclosing
-  /// save stack.
-  SkMatrix GetTransform() const override;
+  DlMatrix GetMatrix() const override;
 
-  void ClipRect(const SkRect& rect, ClipOp clip_op, bool is_aa) override;
-  void ClipOval(const SkRect& bounds, ClipOp clip_op, bool is_aa) override;
+  void ClipRect(const DlRect& rect, ClipOp clip_op, bool is_aa) override;
+  void ClipOval(const DlRect& bounds, ClipOp clip_op, bool is_aa) override;
   void ClipRRect(const SkRRect& rrect, ClipOp clip_op, bool is_aa) override;
-  void ClipPath(const SkPath& path, ClipOp clip_op, bool is_aa) override;
-  void ClipPath(const DlPath& path, ClipOp clip_op, bool is_aa) override {
-    path.WillRenderSkPath();
-    ClipPath(path.GetSkPath(), clip_op, is_aa);
-  }
+  void ClipPath(const DlPath& path, ClipOp clip_op, bool is_aa) override;
 
   /// Conservative estimate of the bounds of all outstanding clip operations
   /// measured in the coordinate space within which this DisplayList will
   /// be rendered.
-  SkRect GetDestinationClipBounds() const override;
+  DlRect GetDestinationClipCoverage() const override;
   /// Conservative estimate of the bounds of all outstanding clip operations
   /// transformed into the local coordinate space in which currently
   /// recorded rendering operations are interpreted.
-  SkRect GetLocalClipBounds() const override;
+  DlRect GetLocalClipCoverage() const override;
 
   /// Return true iff the supplied bounds are easily shown to be outside
   /// of the current clip bounds. This method may conservatively return
   /// false if it cannot make the determination.
-  bool QuickReject(const SkRect& bounds) const override;
+  bool QuickReject(const DlRect& bounds) const override;
 
   void DrawPaint(const DlPaint& paint) override;
   void DrawColor(DlColor color, DlBlendMode mode) override;
-  void DrawLine(const SkPoint& p0,
-                const SkPoint& p1,
+  void DrawLine(const DlPoint& p0,
+                const DlPoint& p1,
                 const DlPaint& paint) override;
   void DrawDashedLine(const DlPoint& p0,
                       const DlPoint& p1,
                       DlScalar on_length,
                       DlScalar off_length,
                       const DlPaint& paint) override;
-  void DrawRect(const SkRect& rect, const DlPaint& paint) override;
-  void DrawOval(const SkRect& bounds, const DlPaint& paint) override;
-  void DrawCircle(const SkPoint& center,
-                  SkScalar radius,
+  void DrawRect(const DlRect& rect, const DlPaint& paint) override;
+  void DrawOval(const DlRect& bounds, const DlPaint& paint) override;
+  void DrawCircle(const DlPoint& center,
+                  DlScalar radius,
                   const DlPaint& paint) override;
   void DrawRRect(const SkRRect& rrect, const DlPaint& paint) override;
   void DrawDRRect(const SkRRect& outer,
                   const SkRRect& inner,
                   const DlPaint& paint) override;
-  void DrawPath(const SkPath& path, const DlPaint& paint) override;
-  void DrawPath(const DlPath& path, const DlPaint& paint) override {
-    path.WillRenderSkPath();
-    DrawPath(path.GetSkPath(), paint);
-  }
-  void DrawArc(const SkRect& bounds,
-               SkScalar start,
-               SkScalar sweep,
+  void DrawPath(const DlPath& path, const DlPaint& paint) override;
+  void DrawArc(const DlRect& bounds,
+               DlScalar start,
+               DlScalar sweep,
                bool useCenter,
                const DlPaint& paint) override;
   void DrawPoints(PointMode mode,
                   uint32_t count,
-                  const SkPoint pts[],
+                  const DlPoint pts[],
                   const DlPaint& paint) override;
   void DrawVertices(const std::shared_ptr<DlVertices>& vertices,
                     DlBlendMode mode,
                     const DlPaint& paint) override;
   void DrawImage(const sk_sp<DlImage>& image,
-                 const SkPoint& point,
+                 const DlPoint& point,
                  DlImageSampling sampling,
                  const DlPaint* paint = nullptr) override;
   void DrawImageRect(
       const sk_sp<DlImage>& image,
-      const SkRect& src,
-      const SkRect& dst,
+      const DlRect& src,
+      const DlRect& dst,
       DlImageSampling sampling,
       const DlPaint* paint = nullptr,
       SrcRectConstraint constraint = SrcRectConstraint::kFast) override;
   void DrawImageNine(const sk_sp<DlImage>& image,
-                     const SkIRect& center,
-                     const SkRect& dst,
+                     const DlIRect& center,
+                     const DlRect& dst,
                      DlFilterMode filter,
                      const DlPaint* paint = nullptr) override;
   void DrawAtlas(const sk_sp<DlImage>& atlas,
                  const SkRSXform xform[],
-                 const SkRect tex[],
+                 const DlRect tex[],
                  const DlColor colors[],
                  int count,
                  DlBlendMode mode,
                  DlImageSampling sampling,
-                 const SkRect* cullRect,
+                 const DlRect* cullRect,
                  const DlPaint* paint = nullptr) override;
   void DrawDisplayList(const sk_sp<DisplayList> display_list,
-                       SkScalar opacity = SK_Scalar1) override;
+                       DlScalar opacity = SK_Scalar1) override;
   void DrawTextBlob(const sk_sp<SkTextBlob>& blob,
-                    SkScalar x,
-                    SkScalar y,
+                    DlScalar x,
+                    DlScalar y,
                     const DlPaint& paint) override;
   void DrawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                     SkScalar x,
-                     SkScalar y,
+                     DlScalar x,
+                     DlScalar y,
                      const DlPaint& paint) override;
-  void DrawShadow(const SkPath& path,
-                  const DlColor color,
-                  const SkScalar elevation,
-                  bool transparent_occluder,
-                  SkScalar dpr) override;
   void DrawShadow(const DlPath& path,
                   const DlColor color,
-                  const SkScalar elevation,
+                  const DlScalar elevation,
                   bool transparent_occluder,
-                  SkScalar dpr) override {
-    path.WillRenderSkPath();
-    DrawShadow(path.GetSkPath(), color, elevation, transparent_occluder, dpr);
-  }
+                  DlScalar dpr) override;
 
   void Flush() override;
+
+  ENABLE_DL_CANVAS_BACKWARDS_COMPATIBILITY
 
  private:
   SkCanvas* delegate_;

--- a/display_list/testing/dl_rendering_unittests.cc
+++ b/display_list/testing/dl_rendering_unittests.cc
@@ -3719,17 +3719,19 @@ sk_sp<DisplayList> makeTestDisplayList() {
   DlPaint paint;
   paint.setDrawStyle(DlDrawStyle::kFill);
   paint.setColor(DlColor(SK_ColorRED));
-  builder.DrawRect({kRenderLeft, kRenderTop, kRenderCenterX, kRenderCenterY},
-                   paint);
+  builder.DrawRect(
+      SkRect{kRenderLeft, kRenderTop, kRenderCenterX, kRenderCenterY}, paint);
   paint.setColor(DlColor(SK_ColorBLUE));
-  builder.DrawRect({kRenderCenterX, kRenderTop, kRenderRight, kRenderCenterY},
-                   paint);
+  builder.DrawRect(
+      SkRect{kRenderCenterX, kRenderTop, kRenderRight, kRenderCenterY}, paint);
   paint.setColor(DlColor(SK_ColorGREEN));
-  builder.DrawRect({kRenderLeft, kRenderCenterY, kRenderCenterX, kRenderBottom},
-                   paint);
+  builder.DrawRect(
+      SkRect{kRenderLeft, kRenderCenterY, kRenderCenterX, kRenderBottom},
+      paint);
   paint.setColor(DlColor(SK_ColorYELLOW));
   builder.DrawRect(
-      {kRenderCenterX, kRenderCenterY, kRenderRight, kRenderBottom}, paint);
+      SkRect{kRenderCenterX, kRenderCenterY, kRenderRight, kRenderBottom},
+      paint);
   return builder.Build();
 }
 
@@ -4603,7 +4605,7 @@ class DisplayListNopTest : public DisplayListRendering {
     std::string desc = desc_stream.str();
     DisplayListBuilder builder({0.0f, 0.0f, 100.0f, 100.0f});
     DlPaint paint = DlPaint(color).setBlendMode(mode);
-    builder.DrawRect({0.0f, 0.0f, 10.0f, 10.0f}, paint);
+    builder.DrawRect(SkRect{0.0f, 0.0f, 10.0f, 10.0f}, paint);
     auto dl = builder.Build();
     if (dl->modifies_transparent_black()) {
       ASSERT_TRUE(dl->op_count() != 0u);
@@ -4700,8 +4702,8 @@ class DisplayListNopTest : public DisplayListRendering {
                         .setBlendMode(mode)            //
                         .setColorFilter(color_filter)  //
                         .setImageFilter(image_filter);
-    builder.DrawImage(DlImage::Make(test_image_src_data->image()), {0, 0},
-                      DlImageSampling::kNearestNeighbor, &paint);
+    builder.DrawImage(DlImage::Make(test_image_src_data->image()),
+                      SkPoint{0, 0}, DlImageSampling::kNearestNeighbor, &paint);
     auto dl = builder.Build();
 
     int w = test_image_src_data->width();

--- a/display_list/utils/dl_matrix_clip_tracker.cc
+++ b/display_list/utils/dl_matrix_clip_tracker.cc
@@ -123,12 +123,12 @@ void DisplayListMatrixClipState::clipRRect(const SkRRect& rrect,
   }
 }
 
-void DisplayListMatrixClipState::clipPath(const SkPath& path,
+void DisplayListMatrixClipState::clipPath(const DlPath& path,
                                           ClipOp op,
                                           bool is_aa) {
   // Map "kDifference of inverse path" to "kIntersect of the original path" and
   // map "kIntersect of inverse path" to "kDifference of the original path"
-  if (path.isInverseFillType()) {
+  if (path.IsInverseFillType()) {
     switch (op) {
       case ClipOp::kIntersect:
         op = ClipOp::kDifference;
@@ -139,8 +139,8 @@ void DisplayListMatrixClipState::clipPath(const SkPath& path,
     }
   }
 
-  DlRect bounds = ToDlRect(path.getBounds());
-  if (path.isRect(nullptr)) {
+  DlRect bounds = path.GetBounds();
+  if (path.IsRect(nullptr)) {
     return clipRect(bounds, op, is_aa);
   }
   switch (op) {
@@ -231,23 +231,23 @@ void DisplayListMatrixClipState::adjustCullRect(const DlRect& clip,
   }
 }
 
-SkRect DisplayListMatrixClipState::local_cull_rect() const {
+DlRect DisplayListMatrixClipState::GetLocalCullCoverage() const {
   if (cull_rect_.IsEmpty()) {
-    return SkRect::MakeEmpty();
+    return DlRect();
   }
   if (!is_matrix_invertable()) {
-    return SkRect::MakeEmpty();
+    return DlRect();
   }
   if (matrix_.HasPerspective2D()) {
     // We could do a 4-point long-form conversion, but since this is
     // only used for culling, let's just return a non-constricting
     // cull rect.
-    return DisplayListBuilder::kMaxCullRect;
+    return ToDlRect(DisplayListBuilder::kMaxCullRect);
   }
   DlMatrix inverse = matrix_.Invert();
   // We eliminated perspective above so we can use the cheaper non-clipping
   // bounds transform method.
-  return ToSkRect(cull_rect_.TransformBounds(inverse));
+  return cull_rect_.TransformBounds(inverse);
 }
 
 bool DisplayListMatrixClipState::rect_covers_cull(const DlRect& content) const {

--- a/display_list/utils/dl_matrix_clip_tracker.h
+++ b/display_list/utils/dl_matrix_clip_tracker.h
@@ -60,8 +60,10 @@ class DisplayListMatrixClipState {
   SkM44 matrix_4x4() const { return SkM44::ColMajor(matrix_.m); }
   SkMatrix matrix_3x3() const { return ToSkMatrix(matrix_); }
 
-  SkRect local_cull_rect() const;
+  SkRect local_cull_rect() const { return ToSkRect(GetLocalCullCoverage()); }
+  DlRect GetLocalCullCoverage() const;
   SkRect device_cull_rect() const { return ToSkRect(cull_rect_); }
+  DlRect GetDeviceCullCoverage() const { return cull_rect_; }
 
   bool rect_covers_cull(const DlRect& content) const;
   bool rect_covers_cull(const SkRect& content) const {
@@ -154,7 +156,10 @@ class DisplayListMatrixClipState {
     clipRect(ToDlRect(bounds), op, is_aa);
   }
   void clipRRect(const SkRRect& rrect, ClipOp op, bool is_aa);
-  void clipPath(const SkPath& path, ClipOp op, bool is_aa);
+  void clipPath(const SkPath& path, ClipOp op, bool is_aa) {
+    clipPath(DlPath(path), op, is_aa);
+  }
+  void clipPath(const DlPath& path, ClipOp op, bool is_aa);
 
  private:
   DlRect cull_rect_;

--- a/flow/layers/display_list_layer_unittests.cc
+++ b/flow/layers/display_list_layer_unittests.cc
@@ -101,7 +101,7 @@ TEST_F(DisplayListLayerTest, SimpleDisplayList) {
 TEST_F(DisplayListLayerTest, CachingDoesNotChangeCullRect) {
   const SkPoint layer_offset = SkPoint::Make(10, 10);
   DisplayListBuilder builder;
-  builder.DrawRect({10, 10, 20, 20}, DlPaint());
+  builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
   auto display_list = builder.Build();
   auto layer = std::make_shared<DisplayListLayer>(layer_offset, display_list,
                                                   true, false);
@@ -546,8 +546,8 @@ TEST_F(DisplayListLayerTest, OverflowCachedDisplayListOpacityInheritance) {
   std::vector<std::shared_ptr<DisplayListLayer>> layers;
   for (int i = 0; i < layer_count; i++) {
     DisplayListBuilder builder(false);
-    builder.DrawRect({0, 0, 100, 100}, DlPaint());
-    builder.DrawRect({50, 50, 100, 100}, DlPaint());
+    builder.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
+    builder.DrawRect(SkRect{50, 50, 100, 100}, DlPaint());
     auto display_list = builder.Build();
     ASSERT_FALSE(display_list->can_apply_group_opacity());
     SkPoint offset = {i * 200.0f, 0};

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -48,7 +48,7 @@ void RasterCacheResult::draw(DlCanvas& canvas,
   canvas.TransformReset();
   flow_.Step();
   if (!preserve_rtree || !rtree_) {
-    canvas.DrawImage(image_, {bounds.fLeft, bounds.fTop},
+    canvas.DrawImage(image_, SkPoint{bounds.fLeft, bounds.fTop},
                      DlImageSampling::kNearestNeighbor, paint);
   } else {
     // On some platforms RTree from overlay layers is used for unobstructed

--- a/flow/stopwatch_sk.cc
+++ b/flow/stopwatch_sk.cc
@@ -180,7 +180,7 @@ void SkStopwatchVisualizer::Visualize(DlCanvas* canvas,
 
   // Draw the cached surface onto the output canvas.
   auto image = DlImage::Make(visualize_cache_surface_->makeImageSnapshot());
-  canvas->DrawImage(image, {rect.x(), rect.y()},
+  canvas->DrawImage(image, SkPoint{rect.x(), rect.y()},
                     DlImageSampling::kNearestNeighbor);
 }
 

--- a/impeller/display_list/aiks_dl_basic_unittests.cc
+++ b/impeller/display_list/aiks_dl_basic_unittests.cc
@@ -329,7 +329,7 @@ TEST_P(AiksTest, CanSaveLayerStandalone) {
 
   builder.SaveLayer(nullptr, &alpha);
 
-  builder.DrawCircle({125, 125}, 125, red);
+  builder.DrawCircle(SkPoint{125, 125}, 125, red);
 
   builder.Restore();
 
@@ -365,7 +365,7 @@ TEST_P(AiksTest, CanRenderDifferentShapesWithSameColorSource) {
 
   builder.Save();
   builder.Translate(100, 400);
-  builder.DrawCircle({100, 100}, 100, paint);
+  builder.DrawCircle(SkPoint{100, 100}, 100, paint);
   builder.Restore();
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -430,7 +430,7 @@ TEST_P(AiksTest, FilledCirclesRenderCorrectly) {
   int radius = 600;
   while (radius > 0) {
     paint.setColor(colors[(c_index++) % color_count]);
-    builder.DrawCircle({10, 10}, radius, paint);
+    builder.DrawCircle(SkPoint{10, 10}, radius, paint);
     if (radius > 30) {
       radius -= 10;
     } else {
@@ -462,14 +462,14 @@ TEST_P(AiksTest, FilledCirclesRenderCorrectly) {
 
   paint.setColorSource(DlColorSource::MakeRadial(
       {500, 600}, 75, 7, gradient_colors, stops, DlTileMode::kMirror));
-  builder.DrawCircle({500, 600}, 100, paint);
+  builder.DrawCircle(SkPoint{500, 600}, 100, paint);
 
   SkMatrix local_matrix = SkMatrix::Translate(700, 200);
   DlImageColorSource image_source(
       image, DlTileMode::kRepeat, DlTileMode::kRepeat,
       DlImageSampling::kNearestNeighbor, &local_matrix);
   paint.setColorSource(&image_source);
-  builder.DrawCircle({800, 300}, 100, paint);
+  builder.DrawCircle(SkPoint{800, 300}, 100, paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -744,7 +744,7 @@ TEST_P(AiksTest, SolidColorCirclesOvalsRRectsMaskBlurCorrectly) {
   for (int i = 0; i < 5; i++) {
     Scalar x = (i + 1) * 100;
     Scalar radius = x / 10.0f;
-    builder.DrawCircle({x + 25, y + 25}, radius, paint);
+    builder.DrawCircle(SkPoint{x + 25, y + 25}, radius, paint);
   }
 
   paint.setColor(DlColor::kGreen());
@@ -875,7 +875,7 @@ TEST_P(AiksTest, CanDrawPerspectiveTransformWithClips) {
       // 4. Draw a semi-translucent blue circle atop all previous draws.
       DlPaint paint;
       paint.setColor(DlColor::kBlue().modulateOpacity(0.4));
-      builder.DrawCircle({}, 230, paint);
+      builder.DrawCircle(SkPoint{}, 230, paint);
     }
     builder.Restore();  // Restore translation.
 
@@ -983,7 +983,7 @@ TEST_P(AiksTest, MatrixImageFilterDoesntCullWhenTranslatedFromOffscreen) {
 
   DlPaint circle_paint;
   circle_paint.setColor(DlColor::kGreen());
-  builder.DrawCircle({-300, 0}, 100, circle_paint);
+  builder.DrawCircle(SkPoint{-300, 0}, 100, circle_paint);
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -1006,7 +1006,7 @@ TEST_P(AiksTest,
 
   DlPaint circle_paint;
   circle_paint.setColor(DlColor::kGreen());
-  builder.DrawCircle({-150, 0}, 50, circle_paint);
+  builder.DrawCircle(SkPoint{-150, 0}, 50, circle_paint);
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -1058,7 +1058,7 @@ TEST_P(AiksTest, EmptySaveLayerRendersWithClear) {
   DisplayListBuilder builder;
   builder.Scale(GetContentScale().x, GetContentScale().y);
   auto image = DlImageImpeller::Make(CreateTextureForFixture("airplane.jpg"));
-  builder.DrawImage(image, {10, 10}, {});
+  builder.DrawImage(image, SkPoint{10, 10}, {});
   builder.ClipRect(SkRect::MakeXYWH(100, 100, 200, 200));
 
   DlPaint paint;
@@ -1443,7 +1443,7 @@ TEST_P(AiksTest, SaveLayerFiltersScaleWithTransform) {
   auto texture = DlImageImpeller::Make(CreateTextureForFixture("boston.jpg"));
   auto draw_image_layer = [&builder, &texture](const DlPaint& paint) {
     builder.SaveLayer(nullptr, &paint);
-    builder.DrawImage(texture, {}, DlImageSampling::kLinear);
+    builder.DrawImage(texture, SkPoint{}, DlImageSampling::kLinear);
     builder.Restore();
   };
 

--- a/impeller/display_list/aiks_dl_blend_unittests.cc
+++ b/impeller/display_list/aiks_dl_blend_unittests.cc
@@ -132,7 +132,7 @@ TEST_P(AiksTest, DrawPaintWithAdvancedBlendOverFilter) {
   paint.setColor(DlColor::kWhite());
   builder.DrawPaint(paint);
   paint.setColor(DlColor::kBlack());
-  builder.DrawCircle({300, 300}, 200, paint);
+  builder.DrawCircle(SkPoint{300, 300}, 200, paint);
   paint.setColor(DlColor::kGreen());
   paint.setBlendMode(DlBlendMode::kScreen);
   builder.DrawPaint(paint);
@@ -166,7 +166,7 @@ TEST_P(AiksTest, DrawAdvancedBlendPartlyOffscreen) {
       ));
   paint.setBlendMode(DlBlendMode::kLighten);
 
-  builder.DrawCircle({100, 100}, 100, paint);
+  builder.DrawCircle(SkPoint{100, 100}, 100, paint);
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
@@ -176,21 +176,21 @@ TEST_P(AiksTest, PaintBlendModeIsRespected) {
   // Default is kSourceOver.
 
   paint.setColor(DlColor::RGBA(1, 0, 0, 0.5));
-  builder.DrawCircle({150, 200}, 100, paint);
+  builder.DrawCircle(SkPoint{150, 200}, 100, paint);
 
   paint.setColor(DlColor::RGBA(0, 1, 0, 0.5));
-  builder.DrawCircle({250, 200}, 100, paint);
+  builder.DrawCircle(SkPoint{250, 200}, 100, paint);
 
   paint.setBlendMode(DlBlendMode::kPlus);
 
   paint.setColor(DlColor::kRed());
-  builder.DrawCircle({450, 250}, 100, paint);
+  builder.DrawCircle(SkPoint{450, 250}, 100, paint);
 
   paint.setColor(DlColor::kGreen());
-  builder.DrawCircle({550, 250}, 100, paint);
+  builder.DrawCircle(SkPoint{550, 250}, 100, paint);
 
   paint.setColor(DlColor::kBlue());
-  builder.DrawCircle({500, 150}, 100, paint);
+  builder.DrawCircle(SkPoint{500, 150}, 100, paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -225,8 +225,8 @@ TEST_P(AiksTest, ColorFilterBlend) {
       builder.Scale(0.4, 0.4);
       {
         DlPaint dstPaint;
-        builder.DrawImage(dst_image, {0, 0}, DlImageSampling::kMipmapLinear,
-                          &dstPaint);
+        builder.DrawImage(dst_image, SkPoint{0, 0},
+                          DlImageSampling::kMipmapLinear, &dstPaint);
       }
       {
         DlPaint srcPaint;
@@ -237,8 +237,8 @@ TEST_P(AiksTest, ColorFilterBlend) {
                                        DlBlendMode::kSrcIn);
           srcPaint.setColorFilter(color_filter);
         }
-        builder.DrawImage(src_image, {0, 0}, DlImageSampling::kMipmapLinear,
-                          &srcPaint);
+        builder.DrawImage(src_image, SkPoint{0, 0},
+                          DlImageSampling::kMipmapLinear, &srcPaint);
       }
       builder.Restore();
     }
@@ -282,8 +282,8 @@ TEST_P(AiksTest, ColorFilterAdvancedBlend) {
       builder.Scale(0.4, 0.4);
       {
         DlPaint dstPaint;
-        builder.DrawImage(dst_image, {0, 0}, DlImageSampling::kMipmapLinear,
-                          &dstPaint);
+        builder.DrawImage(dst_image, SkPoint{0, 0},
+                          DlImageSampling::kMipmapLinear, &dstPaint);
       }
       {
         DlPaint srcPaint;
@@ -294,8 +294,8 @@ TEST_P(AiksTest, ColorFilterAdvancedBlend) {
                                        DlBlendMode::kSrcIn);
           srcPaint.setColorFilter(color_filter);
         }
-        builder.DrawImage(src_image, {0, 0}, DlImageSampling::kMipmapLinear,
-                          &srcPaint);
+        builder.DrawImage(src_image, SkPoint{0, 0},
+                          DlImageSampling::kMipmapLinear, &srcPaint);
       }
       builder.Restore();
     }
@@ -373,8 +373,8 @@ TEST_P(AiksTest, ColorFilterAdvancedBlendNoFbFetch) {
       builder.Scale(0.4, 0.4);
       {
         DlPaint dstPaint;
-        builder.DrawImage(dst_image, {0, 0}, DlImageSampling::kMipmapLinear,
-                          &dstPaint);
+        builder.DrawImage(dst_image, SkPoint{0, 0},
+                          DlImageSampling::kMipmapLinear, &dstPaint);
       }
       {
         DlPaint srcPaint;
@@ -385,8 +385,8 @@ TEST_P(AiksTest, ColorFilterAdvancedBlendNoFbFetch) {
                                        DlBlendMode::kMultiply);
           srcPaint.setColorFilter(color_filter);
         }
-        builder.DrawImage(src_image, {0, 0}, DlImageSampling::kMipmapLinear,
-                          &srcPaint);
+        builder.DrawImage(src_image, SkPoint{0, 0},
+                          DlImageSampling::kMipmapLinear, &srcPaint);
       }
       builder.Restore();
     }
@@ -493,7 +493,7 @@ TEST_P(AiksTest, ClearBlend) {
   DlPaint clear;
   clear.setBlendMode(DlBlendMode::kClear);
 
-  builder.DrawCircle({300.0, 300.0}, 200.0, clear);
+  builder.DrawCircle(SkPoint{300.0, 300.0}, 200.0, clear);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -616,12 +616,12 @@ static sk_sp<DisplayList> BlendModeTest(Vector2 content_scale,
   builder.Save();
   builder.SaveLayer(nullptr, &paint);
   {
-    builder.DrawImage(dst_image, {0, 0}, DlImageSampling::kMipmapLinear,
+    builder.DrawImage(dst_image, SkPoint{0, 0}, DlImageSampling::kMipmapLinear,
                       &paint);
 
     paint.setColor(DlColor::kWhite().withAlpha(src_alpha * 255));
     paint.setBlendMode(static_cast<DlBlendMode>(blend_mode));
-    builder.DrawImage(src_image, {0, 0}, DlImageSampling::kMipmapLinear,
+    builder.DrawImage(src_image, SkPoint{0, 0}, DlImageSampling::kMipmapLinear,
                       &paint);
   }
   builder.Restore();
@@ -633,16 +633,16 @@ static sk_sp<DisplayList> BlendModeTest(Vector2 content_scale,
   DlPaint save_paint;
   builder.SaveLayer(nullptr, &save_paint);
   {
-    builder.DrawImage(dst_image, {400, 0}, DlImageSampling::kMipmapLinear,
-                      nullptr);
+    builder.DrawImage(dst_image, SkPoint{400, 0},
+                      DlImageSampling::kMipmapLinear, nullptr);
 
     DlPaint save_paint;
     save_paint.setColor(DlColor::kWhite().withAlpha(src_alpha * 255));
     save_paint.setBlendMode(static_cast<DlBlendMode>(blend_mode));
     builder.SaveLayer(nullptr, &save_paint);
     {
-      builder.DrawImage(src_image, {400, 0}, DlImageSampling::kMipmapLinear,
-                        nullptr);
+      builder.DrawImage(src_image, SkPoint{400, 0},
+                        DlImageSampling::kMipmapLinear, nullptr);
     }
     builder.Restore();
   }
@@ -724,7 +724,7 @@ TEST_P(AiksTest, ForegroundPipelineBlendAppliesTransformCorrectly) {
       DlColor::RGBA(255.0f / 255.0f, 165.0f / 255.0f, 0.0f / 255.0f, 1.0f),
       DlBlendMode::kSrcIn));
 
-  builder.DrawImage(DlImageImpeller::Make(texture), {200, 200},
+  builder.DrawImage(DlImageImpeller::Make(texture), SkPoint{200, 200},
                     DlImageSampling::kMipmapLinear, &image_paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -742,7 +742,7 @@ TEST_P(AiksTest, ForegroundAdvancedBlendAppliesTransformCorrectly) {
       DlColor::RGBA(255.0f / 255.0f, 165.0f / 255.0f, 0.0f / 255.0f, 1.0f),
       DlBlendMode::kColorDodge));
 
-  builder.DrawImage(DlImageImpeller::Make(texture), {200, 200},
+  builder.DrawImage(DlImageImpeller::Make(texture), SkPoint{200, 200},
                     DlImageSampling::kMipmapLinear, &image_paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -765,7 +765,7 @@ TEST_P(AiksTest, FramebufferAdvancedBlendCoverage) {
   DlPaint image_paint;
   image_paint.setBlendMode(DlBlendMode::kMultiply);
 
-  builder.DrawImage(DlImageImpeller::Make(texture), {20, 20},
+  builder.DrawImage(DlImageImpeller::Make(texture), SkPoint{20, 20},
                     DlImageSampling::kMipmapLinear, &image_paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));

--- a/impeller/display_list/aiks_dl_blur_unittests.cc
+++ b/impeller/display_list/aiks_dl_blur_unittests.cc
@@ -156,7 +156,7 @@ TEST_P(AiksTest, CanRenderMaskBlurHugeSigma) {
   DlPaint paint;
   paint.setColor(DlColor::kGreen());
   paint.setMaskFilter(DlBlurMaskFilter::Make(DlBlurStyle::kNormal, 99999));
-  builder.DrawCircle({400, 400}, 300, paint);
+  builder.DrawCircle(SkPoint{400, 400}, 300, paint);
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -176,7 +176,7 @@ TEST_P(AiksTest, CanRenderForegroundBlendWithMaskBlur) {
       DlBlurMaskFilter::Make(DlBlurStyle::kNormal, sigma.sigma));
   paint.setColorFilter(
       DlBlendColorFilter::Make(DlColor::kGreen(), DlBlendMode::kSrc));
-  builder.DrawCircle({400, 400}, 200, paint);
+  builder.DrawCircle(SkPoint{400, 400}, 200, paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -196,7 +196,7 @@ TEST_P(AiksTest, CanRenderForegroundAdvancedBlendWithMaskBlur) {
       DlBlurMaskFilter::Make(DlBlurStyle::kNormal, sigma.sigma));
   paint.setColorFilter(
       DlBlendColorFilter::Make(DlColor::kGreen(), DlBlendMode::kColor));
-  builder.DrawCircle({400, 400}, 200, paint);
+  builder.DrawCircle(SkPoint{400, 400}, 200, paint);
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -211,16 +211,16 @@ TEST_P(AiksTest, CanRenderBackdropBlurInteractive) {
     DisplayListBuilder builder;
     DlPaint paint;
     paint.setColor(DlColor::kCornflowerBlue());
-    builder.DrawCircle({100, 100}, 50, paint);
+    builder.DrawCircle(SkPoint{100, 100}, 50, paint);
 
     paint.setColor(DlColor::kGreenYellow());
-    builder.DrawCircle({300, 200}, 100, paint);
+    builder.DrawCircle(SkPoint{300, 200}, 100, paint);
 
     paint.setColor(DlColor::kDarkMagenta());
-    builder.DrawCircle({140, 170}, 75, paint);
+    builder.DrawCircle(SkPoint{140, 170}, 75, paint);
 
     paint.setColor(DlColor::kOrangeRed());
-    builder.DrawCircle({180, 120}, 100, paint);
+    builder.DrawCircle(SkPoint{180, 120}, 100, paint);
 
     SkRRect rrect =
         SkRRect::MakeRectXY(SkRect::MakeLTRB(a.x, a.y, b.x, b.y), 20, 20);
@@ -244,16 +244,16 @@ TEST_P(AiksTest, CanRenderBackdropBlur) {
 
   DlPaint paint;
   paint.setColor(DlColor::kCornflowerBlue());
-  builder.DrawCircle({100, 100}, 50, paint);
+  builder.DrawCircle(SkPoint{100, 100}, 50, paint);
 
   paint.setColor(DlColor::kGreenYellow());
-  builder.DrawCircle({300, 200}, 100, paint);
+  builder.DrawCircle(SkPoint{300, 200}, 100, paint);
 
   paint.setColor(DlColor::kDarkMagenta());
-  builder.DrawCircle({140, 170}, 75, paint);
+  builder.DrawCircle(SkPoint{140, 170}, 75, paint);
 
   paint.setColor(DlColor::kOrangeRed());
-  builder.DrawCircle({180, 120}, 100, paint);
+  builder.DrawCircle(SkPoint{180, 120}, 100, paint);
 
   SkRRect rrect =
       SkRRect::MakeRectXY(SkRect::MakeLTRB(75, 50, 375, 275), 20, 20);
@@ -273,7 +273,7 @@ TEST_P(AiksTest, CanRenderBackdropBlurHugeSigma) {
 
   DlPaint paint;
   paint.setColor(DlColor::kGreen());
-  builder.DrawCircle({400, 400}, 300, paint);
+  builder.DrawCircle(SkPoint{400, 400}, 300, paint);
 
   DlPaint save_paint;
   save_paint.setBlendMode(DlBlendMode::kSrc);
@@ -293,7 +293,7 @@ TEST_P(AiksTest, CanRenderClippedBlur) {
   DlPaint paint;
   paint.setColor(DlColor::kGreen());
   paint.setImageFilter(DlBlurImageFilter::Make(20, 20, DlTileMode::kDecal));
-  builder.DrawCircle({400, 400}, 200, paint);
+  builder.DrawCircle(SkPoint{400, 400}, 200, paint);
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -350,7 +350,7 @@ TEST_P(AiksTest, ClearBlendWithBlur) {
   clear.setBlendMode(DlBlendMode::kClear);
   clear.setMaskFilter(DlBlurMaskFilter::Make(DlBlurStyle::kNormal, 20));
 
-  builder.DrawCircle({300.0, 300.0}, 200.0, clear);
+  builder.DrawCircle(SkPoint{300.0, 300.0}, 200.0, clear);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -385,7 +385,7 @@ TEST_P(AiksTest, MaskBlurWithZeroSigmaIsSkipped) {
   paint.setColor(DlColor::kBlue());
   paint.setMaskFilter(DlBlurMaskFilter::Make(DlBlurStyle::kNormal, 0));
 
-  builder.DrawCircle({300, 300}, 200, paint);
+  builder.DrawCircle(SkPoint{300, 300}, 200, paint);
   builder.DrawRect(SkRect::MakeLTRB(100, 300, 500, 600), paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -434,7 +434,7 @@ static sk_sp<DisplayList> MaskBlurVariantTest(
 
   y += y_spacing;
   paint.setColor(DlColor::kBlue().withAlpha(alpha));
-  builder.DrawCircle({x + 25, y + 25}, radius, paint);
+  builder.DrawCircle(SkPoint{x + 25, y + 25}, radius, paint);
 
   y += y_spacing;
   paint.setColor(DlColor::kGreen().withAlpha(alpha));
@@ -643,7 +643,7 @@ TEST_P(AiksTest, MaskBlurTexture) {
 
     builder.DrawImage(
         DlImageImpeller::Make(CreateTextureForFixture("boston.jpg")),
-        {200, 200}, DlImageSampling::kNearestNeighbor, &paint);
+        SkPoint{200, 200}, DlImageSampling::kNearestNeighbor, &paint);
 
     DlPaint red;
     red.setColor(DlColor::kRed());
@@ -1000,7 +1000,7 @@ TEST_P(AiksTest, GaussianBlurOneDimension) {
   builder.Scale(0.5, 0.5);
 
   std::shared_ptr<Texture> boston = CreateTextureForFixture("boston.jpg");
-  builder.DrawImage(DlImageImpeller::Make(boston), {100, 100}, {});
+  builder.DrawImage(DlImageImpeller::Make(boston), SkPoint{100, 100}, {});
 
   DlPaint paint;
   paint.setBlendMode(DlBlendMode::kSrc);
@@ -1250,7 +1250,7 @@ TEST_P(AiksTest, GaussianBlurBackdropTinyMipMap) {
     auto blur_filter = DlBlurImageFilter::Make(0.1, 0.1, DlTileMode::kDecal);
     paint.setImageFilter(blur_filter);
 
-    builder.DrawCircle({400, 400}, 200, paint);
+    builder.DrawCircle(SkPoint{400, 400}, 200, paint);
     builder.Restore();
 
     auto image = DisplayListToTexture(builder.Build(), {1024, 768}, renderer);

--- a/impeller/display_list/aiks_dl_blur_unittests.cc
+++ b/impeller/display_list/aiks_dl_blur_unittests.cc
@@ -88,8 +88,8 @@ sk_sp<flutter::DisplayList> DoGradientOvalStrokeMaskBlur(Vector2 content_Scale,
   {
     DlPaint line_paint;
     line_paint.setColor(DlColor::kWhite());
-    builder.DrawLine({100, 0}, {100, 60}, line_paint);
-    builder.DrawLine({0, 30}, {200, 30}, line_paint);
+    builder.DrawLine(SkPoint{100, 0}, SkPoint{100, 60}, line_paint);
+    builder.DrawLine(SkPoint{0, 30}, SkPoint{200, 30}, line_paint);
   }
 
   SkRRect rrect =

--- a/impeller/display_list/aiks_dl_gradient_unittests.cc
+++ b/impeller/display_list/aiks_dl_gradient_unittests.cc
@@ -362,7 +362,7 @@ TEST_P(AiksTest, CanRenderLinearGradientMaskBlur) {
       DlTileMode::kClamp));
   paint.setMaskFilter(DlBlurMaskFilter::Make(DlBlurStyle::kNormal, 20));
 
-  builder.DrawCircle({300, 300}, 200, paint);
+  builder.DrawCircle(SkPoint{300, 300}, 200, paint);
   builder.DrawRect(SkRect::MakeLTRB(100, 300, 500, 600), paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));

--- a/impeller/display_list/aiks_dl_path_unittests.cc
+++ b/impeller/display_list/aiks_dl_path_unittests.cc
@@ -168,8 +168,8 @@ TEST_P(AiksTest, CanRenderDifferencePaths) {
   path.setFillType(SkPathFillType::kEvenOdd);
 
   builder.DrawImage(
-      DlImageImpeller::Make(CreateTextureForFixture("boston.jpg")), {10, 10},
-      {});
+      DlImageImpeller::Make(CreateTextureForFixture("boston.jpg")),
+      SkPoint{10, 10}, {});
   builder.DrawPath(path, paint);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -317,7 +317,7 @@ TEST_P(AiksTest, DrawLinesRenderCorrectly) {
          {DlStrokeCap::kButt, DlStrokeCap::kSquare, DlStrokeCap::kRound}) {
       paint.setStrokeCap(cap);
       SkPoint origin = {100, 100};
-      builder.DrawLine({150, 100}, {250, 100}, paint);
+      builder.DrawLine(SkPoint{150, 100}, SkPoint{250, 100}, paint);
       for (int d = 15; d < 90; d += 15) {
         Matrix m = Matrix::MakeRotationZ(Degrees(d));
         Point origin = {100, 100};
@@ -329,10 +329,10 @@ TEST_P(AiksTest, DrawLinesRenderCorrectly) {
         builder.DrawLine(SkPoint::Make(a.x, a.y), SkPoint::Make(b.x, b.y),
                          paint);
       }
-      builder.DrawLine({100, 150}, {100, 250}, paint);
+      builder.DrawLine(SkPoint{100, 150}, SkPoint{100, 250}, paint);
       builder.DrawCircle({origin}, 35, paint);
 
-      builder.DrawLine({250, 250}, {250, 250}, paint);
+      builder.DrawLine(SkPoint{250, 250}, SkPoint{250, 250}, paint);
 
       builder.Translate(250, 0);
     }

--- a/impeller/display_list/aiks_dl_unittests.cc
+++ b/impeller/display_list/aiks_dl_unittests.cc
@@ -242,12 +242,12 @@ TEST_P(AiksTest, TranslucentSaveLayerImageDrawsCorrectly) {
   DisplayListBuilder builder(GetCullRect(GetWindowSize()));
 
   auto image = DlImageImpeller::Make(CreateTextureForFixture("airplane.jpg"));
-  builder.DrawImage(image, {100, 100}, DlImageSampling::kMipmapLinear);
+  builder.DrawImage(image, SkPoint{100, 100}, DlImageSampling::kMipmapLinear);
 
   DlPaint paint;
   paint.setColor(DlColor::kBlack().withAlpha(128));
   builder.SaveLayer(nullptr, &paint);
-  builder.DrawImage(image, {100, 500}, DlImageSampling::kMipmapLinear);
+  builder.DrawImage(image, SkPoint{100, 500}, DlImageSampling::kMipmapLinear);
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -257,7 +257,7 @@ TEST_P(AiksTest, TranslucentSaveLayerWithColorMatrixColorFilterDrawsCorrectly) {
   DisplayListBuilder builder(GetCullRect(GetWindowSize()));
 
   auto image = DlImageImpeller::Make(CreateTextureForFixture("airplane.jpg"));
-  builder.DrawImage(image, {100, 100}, {});
+  builder.DrawImage(image, SkPoint{100, 100}, {});
 
   const float matrix[20] = {
       1, 0, 0, 0, 0,  //
@@ -269,7 +269,7 @@ TEST_P(AiksTest, TranslucentSaveLayerWithColorMatrixColorFilterDrawsCorrectly) {
   paint.setColor(DlColor::kBlack().withAlpha(128));
   paint.setColorFilter(DlMatrixColorFilter::Make(matrix));
   builder.SaveLayer(nullptr, &paint);
-  builder.DrawImage(image, {100, 500}, {});
+  builder.DrawImage(image, SkPoint{100, 500}, {});
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -279,7 +279,7 @@ TEST_P(AiksTest, TranslucentSaveLayerWithColorMatrixImageFilterDrawsCorrectly) {
   DisplayListBuilder builder(GetCullRect(GetWindowSize()));
 
   auto image = DlImageImpeller::Make(CreateTextureForFixture("airplane.jpg"));
-  builder.DrawImage(image, {100, 100}, {});
+  builder.DrawImage(image, SkPoint{100, 100}, {});
 
   const float matrix[20] = {
       1, 0, 0, 0, 0,  //
@@ -291,7 +291,7 @@ TEST_P(AiksTest, TranslucentSaveLayerWithColorMatrixImageFilterDrawsCorrectly) {
   paint.setColor(DlColor::kBlack().withAlpha(128));
   paint.setColorFilter(DlMatrixColorFilter::Make(matrix));
   builder.SaveLayer(nullptr, &paint);
-  builder.DrawImage(image, {100, 500}, {});
+  builder.DrawImage(image, SkPoint{100, 500}, {});
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -302,7 +302,7 @@ TEST_P(AiksTest,
   DisplayListBuilder builder(GetCullRect(GetWindowSize()));
 
   auto image = DlImageImpeller::Make(CreateTextureForFixture("airplane.jpg"));
-  builder.DrawImage(image, {100, 100}, {});
+  builder.DrawImage(image, SkPoint{100, 100}, {});
 
   const float matrix[20] = {
       1, 0,   0, 0,   0,  //
@@ -317,7 +317,7 @@ TEST_P(AiksTest,
   paint.setColorFilter(
       DlBlendColorFilter::Make(DlColor::kGreen(), DlBlendMode::kModulate));
   builder.SaveLayer(nullptr, &paint);
-  builder.DrawImage(image, {100, 500}, {});
+  builder.DrawImage(image, SkPoint{100, 500}, {});
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -337,7 +337,7 @@ TEST_P(AiksTest, TranslucentSaveLayerWithAdvancedBlendModeDrawsCorrectly) {
 
   DlPaint draw_paint;
   draw_paint.setColor(DlColor::kGreen());
-  builder.DrawCircle({200, 200}, 100, draw_paint);
+  builder.DrawCircle(SkPoint{200, 200}, 100, draw_paint);
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -358,10 +358,10 @@ TEST_P(AiksTest, CanRenderTinyOverlappingSubpasses) {
 
   DlPaint yellow_paint;
   yellow_paint.setColor(DlColor::kYellow());
-  builder.DrawCircle({100, 100}, 0.1, yellow_paint);
+  builder.DrawCircle(SkPoint{100, 100}, 0.1, yellow_paint);
   builder.Restore();
   builder.SaveLayer({});
-  builder.DrawCircle({100, 100}, 0.1, yellow_paint);
+  builder.DrawCircle(SkPoint{100, 100}, 0.1, yellow_paint);
   builder.Restore();
 
   DlPaint draw_paint;
@@ -387,7 +387,7 @@ TEST_P(AiksTest, CanRenderDestructiveSaveLayer) {
 
   DlPaint draw_paint;
   draw_paint.setColor(DlColor::kGreen());
-  builder.DrawCircle({300, 300}, 100, draw_paint);
+  builder.DrawCircle(SkPoint{300, 300}, 100, draw_paint);
   builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -576,7 +576,7 @@ TEST_P(AiksTest, SetContentsWithRegion) {
   auto image = DlImageImpeller::Make(bridge);
 
   DisplayListBuilder builder;
-  builder.DrawImage(image, {0, 0}, {});
+  builder.DrawImage(image, SkPoint{0, 0}, {});
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -639,7 +639,8 @@ TEST_P(AiksTest, MatrixImageFilterMagnify) {
 
     DlPaint rect_paint;
     rect_paint.setAlpha(0.5 * 255);
-    builder.DrawImage(image, {0, 0}, DlImageSampling::kLinear, &rect_paint);
+    builder.DrawImage(image, SkPoint{0, 0}, DlImageSampling::kLinear,
+                      &rect_paint);
     builder.Restore();
 
     return builder.Build();
@@ -782,7 +783,7 @@ TEST_P(AiksTest, MatrixSaveLayerFilter) {
   {
     paint.setColor(DlColor::kGreen().withAlpha(255 * 0.5));
     paint.setBlendMode(DlBlendMode::kPlus);
-    builder.DrawCircle({200, 200}, 100, paint);
+    builder.DrawCircle(SkPoint{200, 200}, 100, paint);
     // Should render a second circle, centered on the bottom-right-most edge of
     // the circle.
 
@@ -799,7 +800,7 @@ TEST_P(AiksTest, MatrixSaveLayerFilter) {
     DlPaint circle_paint;
     circle_paint.setColor(DlColor::kGreen().withAlpha(255 * 0.5));
     circle_paint.setBlendMode(DlBlendMode::kPlus);
-    builder.DrawCircle({200, 200}, 100, circle_paint);
+    builder.DrawCircle(SkPoint{200, 200}, 100, circle_paint);
     builder.Restore();
   }
   builder.Restore();
@@ -941,7 +942,7 @@ TEST_P(AiksTest, CanPictureConvertToImage) {
   auto image =
       DisplayListToTexture(recorder_canvas.Build(), {1000, 1000}, renderer);
   if (image) {
-    canvas.DrawImage(DlImageImpeller::Make(image), {}, {});
+    canvas.DrawImage(DlImageImpeller::Make(image), SkPoint{}, {});
     paint.setColor(DlColor::RGBA(0.1, 0.1, 0.1, 0.2));
     canvas.DrawRect(SkRect::MakeSize({1000, 1000}), paint);
   }
@@ -965,7 +966,8 @@ TEST_P(AiksTest, CanEmptyPictureConvertToImage) {
   auto result_image =
       DisplayListToTexture(builder.Build(), ISize{1000, 1000}, renderer);
   if (result_image) {
-    recorder_builder.DrawImage(DlImageImpeller::Make(result_image), {}, {});
+    recorder_builder.DrawImage(DlImageImpeller::Make(result_image), SkPoint{},
+                               {});
 
     paint.setColor(DlColor::RGBA(0.1, 0.1, 0.1, 0.2));
     recorder_builder.DrawRect(SkRect::MakeSize({1000, 1000}), paint);

--- a/impeller/display_list/dl_unittests.cc
+++ b/impeller/display_list/dl_unittests.cc
@@ -705,7 +705,7 @@ TEST_P(DisplayListTest, CanDrawBackdropFilter) {
       paint.setStrokeJoin(flutter::DlStrokeJoin::kBevel);
       paint.setStrokeWidth(10);
       paint.setColor(flutter::DlColor::kRed().withAlpha(100));
-      builder.DrawCircle({circle_center.x, circle_center.y}, 100, paint);
+      builder.DrawCircle(SkPoint{circle_center.x, circle_center.y}, 100, paint);
     }
 
     return builder.Build();
@@ -854,7 +854,7 @@ TEST_P(DisplayListTest, CanDrawZeroLengthLine) {
   SkPath path = SkPath().addPoly({{150, 50}, {150, 50}}, false);
   for (auto cap : caps) {
     paint.setStrokeCap(cap);
-    builder.DrawLine({50, 50}, {50, 50}, paint);
+    builder.DrawLine(SkPoint{50, 50}, SkPoint{50, 50}, paint);
     builder.DrawPath(path, paint);
     builder.Translate(0, 150);
   }
@@ -931,11 +931,11 @@ TEST_P(DisplayListTest, CanDrawZeroWidthLine) {
   SkPath path = SkPath().addPoly({{150, 50}, {160, 50}}, false);
   for (auto cap : caps) {
     paint.setStrokeCap(cap);
-    builder.DrawLine({50, 50}, {60, 50}, paint);
-    builder.DrawRect({45, 45, 65, 55}, outline_paint);
-    builder.DrawLine({100, 50}, {100, 50}, paint);
+    builder.DrawLine(SkPoint{50, 50}, SkPoint{60, 50}, paint);
+    builder.DrawRect(SkRect{45, 45, 65, 55}, outline_paint);
+    builder.DrawLine(SkPoint{100, 50}, SkPoint{100, 50}, paint);
     if (cap != flutter::DlStrokeCap::kButt) {
-      builder.DrawRect({95, 45, 105, 55}, outline_paint);
+      builder.DrawRect(SkRect{95, 45, 105, 55}, outline_paint);
     }
     builder.DrawPath(path, paint);
     builder.DrawRect(path.getBounds().makeOutset(5, 5), outline_paint);
@@ -1034,7 +1034,7 @@ TEST_P(DisplayListTest, CanDrawWithMatrixFilter) {
         }
       }
 
-      builder.DrawImage(DlImageImpeller::Make(boston), {},
+      builder.DrawImage(DlImageImpeller::Make(boston), SkPoint{},
                         flutter::DlImageSampling::kLinear, &paint);
     }
     if (enable_savelayer) {
@@ -1320,8 +1320,8 @@ TEST_P(DisplayListTest, DrawShapes) {
     builder.DrawRRect(
         SkRRect::MakeRectXY(SkRect::MakeXYWH(150, 150, 100, 100), 30, 30),
         stroke_paint);
-    builder.DrawCircle({350, 50}, 50, paint);
-    builder.DrawCircle({350, 200}, 50, stroke_paint);
+    builder.DrawCircle(SkPoint{350, 50}, 50, paint);
+    builder.DrawCircle(SkPoint{350, 200}, 50, stroke_paint);
     builder.Translate(0, 300);
   }
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
@@ -1485,7 +1485,7 @@ TEST_P(DisplayListTest, DrawPaintIgnoresMaskFilter) {
   builder.DrawPaint(flutter::DlPaint().setColor(flutter::DlColor::kWhite()));
 
   auto filter = flutter::DlBlurMaskFilter(flutter::DlBlurStyle::kNormal, 10.0f);
-  builder.DrawCircle({300, 300}, 200,
+  builder.DrawCircle(SkPoint{300, 300}, 200,
                      flutter::DlPaint().setMaskFilter(&filter));
 
   std::vector<flutter::DlColor> colors = {flutter::DlColor::kGreen(),

--- a/shell/platform/android/surface_texture_external_texture.cc
+++ b/shell/platform/android/surface_texture_external_texture.cc
@@ -84,7 +84,8 @@ void SurfaceTextureExternalTexture::DrawFrame(
   transform = inverted;
 
   if (transform.isIdentity()) {
-    context.canvas->DrawImage(dl_image_, {0, 0}, sampling, context.paint);
+    context.canvas->DrawImage(dl_image_, SkPoint{0, 0}, sampling,
+                              context.paint);
     return;
   }
 

--- a/shell/platform/android/surface_texture_external_texture_vk_impeller.cc
+++ b/shell/platform/android/surface_texture_external_texture_vk_impeller.cc
@@ -224,7 +224,7 @@ void SurfaceTextureExternalTextureVKImpeller::DrawFrame(
     PaintContext& context,
     const SkRect& bounds,
     const DlImageSampling sampling) const {
-  context.canvas->DrawImage(dl_image_, {0, 0}, sampling, context.paint);
+  context.canvas->DrawImage(dl_image_, SkPoint{0, 0}, sampling, context.paint);
 }
 
 }  // namespace flutter

--- a/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -51,7 +51,8 @@ void EmbedderExternalTextureGL::Paint(PaintContext& context,
     if (bounds != image_bounds) {
       canvas->DrawImageRect(last_image_, image_bounds, bounds, sampling, paint);
     } else {
-      canvas->DrawImage(last_image_, {bounds.x(), bounds.y()}, sampling, paint);
+      canvas->DrawImage(last_image_, SkPoint{bounds.x(), bounds.y()}, sampling,
+                        paint);
     }
   }
 }

--- a/shell/platform/embedder/embedder_external_texture_metal.mm
+++ b/shell/platform/embedder/embedder_external_texture_metal.mm
@@ -49,7 +49,7 @@ void EmbedderExternalTextureMetal::Paint(PaintContext& context,
     if (bounds != image_bounds) {
       canvas->DrawImageRect(last_image_, image_bounds, bounds, sampling, paint);
     } else {
-      canvas->DrawImage(last_image_, {bounds.x(), bounds.y()}, sampling, paint);
+      canvas->DrawImage(last_image_, SkPoint{bounds.x(), bounds.y()}, sampling, paint);
     }
   }
 }

--- a/shell/platform/fuchsia/flutter/canvas_spy_unittests.cc
+++ b/shell/platform/fuchsia/flutter/canvas_spy_unittests.cc
@@ -24,7 +24,7 @@ TEST(CanvasSpyTest, DrawingIsTracked) {
   ASSERT_FALSE(canvas_spy.DidDrawIntoCanvas());
 
   DlPaint paint;
-  spy->DrawCircle({0, 0}, 60, paint);
+  spy->DrawCircle(SkPoint{0, 0}, 60, paint);
   ASSERT_TRUE(canvas_spy.DidDrawIntoCanvas());
 }
 

--- a/testing/mock_canvas.h
+++ b/testing/mock_canvas.h
@@ -82,30 +82,30 @@ class MockCanvas final : public DlCanvas {
 
   struct DrawImageDataNoPaint {
     sk_sp<DlImage> image;
-    SkScalar x;
-    SkScalar y;
+    DlScalar x;
+    DlScalar y;
     DlImageSampling options;
   };
 
   struct DrawImageData {
     sk_sp<DlImage> image;
-    SkScalar x;
-    SkScalar y;
+    DlScalar x;
+    DlScalar y;
     DlImageSampling options;
     DlPaint paint;
   };
 
   struct DrawDisplayListData {
     sk_sp<DisplayList> display_list;
-    SkScalar opacity;
+    DlScalar opacity;
   };
 
   struct DrawShadowData {
     SkPath path;
     DlColor color;
-    SkScalar elevation;
+    DlScalar elevation;
     bool transparent_occluder;
-    SkScalar dpr;
+    DlScalar dpr;
   };
 
   struct ClipRectData {
@@ -169,11 +169,11 @@ class MockCanvas final : public DlCanvas {
   const std::vector<DrawCall>& draw_calls() const { return draw_calls_; }
   void reset_draw_calls() { draw_calls_.clear(); }
 
-  SkISize GetBaseLayerSize() const override;
+  DlISize GetBaseLayerDimensions() const override;
   SkImageInfo GetImageInfo() const override;
 
   void Save() override;
-  void SaveLayer(const SkRect* bounds,
+  void SaveLayer(std::optional<const DlRect>& bounds,
                  const DlPaint* paint = nullptr,
                  const DlImageFilter* backdrop = nullptr) override;
   void Restore() override;
@@ -187,119 +187,116 @@ class MockCanvas final : public DlCanvas {
   // clang-format off
 
   // 2x3 2D affine subset of a 4x4 transform in row major order
-  void Transform2DAffine(SkScalar mxx, SkScalar mxy, SkScalar mxt,
-                         SkScalar myx, SkScalar myy, SkScalar myt) override;
+  void Transform2DAffine(DlScalar mxx, DlScalar mxy, DlScalar mxt,
+                         DlScalar myx, DlScalar myy, DlScalar myt) override;
   // full 4x4 transform in row major order
   void TransformFullPerspective(
-      SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
-      SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
-      SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
-      SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) override;
+      DlScalar mxx, DlScalar mxy, DlScalar mxz, DlScalar mxt,
+      DlScalar myx, DlScalar myy, DlScalar myz, DlScalar myt,
+      DlScalar mzx, DlScalar mzy, DlScalar mzz, DlScalar mzt,
+      DlScalar mwx, DlScalar mwy, DlScalar mwz, DlScalar mwt) override;
   // clang-format on
 
-  void Translate(SkScalar tx, SkScalar ty) override;
-  void Scale(SkScalar sx, SkScalar sy) override;
-  void Rotate(SkScalar degrees) override;
-  void Skew(SkScalar sx, SkScalar sy) override;
+  void Translate(DlScalar tx, DlScalar ty) override;
+  void Scale(DlScalar sx, DlScalar sy) override;
+  void Rotate(DlScalar degrees) override;
+  void Skew(DlScalar sx, DlScalar sy) override;
   void TransformReset() override;
-  void Transform(const SkMatrix* matrix) override;
-  void Transform(const SkM44* matrix44) override;
-  void SetTransform(const SkMatrix* matrix) override;
-  void SetTransform(const SkM44* matrix44) override;
-  using DlCanvas::SetTransform;
-  using DlCanvas::Transform;
+  void Transform(const DlMatrix& matrix) override;
+  void SetTransform(const DlMatrix& matrix) override;
 
-  SkM44 GetTransformFullPerspective() const override;
-  SkMatrix GetTransform() const override;
+  DlMatrix GetMatrix() const override;
 
-  void ClipRect(const SkRect& rect, ClipOp clip_op, bool is_aa) override;
-  void ClipOval(const SkRect& bounds, ClipOp clip_op, bool is_aa) override;
+  void ClipRect(const DlRect& rect, ClipOp clip_op, bool is_aa) override;
+  void ClipOval(const DlRect& bounds, ClipOp clip_op, bool is_aa) override;
   void ClipRRect(const SkRRect& rrect, ClipOp clip_op, bool is_aa) override;
-  void ClipPath(const SkPath& path, ClipOp clip_op, bool is_aa) override;
+  void ClipPath(const DlPath& path, ClipOp clip_op, bool is_aa) override;
 
-  SkRect GetDestinationClipBounds() const override;
-  SkRect GetLocalClipBounds() const override;
-  bool QuickReject(const SkRect& bounds) const override;
+  DlRect GetDestinationClipCoverage() const override;
+  DlRect GetLocalClipCoverage() const override;
+  bool QuickReject(const DlRect& bounds) const override;
 
   void DrawPaint(const DlPaint& paint) override;
   void DrawColor(DlColor color, DlBlendMode mode) override;
-  void DrawLine(const SkPoint& p0,
-                const SkPoint& p1,
+  void DrawLine(const DlPoint& p0,
+                const DlPoint& p1,
                 const DlPaint& paint) override;
   void DrawDashedLine(const DlPoint& p0,
                       const DlPoint& p1,
                       DlScalar on_length,
                       DlScalar off_length,
                       const DlPaint& paint) override;
-  void DrawRect(const SkRect& rect, const DlPaint& paint) override;
-  void DrawOval(const SkRect& bounds, const DlPaint& paint) override;
-  void DrawCircle(const SkPoint& center,
-                  SkScalar radius,
+  void DrawRect(const DlRect& rect, const DlPaint& paint) override;
+  void DrawOval(const DlRect& bounds, const DlPaint& paint) override;
+  void DrawCircle(const DlPoint& center,
+                  DlScalar radius,
                   const DlPaint& paint) override;
   void DrawRRect(const SkRRect& rrect, const DlPaint& paint) override;
   void DrawDRRect(const SkRRect& outer,
                   const SkRRect& inner,
                   const DlPaint& paint) override;
-  void DrawPath(const SkPath& path, const DlPaint& paint) override;
-  void DrawArc(const SkRect& bounds,
-               SkScalar start,
-               SkScalar sweep,
+  void DrawPath(const DlPath& path, const DlPaint& paint) override;
+  void DrawArc(const DlRect& bounds,
+               DlScalar start,
+               DlScalar sweep,
                bool useCenter,
                const DlPaint& paint) override;
   void DrawPoints(PointMode mode,
                   uint32_t count,
-                  const SkPoint pts[],
+                  const DlPoint pts[],
                   const DlPaint& paint) override;
   void DrawVertices(const std::shared_ptr<DlVertices>& vertices,
                     DlBlendMode mode,
                     const DlPaint& paint) override;
 
   void DrawImage(const sk_sp<DlImage>& image,
-                 const SkPoint& point,
+                 const DlPoint& point,
                  DlImageSampling sampling,
                  const DlPaint* paint = nullptr) override;
   void DrawImageRect(
       const sk_sp<DlImage>& image,
-      const SkRect& src,
-      const SkRect& dst,
+      const DlRect& src,
+      const DlRect& dst,
       DlImageSampling sampling,
       const DlPaint* paint = nullptr,
       SrcRectConstraint constraint = SrcRectConstraint::kFast) override;
   void DrawImageNine(const sk_sp<DlImage>& image,
-                     const SkIRect& center,
-                     const SkRect& dst,
+                     const DlIRect& center,
+                     const DlRect& dst,
                      DlFilterMode filter,
                      const DlPaint* paint = nullptr) override;
   void DrawAtlas(const sk_sp<DlImage>& atlas,
                  const SkRSXform xform[],
-                 const SkRect tex[],
+                 const DlRect tex[],
                  const DlColor colors[],
                  int count,
                  DlBlendMode mode,
                  DlImageSampling sampling,
-                 const SkRect* cullRect,
+                 const DlRect* cullRect,
                  const DlPaint* paint = nullptr) override;
 
   void DrawDisplayList(const sk_sp<DisplayList> display_list,
-                       SkScalar opacity) override;
+                       DlScalar opacity) override;
   void DrawTextBlob(const sk_sp<SkTextBlob>& blob,
-                    SkScalar x,
-                    SkScalar y,
+                    DlScalar x,
+                    DlScalar y,
                     const DlPaint& paint) override;
   void DrawTextFrame(const std::shared_ptr<impeller::TextFrame>& text_frame,
-                     SkScalar x,
-                     SkScalar y,
+                     DlScalar x,
+                     DlScalar y,
                      const DlPaint& paint) override;
-  void DrawShadow(const SkPath& path,
+  void DrawShadow(const DlPath& path,
                   const DlColor color,
-                  const SkScalar elevation,
+                  const DlScalar elevation,
                   bool transparent_occluder,
-                  SkScalar dpr) override;
+                  DlScalar dpr) override;
 
   void Flush() override;
 
+  ENABLE_DL_CANVAS_BACKWARDS_COMPATIBILITY
+
  private:
-  SkISize base_layer_size_;
+  DlISize base_layer_size_;
   std::vector<DisplayListMatrixClipState> state_stack_;
   std::vector<DrawCall> draw_calls_;
   int current_layer_;


### PR DESCRIPTION
This is the beginning of the bulk of de-skia-fication work in the engine. All of the standard types in the DlCanvas API now have overloads that specify the corresponding Dl type, mainly for Dl*Rect and DlPoint types. This enables further work to switch from SkFoo types to DlFoo types in the various engine modules culminating in the elimination of the old methods that use the Sk types.

All of the former methods that used the basic Sk types are now implemented as inlinable translation overloads and the underlying implementations of DlCanvas now implement only the newer style interfaces so that they don't need to be further modified as we eliminate the old Skia types from the interface.

There are still a couple of Skia types remaining in the DlCanvas API without any DL type variants which will be handled in a future phase:
- SkRRect
- SkRSXform
- SkTextBlob (will be hidden behind a common interface along with TextFrame)
- SkImageInfo (only used in a few calling sites)