### PR TITLE
Increase timeout for Linux mac_clangd

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -506,6 +506,7 @@ targets:
   # Avoid using a Mac orchestrator to save ~5 minutes of Mac host time.
   - name: Linux mac_clangd
     recipe: engine_v2/engine_v2
+    timeout: 90
     # Do not remove(https://github.com/flutter/flutter/issues/144644)
     # Scheduler will fail to get the platform
     drone_dimensions:

--- a/ci/builders/mac_unopt_debug_no_rbe.json
+++ b/ci/builders/mac_unopt_debug_no_rbe.json
@@ -9,6 +9,7 @@
   ],
   "builds": [
     {
+      "cas_archive": false,
       "drone_dimensions": [
         "device_type=none",
         "os=Mac-13|Mac-14",


### PR DESCRIPTION
This build does not come in under the default 30 minute timeout when the caches are cold and the bot_update steps take too long: https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20mac_clangd/2928/overview
