### PR TITLE
Copy gen_snapshots using python's shutil.copy, avoid links

### DIFF
--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -434,6 +434,7 @@
 ../../../flutter/sky/packages/sky_engine/README.md
 ../../../flutter/sky/packages/sky_engine/lib/_embedder.yaml
 ../../../flutter/sky/packages/sky_engine/pubspec.yaml
+../../../flutter/sky/tools/cp.py
 ../../../flutter/sky/tools/create_embedder_framework.py
 ../../../flutter/sky/tools/create_ios_framework.py
 ../../../flutter/sky/tools/create_macos_binary.py

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -198,12 +198,18 @@ if (host_os == "mac" && (target_os == "mac" || target_os == "ios")) {
     gen_snapshot_target =
         "$dart_src/runtime/bin:$gen_snapshot_target_name($build_toolchain)"
 
-    copy(target_name) {
+    action(target_name) {
+      script = "//flutter/sky/tools/cp.py"
+
       # The toolchain-specific output directory. For cross-compiles, this is a
       # clang-x64 or clang-arm64 subdirectory of the top-level build directory.
       output_dir = get_label_info(gen_snapshot_target, "root_out_dir")
 
-      sources = [ "${output_dir}/${gen_snapshot_target_name}" ]
+      args = [
+        rebase_path("${output_dir}/${gen_snapshot_target_name}"),
+        rebase_path(
+            "${root_out_dir}/artifacts_$host_cpu/gen_snapshot_${target_cpu}"),
+      ]
       outputs =
           [ "${root_out_dir}/artifacts_$host_cpu/gen_snapshot_${target_cpu}" ]
       deps = [ gen_snapshot_target ]

--- a/sky/tools/cp.py
+++ b/sky/tools/cp.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2012 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""Copy a file.
+
+This module works much like the cp posix command - it takes 2 arguments:
+(src, dst) and copies the file with path |src| to |dst|.
+"""
+
+import os
+import shutil
+import sys
+
+
+def Main(src, dst):
+  # Use copy instead of copyfile to ensure the executable bit is copied.
+  shutil.copy(src, os.path.normpath(dst))
+  return 0
+
+
+if __name__ == '__main__':
+  sys.exit(Main(sys.argv[1], sys.argv[2]))

--- a/sky/tools/cp.py
+++ b/sky/tools/cp.py
@@ -15,11 +15,11 @@ import shutil
 import sys
 
 
-def Main(src, dst):
+def main(src, dst):
   # Use copy instead of copyfile to ensure the executable bit is copied.
   shutil.copy(src, os.path.normpath(dst))
   return 0
 
 
 if __name__ == '__main__':
-  sys.exit(Main(sys.argv[1], sys.argv[2]))
+  sys.exit(main(sys.argv[1], sys.argv[2]))


### PR DESCRIPTION
Default implementation of copy does it via hardlink, which seems to be causing issues with Gatekeeper on mac.

BUG=https://github.com/flutter/flutter/issues/154437