### PR TITLE
Request another frame in ImageReaderSurfaceProducer.dequeueImage if more images are pending in the queue

### DIFF
--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -826,4 +826,43 @@ public class FlutterRendererTest {
     // Verify.
     latch.await();
   }
+
+  @Test
+  public void ImageReaderSurfaceProducerSchedulesFrameIfQueueNotEmpty() throws Exception {
+    FlutterRenderer flutterRenderer = spy(engineRule.getFlutterEngine().getRenderer());
+    TextureRegistry.SurfaceProducer producer = flutterRenderer.createSurfaceProducer();
+    FlutterRenderer.ImageReaderSurfaceProducer texture =
+        (FlutterRenderer.ImageReaderSurfaceProducer) producer;
+    texture.disableFenceForTest();
+    texture.setSize(1, 1);
+
+    // Render two frames.
+    for (int i = 0; i < 2; i++) {
+      Surface surface = texture.getSurface();
+      assertNotNull(surface);
+      Canvas canvas = surface.lockHardwareCanvas();
+      canvas.drawARGB(255, 255, 0, 0);
+      surface.unlockCanvasAndPost(canvas);
+      shadowOf(Looper.getMainLooper()).idle();
+    }
+
+    // Each enqueue of an image should result in a call to scheduleEngineFrame.
+    verify(flutterRenderer, times(2)).scheduleEngineFrame();
+
+    // Consume the first image.
+    Image image = texture.acquireLatestImage();
+    shadowOf(Looper.getMainLooper()).idle();
+
+    // The dequeue should call scheduleEngineFrame because another image
+    // remains in the queue.
+    verify(flutterRenderer, times(3)).scheduleEngineFrame();
+
+    // Consume the second image.
+    image = texture.acquireLatestImage();
+    shadowOf(Looper.getMainLooper()).idle();
+
+    // The dequeue should not call scheduleEngineFrame because the queue
+    // is now empty.
+    verify(flutterRenderer, times(3)).scheduleEngineFrame();
+  }
 }


### PR DESCRIPTION
ImageReaderSurfaceProducer will request a frame when an image is enqueued. But there is no guarantee that each request will produce an additional frame.
Multiple requests happening within one vsync interval could be merged into one frame.  If no other frame is scheduled, then some images will remain in the queue and the image shown on screen will not be the latest image.

With this change, ImageReaderSurfaceProducer will continue requesting frames after consuming an image if the queue is not empty.

Fixes https://github.com/flutter/flutter/issues/156903
Fixes https://github.com/flutter/flutter/issues/155787