### PR TITLE
[Impeller] use std::array as RenderTarget attachment storage, set limit to 8.

### DIFF
--- a/impeller/display_list/canvas.cc
+++ b/impeller/display_list/canvas.cc
@@ -882,8 +882,7 @@ void Canvas::DrawAtlas(const std::shared_ptr<AtlasContents>& atlas_contents,
 
 void Canvas::SetupRenderPass() {
   renderer_.GetRenderTargetCache()->Start();
-  auto color0 = render_target_.GetColorAttachments().find(0u)->second;
-
+  auto color0 = render_target_.GetColorAttachment0();
   auto& stencil_attachment = render_target_.GetStencilAttachment();
   auto& depth_attachment = render_target_.GetDepthAttachment();
   if (!stencil_attachment.has_value() || !depth_attachment.has_value()) {
@@ -1445,8 +1444,7 @@ void Canvas::AddRenderEntityToCurrentPass(Entity& entity, bool reuse_depth) {
       RenderTarget& render_target = render_passes_.back()
                                         .inline_pass_context->GetPassTarget()
                                         .GetRenderTarget();
-      ColorAttachment attachment =
-          render_target.GetColorAttachments().find(0u)->second;
+      ColorAttachment attachment = render_target.GetColorAttachment0();
       // Attachment.clear color needs to be premultiplied at all times, but the
       // Color::Blend function requires unpremultiplied colors.
       attachment.clear_color = attachment.clear_color.Unpremultiply()

--- a/impeller/entity/entity_pass_target.cc
+++ b/impeller/entity/entity_pass_target.cc
@@ -18,7 +18,7 @@ EntityPassTarget::EntityPassTarget(const RenderTarget& render_target,
       supports_implicit_msaa_(supports_implicit_msaa) {}
 
 std::shared_ptr<Texture> EntityPassTarget::Flip(Allocator& allocator) {
-  auto color0 = target_.GetColorAttachments().find(0)->second;
+  auto color0 = target_.GetColorAttachment0();
   if (!color0.resolve_texture) {
     VALIDATION_LOG << "EntityPassTarget Flip should never be called for a "
                       "non-MSAA target.";

--- a/impeller/entity/entity_pass_target_unittests.cc
+++ b/impeller/entity/entity_pass_target_unittests.cc
@@ -31,20 +31,14 @@ TEST_P(EntityPassTargetTest, SwapWithMSAATexture) {
 
   auto entity_pass_target = EntityPassTarget(render_target, false, false);
 
-  auto color0 = entity_pass_target.GetRenderTarget()
-                    .GetColorAttachments()
-                    .find(0u)
-                    ->second;
+  auto color0 = entity_pass_target.GetRenderTarget().GetColorAttachment0();
   auto msaa_tex = color0.texture;
   auto resolve_tex = color0.resolve_texture;
 
   entity_pass_target.Flip(
       *content_context->GetContext()->GetResourceAllocator());
 
-  color0 = entity_pass_target.GetRenderTarget()
-               .GetColorAttachments()
-               .find(0u)
-               ->second;
+  color0 = entity_pass_target.GetRenderTarget().GetColorAttachment0();
 
   ASSERT_EQ(msaa_tex, color0.texture);
   ASSERT_NE(resolve_tex, color0.resolve_texture);
@@ -89,10 +83,7 @@ TEST_P(EntityPassTargetTest, SwapWithMSAAImplicitResolve) {
 
   auto entity_pass_target = EntityPassTarget(render_target, false, true);
 
-  auto color0 = entity_pass_target.GetRenderTarget()
-                    .GetColorAttachments()
-                    .find(0u)
-                    ->second;
+  auto color0 = entity_pass_target.GetRenderTarget().GetColorAttachment0();
   auto msaa_tex = color0.texture;
   auto resolve_tex = color0.resolve_texture;
 
@@ -101,10 +92,7 @@ TEST_P(EntityPassTargetTest, SwapWithMSAAImplicitResolve) {
   entity_pass_target.Flip(
       *content_context->GetContext()->GetResourceAllocator());
 
-  color0 = entity_pass_target.GetRenderTarget()
-               .GetColorAttachments()
-               .find(0u)
-               ->second;
+  color0 = entity_pass_target.GetRenderTarget().GetColorAttachment0();
 
   ASSERT_NE(msaa_tex, color0.texture);
   ASSERT_NE(resolve_tex, color0.resolve_texture);

--- a/impeller/entity/inline_pass_context.cc
+++ b/impeller/entity/inline_pass_context.cc
@@ -119,10 +119,9 @@ InlinePassContext::RenderPassResult InlinePassContext::GetRenderPass(
   RenderPassResult result;
   {
     // If the pass target has a resolve texture, then we're using MSAA.
-    bool is_msaa = pass_target_.GetRenderTarget()
-                       .GetColorAttachments()
-                       .find(0)
-                       ->second.resolve_texture != nullptr;
+    bool is_msaa =
+        pass_target_.GetRenderTarget().GetColorAttachment0().resolve_texture !=
+        nullptr;
     if (pass_count_ > 0 && is_msaa) {
       result.backdrop_texture =
           pass_target_.Flip(*renderer_.GetContext()->GetResourceAllocator());
@@ -134,8 +133,7 @@ InlinePassContext::RenderPassResult InlinePassContext::GetRenderPass(
 
   // Find the color attachment a second time, since the target may have just
   // flipped.
-  auto color0 =
-      pass_target_.GetRenderTarget().GetColorAttachments().find(0)->second;
+  auto color0 = pass_target_.GetRenderTarget().GetColorAttachment0();
   bool is_msaa = color0.resolve_texture != nullptr;
 
   if (pass_count_ > 0) {

--- a/impeller/entity/render_target_cache.cc
+++ b/impeller/entity/render_target_cache.cc
@@ -52,9 +52,7 @@ RenderTarget RenderTargetCache::CreateOffscreen(
     const auto other_config = render_target_data.config;
     if (!render_target_data.used_this_frame && other_config == config) {
       render_target_data.used_this_frame = true;
-      auto color0 = render_target_data.render_target.GetColorAttachments()
-                        .find(0u)
-                        ->second;
+      auto color0 = render_target_data.render_target.GetColorAttachment0();
       auto depth = render_target_data.render_target.GetDepthAttachment();
       std::shared_ptr<Texture> depth_tex = depth ? depth->texture : nullptr;
       return RenderTargetAllocator::CreateOffscreen(
@@ -102,9 +100,7 @@ RenderTarget RenderTargetCache::CreateOffscreenMSAA(
     const auto other_config = render_target_data.config;
     if (!render_target_data.used_this_frame && other_config == config) {
       render_target_data.used_this_frame = true;
-      auto color0 = render_target_data.render_target.GetColorAttachments()
-                        .find(0u)
-                        ->second;
+      auto color0 = render_target_data.render_target.GetColorAttachment0();
       auto depth = render_target_data.render_target.GetDepthAttachment();
       std::shared_ptr<Texture> depth_tex = depth ? depth->texture : nullptr;
       return RenderTargetAllocator::CreateOffscreenMSAA(

--- a/impeller/entity/render_target_cache_unittests.cc
+++ b/impeller/entity/render_target_cache_unittests.cc
@@ -104,8 +104,8 @@ TEST_P(RenderTargetCacheTest, CachedTextureGetsNewAttachmentConfig) {
       *GetContext(), {100, 100}, 1, "Offscreen2", color_attachment_config);
   render_target_cache.End();
 
-  auto color1 = target1.GetColorAttachments().find(0)->second;
-  auto color2 = target2.GetColorAttachments().find(0)->second;
+  auto color1 = target1.GetColorAttachment0();
+  auto color2 = target2.GetColorAttachment0();
   // The second color attachment should reuse the first attachment's texture
   // but with attributes from the second AttachmentConfig.
   EXPECT_EQ(color2.texture, color1.texture);

--- a/impeller/playground/playground.cc
+++ b/impeller/playground/playground.cc
@@ -285,7 +285,7 @@ bool Playground::OpenPlaygroundHere(
         return false;
       }
 
-      auto color0 = render_target.GetColorAttachments().find(0)->second;
+      auto color0 = render_target.GetColorAttachment0();
       color0.load_action = LoadAction::kLoad;
       if (color0.resolve_texture) {
         color0.texture = color0.resolve_texture;

--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -11,6 +11,7 @@
 #include "fml/closure.h"
 #include "fml/logging.h"
 #include "impeller/base/validation.h"
+#include "impeller/core/formats.h"
 #include "impeller/renderer/backend/gles/context_gles.h"
 #include "impeller/renderer/backend/gles/device_buffer_gles.h"
 #include "impeller/renderer/backend/gles/formats_gles.h"
@@ -533,9 +534,11 @@ bool RenderPassGLES::OnEncodeCommands(const Context& context) const {
   if (!render_target.HasColorAttachment(0u)) {
     return false;
   }
-  const auto& color0 = render_target.GetColorAttachments().at(0u);
-  const auto& depth0 = render_target.GetDepthAttachment();
-  const auto& stencil0 = render_target.GetStencilAttachment();
+  const ColorAttachment& color0 = render_target.GetColorAttachment0();
+  const std::optional<DepthAttachment>& depth0 =
+      render_target.GetDepthAttachment();
+  const std::optional<StencilAttachment>& stencil0 =
+      render_target.GetStencilAttachment();
 
   auto pass_data = std::make_shared<RenderPassData>();
   pass_data->label = label_;

--- a/impeller/renderer/backend/metal/render_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/render_pass_mtl.mm
@@ -104,15 +104,17 @@ static MTLRenderPassDescriptor* ToMTLRenderPassDescriptor(
     const RenderTarget& desc) {
   auto result = [MTLRenderPassDescriptor renderPassDescriptor];
 
-  const auto& colors = desc.GetColorAttachments();
-
-  for (const auto& color : colors) {
-    if (!ConfigureColorAttachment(color.second,
-                                  result.colorAttachments[color.first])) {
+  size_t index = 0;
+  for (const std::optional<ColorAttachment>& color :
+       desc.GetColorAttachments()) {
+    if (color.has_value() &&
+        !ConfigureColorAttachment(color.value(),
+                                  result.colorAttachments[index])) {
       VALIDATION_LOG << "Could not configure color attachment at index "
-                     << color.first;
+                     << index;
       return nil;
     }
+    index++;
   }
 
   const auto& depth = desc.GetDepthAttachment();

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -5,6 +5,7 @@
 #include "impeller/renderer/backend/vulkan/context_vk.h"
 
 #include "fml/concurrent_message_loop.h"
+#include "impeller/core/formats.h"
 #include "impeller/renderer/backend/vulkan/command_queue_vk.h"
 #include "impeller/renderer/backend/vulkan/render_pass_builder_vk.h"
 #include "impeller/renderer/render_target.h"
@@ -599,15 +600,14 @@ void ContextVK::InitializeCommonlyUsedShadersIfNeeded() const {
       rt_allocator.CreateOffscreenMSAA(*this, {1, 1}, 1);
 
   RenderPassBuilderVK builder;
-  for (const auto& [bind_point, color] : render_target.GetColorAttachments()) {
-    builder.SetColorAttachment(
-        bind_point,                                          //
-        color.texture->GetTextureDescriptor().format,        //
-        color.texture->GetTextureDescriptor().sample_count,  //
-        color.load_action,                                   //
-        color.store_action                                   //
-    );
-  }
+  const ColorAttachment& color0 = render_target.GetColorAttachment0();
+  builder.SetColorAttachment(
+      0,                                                    //
+      color0.texture->GetTextureDescriptor().format,        //
+      color0.texture->GetTextureDescriptor().sample_count,  //
+      color0.load_action,                                   //
+      color0.store_action                                   //
+  );
 
   if (auto depth = render_target.GetDepthAttachment(); depth.has_value()) {
     builder.SetDepthStencilAttachment(

--- a/impeller/renderer/backend/vulkan/render_pass_cache_unittests.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_cache_unittests.cc
@@ -23,8 +23,7 @@ TEST_P(RendererTest, CachesRenderPassAndFramebuffer) {
 
   auto render_target =
       allocator->CreateOffscreenMSAA(*GetContext(), {100, 100}, 1);
-  auto resolve_texture =
-      render_target.GetColorAttachments().find(0u)->second.resolve_texture;
+  auto resolve_texture = render_target.GetColorAttachment0().resolve_texture;
   auto& texture_vk = TextureVK::Cast(*resolve_texture);
 
   EXPECT_EQ(texture_vk.GetCachedFramebuffer(), nullptr);

--- a/impeller/renderer/backend/vulkan/test/swapchain_unittests.cc
+++ b/impeller/renderer/backend/vulkan/test/swapchain_unittests.cc
@@ -86,8 +86,7 @@ TEST(SwapchainTest, CachesRenderPassOnSwapchainImage) {
     auto& depth = render_target.GetDepthAttachment();
     depth_stencil_textures.push_back(depth.has_value() ? depth->texture
                                                        : nullptr);
-    msaa_textures.push_back(
-        render_target.GetColorAttachments().find(0u)->second.texture);
+    msaa_textures.push_back(render_target.GetColorAttachment0().texture);
   }
 
   for (auto i = 1; i < 3; i++) {

--- a/lib/gpu/render_pass.cc
+++ b/lib/gpu/render_pass.cc
@@ -104,9 +104,14 @@ std::shared_ptr<impeller::Pipeline<impeller::PipelineDescriptor>>
 RenderPass::GetOrCreatePipeline() {
   // Infer the pipeline layout based on the shape of the RenderTarget.
   auto pipeline_desc = pipeline_descriptor_;
-  for (const auto& it : render_target_.GetColorAttachments()) {
-    auto& color = GetColorAttachmentDescriptor(it.first);
-    color.format = render_target_.GetRenderTargetPixelFormat();
+  size_t color_attachment_index = 0;
+  for (const std::optional<impeller::ColorAttachment>& attachment :
+       render_target_.GetColorAttachments()) {
+    if (attachment.has_value()) {
+      auto& color = GetColorAttachmentDescriptor(color_attachment_index);
+      color.format = render_target_.GetRenderTargetPixelFormat();
+    }
+    color_attachment_index++;
   }
   pipeline_desc.SetColorAttachmentDescriptors(color_descriptors_);
 


### PR DESCRIPTION
In the interest of heap allocating less crap, lets use a std::array to hold the render target's color attachments. To do so we need to set an upper limit, which I chose as 8.
