### PR TITLE
Move keymap from FlKeyboardViewDelegate to FlKeyboardManager

### DIFF
--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -248,6 +248,7 @@ executable("flutter_linux_unittests") {
     "testing/mock_engine.cc",
     "testing/mock_epoxy.cc",
     "testing/mock_im_context.cc",
+    "testing/mock_keymap.cc",
     "testing/mock_plugin_registrar.cc",
     "testing/mock_renderer.cc",
     "testing/mock_settings.cc",

--- a/shell/platform/linux/fl_keyboard_manager.h
+++ b/shell/platform/linux/fl_keyboard_manager.h
@@ -94,11 +94,26 @@ void fl_keyboard_manager_sync_modifier_if_needed(FlKeyboardManager* manager,
  */
 GHashTable* fl_keyboard_manager_get_pressed_state(FlKeyboardManager* manager);
 
+typedef guint (*FlKeyboardManagerLookupKeyHandler)(const GdkKeymapKey* key,
+                                                   gpointer user_data);
+
+/**
+ * fl_keyboard_manager_set_lookup_key_handler:
+ * @manager: the #FlKeyboardManager self.
+ *
+ * Set the handler for key lookup, for testing purposes only.
+ */
+void fl_keyboard_manager_set_lookup_key_handler(
+    FlKeyboardManager* manager,
+    FlKeyboardManagerLookupKeyHandler lookup_key_handler,
+    gpointer user_data);
+
 /**
  * fl_keyboard_manager_notify_layout_changed:
  * @manager: the #FlKeyboardManager self.
  *
- * Notify the manager the keyboard layout has changed.
+ * Notify the manager the keyboard layout has changed, for testing purposes
+ * only.
  */
 void fl_keyboard_manager_notify_layout_changed(FlKeyboardManager* manager);
 

--- a/shell/platform/linux/fl_keyboard_manager_test.cc
+++ b/shell/platform/linux/fl_keyboard_manager_test.cc
@@ -15,6 +15,7 @@
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_method_codec.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_standard_method_codec.h"
 #include "flutter/shell/platform/linux/testing/fl_test.h"
+#include "flutter/shell/platform/linux/testing/mock_keymap.h"
 #include "flutter/shell/platform/linux/testing/mock_text_input_handler.h"
 #include "flutter/testing/testing.h"
 
@@ -533,6 +534,7 @@ class KeyboardTester {
 // Make sure that the keyboard can be disposed without crashes when there are
 // unresolved pending events.
 TEST(FlKeyboardManagerTest, DisposeWithUnresolvedPends) {
+  ::testing::NiceMock<flutter::testing::MockKeymap> mock_keymap;
   KeyboardTester tester;
   std::vector<CallRecord> call_records;
 
@@ -553,6 +555,7 @@ TEST(FlKeyboardManagerTest, DisposeWithUnresolvedPends) {
 }
 
 TEST(FlKeyboardManagerTest, SingleDelegateWithAsyncResponds) {
+  ::testing::NiceMock<flutter::testing::MockKeymap> mock_keymap;
   KeyboardTester tester;
   std::vector<CallRecord> call_records;
   g_autoptr(GPtrArray) redispatched =
@@ -640,6 +643,7 @@ TEST(FlKeyboardManagerTest, SingleDelegateWithAsyncResponds) {
 }
 
 TEST(FlKeyboardManagerTest, SingleDelegateWithSyncResponds) {
+  ::testing::NiceMock<flutter::testing::MockKeymap> mock_keymap;
   KeyboardTester tester;
   gboolean handler_handled = false;
   std::vector<CallRecord> call_records;
@@ -687,6 +691,7 @@ TEST(FlKeyboardManagerTest, SingleDelegateWithSyncResponds) {
 }
 
 TEST(FlKeyboardManagerTest, WithTwoAsyncDelegates) {
+  ::testing::NiceMock<flutter::testing::MockKeymap> mock_keymap;
   KeyboardTester tester;
   std::vector<CallRecord> call_records;
   g_autoptr(GPtrArray) redispatched =
@@ -746,6 +751,7 @@ TEST(FlKeyboardManagerTest, WithTwoAsyncDelegates) {
 }
 
 TEST(FlKeyboardManagerTest, TextInputHandlerReturnsFalse) {
+  ::testing::NiceMock<flutter::testing::MockKeymap> mock_keymap;
   KeyboardTester tester;
   g_autoptr(GPtrArray) redispatched =
       g_ptr_array_new_with_free_func(g_object_unref);
@@ -769,6 +775,7 @@ TEST(FlKeyboardManagerTest, TextInputHandlerReturnsFalse) {
 }
 
 TEST(FlKeyboardManagerTest, TextInputHandlerReturnsTrue) {
+  ::testing::NiceMock<flutter::testing::MockKeymap> mock_keymap;
   KeyboardTester tester;
   g_autoptr(GPtrArray) redispatched =
       g_ptr_array_new_with_free_func(g_object_unref);
@@ -789,6 +796,7 @@ TEST(FlKeyboardManagerTest, TextInputHandlerReturnsTrue) {
 }
 
 TEST(FlKeyboardManagerTest, CorrectLogicalKeyForLayouts) {
+  ::testing::NiceMock<flutter::testing::MockKeymap> mock_keymap;
   KeyboardTester tester;
 
   std::vector<CallRecord> call_records;
@@ -882,6 +890,7 @@ TEST(FlKeyboardManagerTest, CorrectLogicalKeyForLayouts) {
 }
 
 TEST(FlKeyboardManagerTest, SynthesizeModifiersIfNeeded) {
+  ::testing::NiceMock<flutter::testing::MockKeymap> mock_keymap;
   KeyboardTester tester;
   std::vector<CallRecord> call_records;
   tester.recordEmbedderCallsTo(call_records);
@@ -920,6 +929,7 @@ TEST(FlKeyboardManagerTest, SynthesizeModifiersIfNeeded) {
 }
 
 TEST(FlKeyboardManagerTest, GetPressedState) {
+  ::testing::NiceMock<flutter::testing::MockKeymap> mock_keymap;
   KeyboardTester tester;
   tester.respondToTextInputWith(true);
 

--- a/shell/platform/linux/fl_keyboard_view_delegate.cc
+++ b/shell/platform/linux/fl_keyboard_view_delegate.cc
@@ -32,13 +32,6 @@ gboolean fl_keyboard_view_delegate_text_filter_key_press(
       self, event);
 }
 
-guint fl_keyboard_view_delegate_lookup_key(FlKeyboardViewDelegate* self,
-                                           const GdkKeymapKey* key) {
-  g_return_val_if_fail(FL_IS_KEYBOARD_VIEW_DELEGATE(self), 0);
-
-  return FL_KEYBOARD_VIEW_DELEGATE_GET_IFACE(self)->lookup_key(self, key);
-}
-
 GHashTable* fl_keyboard_view_delegate_get_keyboard_state(
     FlKeyboardViewDelegate* self) {
   g_return_val_if_fail(FL_IS_KEYBOARD_VIEW_DELEGATE(self), nullptr);

--- a/shell/platform/linux/fl_keyboard_view_delegate.h
+++ b/shell/platform/linux/fl_keyboard_view_delegate.h
@@ -42,9 +42,6 @@ struct _FlKeyboardViewDelegateInterface {
   gboolean (*text_filter_key_press)(FlKeyboardViewDelegate* delegate,
                                     FlKeyEvent* event);
 
-  guint (*lookup_key)(FlKeyboardViewDelegate* view_delegate,
-                      const GdkKeymapKey* key);
-
   GHashTable* (*get_keyboard_state)(FlKeyboardViewDelegate* delegate);
 };
 
@@ -76,9 +73,6 @@ void fl_keyboard_view_delegate_send_key_event(FlKeyboardViewDelegate* delegate,
 gboolean fl_keyboard_view_delegate_text_filter_key_press(
     FlKeyboardViewDelegate* delegate,
     FlKeyEvent* event);
-
-guint fl_keyboard_view_delegate_lookup_key(FlKeyboardViewDelegate* delegate,
-                                           const GdkKeymapKey* key);
 
 /**
  * fl_keyboard_view_delegate_get_keyboard_state:

--- a/shell/platform/linux/testing/mock_keymap.cc
+++ b/shell/platform/linux/testing/mock_keymap.cc
@@ -1,5 +1,4 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
-
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/shell/platform/linux/testing/mock_keymap.cc
+++ b/shell/platform/linux/testing/mock_keymap.cc
@@ -1,0 +1,41 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/linux/testing/mock_keymap.h"
+
+using namespace flutter::testing;
+
+G_DECLARE_FINAL_TYPE(FlMockKeymap, fl_mock_keymap, FL, MOCK_KEYMAP, GObject)
+
+struct _FlMockKeymap {
+  GObject parent_instance;
+  MockKeymap* mock;
+};
+
+G_DEFINE_TYPE(FlMockKeymap, fl_mock_keymap, G_TYPE_OBJECT)
+
+static void fl_mock_keymap_class_init(FlMockKeymapClass* klass) {
+  g_signal_new("keys-changed", fl_mock_keymap_get_type(), G_SIGNAL_RUN_LAST, 0,
+               nullptr, nullptr, nullptr, G_TYPE_NONE, 0);
+}
+
+static void fl_mock_keymap_init(FlMockKeymap* self) {}
+
+static MockKeymap* mock = nullptr;
+
+MockKeymap::MockKeymap() {
+  mock = this;
+}
+
+GdkKeymap* gdk_keymap_get_for_display(GdkDisplay* display) {
+  FlMockKeymap* keymap =
+      FL_MOCK_KEYMAP(g_object_new(fl_mock_keymap_get_type(), nullptr));
+  (void)FL_IS_MOCK_KEYMAP(keymap);
+  return reinterpret_cast<GdkKeymap*>(keymap);
+}
+
+guint gdk_keymap_lookup_key(GdkKeymap* keymap, const GdkKeymapKey* key) {
+  return mock->gdk_keymap_lookup_key(keymap, key);
+}

--- a/shell/platform/linux/testing/mock_keymap.h
+++ b/shell/platform/linux/testing/mock_keymap.h
@@ -1,0 +1,28 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_LINUX_TESTING_MOCK_KEYMAP_H_
+#define FLUTTER_SHELL_PLATFORM_LINUX_TESTING_MOCK_KEYMAP_H_
+
+#include "gmock/gmock.h"
+
+#include <gdk/gdk.h>
+
+namespace flutter {
+namespace testing {
+
+class MockKeymap {
+ public:
+  MockKeymap();
+
+  MOCK_METHOD(GdkKeymap*, gdk_keymap_get_for_display, (GdkDisplay * display));
+  MOCK_METHOD(guint,
+              gdk_keymap_lookup_key,
+              (GdkKeymap * keymap, const GdkKeymapKey* key));
+};
+
+}  // namespace testing
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_LINUX_TESTING_MOCK_KEYMAP_H_


### PR DESCRIPTION
Ideally the tests would mock gdk_keymap_lookup_key, but I wasn't able to get it working so I've added fl_keyboard_manager_set_lookup_key_handler for now.
