### PR TITLE
[et] Add support for building Dart SDK from source

### DIFF
--- a/tools/engine_tool/lib/src/commands/build_command.dart
+++ b/tools/engine_tool/lib/src/commands/build_command.dart
@@ -55,6 +55,7 @@ et build //flutter/fml:fml_benchmarks  # Build a specific target in `//flutter/f
           environment,
           plan.build,
           enableRbe: plan.useRbe,
+          extraGnArgs: plan.toGnArgs(),
         )) {
       return 1;
     }

--- a/tools/engine_tool/lib/src/commands/query_command.dart
+++ b/tools/engine_tool/lib/src/commands/query_command.dart
@@ -182,6 +182,7 @@ et query targets //flutter/fml/...  # List all targets under `//flutter/fml`
       environment,
       plan.build,
       enableRbe: plan.useRbe,
+      extraGnArgs: plan.toGnArgs(),
     )) {
       return 1;
     }

--- a/tools/engine_tool/lib/src/commands/test_command.dart
+++ b/tools/engine_tool/lib/src/commands/test_command.dart
@@ -55,6 +55,7 @@ et test //flutter/fml:fml_benchmarks  # Run a single test target in `//flutter/f
       environment,
       plan.build,
       enableRbe: plan.useRbe,
+      extraGnArgs: plan.toGnArgs(),
     )) {
       return 1;
     }
@@ -96,6 +97,7 @@ et test //flutter/fml:fml_benchmarks  # Run a single test target in `//flutter/f
       targets: testTargets.map((target) => target.label).toList(),
       enableRbe: plan.useRbe,
       rbeConfig: plan.toRbeConfig(),
+      extraGnArgs: plan.toGnArgs(),
     );
     if (buildExitCode != 0) {
       return buildExitCode;

--- a/tools/engine_tool/test/build_plan_test.dart
+++ b/tools/engine_tool/test/build_plan_test.dart
@@ -546,6 +546,129 @@ void main() {
     );
   });
 
+  test('dart build defaults to prebuilt', () {
+    final testEnv = TestEnvironment.withTestEngine(
+      withRbe: true,
+    );
+    addTearDown(testEnv.cleanup);
+
+    final testConfig = TestBuilderConfig();
+    testConfig.addBuild(
+      name: 'linux/host_debug',
+      dimension: TestDroneDimension.linux,
+    );
+
+    final parser = ArgParser();
+    final builds = BuildPlan.configureArgParser(
+      parser,
+      testEnv.environment,
+      configs: {
+        'linux_test_config': testConfig.buildConfig(
+          path: 'ci/builders/linux_test_config.json',
+        ),
+      },
+      help: false,
+    );
+
+    final plan = BuildPlan.fromArgResults(
+      parser.parse([]),
+      testEnv.environment,
+      builds: builds,
+    );
+
+    expect(plan.buildDart, BuildDart.prebuilt);
+    expect(
+      plan.toGnArgs(),
+      isNot(contains('--no-prebuilt-dart-sdk')),
+    );
+    expect(
+      plan.toGnArgs(),
+      isNot(contains('--full-dart-sdk')),
+    );
+  });
+
+  test('dart build can be set to from source', () {
+    final testEnv = TestEnvironment.withTestEngine(
+      withRbe: true,
+    );
+    addTearDown(testEnv.cleanup);
+
+    final testConfig = TestBuilderConfig();
+    testConfig.addBuild(
+      name: 'linux/host_debug',
+      dimension: TestDroneDimension.linux,
+    );
+
+    final parser = ArgParser();
+    final builds = BuildPlan.configureArgParser(
+      parser,
+      testEnv.environment,
+      configs: {
+        'linux_test_config': testConfig.buildConfig(
+          path: 'ci/builders/linux_test_config.json',
+        ),
+      },
+      help: false,
+    );
+
+    final plan = BuildPlan.fromArgResults(
+      parser.parse(['--build-dart']),
+      testEnv.environment,
+      builds: builds,
+    );
+
+    expect(plan.buildDart, BuildDart.build);
+    expect(
+      plan.toGnArgs(),
+      contains('--no-prebuilt-dart-sdk'),
+    );
+    expect(
+      plan.toGnArgs(),
+      isNot(contains('--full-dart-sdk')),
+    );
+  });
+
+  test('dart build can be set to full', () {
+    final testEnv = TestEnvironment.withTestEngine(
+      withRbe: true,
+    );
+    addTearDown(testEnv.cleanup);
+
+    final testConfig = TestBuilderConfig();
+    testConfig.addBuild(
+      name: 'linux/host_debug',
+      dimension: TestDroneDimension.linux,
+    );
+
+    final parser = ArgParser();
+    final builds = BuildPlan.configureArgParser(
+      parser,
+      testEnv.environment,
+      configs: {
+        'linux_test_config': testConfig.buildConfig(
+          path: 'ci/builders/linux_test_config.json',
+        ),
+      },
+      help: false,
+    );
+
+    final plan = BuildPlan.fromArgResults(
+      parser.parse(['--build-dart-full']),
+      testEnv.environment,
+      builds: builds,
+    );
+
+    expect(plan.buildDart, BuildDart.buildFull);
+    expect(
+      plan.toGnArgs(),
+      contains('--no-prebuilt-dart-sdk'),
+    );
+    expect(
+      plan.toGnArgs(),
+      contains('--full-dart-sdk'),
+    );
+  });
+
   test('build defaults to host_debug', () {
     final testEnv = TestEnvironment.withTestEngine(
       withRbe: true,


### PR DESCRIPTION
Add support for building Dart from source (for doing HHH development locally).

Supports workflow tried in:

* https://github.com/flutter/flutter/issues/156575

It would be even better if `et` could detect if third_party/dart is the expected version. But I'm not entirely sure how to approach that.

Maybe the cli should be a config `--dart=prebuilt` `--dart=build` `--dart=build-full` instead.

(FYI: I'm OOO for the next couple of weeks.)