### PR TITLE
[ios][platform_view]force reset forwarding recognizer state when its stuck

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -526,7 +526,7 @@ static BOOL _preparedOnce = NO;
 // setting the state to `UIGestureRecognizerStateEnded`.
 @property(nonatomic) BOOL touchedEndedWithoutBlocking;
 
-@property(nonatomic, readonly) UIGestureRecognizer* forwardingRecognizer;
+@property(nonatomic) UIGestureRecognizer* forwardingRecognizer;
 
 - (instancetype)initWithTarget:(id)target
                         action:(SEL)action
@@ -547,6 +547,7 @@ static BOOL _preparedOnce = NO;
 - (instancetype)initWithTarget:(id)target
        platformViewsController:
            (fml::WeakPtr<flutter::PlatformViewsController>)platformViewsController;
+- (ForwardingGestureRecognizer*)recreateRecognizerWithTarget:(id)target;
 @end
 
 @interface FlutterTouchInterceptingView ()
@@ -584,6 +585,20 @@ static BOOL _preparedOnce = NO;
     [self addGestureRecognizer:forwardingRecognizer];
   }
   return self;
+}
+
+- (void)forceResetForwardingGestureRecognizerState {
+  // When iPad pencil is involved in a finger touch gesture, the gesture is not reset to "possible"
+  // state, which causes subsequent touches to be blocked. As a workaround, we force reset the state
+  // by recreating the forwarding gesture recognizer. See:
+  // https://github.com/flutter/flutter/issues/136244
+  ForwardingGestureRecognizer* oldForwardingRecognizer =
+      (ForwardingGestureRecognizer*)self.delayingRecognizer.forwardingRecognizer;
+  ForwardingGestureRecognizer* newForwardingRecognizer =
+      [oldForwardingRecognizer recreateRecognizerWithTarget:self];
+  self.delayingRecognizer.forwardingRecognizer = newForwardingRecognizer;
+  [self removeGestureRecognizer:oldForwardingRecognizer];
+  [self addGestureRecognizer:newForwardingRecognizer];
 }
 
 - (void)releaseGesture {
@@ -715,6 +730,11 @@ static BOOL _preparedOnce = NO;
   return self;
 }
 
+- (ForwardingGestureRecognizer*)recreateRecognizerWithTarget:(id)target {
+  return [[ForwardingGestureRecognizer alloc] initWithTarget:target
+                                     platformViewsController:std::move(_platformViewsController)];
+}
+
 - (void)touchesBegan:(NSSet*)touches withEvent:(UIEvent*)event {
   FML_DCHECK(_currentTouchPointersCount >= 0);
   if (_currentTouchPointersCount == 0) {
@@ -741,6 +761,7 @@ static BOOL _preparedOnce = NO;
   if (_currentTouchPointersCount == 0) {
     self.state = UIGestureRecognizerStateFailed;
     _flutterViewController.reset(nil);
+    [self forceResetStateIfNeeded];
   }
 }
 
@@ -755,7 +776,21 @@ static BOOL _preparedOnce = NO;
   if (_currentTouchPointersCount == 0) {
     self.state = UIGestureRecognizerStateFailed;
     _flutterViewController.reset(nil);
+    [self forceResetStateIfNeeded];
   }
+}
+
+- (void)forceResetStateIfNeeded {
+  __weak ForwardingGestureRecognizer* weakSelf = self;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    ForwardingGestureRecognizer* strongSelf = weakSelf;
+    if (!strongSelf) {
+      return;
+    }
+    if (strongSelf.state != UIGestureRecognizerStatePossible) {
+      [(FlutterTouchInterceptingView*)strongSelf.view forceResetForwardingGestureRecognizerState];
+    }
+  });
 }
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer*)gestureRecognizer

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -589,8 +589,8 @@ static BOOL _preparedOnce = NO;
 
 - (void)forceResetForwardingGestureRecognizerState {
   // When iPad pencil is involved in a finger touch gesture, the gesture is not reset to "possible"
-  // state, which causes subsequent touches to be blocked. As a workaround, we force reset the state
-  // by recreating the forwarding gesture recognizer. See:
+  // state and is stuck on "failed" state, which causes subsequent touches to be blocked. As a
+  // workaround, we force reset the state by recreating the forwarding gesture recognizer. See:
   // https://github.com/flutter/flutter/issues/136244
   ForwardingGestureRecognizer* oldForwardingRecognizer =
       (ForwardingGestureRecognizer*)self.delayingRecognizer.forwardingRecognizer;


### PR DESCRIPTION
This PR force reset forwarding recognizer state when it's stuck at failed state, by recreating the recognizer (we are not able to reset the state back to possible - it has to be reset by UIKit). 

This is a tricky one since pencil and finger triggers exactly the same callbacks. It turns out that when pencil is involved after finger interaction, the platform view's "forwarding" gesture recognizer is stuck at failed state. This seems to be an iOS bug, because according to [the API doc](https://developer.apple.com/documentation/uikit/uigesturerecognizerstate/uigesturerecognizerstatefailed?language=objc), it should be reset back to "possible" state:

> No action message is sent and the gesture recognizer is reset to [UIGestureRecognizerStatePossible](https://developer.apple.com/documentation/uikit/uigesturerecognizerstate/uigesturerecognizerstatepossible?language=objc).

However, when iPad pencil is involved, the state is not reset. I tried to KVO the state property, and wasn't able to capture the change. This means the state change very likely happened internally within the recognizer via the backing ivar of the state property.



Fixes https://github.com/flutter/flutter/issues/136244

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
