### PR TITLE
[web] Do not copy invalid images in the Skia test image collection

### DIFF
--- a/lib/web_ui/dev/steps/copy_artifacts_step.dart
+++ b/lib/web_ui/dev/steps/copy_artifacts_step.dart
@@ -137,6 +137,10 @@ class CopyArtifactsStep implements PipelineStep {
     ));
 
     for (final io.File imageFile in testImagesDir.listSync(recursive: true).whereType<io.File>()) {
+      // Skip files that are used by Skia to test handling of invalid input.
+      if (pathlib.basename(imageFile.path).contains("invalid")) {
+        continue;
+      }
       final io.File destination = io.File(pathlib.join(
         environment.webTestsArtifactsDir.path,
         'test_images',

--- a/lib/web_ui/dev/steps/copy_artifacts_step.dart
+++ b/lib/web_ui/dev/steps/copy_artifacts_step.dart
@@ -138,7 +138,7 @@ class CopyArtifactsStep implements PipelineStep {
 
     for (final io.File imageFile in testImagesDir.listSync(recursive: true).whereType<io.File>()) {
       // Skip files that are used by Skia to test handling of invalid input.
-      if (pathlib.basename(imageFile.path).contains("invalid")) {
+      if (pathlib.basename(imageFile.path).contains('invalid')) {
         continue;
       }
       final io.File destination = io.File(pathlib.join(


### PR DESCRIPTION
A recent Skia commit added a test image that is used to check handling of invalid input.  This is causing some web tests to fail because Firefox rejects the image.

(see https://skia.googlesource.com/skia.git/+/ff59ce65022d71f883b7e3be146bbd32facadaf8)