### PR TITLE
Roll buildroot for flutter/buildroot#912

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -277,7 +277,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '4006f2730e566c2a4c2bbbbba406f888c401e094',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'c8f93f25a19cefaaeb64d4323e2fc8c9ccd20479',
 
   'src/flutter/third_party/depot_tools':
   Var('chromium_git') + '/chromium/tools/depot_tools.git' + '@' + '580b4ff3f5cd0dcaa2eacda28cefe0f45320e8f7',


### PR DESCRIPTION
This change switches from using `xcodebuild` to `xcrun` for discovering the paths of installed Apple SDKs. `xcrun` tries reading this information from a cache first, which may help avoid timeouts in CI.

Related https://github.com/flutter/flutter/issues/155106