### PR TITLE
[Impeller] fix memory leak during gif upload.

### DIFF
--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -483,6 +483,9 @@ ImageDecoderImpeller::UploadTextureToStorage(
   }
 
   texture->SetLabel(impeller::SPrintF("ui.Image(%p)", texture.get()).c_str());
+
+  context->DisposeThreadLocalCachedResources();
+
   return std::make_pair(impeller::DlImageImpeller::Make(std::move(texture)),
                         std::string());
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/156728

Need to periodically flush the TLS command buffer pools in multiframe codec just like single frame codec.