### PR TITLE
[web] implement selectable semantics

### DIFF
--- a/lib/web_ui/lib/src/engine/semantics/checkable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/checkable.dart
@@ -48,7 +48,10 @@ _CheckableKind _checkableKindFromSemanticsFlag(
 ///
 /// See also [ui.SemanticsFlag.hasCheckedState], [ui.SemanticsFlag.isChecked],
 /// [ui.SemanticsFlag.isInMutuallyExclusiveGroup], [ui.SemanticsFlag.isToggled],
-/// [ui.SemanticsFlag.hasToggledState]
+/// [ui.SemanticsFlag.hasToggledState].
+///
+/// See also [Selectable] behavior, which expresses a similar but different
+/// boolean state of being "selected".
 class SemanticCheckable extends SemanticRole {
   SemanticCheckable(SemanticsObject semanticsObject)
       : _kind = _checkableKindFromSemanticsFlag(semanticsObject),
@@ -112,4 +115,29 @@ class SemanticCheckable extends SemanticRole {
 
   @override
   bool focusAsRouteDefault() => focusable?.focusAsRouteDefault() ?? false;
+}
+
+/// Adds selectability behavior to a semantic node.
+///
+/// A selectable node would have the `aria-selected` set to "true" if the node
+/// is currently selected (i.e. [SemanticsObject.isSelected] is true), and set
+/// to "false" if it's not selected (i.e. [SemanticsObject.isSelected] is
+/// false). If the node is not selectable (i.e. [SemanticsObject.isSelectable]
+/// is false), then `aria-selected` is unset.
+///
+/// See also [SemanticCheckable], which expresses a similar but different
+/// boolean state of being "checked" or "toggled".
+class Selectable extends SemanticBehavior {
+  Selectable(super.semanticsObject, super.owner);
+
+  @override
+  void update() {
+    if (semanticsObject.isFlagsDirty) {
+      if (semanticsObject.isSelectable) {
+        owner.setAttribute('aria-selected', semanticsObject.isSelected);
+      } else {
+        owner.removeAttribute('aria-selected');
+      }
+    }
+  }
 }

--- a/lib/web_ui/lib/src/engine/semantics/heading.dart
+++ b/lib/web_ui/lib/src/engine/semantics/heading.dart
@@ -15,6 +15,7 @@ class SemanticHeading extends SemanticRole {
     addLiveRegion();
     addRouteName();
     addLabelAndValue(preferredRepresentation: LabelRepresentation.domText);
+    addSelectableBehavior();
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/semantics/image.dart
+++ b/lib/web_ui/lib/src/engine/semantics/image.dart
@@ -21,6 +21,7 @@ class SemanticImage extends SemanticRole {
     addLiveRegion();
     addRouteName();
     addTappable();
+    addSelectableBehavior();
   }
 
   @override

--- a/lib/web_ui/test/engine/semantics/semantics_tester.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_tester.dart
@@ -32,6 +32,7 @@ class SemanticsTester {
     int flags = 0,
     bool? hasCheckedState,
     bool? isChecked,
+    bool? isSelectable,
     bool? isSelected,
     bool? isButton,
     bool? isLink,
@@ -121,6 +122,9 @@ class SemanticsTester {
     }
     if (isChecked ?? false) {
       flags |= ui.SemanticsFlag.isChecked.index;
+    }
+    if (isSelectable ?? false) {
+      flags |= ui.SemanticsFlag.hasSelectedState.index;
     }
     if (isSelected ?? false) {
       flags |= ui.SemanticsFlag.isSelected.index;


### PR DESCRIPTION
Implement `SemanticsFlag.hasSelectedState` and `SemanticsFlag.isSelected` for web in terms of `aria-selected`.

Fixes https://github.com/flutter/flutter/issues/66673