### PR TITLE
[Impeller] libImpeller: Allow appending to the transformation stack.

### DIFF
--- a/impeller/toolkit/interop/dl_builder.cc
+++ b/impeller/toolkit/interop/dl_builder.cc
@@ -55,6 +55,11 @@ void DisplayListBuilder::SetTransform(const Matrix& matrix) {
   builder_.SetTransform(&sk_matrix);
 }
 
+void DisplayListBuilder::Transform(const Matrix& matrix) {
+  const auto sk_matrix = SkM44::ColMajor(matrix.m);
+  builder_.Transform(&sk_matrix);
+}
+
 void DisplayListBuilder::ResetTransform() {
   builder_.TransformReset();
 }

--- a/impeller/toolkit/interop/dl_builder.h
+++ b/impeller/toolkit/interop/dl_builder.h
@@ -51,6 +51,8 @@ class DisplayListBuilder final
 
   void SetTransform(const Matrix& matrix);
 
+  void Transform(const Matrix& matrix);
+
   void ResetTransform();
 
   uint32_t GetSaveCount() const;

--- a/impeller/toolkit/interop/impeller.cc
+++ b/impeller/toolkit/interop/impeller.cc
@@ -168,6 +168,12 @@ void ImpellerDisplayListBuilderSetTransform(ImpellerDisplayListBuilder builder,
 }
 
 IMPELLER_EXTERN_C
+void ImpellerDisplayListBuilderTransform(ImpellerDisplayListBuilder builder,
+                                         const ImpellerMatrix* transform) {
+  GetPeer(builder)->Transform(ToImpellerType(*transform));
+}
+
+IMPELLER_EXTERN_C
 void ImpellerDisplayListBuilderGetTransform(ImpellerDisplayListBuilder builder,
                                             ImpellerMatrix* out_transform) {
   FromImpellerType(GetPeer(builder)->GetTransform(), *out_transform);

--- a/impeller/toolkit/interop/impeller.h
+++ b/impeller/toolkit/interop/impeller.h
@@ -1644,6 +1644,18 @@ void ImpellerDisplayListBuilderTranslate(
     float y_translation);
 
 //------------------------------------------------------------------------------
+/// @brief      Appends the the provided transformation to the transformation
+///             already on the save stack.
+///
+/// @param[in]  builder    The builder.
+/// @param[in]  transform  The transform to append.
+///
+IMPELLER_EXPORT
+void ImpellerDisplayListBuilderTransform(
+    ImpellerDisplayListBuilder IMPELLER_NONNULL builder,
+    const ImpellerMatrix* IMPELLER_NONNULL transform);
+
+//------------------------------------------------------------------------------
 /// @brief      Clear the transformation on top of the save stack and replace it
 ///             with a new value.
 ///

--- a/impeller/toolkit/interop/impeller_unittests.cc
+++ b/impeller/toolkit/interop/impeller_unittests.cc
@@ -69,6 +69,15 @@ TEST_P(InteropPlaygroundTest, CanDrawRect) {
   color = {1.0, 0.0, 0.0, 1.0};
   ImpellerPaintSetColor(paint.GetC(), &color);
   ImpellerDisplayListBuilderTranslate(builder.GetC(), 110, 210);
+  ImpellerMatrix scale_transform = {
+      // clang-format off
+      2.0, 0.0, 0.0, 0.0, //
+      0.0, 2.0, 0.0, 0.0, //
+      0.0, 0.0, 1.0, 0.0, //
+      0.0, 0.0, 0.0, 1.0, //
+      // clang-format on
+  };
+  ImpellerDisplayListBuilderTransform(builder.GetC(), &scale_transform);
   ImpellerDisplayListBuilderDrawRect(builder.GetC(), &rect, paint.GetC());
   auto dl = Adopt<DisplayList>(
       ImpellerDisplayListBuilderCreateDisplayListNew(builder.GetC()));


### PR DESCRIPTION
Currently @lyceel has a workaround where they get the transform, create a new one, and call SetTransform. They would like to avoid this.

Fixes https://github.com/flutter/flutter/issues/156604
