### PR TITLE
Revert "Reland "iOS: Migrate FlutterEngine to ARC" (#55937)"

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -70,9 +70,7 @@ source_set("flutter_framework_source_arc") {
     "framework/Source/FlutterDartVMServicePublisher.mm",
     "framework/Source/FlutterEmbedderKeyResponder.h",
     "framework/Source/FlutterEmbedderKeyResponder.mm",
-    "framework/Source/FlutterEngine.mm",
     "framework/Source/FlutterEngineGroup.mm",
-    "framework/Source/FlutterEngine_Internal.h",
     "framework/Source/FlutterHeadlessDartRunner.mm",
     "framework/Source/FlutterKeyPrimaryResponder.h",
     "framework/Source/FlutterKeySecondaryResponder.h",
@@ -188,6 +186,8 @@ source_set("flutter_framework_source") {
     # iOS embedder is migrating to ARC.
     # New files are highly encouraged to be in ARC.
     # To add new files in ARC, add them to the `flutter_framework_source_arc` target.
+    "framework/Source/FlutterEngine.mm",
+    "framework/Source/FlutterEngine_Internal.h",
     "framework/Source/FlutterViewController.mm",
     "framework/Source/FlutterViewController_Internal.h",
     "platform_view_ios.h",

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h
@@ -12,7 +12,7 @@
 @interface FlutterPlatformPlugin : NSObject
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-- (instancetype)initWithEngine:(FlutterEngine*)engine NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithEngine:(fml::WeakNSObject<FlutterEngine>)engine NS_DESIGNATED_INITIALIZER;
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result;
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -82,7 +82,7 @@ static void SetStatusBarStyleForSharedApplication(UIStatusBarStyle style) {
 
 @implementation FlutterPlatformPlugin
 
-- (instancetype)initWithEngine:(FlutterEngine*)engine {
+- (instancetype)initWithEngine:(fml::WeakNSObject<FlutterEngine>)engine {
   FML_DCHECK(engine) << "engine must be set";
   self = [super init];
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPluginTest.mm
@@ -37,12 +37,15 @@ FLUTTER_ASSERT_ARC
   OCMStub([mockApplication sharedApplication]).andReturn(mockApplication);
 
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
+  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
+      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
   [engine runWithEntrypoint:nil];
 
   XCTestExpectation* invokeExpectation =
       [self expectationWithDescription:@"Web search launched with escaped search term"];
 
-  FlutterPlatformPlugin* plugin = [[FlutterPlatformPlugin alloc] initWithEngine:engine];
+  FlutterPlatformPlugin* plugin =
+      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
   FlutterPlatformPlugin* mockPlugin = OCMPartialMock(plugin);
 
   FlutterMethodCall* methodCall = [FlutterMethodCall methodCallWithMethodName:@"SearchWeb.invoke"
@@ -68,12 +71,15 @@ FLUTTER_ASSERT_ARC
   OCMStub([mockApplication sharedApplication]).andReturn(mockApplication);
 
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
+  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
+      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
   [engine runWithEntrypoint:nil];
 
   XCTestExpectation* invokeExpectation =
       [self expectationWithDescription:@"Web search launched with non escaped search term"];
 
-  FlutterPlatformPlugin* plugin = [[FlutterPlatformPlugin alloc] initWithEngine:engine];
+  FlutterPlatformPlugin* plugin =
+      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
   FlutterPlatformPlugin* mockPlugin = OCMPartialMock(plugin);
 
   FlutterMethodCall* methodCall = [FlutterMethodCall methodCallWithMethodName:@"SearchWeb.invoke"
@@ -97,6 +103,8 @@ FLUTTER_ASSERT_ARC
 - (void)testLookUpCallInitiated {
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
   [engine runWithEntrypoint:nil];
+  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
+      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
 
   XCTestExpectation* presentExpectation =
       [self expectationWithDescription:@"Look Up view controller presented"];
@@ -106,7 +114,8 @@ FLUTTER_ASSERT_ARC
                                                                                        bundle:nil];
   FlutterViewController* mockEngineViewController = OCMPartialMock(engineViewController);
 
-  FlutterPlatformPlugin* plugin = [[FlutterPlatformPlugin alloc] initWithEngine:engine];
+  FlutterPlatformPlugin* plugin =
+      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
   FlutterPlatformPlugin* mockPlugin = OCMPartialMock(plugin);
 
   FlutterMethodCall* methodCall = [FlutterMethodCall methodCallWithMethodName:@"LookUp.invoke"
@@ -125,6 +134,8 @@ FLUTTER_ASSERT_ARC
 - (void)testShareScreenInvoked {
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
   [engine runWithEntrypoint:nil];
+  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
+      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
 
   XCTestExpectation* presentExpectation =
       [self expectationWithDescription:@"Share view controller presented"];
@@ -138,7 +149,8 @@ FLUTTER_ASSERT_ARC
                    animated:YES
                  completion:nil]);
 
-  FlutterPlatformPlugin* plugin = [[FlutterPlatformPlugin alloc] initWithEngine:engine];
+  FlutterPlatformPlugin* plugin =
+      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
   FlutterPlatformPlugin* mockPlugin = OCMPartialMock(plugin);
 
   FlutterMethodCall* methodCall = [FlutterMethodCall methodCallWithMethodName:@"Share.invoke"
@@ -157,6 +169,8 @@ FLUTTER_ASSERT_ARC
 - (void)testShareScreenInvokedOnIPad {
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
   [engine runWithEntrypoint:nil];
+  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
+      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
 
   XCTestExpectation* presentExpectation =
       [self expectationWithDescription:@"Share view controller presented on iPad"];
@@ -173,7 +187,8 @@ FLUTTER_ASSERT_ARC
   id mockTraitCollection = OCMClassMock([UITraitCollection class]);
   OCMStub([mockTraitCollection userInterfaceIdiom]).andReturn(UIUserInterfaceIdiomPad);
 
-  FlutterPlatformPlugin* plugin = [[FlutterPlatformPlugin alloc] initWithEngine:engine];
+  FlutterPlatformPlugin* plugin =
+      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
   FlutterPlatformPlugin* mockPlugin = OCMPartialMock(plugin);
 
   FlutterMethodCall* methodCall = [FlutterMethodCall methodCallWithMethodName:@"Share.invoke"
@@ -192,7 +207,10 @@ FLUTTER_ASSERT_ARC
 - (void)testClipboardHasCorrectStrings {
   [UIPasteboard generalPasteboard].string = nil;
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
-  FlutterPlatformPlugin* plugin = [[FlutterPlatformPlugin alloc] initWithEngine:engine];
+  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
+      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
+  FlutterPlatformPlugin* plugin =
+      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
 
   XCTestExpectation* setStringExpectation = [self expectationWithDescription:@"setString"];
   FlutterResult resultSet = ^(id result) {
@@ -228,7 +246,10 @@ FLUTTER_ASSERT_ARC
 - (void)testClipboardSetDataToNullDoNotCrash {
   [UIPasteboard generalPasteboard].string = nil;
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
-  FlutterPlatformPlugin* plugin = [[FlutterPlatformPlugin alloc] initWithEngine:engine];
+  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
+      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
+  FlutterPlatformPlugin* plugin =
+      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
 
   XCTestExpectation* setStringExpectation = [self expectationWithDescription:@"setData"];
   FlutterResult resultSet = ^(id result) {
@@ -259,7 +280,10 @@ FLUTTER_ASSERT_ARC
       [[UINavigationController alloc] initWithRootViewController:flutterViewController];
   UITabBarController* tabBarController = [[UITabBarController alloc] init];
   tabBarController.viewControllers = @[ navigationController ];
-  FlutterPlatformPlugin* plugin = [[FlutterPlatformPlugin alloc] initWithEngine:engine];
+  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
+      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
+  FlutterPlatformPlugin* plugin =
+      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
 
   id navigationControllerMock = OCMPartialMock(navigationController);
   OCMStub([navigationControllerMock popViewControllerAnimated:YES]);
@@ -279,9 +303,12 @@ FLUTTER_ASSERT_ARC
 
 - (void)testWhetherDeviceHasLiveTextInputInvokeCorrectly {
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
+  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
+      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
   XCTestExpectation* invokeExpectation =
       [self expectationWithDescription:@"isLiveTextInputAvailableInvoke"];
-  FlutterPlatformPlugin* plugin = [[FlutterPlatformPlugin alloc] initWithEngine:engine];
+  FlutterPlatformPlugin* plugin =
+      [[FlutterPlatformPlugin alloc] initWithEngine:_weakFactory->GetWeakNSObject()];
   FlutterPlatformPlugin* mockPlugin = OCMPartialMock(plugin);
   FlutterMethodCall* methodCall =
       [FlutterMethodCall methodCallWithMethodName:@"LiveText.isLiveTextInputAvailable"
@@ -304,6 +331,8 @@ FLUTTER_ASSERT_ARC
     [engine runWithEntrypoint:nil];
     FlutterViewController* flutterViewController =
         [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
+    std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
+        std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
     XCTAssertFalse(flutterViewController.prefersStatusBarHidden);
 
     // Update to hidden.
@@ -342,6 +371,8 @@ FLUTTER_ASSERT_ARC
     [engine runWithEntrypoint:nil];
     FlutterViewController* flutterViewController =
         [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
+    std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
+        std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
     XCTAssertFalse(flutterViewController.prefersStatusBarHidden);
 
     // Update to hidden.
@@ -389,6 +420,8 @@ FLUTTER_ASSERT_ARC
   [engine runWithEntrypoint:nil];
   FlutterViewController* flutterViewController =
       [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
+  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
+      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
 
   // Update to hidden.
   FlutterPlatformPlugin* plugin = [engine platformPlugin];
@@ -438,6 +471,8 @@ FLUTTER_ASSERT_ARC
   [engine runWithEntrypoint:nil];
   FlutterViewController* flutterViewController =
       [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
+  std::unique_ptr<fml::WeakNSObjectFactory<FlutterEngine>> _weakFactory =
+      std::make_unique<fml::WeakNSObjectFactory<FlutterEngine>>(engine);
   XCTAssertFalse(flutterViewController.prefersStatusBarHidden);
 
   FlutterPlatformPlugin* plugin = [engine platformPlugin];

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -1146,7 +1146,6 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                                                                                   nibName:nil
                                                                                    bundle:nil];
     weakViewController = viewController;
-    [viewController loadView];
     [viewController viewDidLoad];
     weakView = viewController.view;
     XCTAssertTrue([viewController.view isKindOfClass:[FlutterView class]]);


### PR DESCRIPTION
There are still a couple closures where on engine shutdown, the last live reference to FlutterEngine may be on a thread other than the platform thread.

Specifically, the profiling data capture callback can result in the last live reference to a FlutterEngine being on a profiling thread, resulting in an assertion failure in the destructor of the PlatformViewsController held by FlutterEngine, because PlatformViewsController holds a WeakPtrFactory whose destructor asserts that it be on the platform thread.

See:
https://github.com/flutter/engine/blob/ad9e4fef451a73427285826455db5fbdde502bd7/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm#L511-L515

Backtrace of such a crash:
```
=================================================================
Main Thread Checker: UI API called on a background thread: -[UIView removeFromSuperview]
PID: 46919, TID: 333147, Thread name: FlutterEngine.166.profiler, Queue name: com.apple.root.default-qos.overcommit, QoS: 0
Backtrace:
4   libios_test_flutter.dylib           0x000000014b658aed -[FlutterTextInputPlugin dealloc] + 27
5   libobjc.A.dylib                     0x00007ff800055228 _ZN11objc_object17sidetable_releaseEbb + 204
6   libios_test_flutter.dylib           0x000000014b63df5a -[FlutterEngine .cxx_destruct] + 135
7   libobjc.A.dylib                     0x00007ff800035766 _ZL27object_cxxDestructFromClassP11objc_objectP10objc_class + 83
8   libobjc.A.dylib                     0x00007ff80004ddfc objc_destructInstance + 61
9   CoreFoundation                      0x00007ff8004a286b -[NSObject(NSObject) __dealloc_zombie] + 159
10  libios_test_flutter.dylib           0x000000014b635fea -[FlutterEngine dealloc] + 334
11  libobjc.A.dylib                     0x00007ff800055228 _ZN11objc_object17sidetable_releaseEbb + 204
12  libios_test_flutter.dylib           0x000000014b63eda9 _ZNSt3_fl10__function6__funcIZ30-[FlutterEngine startProfiler]E3$_0NS_9allocatorIS2_EEFN7flutter13ProfileSampleEvEEclEv + 69
13  libios_test_flutter.dylib           0x000000014bcd8eaa _ZNSt3_fl10__function6__funcIZNK7flutter16SamplingProfiler16SampleRepeatedlyEN3fml9TimeDeltaEE3$_0NS_9allocatorIS6_EEFvvEEclEv + 40
14  libios_test_flutter.dylib           0x000000014b868786 _ZN3fml15MessageLoopImpl10FlushTasksENS_9FlushTypeE + 156
15  libios_test_flutter.dylib           0x000000014b86ecca _ZN3fml17MessageLoopDarwin11OnTimerFireEP16__CFRunLoopTimerPS0_ + 26
16  CoreFoundation                      0x00007ff8003ea4a5 __CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__ + 20
17  CoreFoundation                      0x00007ff8003ea032 __CFRunLoopDoTimer + 801
18  CoreFoundation                      0x00007ff8003e97b6 __CFRunLoopDoTimers + 243
19  CoreFoundation                      0x00007ff8003e4028 __CFRunLoopRun + 2108
20  CoreFoundation                      0x00007ff8003e3409 CFRunLoopRunSpecific + 557
21  libios_test_flutter.dylib           0x000000014b86ee07 _ZN3fml17MessageLoopDarwin3RunEv + 65
22  libios_test_flutter.dylib           0x000000014b8686a4 _ZN3fml15MessageLoopImpl5DoRunEv + 22
23  libios_test_flutter.dylib           0x000000014b86dce5 _ZNSt3_fl10__function6__funcIZN3fml6ThreadC1ERKNS_8functionIFvRKNS3_12ThreadConfigEEEES7_E3$_0NS_9allocatorISC_EEFvvEEclEv + 135
24  libios_test_flutter.dylib           0x000000014b86da87 _ZZN3fml12ThreadHandleC1EONSt3_fl8functionIFvvEEEEN3$_08__invokeEPv + 27
25  libsystem_pthread.dylib             0x000000010d6a818b _pthread_start + 99
26  libsystem_pthread.dylib             0x000000010d6a3ae3 thread_start + 15
2024-10-18 09:31:27.549111-0700 IosUnitTests[46919:333147] [reports] Main Thread Checker: UI API called on a background thread: -[UIView removeFromSuperview]
PID: 46919, TID: 333147, Thread name: FlutterEngine.166.profiler, Queue name: com.apple.root.default-qos.overcommit, QoS: 0
Backtrace:
4   libios_test_flutter.dylib           0x000000014b658aed -[FlutterTextInputPlugin dealloc] + 27
5   libobjc.A.dylib                     0x00007ff800055228 _ZN11objc_object17sidetable_releaseEbb + 204
6   libios_test_flutter.dylib           0x000000014b63df5a -[FlutterEngine .cxx_destruct] + 135
7   libobjc.A.dylib                     0x00007ff800035766 _ZL27object_cxxDestructFromClassP11objc_objectP10objc_class + 83
8   libobjc.A.dylib                     0x00007ff80004ddfc objc_destructInstance + 61
9   CoreFoundation                      0x00007ff8004a286b -[NSObject(NSObject) __dealloc_zombie] + 159
10  libios_test_flutter.dylib           0x000000014b635fea -[FlutterEngine dealloc] + 334
11  libobjc.A.dylib                     0x00007ff800055228 _ZN11objc_object17sidetable_releaseEbb + 204
12  libios_test_flutter.dylib           0x000000014b63eda9 _ZNSt3_fl10__function6__funcIZ30-[FlutterEngine startProfiler]E3$_0NS_9allocatorIS2_EEFN7flutter13ProfileSampleEvEEclEv + 69
13  libios_test_flutter.dylib           0x000000014bcd8eaa _ZNSt3_fl10__function6__funcIZNK7flutter16SamplingProfiler16SampleRepeatedlyEN3fml9TimeDeltaEE3$_0NS_9allocatorIS6_EEFvvEEclEv + 40
14  libios_test_flutter.dylib           0x000000014b868786 _ZN3fml15MessageLoopImpl10FlushTasksENS_9FlushTypeE + 156
15  libios_test_flutter.dylib           0x000000014b86ecca _ZN3fml17MessageLoopDarwin11OnTimerFireEP16__CFRunLoopTimerPS0_ + 26
16  CoreFoundation                      0x00007ff8003ea4a5 __CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__ + 20
17  CoreFoundation                      0x00007ff8003ea032 __CFRunLoopDoTimer + 801
18  CoreFoundation                      0x00007ff8003e97b6 __CFRunLoopDoTimers + 243
19  CoreFoundation                      0x00007ff8003e4028 __CFRunLoopRun + 2108
20  CoreFoundation                      0x00007ff8003e3409 CFRunLoopRunSpecific + 557
21  libios_test_flutter.dylib           0x000000014b86ee07 _ZN3fml17MessageLoopDarwin3RunEv + 65
22  libios_test_flutter.dylib           0x000000014b8686a4 _ZN3fml15MessageLoopImpl5DoRunEv + 22
23  libios_test_flutter.dylib           0x000000014b86dce5 _ZNSt3_fl10__function6__funcIZN3fml6ThreadC1ERKNS_8functionIFvRKNS3_12ThreadConfigEEEES7_E3$_0NS_9allocatorISC_EEFvvEEclEv + 135
24  libios_test_flutter.dylib           0x000000014b86da87 _ZZN3fml12ThreadHandleC1EONSt3_fl8functionIFvvEEEEN3$_08__invokeEPv + 27
25  libsystem_pthread.dylib             0x000000010d6a818b _pthread_start + 99
26  libsystem_pthread.dylib             0x000000010d6a3ae3 thread_start + 15
IosUnitTests(47009,0x10ec76240) malloc: enabling scribbling to detect mods to free blocks
IosUnitTests(47009) MallocStackLogging: could not tag MSL-related memory as no_footprint, so those pages will be included in process footprint - (null)
IosUnitTests(47009) MallocStackLogging: stack logs being written to /private/tmp/stack-logs.47009.1057b6000.IosUnitTests.0o4HgN.index
IosUnitTests(47009) MallocStackLogging: recording malloc and VM allocation stacks to disk using standard recorder
IosUnitTests(47009) MallocStackLogging: process 46919 no longer exists, stack logs deleted from /tmp/stack-logs.46919.10d1fc000.IosUnitTests.kFionm.index
```

This reverts commit 02fc8a455d0c4b70a70d36e7f4329f5ad706596d.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
