### PR TITLE
update the SoT location for package:http_parser

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -67,6 +67,7 @@ vars = {
   'dart_clock_rev': '7956d60042f4ea979c4554d43eeb57d087627869',
   'dart_collection_rev': '887b826b50f48d6a9cd2c0684aa353e8e3a0fad0',
   'dart_devtools_rev': 'dcef4f6efe986f110f55dbbe7f3731802e86690a',
+  'dart_http_rev': '5e2281edd25f9addbf26242a0658d8f2dfa1134b',
   'dart_libprotobuf_rev': '24487dd1045c7f3d64a21f38a3f0c06cc4cf2edb',
   'dart_perfetto_rev': '13ce0c9e13b0940d2476cd0cff2301708a9a2e2b',
   'dart_protobuf_gn_rev': 'ca669f79945418f6229e4fef89b666b2a88cbb10',
@@ -183,7 +184,6 @@ vars = {
   "upstream_harfbuzz": "https://github.com/harfbuzz/harfbuzz.git",
   "upstream_html": "https://github.com/dart-lang/html.git",
   "upstream_http_multi_server": "https://github.com/dart-lang/http_multi_server.git",
-  "upstream_http_parser": "https://github.com/dart-lang/http_parser.git",
   "upstream_http": "https://github.com/dart-lang/http.git",
   "upstream_icu": "https://github.com/unicode-org/icu.git",
   "upstream_intl": "https://github.com/dart-lang/intl.git",
@@ -400,13 +400,10 @@ deps = {
    Var('dart_git') + '/html.git@6d3bc86cf2ab530ef3fa5f84b5980dc318a02af4',
 
   'src/flutter/third_party/dart/third_party/pkg/http':
-   Var('dart_git') + '/http.git@5e2281edd25f9addbf26242a0658d8f2dfa1134b',
+   Var('dart_git') + '/http.git' + '@' + Var('dart_http_rev'),
 
   'src/flutter/third_party/dart/third_party/pkg/http_multi_server':
    Var('dart_git') + '/http_multi_server.git@e7515b5896b83d522189802a1e14e103e19426c0',
-
-  'src/flutter/third_party/dart/third_party/pkg/http_parser':
-   Var('dart_git') + '/http_parser.git@23d775898ee90be9daf3297e298a8869bc755d84',
 
   'src/flutter/third_party/dart/third_party/pkg/intl':
    Var('dart_git') + '/intl.git@5d65e3808ce40e6282e40881492607df4e35669f',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -214,7 +214,7 @@ dependency_overrides:
   http_multi_server:
     path: ./third_party/dart/third_party/pkg/http_multi_server
   http_parser:
-    path: ./third_party/dart/third_party/pkg/http_parser
+    path: ./third_party/dart/third_party/pkg/http/pkgs/http_parser
   io:
     path: ./third_party/pkg/io
   js:


### PR DESCRIPTION
This PR updates the SoT location for `package:http_parser`; it's moved from dart-lang/http_parser to dart-lang/http (in pkgs/http_parser).

Issues:
- https://github.com/dart-lang/sdk/issues/56591

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
