### PR TITLE
[Impeller] libImpeller: Allow custom font registrations.

### DIFF
--- a/impeller/toolkit/interop/impeller.cc
+++ b/impeller/toolkit/interop/impeller.cc
@@ -1133,4 +1133,20 @@ void ImpellerTypographyContextRelease(ImpellerTypographyContext context) {
   ObjectBase::SafeRelease(context);
 }
 
+IMPELLER_EXTERN_C
+bool ImpellerTypographyContextRegisterFont(ImpellerTypographyContext context,
+                                           const ImpellerMapping* contents,
+                                           void* contents_on_release_user_data,
+                                           const char* family_name_alias) {
+  auto wrapped_contents = std::make_unique<fml::NonOwnedMapping>(
+      contents->data,    // data ptr
+      contents->length,  // data length
+      [contents, contents_on_release_user_data](auto, auto) {
+        contents->on_release(contents_on_release_user_data);
+      }  // release callback
+  );
+  return GetPeer(context)->RegisterFont(std::move(wrapped_contents),
+                                        ReadString(family_name_alias));
+}
+
 }  // namespace impeller::interop

--- a/impeller/toolkit/interop/impeller.cc
+++ b/impeller/toolkit/interop/impeller.cc
@@ -1146,7 +1146,7 @@ bool ImpellerTypographyContextRegisterFont(ImpellerTypographyContext context,
       }  // release callback
   );
   return GetPeer(context)->RegisterFont(std::move(wrapped_contents),
-                                        ReadString(family_name_alias));
+                                        family_name_alias);
 }
 
 }  // namespace impeller::interop

--- a/impeller/toolkit/interop/impeller.h
+++ b/impeller/toolkit/interop/impeller.h
@@ -851,6 +851,13 @@ IMPELLER_EXPORT
 void ImpellerTypographyContextRelease(
     ImpellerTypographyContext IMPELLER_NULLABLE context);
 
+IMPELLER_EXPORT
+bool ImpellerTypographyContextRegisterFont(
+    ImpellerTypographyContext IMPELLER_NONNULL context,
+    const ImpellerMapping* IMPELLER_NONNULL contents,
+    void* IMPELLER_NULLABLE contents_on_release_user_data,
+    const char* IMPELLER_NULLABLE family_name_alias);
+
 //------------------------------------------------------------------------------
 // Paragraph Style
 //------------------------------------------------------------------------------

--- a/impeller/toolkit/interop/typography_context.cc
+++ b/impeller/toolkit/interop/typography_context.cc
@@ -7,6 +7,8 @@
 #include <mutex>
 
 #include "flutter/fml/icu_util.h"
+#include "flutter/third_party/txt/src/txt/platform.h"
+#include "impeller/base/validation.h"
 #include "impeller/toolkit/interop/embedded_icu_data.h"
 
 namespace impeller::interop {
@@ -19,7 +21,12 @@ TypographyContext::TypographyContext()
         impeller_embedded_icu_data_data, impeller_embedded_icu_data_length);
     fml::icu::InitializeICUFromMapping(std::move(icu_data));
   });
+  // The fallback for all fonts. Looks in platform specific locations.
   collection_->SetupDefaultFontManager(0u);
+
+  // Looks for fonts in user supplied blobs.
+  asset_font_manager_ = sk_make_sp<skia::textlayout::TypefaceFontProvider>();
+  collection_->SetAssetFontManager(asset_font_manager_);
 }
 
 TypographyContext::~TypographyContext() = default;
@@ -31,6 +38,49 @@ bool TypographyContext::IsValid() const {
 const std::shared_ptr<txt::FontCollection>&
 TypographyContext::GetFontCollection() const {
   return collection_;
+}
+
+static sk_sp<SkTypeface> CreateTypefaceFromFontData(
+    std::unique_ptr<fml::Mapping> font_data) {
+  if (!font_data) {
+    VALIDATION_LOG << "Invalid font data.";
+    return nullptr;
+  }
+  auto sk_data_context = font_data.release();
+  auto sk_data = SkData::MakeWithProc(
+      sk_data_context->GetMapping(),  // data ptr
+      sk_data_context->GetSize(),     // data size
+      [](const void*, void* context) {
+        delete reinterpret_cast<decltype(sk_data_context)>(context);
+      },               // release callback
+      sk_data_context  // release callback context
+  );
+  auto sk_data_stream = SkMemoryStream::Make(sk_data);
+  auto sk_typeface =
+      txt::GetDefaultFontManager()->makeFromStream(std::move(sk_data_stream));
+  if (!sk_typeface) {
+    VALIDATION_LOG << "Could not create typeface with data.";
+    return nullptr;
+  }
+  return sk_typeface;
+}
+
+bool TypographyContext::RegisterFont(std::unique_ptr<fml::Mapping> font_data,
+                                     const std::string& family_name_alias) {
+  auto typeface = CreateTypefaceFromFontData(std::move(font_data));
+  if (typeface == nullptr) {
+    return false;
+  }
+  SkString family_name;
+  typeface->getFamilyName(&family_name);
+  size_t result = 0u;
+  if (family_name_alias.empty()) {
+    result = asset_font_manager_->registerTypeface(std::move(typeface));
+  } else {
+    result = asset_font_manager_->registerTypeface(std::move(typeface),
+                                                   SkString{family_name_alias});
+  }
+  return result != 0;
 }
 
 }  // namespace impeller::interop

--- a/impeller/toolkit/interop/typography_context.cc
+++ b/impeller/toolkit/interop/typography_context.cc
@@ -71,8 +71,6 @@ bool TypographyContext::RegisterFont(std::unique_ptr<fml::Mapping> font_data,
   if (typeface == nullptr) {
     return false;
   }
-  SkString family_name;
-  typeface->getFamilyName(&family_name);
   size_t result = 0u;
   if (family_name_alias.empty()) {
     result = asset_font_manager_->registerTypeface(std::move(typeface));

--- a/impeller/toolkit/interop/typography_context.cc
+++ b/impeller/toolkit/interop/typography_context.cc
@@ -66,13 +66,13 @@ static sk_sp<SkTypeface> CreateTypefaceFromFontData(
 }
 
 bool TypographyContext::RegisterFont(std::unique_ptr<fml::Mapping> font_data,
-                                     const std::string& family_name_alias) {
+                                     const char* family_name_alias) {
   auto typeface = CreateTypefaceFromFontData(std::move(font_data));
   if (typeface == nullptr) {
     return false;
   }
   size_t result = 0u;
-  if (family_name_alias.empty()) {
+  if (family_name_alias == nullptr) {
     result = asset_font_manager_->registerTypeface(std::move(typeface));
   } else {
     result = asset_font_manager_->registerTypeface(std::move(typeface),

--- a/impeller/toolkit/interop/typography_context.h
+++ b/impeller/toolkit/interop/typography_context.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "flutter/third_party/skia/modules/skparagraph/include/TypefaceFontProvider.h"
 #include "flutter/third_party/txt/src/txt/font_collection.h"
 #include "impeller/toolkit/interop/impeller.h"
 #include "impeller/toolkit/interop/object.h"
@@ -29,8 +30,22 @@ class TypographyContext final
 
   const std::shared_ptr<txt::FontCollection>& GetFontCollection() const;
 
+  //----------------------------------------------------------------------------
+  /// @brief      Registers custom font data. If an alias for the family name is
+  ///             provided, subsequent lookups will need to use that same alias.
+  ///             If not, the family name will be read from the font data.
+  ///
+  /// @param[in]  font_data          The font data
+  /// @param[in]  family_name_alias  The family name alias
+  ///
+  /// @return     If the font data could be successfully registered.
+  ///
+  bool RegisterFont(std::unique_ptr<fml::Mapping> font_data,
+                    const std::string& family_name_alias = "");
+
  private:
   std::shared_ptr<txt::FontCollection> collection_;
+  sk_sp<skia::textlayout::TypefaceFontProvider> asset_font_manager_;
 };
 
 }  // namespace impeller::interop

--- a/impeller/toolkit/interop/typography_context.h
+++ b/impeller/toolkit/interop/typography_context.h
@@ -41,7 +41,7 @@ class TypographyContext final
   /// @return     If the font data could be successfully registered.
   ///
   bool RegisterFont(std::unique_ptr<fml::Mapping> font_data,
-                    const std::string& family_name_alias = "");
+                    const char* family_name_alias);
 
  private:
   std::shared_ptr<txt::FontCollection> collection_;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/156361

cc @lyceel. A bit of miscommunication on the priority of this one. I thought the default font factories were sufficient for the next release. But it turns out that was not true on the board which is a custom platform.

In any case, this should unblock custom font registrations. See the `CanCreateParagraphsWithCustomFont` case for an example. If you don't provide the family name alias for the custom font, the name will be read from the font data. This example uses the custom "WhatTheFlutter" custom font family in "wtf.otf".

<img width="1136" alt="Screenshot 2024-10-17 at 1 26 36 PM" src="https://github.com/user-attachments/assets/dbbef2fd-f854-4330-8c82-fc8378489769">
