### PR TITLE
Move redispatch_event from FlKeyboardViewDelegate to FlKeyboardManager

### DIFF
--- a/shell/platform/linux/fl_keyboard_manager.h
+++ b/shell/platform/linux/fl_keyboard_manager.h
@@ -102,6 +102,20 @@ GHashTable* fl_keyboard_manager_get_pressed_state(FlKeyboardManager* manager);
  */
 void fl_keyboard_manager_notify_layout_changed(FlKeyboardManager* manager);
 
+typedef void (*FlKeyboardManagerRedispatchEventHandler)(FlKeyEvent* event,
+                                                        gpointer user_data);
+
+/**
+ * fl_keyboard_manager_set_redispatch_handler:
+ * @manager: the #FlKeyboardManager self.
+ *
+ * Set the handler for redispatches, for testing purposes only.
+ */
+void fl_keyboard_manager_set_redispatch_handler(
+    FlKeyboardManager* manager,
+    FlKeyboardManagerRedispatchEventHandler redispatch_handler,
+    gpointer user_data);
+
 G_END_DECLS
 
 #endif  // FLUTTER_SHELL_PLATFORM_LINUX_FL_KEYBOARD_MANAGER_H_

--- a/shell/platform/linux/fl_keyboard_view_delegate.cc
+++ b/shell/platform/linux/fl_keyboard_view_delegate.cc
@@ -32,15 +32,6 @@ gboolean fl_keyboard_view_delegate_text_filter_key_press(
       self, event);
 }
 
-void fl_keyboard_view_delegate_redispatch_event(FlKeyboardViewDelegate* self,
-                                                FlKeyEvent* event) {
-  g_return_if_fail(FL_IS_KEYBOARD_VIEW_DELEGATE(self));
-  g_return_if_fail(event != nullptr);
-
-  return FL_KEYBOARD_VIEW_DELEGATE_GET_IFACE(self)->redispatch_event(self,
-                                                                     event);
-}
-
 guint fl_keyboard_view_delegate_lookup_key(FlKeyboardViewDelegate* self,
                                            const GdkKeymapKey* key) {
   g_return_val_if_fail(FL_IS_KEYBOARD_VIEW_DELEGATE(self), 0);

--- a/shell/platform/linux/fl_keyboard_view_delegate.h
+++ b/shell/platform/linux/fl_keyboard_view_delegate.h
@@ -42,8 +42,6 @@ struct _FlKeyboardViewDelegateInterface {
   gboolean (*text_filter_key_press)(FlKeyboardViewDelegate* delegate,
                                     FlKeyEvent* event);
 
-  void (*redispatch_event)(FlKeyboardViewDelegate* delegate, FlKeyEvent* event);
-
   guint (*lookup_key)(FlKeyboardViewDelegate* view_delegate,
                       const GdkKeymapKey* key);
 
@@ -76,16 +74,6 @@ void fl_keyboard_view_delegate_send_key_event(FlKeyboardViewDelegate* delegate,
  * The ownership of the `event` is kept by the keyboard handler.
  */
 gboolean fl_keyboard_view_delegate_text_filter_key_press(
-    FlKeyboardViewDelegate* delegate,
-    FlKeyEvent* event);
-
-/**
- * fl_keyboard_view_delegate_redispatch_event:
- *
- * Handles `FlKeyboardHandler`'s request to insert a GDK event to the system for
- * redispatching.
- */
-void fl_keyboard_view_delegate_redispatch_event(
     FlKeyboardViewDelegate* delegate,
     FlKeyEvent* event);
 

--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -385,15 +385,6 @@ static void fl_view_keyboard_delegate_iface_init(
                                                  event);
   };
 
-  iface->redispatch_event = [](FlKeyboardViewDelegate* view_delegate,
-                               FlKeyEvent* event) {
-    GdkEventType event_type =
-        gdk_event_get_event_type(fl_key_event_get_origin(event));
-    g_return_if_fail(event_type == GDK_KEY_PRESS ||
-                     event_type == GDK_KEY_RELEASE);
-    gdk_event_put(fl_key_event_get_origin(event));
-  };
-
   iface->lookup_key = [](FlKeyboardViewDelegate* view_delegate,
                          const GdkKeymapKey* key) -> guint {
     FlView* self = FL_VIEW(view_delegate);


### PR DESCRIPTION
Events can only be redispatched using gdk_event_put which is not dependent on the view.

Ideally the tests would mock gdk_event_put, but I wasn't able to get it working so I've added fl_keyboard_manager_set_redispatch_handler for now.

