### PR TITLE
[Impeller] flush thread local resources during toImage/toImageSync.

### DIFF
--- a/impeller/display_list/dl_dispatcher.cc
+++ b/impeller/display_list/dl_dispatcher.cc
@@ -1275,6 +1275,7 @@ std::shared_ptr<Texture> DisplayListToTexture(
     context.GetContentContext().GetTransientsBuffer().Reset();
   }
   context.GetContentContext().GetLazyGlyphAtlas()->ResetTextFrames();
+  context.GetContext()->DisposeThreadLocalCachedResources();
 
   return target.GetRenderTargetTexture();
 }


### PR DESCRIPTION
I suspect not flushing is related to occassionaly timeouts on flutter tester --enable impelller. because the flutter_tester never actually pumps a frame, it won't naturally flush these resources.

It shouldn't be harmful to otherwise flush.
