### PR TITLE
[Impeller] Lock access to descriptor pool map.

### DIFF
--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -503,15 +503,18 @@ std::shared_ptr<CommandBuffer> ContextVK::CreateCommandBuffer() const {
 
   // look up a cached descriptor pool for the current frame and reuse it
   // if it exists, otherwise create a new pool.
-  DescriptorPoolMap::iterator current_pool =
-      cached_descriptor_pool_.find(std::this_thread::get_id());
   std::shared_ptr<DescriptorPoolVK> descriptor_pool;
-  if (current_pool == cached_descriptor_pool_.end()) {
-    descriptor_pool =
-        (cached_descriptor_pool_[std::this_thread::get_id()] =
-             std::make_shared<DescriptorPoolVK>(weak_from_this()));
-  } else {
-    descriptor_pool = current_pool->second;
+  {
+    Lock lock(desc_pool_mutex_);
+    DescriptorPoolMap::iterator current_pool =
+        cached_descriptor_pool_.find(std::this_thread::get_id());
+    if (current_pool == cached_descriptor_pool_.end()) {
+      descriptor_pool =
+          (cached_descriptor_pool_[std::this_thread::get_id()] =
+               std::make_shared<DescriptorPoolVK>(weak_from_this()));
+    } else {
+      descriptor_pool = current_pool->second;
+    }
   }
 
   auto tracked_objects = std::make_shared<TrackedObjectsVK>(
@@ -668,6 +671,7 @@ void ContextVK::InitializeCommonlyUsedShadersIfNeeded() const {
 }
 
 void ContextVK::DisposeThreadLocalCachedResources() {
+  Lock lock(desc_pool_mutex_);
   cached_descriptor_pool_.erase(std::this_thread::get_id());
   command_pool_recycler_->Dispose();
 }

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -574,7 +574,9 @@ void ContextVK::Shutdown() {
   // tl;dr: Without it, we get thread::join failures on shutdown.
   fence_waiter_.reset();
   resource_manager_.reset();
-  tls_descriptor_pool_map->erase(GetHash());
+  if (tls_descriptor_pool_map.get()) {
+    tls_descriptor_pool_map->erase(GetHash());
+  }
 
   raster_message_loop_->Terminate();
 }
@@ -681,7 +683,9 @@ void ContextVK::InitializeCommonlyUsedShadersIfNeeded() const {
 }
 
 void ContextVK::DisposeThreadLocalCachedResources() {
-  tls_descriptor_pool_map->erase(GetHash());
+  if (tls_descriptor_pool_map.get()) {
+    tls_descriptor_pool_map->erase(GetHash());
+  }
   command_pool_recycler_->Dispose();
 }
 

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -574,9 +574,7 @@ void ContextVK::Shutdown() {
   // tl;dr: Without it, we get thread::join failures on shutdown.
   fence_waiter_.reset();
   resource_manager_.reset();
-  if (tls_descriptor_pool_map.get()) {
-    tls_descriptor_pool_map->erase(GetHash());
-  }
+  tls_descriptor_pool_map->erase(GetHash());
 
   raster_message_loop_->Terminate();
 }
@@ -683,9 +681,7 @@ void ContextVK::InitializeCommonlyUsedShadersIfNeeded() const {
 }
 
 void ContextVK::DisposeThreadLocalCachedResources() {
-  if (tls_descriptor_pool_map.get()) {
-    tls_descriptor_pool_map->erase(GetHash());
-  }
+  tls_descriptor_pool_map->erase(GetHash());
   command_pool_recycler_->Dispose();
 }
 

--- a/impeller/renderer/backend/vulkan/context_vk.cc
+++ b/impeller/renderer/backend/vulkan/context_vk.cc
@@ -671,8 +671,10 @@ void ContextVK::InitializeCommonlyUsedShadersIfNeeded() const {
 }
 
 void ContextVK::DisposeThreadLocalCachedResources() {
-  Lock lock(desc_pool_mutex_);
-  cached_descriptor_pool_.erase(std::this_thread::get_id());
+  {
+    Lock lock(desc_pool_mutex_);
+    cached_descriptor_pool_.erase(std::this_thread::get_id());
+  }
   command_pool_recycler_->Dispose();
 }
 

--- a/impeller/renderer/backend/vulkan/context_vk.h
+++ b/impeller/renderer/backend/vulkan/context_vk.h
@@ -234,7 +234,9 @@ class ContextVK final : public Context,
   using DescriptorPoolMap =
       std::unordered_map<std::thread::id, std::shared_ptr<DescriptorPoolVK>>;
 
-  mutable DescriptorPoolMap cached_descriptor_pool_;
+  mutable Mutex desc_pool_mutex_;
+  mutable DescriptorPoolMap IPLR_GUARDED_BY(desc_pool_mutex_)
+      cached_descriptor_pool_;
   bool should_disable_surface_control_ = false;
   bool should_batch_cmd_buffers_ = false;
   std::vector<std::shared_ptr<CommandBuffer>> pending_command_buffers_;

--- a/impeller/renderer/backend/vulkan/context_vk.h
+++ b/impeller/renderer/backend/vulkan/context_vk.h
@@ -231,12 +231,6 @@ class ContextVK final : public Context,
   std::shared_ptr<GPUTracerVK> gpu_tracer_;
   std::shared_ptr<CommandQueue> command_queue_vk_;
 
-  using DescriptorPoolMap =
-      std::unordered_map<std::thread::id, std::shared_ptr<DescriptorPoolVK>>;
-
-  mutable Mutex desc_pool_mutex_;
-  mutable DescriptorPoolMap IPLR_GUARDED_BY(desc_pool_mutex_)
-      cached_descriptor_pool_;
   bool should_disable_surface_control_ = false;
   bool should_batch_cmd_buffers_ = false;
   std::vector<std::shared_ptr<CommandBuffer>> pending_command_buffers_;

--- a/impeller/renderer/backend/vulkan/context_vk.h
+++ b/impeller/renderer/backend/vulkan/context_vk.h
@@ -231,6 +231,12 @@ class ContextVK final : public Context,
   std::shared_ptr<GPUTracerVK> gpu_tracer_;
   std::shared_ptr<CommandQueue> command_queue_vk_;
 
+  using DescriptorPoolMap =
+      std::unordered_map<std::thread::id, std::shared_ptr<DescriptorPoolVK>>;
+
+  mutable Mutex desc_pool_mutex_;
+  mutable DescriptorPoolMap IPLR_GUARDED_BY(desc_pool_mutex_)
+      cached_descriptor_pool_;
   bool should_disable_surface_control_ = false;
   bool should_batch_cmd_buffers_ = false;
   std::vector<std::shared_ptr<CommandBuffer>> pending_command_buffers_;


### PR DESCRIPTION
Speculative fix for https://github.com/flutter/flutter/issues/157565 which looks like the kind of error that might happen if we concurrently mutate this hashmap.