### PR TITLE
Fix iOS text selection crash by returning nil range

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1291,8 +1291,9 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
            @"Expected a FlutterTextRange for range (got %@).", [range class]);
   NSRange textRange = ((FlutterTextRange*)range).range;
   if (textRange.location == NSNotFound) {
-    /// Avoids [crashes](https://github.com/flutter/flutter/issues/138464) from an assertion
-    /// against NSNotFound.
+    // Avoids [crashes](https://github.com/flutter/flutter/issues/138464) from an assertion
+    // against NSNotFound.
+    // TODO(hellohuanlin): root cause https://github.com/flutter/flutter/issues/160100
     return nil;
   }
   // Sanitize the range to prevent going out of bounds.

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1291,7 +1291,8 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
            @"Expected a FlutterTextRange for range (got %@).", [range class]);
   NSRange textRange = ((FlutterTextRange*)range).range;
   if (textRange.location == NSNotFound) {
-    /// Avoids [crashes](https://github.com/flutter/flutter/issues/138464) from an assertion against NSNotFound.
+    /// Avoids [crashes](https://github.com/flutter/flutter/issues/138464) from an assertion
+    /// against NSNotFound.
     return nil;
   }
   // Sanitize the range to prevent going out of bounds.

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1293,7 +1293,9 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
   if (textRange.location == NSNotFound) {
     // Avoids [crashes](https://github.com/flutter/flutter/issues/138464) from an assertion
     // against NSNotFound.
-    // TODO(hellohuanlin): root cause https://github.com/flutter/flutter/issues/160100
+    // TODO(hellohuanlin): This is a temp workaround, but we should look into why
+    // framework is providing NSNotFound to the engine.
+    // https://github.com/flutter/flutter/issues/160100
     return nil;
   }
   // Sanitize the range to prevent going out of bounds.

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1290,7 +1290,9 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
   NSAssert([range isKindOfClass:[FlutterTextRange class]],
            @"Expected a FlutterTextRange for range (got %@).", [range class]);
   NSRange textRange = ((FlutterTextRange*)range).range;
-  NSAssert(textRange.location != NSNotFound, @"Expected a valid text range.");
+  if (textRange.location == NSNotFound) {
+    return nil;
+  }
   // Sanitize the range to prevent going out of bounds.
   NSUInteger location = MIN(textRange.location, self.text.length);
   NSUInteger length = MIN(self.text.length - location, textRange.length);

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1291,6 +1291,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
            @"Expected a FlutterTextRange for range (got %@).", [range class]);
   NSRange textRange = ((FlutterTextRange*)range).range;
   if (textRange.location == NSNotFound) {
+    /// Avoids [crashes](https://github.com/flutter/flutter/issues/138464) from an assertion against NSNotFound.
     return nil;
   }
   // Sanitize the range to prevent going out of bounds.

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -516,6 +516,19 @@ FLUTTER_ASSERT_ARC
   XCTAssertEqual(substring.length, 0ul);
 }
 
+- (void)testTextInRangeAcceptsNSNotFoundLocationGracefully {
+  NSDictionary* config = self.mutableTemplateCopy;
+  [self setClientId:123 configuration:config];
+  NSArray<FlutterTextInputView*>* inputFields = self.installedInputViews;
+  FlutterTextInputView* inputView = inputFields[0];
+
+  [inputView insertText:@"text"];
+  UITextRange* range = [FlutterTextRange rangeWithNSRange:NSMakeRange(NSNotFound, 0)];
+
+  NSString* substring = [inputView textInRange:range];
+  XCTAssertNil(substring);
+}
+
 - (void)testStandardEditActions {
   NSDictionary* config = self.mutableTemplateCopy;
   [self setClientId:123 configuration:config];

--- a/shell/platform/darwin/ios/framework/Source/TextInputSemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/TextInputSemanticsObject.mm
@@ -43,8 +43,9 @@ static const UIAccessibilityTraits kUIAccessibilityTraitUndocumentedEmptyLine = 
            @"Expected a FlutterTextRange for range (got %@).", [range class]);
   NSRange textRange = ((FlutterTextRange*)range).range;
   if (textRange.location == NSNotFound) {
-    /// Avoids [crashes](https://github.com/flutter/flutter/issues/138464) from an assertion
-    /// against NSNotFound.
+    // Avoids [crashes](https://github.com/flutter/flutter/issues/138464) from an assertion
+    // against NSNotFound.
+    // TODO(hellohuanlin): root cause https://github.com/flutter/flutter/issues/160100
     return nil;
   }
   return [self.text substringWithRange:textRange];

--- a/shell/platform/darwin/ios/framework/Source/TextInputSemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/TextInputSemanticsObject.mm
@@ -43,7 +43,8 @@ static const UIAccessibilityTraits kUIAccessibilityTraitUndocumentedEmptyLine = 
            @"Expected a FlutterTextRange for range (got %@).", [range class]);
   NSRange textRange = ((FlutterTextRange*)range).range;
   if (textRange.location == NSNotFound) {
-    /// Avoids [crashes](https://github.com/flutter/flutter/issues/138464) from an assertion against NSNotFound.
+    /// Avoids [crashes](https://github.com/flutter/flutter/issues/138464) from an assertion
+    /// against NSNotFound.
     return nil;
   }
   return [self.text substringWithRange:textRange];

--- a/shell/platform/darwin/ios/framework/Source/TextInputSemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/TextInputSemanticsObject.mm
@@ -45,7 +45,7 @@ static const UIAccessibilityTraits kUIAccessibilityTraitUndocumentedEmptyLine = 
   if (textRange.location == NSNotFound) {
     // Avoids [crashes](https://github.com/flutter/flutter/issues/138464) from an assertion
     // against NSNotFound.
-    // TODO(hellohuanlin): root cause https://github.com/flutter/flutter/issues/160100
+    // TODO(hellohuanlin): https://github.com/flutter/flutter/issues/160100
     return nil;
   }
   return [self.text substringWithRange:textRange];

--- a/shell/platform/darwin/ios/framework/Source/TextInputSemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/TextInputSemanticsObject.mm
@@ -45,7 +45,9 @@ static const UIAccessibilityTraits kUIAccessibilityTraitUndocumentedEmptyLine = 
   if (textRange.location == NSNotFound) {
     // Avoids [crashes](https://github.com/flutter/flutter/issues/138464) from an assertion
     // against NSNotFound.
-    // TODO(hellohuanlin): https://github.com/flutter/flutter/issues/160100
+    // TODO(hellohuanlin): This is a temp workaround, but we should look into why
+    // framework is providing NSNotFound to the engine.
+    // https://github.com/flutter/flutter/issues/160100
     return nil;
   }
   return [self.text substringWithRange:textRange];

--- a/shell/platform/darwin/ios/framework/Source/TextInputSemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/TextInputSemanticsObject.mm
@@ -42,7 +42,9 @@ static const UIAccessibilityTraits kUIAccessibilityTraitUndocumentedEmptyLine = 
   NSAssert([range isKindOfClass:[FlutterTextRange class]],
            @"Expected a FlutterTextRange for range (got %@).", [range class]);
   NSRange textRange = ((FlutterTextRange*)range).range;
-  NSAssert(textRange.location != NSNotFound, @"Expected a valid text range.");
+  if (textRange.location == NSNotFound) {
+    return nil;
+  }
   return [self.text substringWithRange:textRange];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/TextInputSemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/TextInputSemanticsObject.mm
@@ -43,6 +43,7 @@ static const UIAccessibilityTraits kUIAccessibilityTraitUndocumentedEmptyLine = 
            @"Expected a FlutterTextRange for range (got %@).", [range class]);
   NSRange textRange = ((FlutterTextRange*)range).range;
   if (textRange.location == NSNotFound) {
+    /// Avoids [crashes](https://github.com/flutter/flutter/issues/138464) from an assertion against NSNotFound.
     return nil;
   }
   return [self.text substringWithRange:textRange];


### PR DESCRIPTION
Reverts a runtime crashing assertion introduced by #16496. Defensively favors returning a nil text selection range rather than crash. See issue [#138464](https://github.com/flutter/flutter/issues/138464) for crash reports and reproduction recordings. 

Without this revert, to avoid a crash hit in a minority of user interactions with a text field, we must degrade experiences for all users by disabling useful iOS text field behaviors (see [#138464](https://github.com/flutter/flutter/issues/138464) for workarounds).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat


Fix iOS text selection crash by returning nil range