### PR TITLE
[android] make failing to acquire a java image non-fatal.

### DIFF
--- a/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/shell/platform/android/platform_view_android_jni_impl.cc
@@ -1584,8 +1584,11 @@ PlatformViewAndroidJNIImpl::ImageProducerTextureEntryAcquireLatestImage(
   JavaLocalRef r = JavaLocalRef(
       env, env->CallObjectMethod(image_producer_texture_entry_local_ref.obj(),
                                  g_acquire_latest_image_method));
-  FML_CHECK(fml::jni::CheckException(env));
-  return r;
+  if (fml::jni::CheckException(env)) {
+    return r;
+  }
+  // Return null.
+  return JavaLocalRef();
 }
 
 JavaLocalRef PlatformViewAndroidJNIImpl::ImageGetHardwareBuffer(


### PR DESCRIPTION
See failures in https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8733165720607371809/+/u/step_is_flaky:_run_platform_views_scroll_perf__timeline_summary/stdout

If we fail to acquire the next image from the image reader, its ok to return null from this method as the engine already handles displaying nothing.

THe crashes are due to us ... choosing to crash, which isn't really meaningful.
