### PR TITLE
[Impeller] remove extra copy from drawPoints.

### DIFF
--- a/impeller/entity/geometry/point_field_geometry.h
+++ b/impeller/entity/geometry/point_field_geometry.h
@@ -9,6 +9,7 @@
 
 namespace impeller {
 
+/// @brief A geometry class specialized for Canvas::DrawPoints.
 class PointFieldGeometry final : public Geometry {
  public:
   PointFieldGeometry(std::vector<Point> points, Scalar radius, bool round);


### PR DESCRIPTION
Remove the extra host -> host copy performed by the VertexBufferBuilder. Instead, write the drawPoint geometry right into the transients buffer.

https://github.com/flutter/flutter/issues/152702
