### PR TITLE
iOS: Reduce rerun flakes by eliminating timeouts

### DIFF
--- a/shell/platform/darwin/common/framework/Source/FlutterChannelsTest.m
+++ b/shell/platform/darwin/common/framework/Source/FlutterChannelsTest.m
@@ -91,7 +91,7 @@ FLUTTER_ASSERT_ARC
                    XCTAssertEqual(FlutterMethodNotImplemented, result);
                  }];
   OCMVerifyAll(binaryMessenger);
-  [self waitForExpectationsWithTimeout:1.0 handler:nil];
+  [self waitForExpectations:@[ didCallReply ]];
 }
 
 - (void)testMethodMessageHandler {
@@ -141,7 +141,7 @@ FLUTTER_ASSERT_ARC
     [didCallReply fulfill];
     XCTAssertEqual(replyEnvelopeData, reply);
   });
-  [self waitForExpectationsWithTimeout:1.0 handler:nil];
+  [self waitForExpectations:@[ didCallHandler, didCallReply ]];
 }
 
 - (void)testResize {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPluginTest.mm
@@ -59,7 +59,7 @@ FLUTTER_ASSERT_ARC
   };
 
   [mockPlugin handleMethodCall:methodCall result:result];
-  [self waitForExpectationsWithTimeout:1 handler:nil];
+  [self waitForExpectations:@[ invokeExpectation ]];
   [mockApplication stopMocking];
 }
 
@@ -90,7 +90,7 @@ FLUTTER_ASSERT_ARC
   };
 
   [mockPlugin handleMethodCall:methodCall result:result];
-  [self waitForExpectationsWithTimeout:1 handler:nil];
+  [self waitForExpectations:@[ invokeExpectation ]];
   [mockApplication stopMocking];
 }
 
@@ -119,7 +119,7 @@ FLUTTER_ASSERT_ARC
     [presentExpectation fulfill];
   };
   [mockPlugin handleMethodCall:methodCall result:result];
-  [self waitForExpectationsWithTimeout:2 handler:nil];
+  [self waitForExpectations:@[ presentExpectation ]];
 }
 
 - (void)testShareScreenInvoked {
@@ -151,7 +151,7 @@ FLUTTER_ASSERT_ARC
     [presentExpectation fulfill];
   };
   [mockPlugin handleMethodCall:methodCall result:result];
-  [self waitForExpectationsWithTimeout:1 handler:nil];
+  [self waitForExpectations:@[ presentExpectation ]];
 }
 
 - (void)testShareScreenInvokedOnIPad {
@@ -186,7 +186,7 @@ FLUTTER_ASSERT_ARC
     [presentExpectation fulfill];
   };
   [mockPlugin handleMethodCall:methodCall result:result];
-  [self waitForExpectationsWithTimeout:1 handler:nil];
+  [self waitForExpectations:@[ presentExpectation ]];
 }
 
 - (void)testClipboardHasCorrectStrings {
@@ -202,7 +202,7 @@ FLUTTER_ASSERT_ARC
       [FlutterMethodCall methodCallWithMethodName:@"Clipboard.setData"
                                         arguments:@{@"text" : @"some string"}];
   [plugin handleMethodCall:methodCallSet result:resultSet];
-  [self waitForExpectationsWithTimeout:1 handler:nil];
+  [self waitForExpectations:@[ setStringExpectation ]];
 
   XCTestExpectation* hasStringsExpectation = [self expectationWithDescription:@"hasStrings"];
   FlutterResult result = ^(id result) {
@@ -212,7 +212,7 @@ FLUTTER_ASSERT_ARC
   FlutterMethodCall* methodCall =
       [FlutterMethodCall methodCallWithMethodName:@"Clipboard.hasStrings" arguments:nil];
   [plugin handleMethodCall:methodCall result:result];
-  [self waitForExpectationsWithTimeout:1 handler:nil];
+  [self waitForExpectations:@[ hasStringsExpectation ]];
 
   XCTestExpectation* getDataExpectation = [self expectationWithDescription:@"getData"];
   FlutterResult getDataResult = ^(id result) {
@@ -222,7 +222,7 @@ FLUTTER_ASSERT_ARC
   FlutterMethodCall* methodCallGetData =
       [FlutterMethodCall methodCallWithMethodName:@"Clipboard.getData" arguments:@"text/plain"];
   [plugin handleMethodCall:methodCallGetData result:getDataResult];
-  [self waitForExpectationsWithTimeout:1 handler:nil];
+  [self waitForExpectations:@[ getDataExpectation ]];
 }
 
 - (void)testClipboardSetDataToNullDoNotCrash {
@@ -247,7 +247,7 @@ FLUTTER_ASSERT_ARC
   FlutterMethodCall* methodCall = [FlutterMethodCall methodCallWithMethodName:@"Clipboard.getData"
                                                                     arguments:@"text/plain"];
   [plugin handleMethodCall:methodCall result:result];
-  [self waitForExpectationsWithTimeout:1 handler:nil];
+  [self waitForExpectations:@[ setStringExpectation, getDataExpectation ]];
 }
 
 - (void)testPopSystemNavigator {
@@ -271,7 +271,7 @@ FLUTTER_ASSERT_ARC
   FlutterMethodCall* methodCallSet =
       [FlutterMethodCall methodCallWithMethodName:@"SystemNavigator.pop" arguments:@(YES)];
   [plugin handleMethodCall:methodCallSet result:resultSet];
-  [self waitForExpectationsWithTimeout:1 handler:nil];
+  [self waitForExpectations:@[ navigationPopCalled ]];
   OCMVerify([navigationControllerMock popViewControllerAnimated:YES]);
 
   [flutterViewController deregisterNotifications];
@@ -291,7 +291,7 @@ FLUTTER_ASSERT_ARC
     [invokeExpectation fulfill];
   };
   [mockPlugin handleMethodCall:methodCall result:result];
-  [self waitForExpectationsWithTimeout:1 handler:nil];
+  [self waitForExpectations:@[ invokeExpectation ]];
 }
 
 - (void)testViewControllerBasedStatusBarHiddenUpdate {
@@ -318,7 +318,7 @@ FLUTTER_ASSERT_ARC
         [FlutterMethodCall methodCallWithMethodName:@"SystemChrome.setEnabledSystemUIOverlays"
                                           arguments:@[ @"SystemUiOverlay.bottom" ]];
     [plugin handleMethodCall:methodCallSet result:resultSet];
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectations:@[ enableSystemUIOverlaysCalled ]];
     XCTAssertTrue(flutterViewController.prefersStatusBarHidden);
 
     // Update to shown.
@@ -331,7 +331,7 @@ FLUTTER_ASSERT_ARC
         [FlutterMethodCall methodCallWithMethodName:@"SystemChrome.setEnabledSystemUIOverlays"
                                           arguments:@[ @"SystemUiOverlay.top" ]];
     [plugin handleMethodCall:methodCallSet2 result:resultSet2];
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectations:@[ enableSystemUIOverlaysCalled2 ]];
     XCTAssertFalse(flutterViewController.prefersStatusBarHidden);
 
     [flutterViewController deregisterNotifications];
@@ -356,7 +356,7 @@ FLUTTER_ASSERT_ARC
         [FlutterMethodCall methodCallWithMethodName:@"SystemChrome.setEnabledSystemUIMode"
                                           arguments:@"SystemUiMode.immersive"];
     [plugin handleMethodCall:methodCallSet result:resultSet];
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectations:@[ enableSystemUIModeCalled ]];
     XCTAssertTrue(flutterViewController.prefersStatusBarHidden);
 
     // Update to shown.
@@ -369,7 +369,7 @@ FLUTTER_ASSERT_ARC
         [FlutterMethodCall methodCallWithMethodName:@"SystemChrome.setEnabledSystemUIMode"
                                           arguments:@"SystemUiMode.edgeToEdge"];
     [plugin handleMethodCall:methodCallSet2 result:resultSet2];
-    [self waitForExpectationsWithTimeout:1 handler:nil];
+    [self waitForExpectations:@[ enableSystemUIModeCalled2 ]];
     XCTAssertFalse(flutterViewController.prefersStatusBarHidden);
 
     [flutterViewController deregisterNotifications];
@@ -402,7 +402,7 @@ FLUTTER_ASSERT_ARC
       [FlutterMethodCall methodCallWithMethodName:@"SystemChrome.setEnabledSystemUIOverlays"
                                         arguments:@[ @"SystemUiOverlay.bottom" ]];
   [plugin handleMethodCall:methodCallSet result:resultSet];
-  [self waitForExpectationsWithTimeout:1 handler:nil];
+  [self waitForExpectations:@[ enableSystemUIOverlaysCalled ]];
 #if not APPLICATION_EXTENSION_API_ONLY
   OCMVerify([mockApplication setStatusBarHidden:YES]);
 #endif
@@ -417,7 +417,7 @@ FLUTTER_ASSERT_ARC
       [FlutterMethodCall methodCallWithMethodName:@"SystemChrome.setEnabledSystemUIOverlays"
                                         arguments:@[ @"SystemUiOverlay.top" ]];
   [plugin handleMethodCall:methodCallSet2 result:resultSet2];
-  [self waitForExpectationsWithTimeout:1 handler:nil];
+  [self waitForExpectations:@[ enableSystemUIOverlaysCalled2 ]];
 #if not APPLICATION_EXTENSION_API_ONLY
   OCMVerify([mockApplication setStatusBarHidden:NO]);
 #endif
@@ -451,7 +451,7 @@ FLUTTER_ASSERT_ARC
       [FlutterMethodCall methodCallWithMethodName:@"SystemChrome.setSystemUIOverlayStyle"
                                         arguments:@{@"statusBarBrightness" : @"Brightness.dark"}];
   [plugin handleMethodCall:methodCallSet result:resultSet];
-  [self waitForExpectationsWithTimeout:1 handler:nil];
+  [self waitForExpectations:@[ enableSystemUIModeCalled ]];
 
 #if not APPLICATION_EXTENSION_API_ONLY
   OCMVerify([mockApplication setStatusBarStyle:UIStatusBarStyleLightContent]);

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -3587,7 +3587,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
 
     flutterPlatformViewsController->OnMethodCall(
         [FlutterMethodCall methodCallWithMethodName:@"dispose" arguments:@0], disposeResult);
-    [self waitForExpectationsWithTimeout:30 handler:nil];
+    [self waitForExpectations:@[ expectation ]];
 
     const SkImageInfo image_info = SkImageInfo::MakeN32Premul(1000, 1000);
     sk_sp<SkSurface> mock_sk_surface = SkSurfaces::Raster(image_info);

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -530,7 +530,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   };
   CFTimeInterval startTime = CACurrentMediaTime();
   [viewController setUpKeyboardAnimationVsyncClient:callback];
-  [self waitForExpectationsWithTimeout:5.0 handler:nil];
+  [self waitForExpectations:@[ expectation ]];
   XCTAssertTrue(fulfillTime - startTime > delayTime);
 }
 
@@ -754,7 +754,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
   [viewControllerMock handleKeyboardNotification:notification];
   XCTAssertTrue(viewControllerMock.targetViewInsetBottom == 320 * screen.scale);
   OCMVerify([viewControllerMock startKeyBoardAnimation:0.25]);
-  [self waitForExpectationsWithTimeout:5.0 handler:nil];
+  [self waitForExpectations:@[ expectation ]];
 }
 
 - (void)testEnsureBottomInsetIsZeroWhenKeyboardDismissed {
@@ -1661,7 +1661,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
     XCTAssertNotNil(realVC);
     realVC = nil;
   }
-  [self waitForExpectations:@[ expectation ] timeout:1.0];
+  [self waitForExpectations:@[ expectation ]];
 }
 
 - (void)testReleasesKeyboardManagerOnDealloc {
@@ -1943,7 +1943,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                    OCMVerify([mockVC goToApplicationLifecycle:@"AppLifecycleState.resumed"]);
                    [flutterViewController deregisterNotifications];
                  });
-  [self waitForExpectationsWithTimeout:5.0 handler:nil];
+  [self waitForExpectations:@[ timeoutApplicationLifeCycle ]];
 }
 
 - (void)testLifeCycleNotificationWillResignActive {
@@ -2088,7 +2088,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
                    [timeoutApplicationLifeCycle fulfill];
                    [flutterViewController deregisterNotifications];
                  });
-  [self waitForExpectationsWithTimeout:5.0 handler:nil];
+  [self waitForExpectations:@[ timeoutApplicationLifeCycle ]];
 }
 
 - (void)testSetupKeyboardAnimationVsyncClientWillCreateNewVsyncClientForFlutterViewController {

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -1149,7 +1149,9 @@ const float kFloatCompareEpsilon = 0.001;
   [partialSemanticsObject selectAll:nil];
   [partialSemanticsObject delete:nil];
 
-  [self waitForExpectationsWithTimeout:1 handler:nil];
+  [self waitForExpectations:@[
+    copyExpectation, cutExpectation, pasteExpectation, selectAllExpectation, deleteExpectation
+  ]];
 }
 
 @end

--- a/shell/platform/darwin/ios/platform_message_handler_ios_test.mm
+++ b/shell/platform/darwin/ios/platform_message_handler_ios_test.mm
@@ -72,7 +72,7 @@ class MockPlatformMessageResponse : public PlatformMessageResponse {
     auto platform_message = std::make_unique<flutter::PlatformMessage>(channel, response);
     handler->HandlePlatformMessage(std::move(platform_message));
   });
-  [self waitForExpectationsWithTimeout:1.0 handler:nil];
+  [self waitForExpectations:@[ didCallReply ]];
   XCTAssertTrue(response->is_complete());
 }
 
@@ -100,7 +100,7 @@ class MockPlatformMessageResponse : public PlatformMessageResponse {
     handler->HandlePlatformMessage(std::move(platform_message));
     [didCallMessage fulfill];
   });
-  [self waitForExpectationsWithTimeout:1.0 handler:nil];
+  [self waitForExpectations:@[ didCallMessage ]];
   XCTAssertTrue(response->is_complete());
 }
 
@@ -128,7 +128,7 @@ class MockPlatformMessageResponse : public PlatformMessageResponse {
     auto platform_message = std::make_unique<flutter::PlatformMessage>(channel, response);
     handler->HandlePlatformMessage(std::move(platform_message));
   });
-  [self waitForExpectationsWithTimeout:1.0 handler:nil];
+  [self waitForExpectations:@[ didCallReply ]];
   XCTAssertTrue(response->is_complete());
 }
 @end


### PR DESCRIPTION
When run repeatedly, some of the iOS unit tests can relatively easily
blow their test timeouts. Since we're testing behaviour and not
performance in these tests there's no need to enforce a particular
timeout.

The bots will fail if the tests timeout, regardless.

Issue: https://github.com/flutter/flutter/issues/157231

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
