### PR TITLE
[Impeller] simpler labels for render target textures and cmd buffers.

### DIFF
--- a/impeller/core/texture.h
+++ b/impeller/core/texture.h
@@ -18,7 +18,16 @@ class Texture {
  public:
   virtual ~Texture();
 
+  /// @brief Label this resource for inspection in GPU debugging tools.
+  ///
+  /// This functionality may be disabled in release builds.
   virtual void SetLabel(std::string_view label) = 0;
+
+  /// @brief Label this resource for inspection in GPU debugging tools, with
+  ///        label and trailing will be concatenated together.
+  ///
+  /// This functionality may be disabled in release builds.
+  virtual void SetLabel(std::string_view label, std::string_view trailing) = 0;
 
   // Deprecated: use BlitPass::AddCopy instead.
   [[nodiscard]] bool SetContents(const uint8_t* contents,

--- a/impeller/entity/inline_pass_context.cc
+++ b/impeller/entity/inline_pass_context.cc
@@ -112,9 +112,7 @@ InlinePassContext::RenderPassResult InlinePassContext::GetRenderPass(
     return {};
   }
 
-  command_buffer_->SetLabel(
-      "EntityPass Command Buffer: Depth=" + std::to_string(pass_depth) +
-      " Count=" + std::to_string(pass_count_));
+  command_buffer_->SetLabel("EntityPass Command Buffer");
 
   RenderPassResult result;
   {
@@ -183,9 +181,7 @@ InlinePassContext::RenderPassResult InlinePassContext::GetRenderPass(
   // buffer while encoding can add a surprising amount of overhead. We make a
   // conservative npot estimate to avoid this case.
   pass_->ReserveCommands(Allocation::NextPowerOfTwoSize(entity_count_));
-  pass_->SetLabel(
-      "EntityPass Render Pass: Depth=" + std::to_string(pass_depth) +
-      " Count=" + std::to_string(pass_count_));
+  pass_->SetLabel("EntityPass Render Pass");
 
   result.pass = pass_;
   result.just_created = true;

--- a/impeller/renderer/backend/gles/reactor_gles.cc
+++ b/impeller/renderer/backend/gles/reactor_gles.cc
@@ -28,6 +28,10 @@ bool ReactorGLES::IsValid() const {
   return is_valid_;
 }
 
+bool ReactorGLES::CanSetDebugLabels() const {
+  return can_set_debug_labels_;
+}
+
 ReactorGLES::WorkerID ReactorGLES::AddWorker(std::weak_ptr<Worker> worker) {
   Lock lock(workers_mutex_);
   auto id = WorkerID{};

--- a/impeller/renderer/backend/gles/reactor_gles.h
+++ b/impeller/renderer/backend/gles/reactor_gles.h
@@ -192,6 +192,13 @@ class ReactorGLES {
   ///
   void SetDebugLabel(const HandleGLES& handle, std::string_view label);
 
+  //----------------------------------------------------------------------------
+  /// @brief      Whether the device is capable of writing debug labels.
+  ///
+  ///             This function is useful for short circuiting expensive debug
+  ///             labeling.
+  bool CanSetDebugLabels() const;
+
   using Operation = std::function<void(const ReactorGLES& reactor)>;
 
   //----------------------------------------------------------------------------

--- a/impeller/renderer/backend/gles/texture_gles.cc
+++ b/impeller/renderer/backend/gles/texture_gles.cc
@@ -11,6 +11,7 @@
 #include "flutter/fml/mapping.h"
 #include "flutter/fml/trace_event.h"
 #include "impeller/base/allocation.h"
+#include "impeller/base/strings.h"
 #include "impeller/base/validation.h"
 #include "impeller/core/formats.h"
 #include "impeller/core/texture_descriptor.h"
@@ -207,7 +208,19 @@ bool TextureGLES::IsValid() const {
 
 // |Texture|
 void TextureGLES::SetLabel(std::string_view label) {
-  reactor_->SetDebugLabel(handle_, std::string{label.data(), label.size()});
+#ifdef IMPELLER_DEBUG
+  reactor_->SetDebugLabel(handle_, label);
+#endif  // IMPELLER_DEBUG
+}
+
+// |Texture|
+void TextureGLES::SetLabel(std::string_view label, std::string_view trailing) {
+#ifdef IMPELLER_DEBUG
+  if (reactor_->CanSetDebugLabels()) {
+    reactor_->SetDebugLabel(handle_,
+                            SPrintF("%s %s", label.data(), trailing.data()));
+  }
+#endif  // IMPELLER_DEBUG
 }
 
 // |Texture|

--- a/impeller/renderer/backend/gles/texture_gles.h
+++ b/impeller/renderer/backend/gles/texture_gles.h
@@ -95,6 +95,9 @@ class TextureGLES final : public Texture,
   void SetLabel(std::string_view label) override;
 
   // |Texture|
+  void SetLabel(std::string_view label, std::string_view trailing) override;
+
+  // |Texture|
   bool OnSetContents(const uint8_t* contents,
                      size_t length,
                      size_t slice) override;

--- a/impeller/renderer/backend/metal/texture_mtl.h
+++ b/impeller/renderer/backend/metal/texture_mtl.h
@@ -67,6 +67,9 @@ class TextureMTL final : public Texture,
   void SetLabel(std::string_view label) override;
 
   // |Texture|
+  void SetLabel(std::string_view label, std::string_view trailing) override;
+
+  // |Texture|
   bool OnSetContents(const uint8_t* contents,
                      size_t length,
                      size_t slice) override;

--- a/impeller/renderer/backend/metal/texture_mtl.mm
+++ b/impeller/renderer/backend/metal/texture_mtl.mm
@@ -5,6 +5,7 @@
 #include "impeller/renderer/backend/metal/texture_mtl.h"
 #include <memory>
 
+#include "impeller/base/strings.h"
 #include "impeller/base/validation.h"
 #include "impeller/core/formats.h"
 #include "impeller/core/texture_descriptor.h"
@@ -73,10 +74,22 @@ TextureMTL::~TextureMTL() {
 }
 
 void TextureMTL::SetLabel(std::string_view label) {
+#ifdef IMPELLER_DEBUG
   if (is_drawable_) {
     return;
   }
   [aquire_proc_() setLabel:@(label.data())];
+#endif  // IMPELLER_DEBUG
+}
+
+void TextureMTL::SetLabel(std::string_view label, std::string_view trailing) {
+#ifdef IMPELLER_DEBUG
+  if (is_drawable_) {
+    return;
+  }
+  std::string combined = SPrintF("%s %s", label.data(), trailing.data());
+  [aquire_proc_() setLabel:@(combined.data())];
+#endif  // IMPELLER_DEBUG
 }
 
 // |Texture|

--- a/impeller/renderer/backend/vulkan/context_vk.h
+++ b/impeller/renderer/backend/vulkan/context_vk.h
@@ -12,6 +12,7 @@
 #include "flutter/fml/unique_fd.h"
 #include "fml/thread.h"
 #include "impeller/base/backend_cast.h"
+#include "impeller/base/strings.h"
 #include "impeller/core/formats.h"
 #include "impeller/renderer/backend/vulkan/command_pool_vk.h"
 #include "impeller/renderer/backend/vulkan/device_holder_vk.h"
@@ -108,6 +109,18 @@ class ContextVK final : public Context,
   template <typename T>
   bool SetDebugName(T handle, std::string_view label) const {
     return SetDebugName(GetDevice(), handle, label);
+  }
+
+  template <typename T>
+  bool SetDebugName(T handle,
+                    std::string_view label,
+                    std::string_view trailing) const {
+    if (!HasValidationLayers()) {
+      // No-op if validation layers are not enabled.
+      return true;
+    }
+    std::string combined = SPrintF("%s %s", label.data(), trailing.data());
+    return SetDebugName(GetDevice(), handle, combined);
   }
 
   template <typename T>

--- a/impeller/renderer/backend/vulkan/texture_vk.cc
+++ b/impeller/renderer/backend/vulkan/texture_vk.cc
@@ -19,6 +19,7 @@ TextureVK::TextureVK(std::weak_ptr<Context> context,
 TextureVK::~TextureVK() = default;
 
 void TextureVK::SetLabel(std::string_view label) {
+#ifdef IMPELLER_DEBUG
   auto context = context_.lock();
   if (!context) {
     // The context may have died.
@@ -26,6 +27,20 @@ void TextureVK::SetLabel(std::string_view label) {
   }
   ContextVK::Cast(*context).SetDebugName(GetImage(), label);
   ContextVK::Cast(*context).SetDebugName(GetImageView(), label);
+#endif  // IMPELLER_DEBUG
+}
+
+void TextureVK::SetLabel(std::string_view label, std::string_view trailing) {
+#ifdef IMPELLER_DEBUG
+  auto context = context_.lock();
+  if (!context) {
+    // The context may have died.
+    return;
+  }
+
+  ContextVK::Cast(*context).SetDebugName(GetImage(), label, trailing);
+  ContextVK::Cast(*context).SetDebugName(GetImageView(), label, trailing);
+#endif  // IMPELLER_DEBUG
 }
 
 bool TextureVK::OnSetContents(const uint8_t* contents,

--- a/impeller/renderer/backend/vulkan/texture_vk.h
+++ b/impeller/renderer/backend/vulkan/texture_vk.h
@@ -82,6 +82,9 @@ class TextureVK final : public Texture, public BackendCast<TextureVK, Texture> {
   void SetLabel(std::string_view label) override;
 
   // |Texture|
+  void SetLabel(std::string_view label, std::string_view trailing) override;
+
+  // |Texture|
   bool OnSetContents(const uint8_t* contents,
                      size_t length,
                      size_t slice) override;

--- a/impeller/renderer/render_target.cc
+++ b/impeller/renderer/render_target.cc
@@ -289,9 +289,7 @@ RenderTarget RenderTargetAllocator::CreateOffscreen(
       return {};
     }
   }
-#ifdef IMPELLER_DEBUG
-  color0_tex->SetLabel(SPrintF("%s Color Texture", label.data()));
-#endif  // IMPELLER_DEBUG
+  color0_tex->SetLabel(label, "Color Texture");
 
   ColorAttachment color0;
   color0.clear_color = color_attachment_config.clear_color;
@@ -351,10 +349,7 @@ RenderTarget RenderTargetAllocator::CreateOffscreenMSAA(
       return {};
     }
   }
-#ifdef IMPELLER_DEBUG
-  color0_msaa_tex->SetLabel(
-      SPrintF("%s Color Texture (Multisample)", label.data()));
-#endif  // IMPELLER_DEBUG
+  color0_msaa_tex->SetLabel(label, "Color Texture (Multisample)");
 
   // Create color resolve texture.
   std::shared_ptr<Texture> color0_resolve_tex;
@@ -376,9 +371,7 @@ RenderTarget RenderTargetAllocator::CreateOffscreenMSAA(
       return {};
     }
   }
-#ifdef IMPELLER_DEBUG
-  color0_resolve_tex->SetLabel(SPrintF("%s Color Texture", label.data()));
-#endif  // IMPELLER_DEBUG
+  color0_resolve_tex->SetLabel(label, "Color Texture");
 
   // Color attachment.
 
@@ -456,10 +449,8 @@ void RenderTarget::SetupDepthStencilAttachments(
   stencil0.store_action = stencil_attachment_config.store_action;
   stencil0.clear_stencil = 0u;
   stencil0.texture = std::move(depth_stencil_texture);
+  stencil0.texture->SetLabel(label, "Depth+Stencil Texture");
 
-#ifdef IMPELLER_DEBUG
-  stencil0.texture->SetLabel(SPrintF("%s Depth+Stencil Texture", label.data()));
-#endif  // IMPELLER_DEBUG
   SetDepthAttachment(std::move(depth0));
   SetStencilAttachment(std::move(stencil0));
 }

--- a/impeller/renderer/testing/mocks.h
+++ b/impeller/renderer/testing/mocks.h
@@ -189,6 +189,10 @@ class MockTexture : public Texture {
  public:
   explicit MockTexture(const TextureDescriptor& desc) : Texture(desc) {}
   MOCK_METHOD(void, SetLabel, (std::string_view label), (override));
+  MOCK_METHOD(void,
+              SetLabel,
+              (std::string_view label, std::string_view trailing),
+              (override));
   MOCK_METHOD(bool, IsValid, (), (const, override));
   MOCK_METHOD(ISize, GetSize, (), (const, override));
   MOCK_METHOD(bool,

--- a/lib/ui/painting/image_decoder_no_gl_unittests.h
+++ b/lib/ui/painting/image_decoder_no_gl_unittests.h
@@ -22,6 +22,7 @@ class TestImpellerTexture : public Texture {
   explicit TestImpellerTexture(TextureDescriptor desc) : Texture(desc) {}
 
   void SetLabel(std::string_view label) override {}
+  void SetLabel(std::string_view label, std::string_view trailing) override {}
   bool IsValid() const override { return true; }
   ISize GetSize() const { return GetTextureDescriptor().size; }
 


### PR DESCRIPTION
Avoid Sprintf'ing labels for textures/cmd buffers/render passes. For the render target textures, defer combined label construction until we know the label will be used.
