### PR TITLE
Move send_key_event from FlKeyboardViewDelegate to FlKeyboardManager.

### DIFF
--- a/shell/platform/linux/fl_keyboard_manager.h
+++ b/shell/platform/linux/fl_keyboard_manager.h
@@ -8,7 +8,7 @@
 #include <gdk/gdk.h>
 
 #include "flutter/shell/platform/linux/fl_keyboard_view_delegate.h"
-#include "flutter/shell/platform/linux/public/flutter_linux/fl_binary_messenger.h"
+#include "flutter/shell/platform/linux/public/flutter_linux/fl_engine.h"
 
 G_BEGIN_DECLS
 
@@ -36,7 +36,7 @@ G_DECLARE_FINAL_TYPE(FlKeyboardManager,
 
 /**
  * fl_keyboard_manager_new:
- * @messenger: an #FlBinaryMessenger.
+ * @engine: an #FlEngine.
  * @view_delegate: An interface that the manager requires to communicate with
  * the platform. Usually implemented by FlView.
  *
@@ -45,7 +45,7 @@ G_DECLARE_FINAL_TYPE(FlKeyboardManager,
  * Returns: a new #FlKeyboardManager.
  */
 FlKeyboardManager* fl_keyboard_manager_new(
-    FlBinaryMessenger* messenger,
+    FlEngine* engine,
     FlKeyboardViewDelegate* view_delegate);
 
 /**
@@ -93,6 +93,23 @@ void fl_keyboard_manager_sync_modifier_if_needed(FlKeyboardManager* manager,
  * pressed keys, mapping from the logical key to the physical key.*
  */
 GHashTable* fl_keyboard_manager_get_pressed_state(FlKeyboardManager* manager);
+
+typedef void (*FlKeyboardManagerSendKeyEventHandler)(
+    const FlutterKeyEvent* event,
+    FlutterKeyEventCallback callback,
+    void* callback_user_data,
+    gpointer user_data);
+
+/**
+ * fl_keyboard_manager_set_send_key_event_handler:
+ * @manager: the #FlKeyboardManager self.
+ *
+ * Set the handler for sending events, for testing purposes only.
+ */
+void fl_keyboard_manager_set_send_key_event_handler(
+    FlKeyboardManager* manager,
+    FlKeyboardManagerSendKeyEventHandler send_key_event_handler,
+    gpointer user_data);
 
 typedef guint (*FlKeyboardManagerLookupKeyHandler)(const GdkKeymapKey* key,
                                                    gpointer user_data);

--- a/shell/platform/linux/fl_keyboard_view_delegate.cc
+++ b/shell/platform/linux/fl_keyboard_view_delegate.cc
@@ -11,17 +11,6 @@ G_DEFINE_INTERFACE(FlKeyboardViewDelegate,
 static void fl_keyboard_view_delegate_default_init(
     FlKeyboardViewDelegateInterface* iface) {}
 
-void fl_keyboard_view_delegate_send_key_event(FlKeyboardViewDelegate* self,
-                                              const FlutterKeyEvent* event,
-                                              FlutterKeyEventCallback callback,
-                                              void* user_data) {
-  g_return_if_fail(FL_IS_KEYBOARD_VIEW_DELEGATE(self));
-  g_return_if_fail(event != nullptr);
-
-  FL_KEYBOARD_VIEW_DELEGATE_GET_IFACE(self)->send_key_event(
-      self, event, callback, user_data);
-}
-
 gboolean fl_keyboard_view_delegate_text_filter_key_press(
     FlKeyboardViewDelegate* self,
     FlKeyEvent* event) {

--- a/shell/platform/linux/fl_keyboard_view_delegate.h
+++ b/shell/platform/linux/fl_keyboard_view_delegate.h
@@ -34,33 +34,11 @@ G_DECLARE_INTERFACE(FlKeyboardViewDelegate,
 struct _FlKeyboardViewDelegateInterface {
   GTypeInterface g_iface;
 
-  void (*send_key_event)(FlKeyboardViewDelegate* delegate,
-                         const FlutterKeyEvent* event,
-                         FlutterKeyEventCallback callback,
-                         void* user_data);
-
   gboolean (*text_filter_key_press)(FlKeyboardViewDelegate* delegate,
                                     FlKeyEvent* event);
 
   GHashTable* (*get_keyboard_state)(FlKeyboardViewDelegate* delegate);
 };
-
-/**
- * fl_keyboard_view_delegate_send_key_event:
- *
- * Handles `FlKeyboardHandler`'s request to send a `FlutterKeyEvent` through the
- * embedder API to the framework.
- *
- * The ownership of the `event` is kept by the keyboard handler, and the `event`
- * might be immediately destroyed after this function returns.
- *
- * The `callback` must eventually be called exactly once with the event result
- * and the `user_data`.
- */
-void fl_keyboard_view_delegate_send_key_event(FlKeyboardViewDelegate* delegate,
-                                              const FlutterKeyEvent* event,
-                                              FlutterKeyEventCallback callback,
-                                              void* user_data);
 
 /**
  * fl_keyboard_view_delegate_text_filter_key_press:

--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -151,7 +151,7 @@ static void init_keyboard(FlView* self) {
       fl_keyboard_handler_new(messenger, FL_KEYBOARD_VIEW_DELEGATE(self));
   g_clear_object(&self->keyboard_manager);
   self->keyboard_manager =
-      fl_keyboard_manager_new(messenger, FL_KEYBOARD_VIEW_DELEGATE(self));
+      fl_keyboard_manager_new(self->engine, FL_KEYBOARD_VIEW_DELEGATE(self));
 }
 
 static void init_scrolling(FlView* self) {
@@ -364,15 +364,6 @@ static void fl_view_plugin_registry_iface_init(
 
 static void fl_view_keyboard_delegate_iface_init(
     FlKeyboardViewDelegateInterface* iface) {
-  iface->send_key_event =
-      [](FlKeyboardViewDelegate* view_delegate, const FlutterKeyEvent* event,
-         FlutterKeyEventCallback callback, void* user_data) {
-        FlView* self = FL_VIEW(view_delegate);
-        if (self->engine != nullptr) {
-          fl_engine_send_key_event(self->engine, event, callback, user_data);
-        };
-      };
-
   iface->text_filter_key_press = [](FlKeyboardViewDelegate* view_delegate,
                                     FlKeyEvent* event) {
     FlView* self = FL_VIEW(view_delegate);


### PR DESCRIPTION
Ideally the tests would mock FlEngine, but I wasn't able to get it working so I've added fl_keyboard_manager_set_send_key_event_handler for now.

