### PR TITLE
[display_list] add back FML check for large display_list allocation

### DIFF
--- a/display_list/dl_builder.cc
+++ b/display_list/dl_builder.cc
@@ -62,6 +62,7 @@ static constexpr inline bool is_power_of_two(int value) {
 template <typename T, typename... Args>
 void* DisplayListBuilder::Push(size_t pod, Args&&... args) {
   size_t size = SkAlignPtr(sizeof(T) + pod);
+  FML_CHECK(size < (1 << 24));
   if (used_ + size > allocated_) {
     static_assert(is_power_of_two(kDLPageSize),
                   "This math needs updating for non-pow2.");


### PR DESCRIPTION
This check is still load bearing. Though we haven't ever seen it fire it prevents serious issues with massive allocations
