### PR TITLE
[UI] fix scene builder parameter naming.

### DIFF
--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -194,9 +194,9 @@ void SceneBuilder::pushShaderMask(Dart_Handle layer_handle,
                                   int blend_mode,
                                   int filter_quality_index,
                                   const fml::RefPtr<EngineLayer>& old_layer) {
-  SkRect rect =
-      SkRect::MakeLTRB(SafeNarrow(mask_rect_left), SafeNarrow(mask_rect_top),
-                       SafeNarrow(mask_rect_right), SafeNarrow(mask_rect_bottom));
+  SkRect rect = SkRect::MakeLTRB(
+      SafeNarrow(mask_rect_left), SafeNarrow(mask_rect_top),
+      SafeNarrow(mask_rect_right), SafeNarrow(mask_rect_bottom));
   auto sampling = ImageFilter::SamplingFromIndex(filter_quality_index);
   auto layer = std::make_shared<flutter::ShaderMaskLayer>(
       shader->shader(sampling), rect, static_cast<DlBlendMode>(blend_mode));

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -190,13 +190,13 @@ void SceneBuilder::pushShaderMask(Dart_Handle layer_handle,
                                   double mask_rect_left,
                                   double mask_rect_right,
                                   double mask_rect_top,
-                                  double mask_Rect_bottom,
+                                  double mask_rect_bottom,
                                   int blend_mode,
                                   int filter_quality_index,
                                   const fml::RefPtr<EngineLayer>& old_layer) {
   SkRect rect =
-      SkRect::MakeLTRB(SafeNarrow(mask_rect_right), SafeNarrow(mask_rect_right),
-                       SafeNarrow(mask_rect_top), SafeNarrow(mask_Rect_bottom));
+      SkRect::MakeLTRB(SafeNarrow(mask_rect_left), SafeNarrow(mask_rect_top),
+                       SafeNarrow(mask_rect_right), SafeNarrow(mask_rect_bottom));
   auto sampling = ImageFilter::SamplingFromIndex(filter_quality_index);
   auto layer = std::make_shared<flutter::ShaderMaskLayer>(
       shader->shader(sampling), rect, static_cast<DlBlendMode>(blend_mode));


### PR DESCRIPTION
This is reponsible for the bdf golden breaking shader mask.
