### PR TITLE
[Flutter GPU] Remove Command/VertexBuffer usage from Flutter GPU.

### DIFF
--- a/impeller/entity/contents/text_contents.cc
+++ b/impeller/entity/contents/text_contents.cc
@@ -256,8 +256,9 @@ bool TextContents::Render(const ContentContext& renderer,
         }
       });
 
-  pass.SetVertexBuffer(std::move(buffer_view), vertex_count);
+  pass.SetVertexBuffer(std::move(buffer_view));
   pass.SetIndexBuffer({}, IndexType::kNone);
+  pass.SetElementCount(vertex_count);
 
   return pass.Draw().ok();
 }

--- a/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -415,7 +415,7 @@ std::optional<size_t> BufferBindingsGLES::BindTextures(
     /// If there is a sampler for the texture at the same index, configure the
     /// bound texture using that sampler.
     ///
-    const auto& sampler_gles = SamplerGLES::Cast(*data.sampler);
+    const auto& sampler_gles = SamplerGLES::Cast(**data.sampler);
     if (!sampler_gles.ConfigureBoundTexture(texture_gles, gl)) {
       return std::nullopt;
     }

--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -455,7 +455,7 @@ static bool BindVertexBuffer(const ProcTableGLES& gl,
     /// Finally! Invoke the draw call.
     ///
     if (command.index_type == IndexType::kNone) {
-      gl.DrawArrays(mode, command.base_vertex, command.vertex_count);
+      gl.DrawArrays(mode, command.base_vertex, command.element_count);
     } else {
       // Bind the index buffer if necessary.
       auto index_buffer_view = command.index_buffer;
@@ -466,7 +466,7 @@ static bool BindVertexBuffer(const ProcTableGLES& gl,
         return false;
       }
       gl.DrawElements(mode,                             // mode
-                      command.vertex_count,             // count
+                      command.element_count,            // count
                       ToIndexType(command.index_type),  // type
                       reinterpret_cast<const GLvoid*>(static_cast<GLsizei>(
                           index_buffer_view.range.offset))  // indices

--- a/impeller/renderer/backend/metal/render_pass_mtl.h
+++ b/impeller/renderer/backend/metal/render_pass_mtl.h
@@ -80,12 +80,14 @@ class RenderPassMTL final : public RenderPass {
   void SetScissor(IRect scissor) override;
 
   // |RenderPass|
+  void SetElementCount(size_t count) override;
+
+  // |RenderPass|
   void SetInstanceCount(size_t count) override;
 
   // |RenderPass|
   bool SetVertexBuffer(BufferView vertex_buffers[],
-                       size_t vertex_buffer_count,
-                       size_t vertex_count) override;
+                       size_t vertex_buffer_count) override;
 
   // |RenderPass|
   bool SetIndexBuffer(BufferView index_buffer, IndexType index_type) override;

--- a/impeller/renderer/backend/metal/render_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/render_pass_mtl.mm
@@ -284,14 +284,18 @@ void RenderPassMTL::SetScissor(IRect scissor) {
 }
 
 // |RenderPass|
+void RenderPassMTL::SetElementCount(size_t count) {
+  vertex_count_ = count;
+}
+
+// |RenderPass|
 void RenderPassMTL::SetInstanceCount(size_t count) {
   instance_count_ = count;
 }
 
 // |RenderPass|
 bool RenderPassMTL::SetVertexBuffer(BufferView vertex_buffers[],
-                                    size_t vertex_buffer_count,
-                                    size_t vertex_count) {
+                                    size_t vertex_buffer_count) {
   if (!ValidateVertexBuffers(vertex_buffers, vertex_buffer_count)) {
     return false;
   }
@@ -303,8 +307,6 @@ bool RenderPassMTL::SetVertexBuffer(BufferView vertex_buffers[],
       return false;
     }
   }
-
-  vertex_count_ = vertex_count;
 
   return true;
 }

--- a/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -366,14 +366,18 @@ void RenderPassVK::SetScissor(IRect scissor) {
 }
 
 // |RenderPass|
+void RenderPassVK::SetElementCount(size_t count) {
+  element_count_ = count;
+}
+
+// |RenderPass|
 void RenderPassVK::SetInstanceCount(size_t count) {
   instance_count_ = count;
 }
 
 // |RenderPass|
 bool RenderPassVK::SetVertexBuffer(BufferView vertex_buffers[],
-                                   size_t vertex_buffer_count,
-                                   size_t vertex_count) {
+                                   size_t vertex_buffer_count) {
   if (!ValidateVertexBuffers(vertex_buffers, vertex_buffer_count)) {
     return false;
   }
@@ -389,8 +393,6 @@ bool RenderPassVK::SetVertexBuffer(BufferView vertex_buffers[],
   // Bind the vertex buffers.
   command_buffer_vk_.bindVertexBuffers(0u, vertex_buffer_count, buffers,
                                        vertex_buffer_offsets);
-
-  vertex_count_ = vertex_count;
 
   return true;
 }
@@ -507,14 +509,14 @@ fml::Status RenderPassVK::Draw() {
   }
 
   if (has_index_buffer_) {
-    command_buffer_vk_.drawIndexed(vertex_count_,    // index count
+    command_buffer_vk_.drawIndexed(element_count_,   // index count
                                    instance_count_,  // instance count
                                    0u,               // first index
                                    base_vertex_,     // vertex offset
                                    0u                // first instance
     );
   } else {
-    command_buffer_vk_.draw(vertex_count_,    // vertex count
+    command_buffer_vk_.draw(element_count_,   // vertex count
                             instance_count_,  // instance count
                             base_vertex_,     // vertex offset
                             0u                // first instance
@@ -533,7 +535,7 @@ fml::Status RenderPassVK::Draw() {
   descriptor_write_offset_ = 0u;
   instance_count_ = 1u;
   base_vertex_ = 0u;
-  vertex_count_ = 0u;
+  element_count_ = 0u;
   pipeline_ = nullptr;
   pipeline_uses_input_attachments_ = false;
   immutable_sampler_ = nullptr;

--- a/impeller/renderer/backend/vulkan/render_pass_vk.h
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.h
@@ -46,7 +46,7 @@ class RenderPassVK final : public RenderPass {
   size_t descriptor_write_offset_ = 0u;
   size_t instance_count_ = 1u;
   size_t base_vertex_ = 0u;
-  size_t vertex_count_ = 0u;
+  size_t element_count_ = 0u;
   bool has_index_buffer_ = false;
   bool has_label_ = false;
   const Pipeline<PipelineDescriptor>* pipeline_;
@@ -77,12 +77,14 @@ class RenderPassVK final : public RenderPass {
   void SetScissor(IRect scissor) override;
 
   // |RenderPass|
+  void SetElementCount(size_t count) override;
+
+  // |RenderPass|
   void SetInstanceCount(size_t count) override;
 
   // |RenderPass|
   bool SetVertexBuffer(BufferView vertex_buffers[],
-                       size_t vertex_buffer_count,
-                       size_t vertex_count) override;
+                       size_t vertex_buffer_count) override;
 
   // |RenderPass|
   bool SetIndexBuffer(BufferView index_buffer, IndexType index_type) override;

--- a/impeller/renderer/command.cc
+++ b/impeller/renderer/command.cc
@@ -89,14 +89,14 @@ bool Command::BindResource(ShaderStage stage,
       vertex_bindings.sampled_images.emplace_back(TextureAndSampler{
           .slot = slot,
           .texture = {&metadata, std::move(texture)},
-          .sampler = sampler,
+          .sampler = &sampler,
       });
       return true;
     case ShaderStage::kFragment:
       fragment_bindings.sampled_images.emplace_back(TextureAndSampler{
           .slot = slot,
           .texture = {&metadata, std::move(texture)},
-          .sampler = sampler,
+          .sampler = &sampler,
       });
       return true;
     case ShaderStage::kCompute:

--- a/impeller/renderer/command.cc
+++ b/impeller/renderer/command.cc
@@ -20,7 +20,7 @@ bool Command::BindVertices(const VertexBuffer& buffer) {
 
   vertex_buffers = {buffer.vertex_buffer};
   vertex_buffer_count = 1u;
-  vertex_count = buffer.vertex_count;
+  element_count = buffer.vertex_count;
   index_buffer = buffer.index_buffer;
   index_type = buffer.index_type;
   return true;

--- a/impeller/renderer/command.h
+++ b/impeller/renderer/command.h
@@ -160,14 +160,13 @@ struct Command : public ResourceBinder {
   BufferView index_buffer;
 
   //----------------------------------------------------------------------------
-  /// The total count of vertices, either in the vertex_buffer if the
-  /// index_type is IndexType::kNone or in the index_buffer otherwise.
-  size_t vertex_count = 0u;
+  /// The number of elements to draw. When only a vertex buffer is set, this is
+  /// the vertex count. When an index buffer is set, this is the index count.
+  size_t element_count = 0u;
 
   //----------------------------------------------------------------------------
   /// The type of indices in the index buffer. The indices must be tightly
   /// packed in the index buffer.
-  ///
   IndexType index_type = IndexType::kUnknown;
 
   //----------------------------------------------------------------------------

--- a/impeller/renderer/command.h
+++ b/impeller/renderer/command.h
@@ -61,7 +61,7 @@ using TextureResource = Resource<std::shared_ptr<const Texture>>;
 struct TextureAndSampler {
   SampledImageSlot slot;
   TextureResource texture;
-  const std::unique_ptr<const Sampler>& sampler;
+  const std::unique_ptr<const Sampler>* sampler;
 };
 
 /// @brief combines the buffer resource and its uniform slot information.

--- a/impeller/renderer/render_pass.cc
+++ b/impeller/renderer/render_pass.cc
@@ -72,7 +72,7 @@ bool RenderPass::AddCommand(Command&& command) {
     }
   }
 
-  if (command.vertex_count == 0u || command.instance_count == 0u) {
+  if (command.element_count == 0u || command.instance_count == 0u) {
     // Essentially a no-op. Don't record the command but this is not necessary
     // an error either.
     return true;
@@ -117,40 +117,40 @@ void RenderPass::SetScissor(IRect scissor) {
   pending_.scissor = scissor;
 }
 
+void RenderPass::SetElementCount(size_t count) {
+  pending_.element_count = count;
+}
+
 void RenderPass::SetInstanceCount(size_t count) {
   pending_.instance_count = count;
 }
 
 bool RenderPass::SetVertexBuffer(VertexBuffer buffer) {
-  if (!SetVertexBuffer(&buffer.vertex_buffer, 1u, buffer.vertex_count)) {
+  if (!SetVertexBuffer(&buffer.vertex_buffer, 1u)) {
     return false;
   }
   if (!SetIndexBuffer(buffer.index_buffer, buffer.index_type)) {
     return false;
   }
+  SetElementCount(buffer.vertex_count);
 
   return true;
 }
 
-bool RenderPass::SetVertexBuffer(BufferView vertex_buffer,
-                                 size_t vertex_count) {
-  return SetVertexBuffer(&vertex_buffer, 1, vertex_count);
+bool RenderPass::SetVertexBuffer(BufferView vertex_buffer) {
+  return SetVertexBuffer(&vertex_buffer, 1);
 }
 
-bool RenderPass::SetVertexBuffer(std::vector<BufferView> vertex_buffers,
-                                 size_t vertex_count) {
-  return SetVertexBuffer(vertex_buffers.data(), vertex_buffers.size(),
-                         vertex_count);
+bool RenderPass::SetVertexBuffer(std::vector<BufferView> vertex_buffers) {
+  return SetVertexBuffer(vertex_buffers.data(), vertex_buffers.size());
 }
 
 bool RenderPass::SetVertexBuffer(BufferView vertex_buffers[],
-                                 size_t vertex_buffer_count,
-                                 size_t vertex_count) {
+                                 size_t vertex_buffer_count) {
   if (!ValidateVertexBuffers(vertex_buffers, vertex_buffer_count)) {
     return false;
   }
 
-  pending_.vertex_count = vertex_count;
   pending_.vertex_buffer_count = vertex_buffer_count;
   for (size_t i = 0; i < vertex_buffer_count; i++) {
     pending_.vertex_buffers[i] = std::move(vertex_buffers[i]);

--- a/impeller/renderer/render_pass.h
+++ b/impeller/renderer/render_pass.h
@@ -90,6 +90,12 @@ class RenderPass : public ResourceBinder {
   virtual void SetScissor(IRect scissor);
 
   //----------------------------------------------------------------------------
+  /// The number of elements to draw. When only a vertex buffer is set, this is
+  /// the vertex count. When an index buffer is set, this is the index count.
+  ///
+  virtual void SetElementCount(size_t count);
+
+  //----------------------------------------------------------------------------
   /// The number of instances of the given set of vertices to render. Not all
   /// backends support rendering more than one instance at a time.
   ///
@@ -115,11 +121,9 @@ class RenderPass : public ResourceBinder {
   ///
   /// @param[in]  vertex_buffer  The buffer view to use for sourcing vertices.
   ///
-  /// @param[in]  vertex_count   The number of vertices to draw.
-  ///
   /// @return     Returns false if the given buffer view is invalid.
   ///
-  bool SetVertexBuffer(BufferView vertex_buffer, size_t vertex_count);
+  bool SetVertexBuffer(BufferView vertex_buffer);
 
   //----------------------------------------------------------------------------
   /// @brief      Specify a set of vertex buffers to use for this command.
@@ -131,12 +135,9 @@ class RenderPass : public ResourceBinder {
   /// @param[in]  vertex_buffers  The array of vertex buffer views to use.
   ///                             The maximum number of vertex buffers is 16.
   ///
-  /// @param[in]  vertex_count    The number of vertices to draw.
-  ///
   /// @return     Returns false if any of the given buffer views are invalid.
   ///
-  bool SetVertexBuffer(std::vector<BufferView> vertex_buffers,
-                       size_t vertex_count);
+  bool SetVertexBuffer(std::vector<BufferView> vertex_buffers);
 
   //----------------------------------------------------------------------------
   /// @brief      Specify a set of vertex buffers to use for this command.
@@ -152,22 +153,20 @@ class RenderPass : public ResourceBinder {
   /// @param[in]  vertex_buffer_count The number of vertex buffers to copy from
   ///                                 the array (max 16).
   ///
-  /// @param[in]  vertex_count        The number of vertices to draw.
-  ///
   /// @return     Returns false if any of the given buffer views are invalid.
   ///
   virtual bool SetVertexBuffer(BufferView vertex_buffers[],
-                               size_t vertex_buffer_count,
-                               size_t vertex_count);
+                               size_t vertex_buffer_count);
 
   //----------------------------------------------------------------------------
   /// @brief      Specify an index buffer to use for this command.
   ///             To unset the index buffer, pass IndexType::kNone to
   ///             index_type.
   ///
-  /// @param[in]  index_buffer  The buffer view to use for sourcing indices. The
-  ///                           total number of indices is inferred from the
-  ///                           buffer view size and index type.
+  /// @param[in]  index_buffer  The buffer view to use for sourcing indices.
+  ///                           When an index buffer is bound, the
+  ///                           `vertex_count` set via `SetVertexBuffer` is used
+  ///                           as the number of indices to draw.
   ///
   /// @param[in]  index_type    The size of each index in the index buffer. Pass
   ///                           IndexType::kNone to unset the index buffer.

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -266,7 +266,8 @@ TEST_P(RendererTest, CanRenderPerspectiveCube) {
     BufferView index_buffer = {
         .buffer = device_buffer,
         .range = Range(offsetof(Cube, indices), sizeof(Cube::indices))};
-    pass.SetVertexBuffer(vertex_buffers.data(), vertex_buffers.size(), 36);
+    pass.SetVertexBuffer(vertex_buffers.data(), vertex_buffers.size());
+    pass.SetElementCount(36);
     pass.SetIndexBuffer(index_buffer, IndexType::k16bit);
 
     VS::UniformBuffer uniforms;

--- a/lib/gpu/render_pass.cc
+++ b/lib/gpu/render_pass.cc
@@ -442,6 +442,12 @@ static bool BindUniform(
     case impeller::ShaderStage::kCompute:
       return false;
   }
+
+  if (!buffer || static_cast<size_t>(offset_in_bytes + length_in_bytes) <
+                     buffer->GetDeviceBufferDescriptor().size) {
+    return false;
+  }
+
   uniform_map->emplace(
       uniform_struct,
       impeller::BufferAndUniformSlot{

--- a/lib/gpu/render_pass.cc
+++ b/lib/gpu/render_pass.cc
@@ -441,7 +441,7 @@ static bool BindUniform(
       return false;
   }
 
-  if (!buffer || static_cast<size_t>(offset_in_bytes + length_in_bytes) <
+  if (!buffer || static_cast<size_t>(offset_in_bytes + length_in_bytes) >=
                      buffer->GetDeviceBufferDescriptor().size) {
     return false;
   }

--- a/lib/gpu/render_pass.cc
+++ b/lib/gpu/render_pass.cc
@@ -419,8 +419,6 @@ static bool BindUniform(
     const std::shared_ptr<const impeller::DeviceBuffer>& buffer,
     int offset_in_bytes,
     int length_in_bytes) {
-  auto& render_pass = wrapper->GetRenderPass();
-
   auto uniform_name = tonic::StdStringFromDart(uniform_name_handle);
   const flutter::gpu::Shader::UniformBinding* uniform_struct =
       shader->GetUniformStruct(uniform_name);
@@ -502,8 +500,6 @@ bool InternalFlutterGpu_RenderPass_BindTexture(
     int mip_filter,
     int width_address_mode,
     int height_address_mode) {
-  auto& render_pass = wrapper->GetRenderPass();
-
   auto uniform_name = tonic::StdStringFromDart(uniform_name_handle);
   const flutter::gpu::Shader::TextureBinding* texture_binding =
       shader->GetUniformTexture(uniform_name);

--- a/lib/gpu/render_pass.cc
+++ b/lib/gpu/render_pass.cc
@@ -182,7 +182,7 @@ bool RenderPass::Draw() {
     render_pass_->BindResource(impeller::ShaderStage::kVertex,
                                impeller::DescriptorType::kSampledImage,
                                texture.slot, *texture.texture.GetMetadata(),
-                               texture.texture.resource, texture.sampler);
+                               texture.texture.resource, *texture.sampler);
   }
   for (const auto& [_, buffer] : fragment_uniform_bindings) {
     render_pass_->BindResource(impeller::ShaderStage::kFragment,
@@ -194,7 +194,7 @@ bool RenderPass::Draw() {
     render_pass_->BindResource(impeller::ShaderStage::kFragment,
                                impeller::DescriptorType::kSampledImage,
                                texture.slot, *texture.texture.GetMetadata(),
-                               texture.texture.resource, texture.sampler);
+                               texture.texture.resource, *texture.sampler);
   }
 
   render_pass_->SetVertexBuffer(vertex_buffer);
@@ -429,7 +429,7 @@ static bool BindUniform(
     return false;
   }
 
-  uniform_map->emplace(
+  uniform_map->insert_or_assign(
       uniform_struct,
       impeller::BufferAndUniformSlot{
           .slot = uniform_struct->slot,
@@ -515,12 +515,12 @@ bool InternalFlutterGpu_RenderPass_BindTexture(
     case impeller::ShaderStage::kCompute:
       return false;
   }
-  uniform_map->emplace(
+  uniform_map->insert_or_assign(
       texture_binding,
       impeller::TextureAndSampler{
           .slot = texture_binding->slot,
           .texture = {&texture_binding->metadata, texture->GetTexture()},
-          .sampler = sampler,
+          .sampler = &sampler,
       });
   return true;
 }

--- a/lib/gpu/render_pass.h
+++ b/lib/gpu/render_pass.h
@@ -62,7 +62,21 @@ class RenderPass : public RefCountedDartWrappable<RenderPass> {
 
   bool HasIndexBuffer() const;
 
+  void ClearBindings();
+
   bool Draw();
+
+  using BufferUniformMap =
+      std::unordered_map<const flutter::gpu::Shader::UniformBinding*,
+                         impeller::BufferAndUniformSlot>;
+  using TextureUniformMap =
+      std::unordered_map<const flutter::gpu::Shader::TextureBinding*,
+                         impeller::TextureAndSampler>;
+
+  BufferUniformMap vertex_uniform_bindings;
+  TextureUniformMap vertex_texture_bindings;
+  BufferUniformMap fragment_uniform_bindings;
+  TextureUniformMap fragment_texture_bindings;
 
  private:
   /// Lookup an Impeller pipeline by building a descriptor based on the current

--- a/testing/dart/gpu_test.dart
+++ b/testing/dart/gpu_test.dart
@@ -472,11 +472,6 @@ void main() async {
     // the API.
     state.renderPass.setStencilConfig(
         gpu.StencilConfig(compareFunction: gpu.CompareFunction.equal));
-    // TODO(bdero): https://github.com/flutter/flutter/issues/155335
-    //              Re-binding the same uniform with `bindUniform` does not
-    //              replace the previous binding. We shouldn't need to clear the
-    //              command bindings to work around this.
-    state.renderPass.clearBindings();
     state.renderPass.bindUniform(vertInfo, outerGreenVertInfo);
     state.renderPass.draw();
 
@@ -511,9 +506,6 @@ void main() async {
 
       final gpu.UniformSlot vertInfo =
           pipeline.vertexShader.getUniformSlot('VertInfo');
-      // TODO(bdero): Overwrite bindings with the same slot so we don't need to clear.
-      //              https://github.com/flutter/flutter/issues/155335
-      state.renderPass.clearBindings();
       state.renderPass.bindVertexBuffer(vertices, 3);
       state.renderPass.bindUniform(vertInfo, vertInfoUboFront);
       state.renderPass.draw();


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/156764.
Resolves https://github.com/flutter/flutter/issues/155335.

- Remove Command/VertexBuffer from Flutter GPU.
- Separate vertex/index count into `impeller::RenderPass::SetElementCount(size_t count)` & accurately document its behavior.
- Make Flutter GPU uniform/texture bindings re-assignable.
- Remove unnecessary templates.