### PR TITLE
iOS: Eliminate needless profiler metrics ivar

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -125,7 +125,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 
   std::shared_ptr<flutter::PlatformViewsController> _platformViewsController;
   flutter::IOSRenderingAPI _renderingApi;
-  std::shared_ptr<flutter::ProfilerMetricsIOS> _profiler_metrics;
   std::shared_ptr<flutter::SamplingProfiler> _profiler;
 
   // Channels
@@ -570,10 +569,13 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 
 - (void)startProfiler {
   FML_DCHECK(!_threadHost->name_prefix.empty());
-  _profiler_metrics = std::make_shared<flutter::ProfilerMetricsIOS>();
   _profiler = std::make_shared<flutter::SamplingProfiler>(
       _threadHost->name_prefix.c_str(), _threadHost->profiler_thread->GetTaskRunner(),
-      [self]() { return self->_profiler_metrics->GenerateSample(); }, kNumProfilerSamplesPerSec);
+      []() {
+        flutter::ProfilerMetricsIOS profiler_metrics;
+        return profiler_metrics.GenerateSample();
+      },
+      kNumProfilerSamplesPerSec);
   _profiler->Start();
 }
 
@@ -1486,7 +1488,6 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
 
   result->_threadHost = _threadHost;
   result->_profiler = _profiler;
-  result->_profiler_metrics = _profiler_metrics;
   result->_isGpuDisabled = _isGpuDisabled;
   [result setUpShell:std::move(shell) withVMServicePublication:NO];
   return [result autorelease];


### PR DESCRIPTION
iOS profiling is implemented in ProfileMetricsIOS, which has a default constructor, no member fields, and no superclass. i.e. it's roughly zero cost to create and holds no state. There's therefore no reason to make it an ivar on FlutterEngine.

Further, making it an ivar on FlutterEngine means that the profiling sampler lambda needs to capture self which, in the case where all other FlutterEngine references go out of scope during sampling, means that the last FlutterEngine reference exists on a profiling thread, and when the sampling lambda block completes, the engine is dealloc'ed.

The engine *must* be deallocated on the platform (main in Apple terminology) thread because FlutterEngine holds a reference to a PlatformViewsController, which owns a WeakPtrFactory. WeakPtrFactory's dtor asserts that it executes on the thread on which it was created, in this case, the platform thread. Further, the engine holds direct and indirect references to other UIKit objects such as `UITextInput` in FlutterTextInputPlugin, which must be dealloc'ed on the main thread.

Since there's no need for ProfileMetricsIOS to be tied to the engine, we now create it on the fly in the sampler.

No test changes because no semantic changes.

Uncovered by ARC migration.

Issue: https://github.com/flutter/flutter/issues/137801
Issue: https://github.com/flutter/flutter/issues/156177

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
