### PR TITLE
Beta fix macos xcprivacy manifest copy location

### DIFF
--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -253,7 +253,8 @@ copy("copy_framework_module_map") {
 copy("copy_framework_privacy_manifest") {
   visibility = [ ":*" ]
   sources = [ "framework/PrivacyInfo.xcprivacy" ]
-  outputs = [ "$_flutter_framework_dir/Versions/A/Resources/PrivacyInfo.xcprivacy" ]
+  outputs =
+      [ "$_flutter_framework_dir/Versions/A/Resources/PrivacyInfo.xcprivacy" ]
 }
 
 action("copy_framework_headers") {

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -253,7 +253,7 @@ copy("copy_framework_module_map") {
 copy("copy_framework_privacy_manifest") {
   visibility = [ ":*" ]
   sources = [ "framework/PrivacyInfo.xcprivacy" ]
-  outputs = [ "$_flutter_framework_dir/PrivacyInfo.xcprivacy" ]
+  outputs = [ "$_flutter_framework_dir/Versions/A/Resources/PrivacyInfo.xcprivacy" ]
 }
 
 action("copy_framework_headers") {


### PR DESCRIPTION
We were copying the macOS privacy manifest to the wrong path, which led to codesigning failing.

See https://github.com/flutter/flutter/issues/157016#issuecomment-2420786225 for more context.