### PR TITLE
[Impeller] use render pass to transition attachments to eGeneral instead of barriers.

### DIFF
--- a/impeller/renderer/backend/vulkan/render_pass_builder_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_builder_vk.cc
@@ -39,7 +39,7 @@ RenderPassBuilderVK& RenderPassBuilderVK::SetColorAttachment(
   desc.storeOp = ToVKAttachmentStoreOp(store_action, false);
   desc.stencilLoadOp = vk::AttachmentLoadOp::eDontCare;
   desc.stencilStoreOp = vk::AttachmentStoreOp::eDontCare;
-  desc.initialLayout = vk::ImageLayout::eGeneral;
+  desc.initialLayout = vk::ImageLayout::eUndefined;
   desc.finalLayout = vk::ImageLayout::eGeneral;
   colors_[index] = desc;
 

--- a/impeller/renderer/backend/vulkan/render_pass_builder_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_builder_vk_unittests.cc
@@ -47,7 +47,7 @@ TEST(RenderPassBuilder, CreatesRenderPassWithCombinedDepthStencil) {
   ASSERT_NE(maybe_color, builder.GetColorAttachments().end());
   auto color = maybe_color->second;
 
-  EXPECT_EQ(color.initialLayout, vk::ImageLayout::eGeneral);
+  EXPECT_EQ(color.initialLayout, vk::ImageLayout::eUndefined);
   EXPECT_EQ(color.finalLayout, vk::ImageLayout::eGeneral);
   EXPECT_EQ(color.loadOp, vk::AttachmentLoadOp::eClear);
   EXPECT_EQ(color.storeOp, vk::AttachmentStoreOp::eStore);
@@ -117,7 +117,7 @@ TEST(RenderPassBuilder, CreatesMSAAResolveWithCorrectStore) {
   auto color = maybe_color->second;
 
   // MSAA Texture.
-  EXPECT_EQ(color.initialLayout, vk::ImageLayout::eGeneral);
+  EXPECT_EQ(color.initialLayout, vk::ImageLayout::eUndefined);
   EXPECT_EQ(color.finalLayout, vk::ImageLayout::eGeneral);
   EXPECT_EQ(color.loadOp, vk::AttachmentLoadOp::eClear);
   EXPECT_EQ(color.storeOp, vk::AttachmentStoreOp::eDontCare);
@@ -127,7 +127,7 @@ TEST(RenderPassBuilder, CreatesMSAAResolveWithCorrectStore) {
   auto resolve = maybe_resolve->second;
 
   // MSAA Resolve Texture.
-  EXPECT_EQ(resolve.initialLayout, vk::ImageLayout::eGeneral);
+  EXPECT_EQ(resolve.initialLayout, vk::ImageLayout::eUndefined);
   EXPECT_EQ(resolve.finalLayout, vk::ImageLayout::eGeneral);
   EXPECT_EQ(resolve.loadOp, vk::AttachmentLoadOp::eClear);
   EXPECT_EQ(resolve.storeOp, vk::AttachmentStoreOp::eStore);

--- a/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -81,16 +81,6 @@ SharedHandleVK<vk::RenderPass> RenderPassVK::CreateVKRenderPass(
     const ContextVK& context,
     const SharedHandleVK<vk::RenderPass>& recycled_renderpass,
     const std::shared_ptr<CommandBufferVK>& command_buffer) const {
-  BarrierVK barrier;
-  barrier.new_layout = vk::ImageLayout::eGeneral;
-  barrier.cmd_buffer = command_buffer->GetCommandBuffer();
-  barrier.src_access = vk::AccessFlagBits::eShaderRead;
-  barrier.src_stage = vk::PipelineStageFlagBits::eFragmentShader;
-  barrier.dst_access = vk::AccessFlagBits::eColorAttachmentWrite |
-                       vk::AccessFlagBits::eTransferWrite;
-  barrier.dst_stage = vk::PipelineStageFlagBits::eColorAttachmentOutput |
-                      vk::PipelineStageFlagBits::eTransfer;
-
   RenderPassBuilderVK builder;
 
   for (const auto& [bind_point, color] : render_target_.GetColorAttachments()) {
@@ -101,9 +91,11 @@ SharedHandleVK<vk::RenderPass> RenderPassVK::CreateVKRenderPass(
         color.load_action,                                   //
         color.store_action                                   //
     );
-    TextureVK::Cast(*color.texture).SetLayout(barrier);
+    TextureVK::Cast(*color.texture)
+        .SetLayoutWithoutEncoding(vk::ImageLayout::eGeneral);
     if (color.resolve_texture) {
-      TextureVK::Cast(*color.resolve_texture).SetLayout(barrier);
+      TextureVK::Cast(*color.resolve_texture)
+          .SetLayoutWithoutEncoding(vk::ImageLayout::eGeneral);
     }
   }
 


### PR DESCRIPTION
From local testing:

1. This is slightly faster
2. This still renders correctly even on old phones (S10)
3. This is validation error clean.

---------------

The vk RenderPass has a built in mechanism to transition the attachments between layout states. Since we expect the images to be in eGeneral layout, we can configure the render pass to do an eUnderfined -> eGeneral  transition. eUnderfined means "we don't care what was here before". This is OK because we're about to clear the texture anyway.

Since the RenderPass is doing the transition, we don't need an explicit barrier. All we have to do is update our own state tracking mechanism that the image attachments should behave as if they were in eGeneral layout  - because they are once the render pass is started.