### PR TITLE
Add ci/ios_debug_sim_extension_safe_nocopy that avoid gen_snapshot copying.

### DIFF
--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -307,6 +307,61 @@
             },
             "gn": [
                 "--target-dir",
+                "ci/ios_debug_sim_extension_safe",
+                "--ios",
+                "--runtime-mode",
+                "debug",
+                "--simulator",
+                "--no-lto",
+                "--darwin-extension-safe",
+                "--rbe",
+                "--no-goma",
+                "--xcode-symlinks"
+            ],
+            "name": "ci/ios_debug_sim_extension_safe_nocopy",
+            "description": "Produces extension safe debug mode artifacts to target the x64 iOS simulator, no gen_snapshots copying.",
+            "ninja": {
+                "config": "ci/ios_debug_sim_extension_safe",
+                "targets": [
+                    "flutter:unittests",
+                    "flutter/lib/shell/platform/embedder:flutter_engine",
+                    "flutter/sky:sky",
+                    "flutter/testing/scenario_app:scenario_app"
+                ]
+            },
+            "postsubmit_overrides": {
+                "gn": [
+                    "--target-dir",
+                    "ci/ios_debug_sim_extension_safe",
+                    "--ios",
+                    "--runtime-mode",
+                    "debug",
+                    "--simulator",
+                    "--no-lto",
+                    "--darwin-extension-safe",
+                    "--no-rbe",
+                    "--no-goma"
+                ]
+            },
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "15a240d"
+                }
+            }
+        },
+        {
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Mac-13|Mac-14",
+                "cpu=arm64"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "download_jdk": false,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
                 "ci/ios_debug_sim_arm64_extension_safe",
                 "--ios",
                 "--runtime-mode",

--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -321,7 +321,7 @@
             "name": "ci/ios_debug_sim_extension_safe_nocopy",
             "description": "Produces extension safe debug mode artifacts to target the x64 iOS simulator, no gen_snapshots copying.",
             "ninja": {
-                "config": "ci/ios_debug_sim_extension_safe",
+                "config": "ci/ios_debug_sim_extension_safe_nocopy",
                 "targets": [
                     "flutter:unittests",
                     "flutter/shell/platform/embedder:flutter_engine",

--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -324,7 +324,7 @@
                 "config": "ci/ios_debug_sim_extension_safe",
                 "targets": [
                     "flutter:unittests",
-                    "flutter/lib/shell/platform/embedder:flutter_engine",
+                    "flutter/shell/platform/embedder:flutter_engine",
                     "flutter/sky:sky",
                     "flutter/testing/scenario_app:scenario_app"
                 ]

--- a/ci/builders/mac_ios_engine.json
+++ b/ci/builders/mac_ios_engine.json
@@ -307,7 +307,7 @@
             },
             "gn": [
                 "--target-dir",
-                "ci/ios_debug_sim_extension_safe",
+                "ci/ios_debug_sim_extension_safe_nocopy",
                 "--ios",
                 "--runtime-mode",
                 "debug",
@@ -332,7 +332,7 @@
             "postsubmit_overrides": {
                 "gn": [
                     "--target-dir",
-                    "ci/ios_debug_sim_extension_safe",
+                    "ci/ios_debug_sim_extension_safe_nocopy",
                     "--ios",
                     "--runtime-mode",
                     "debug",


### PR DESCRIPTION
This is to troubleshoot https://github.com/flutter/flutter/issues/154437

New build is identical to `ci/ios_debug_sim_extension_safe` except it doesn't produce artifacts_* folder, doesn't copy `gen_snapshot`. Therefore, the hypothesis is that it should never exhibit failures running `gen_snapshot` seen for example on https://ci.chromium.org/ui/p/flutter/builders/prod/Mac%20Production%20Engine%20Drone/484147/overview