### PR TITLE
[Impeller] fix initial layout for loadOp load and incorrect usage of host visible textures.

### DIFF
--- a/impeller/playground/playground.cc
+++ b/impeller/playground/playground.cc
@@ -388,8 +388,8 @@ static std::shared_ptr<Texture> CreateTextureForDecompressedImage(
     const std::shared_ptr<Context>& context,
     DecompressedImage& decompressed_image,
     bool enable_mipmapping) {
-  auto texture_descriptor = TextureDescriptor{};
-  texture_descriptor.storage_mode = StorageMode::kHostVisible;
+  TextureDescriptor texture_descriptor;
+  texture_descriptor.storage_mode = StorageMode::kDevicePrivate;
   texture_descriptor.format = PixelFormat::kR8G8B8A8UNormInt;
   texture_descriptor.size = decompressed_image.GetSize();
   texture_descriptor.mip_count =
@@ -463,8 +463,8 @@ std::shared_ptr<Texture> Playground::CreateTextureCubeForFixture(
     images[i] = image.value();
   }
 
-  auto texture_descriptor = TextureDescriptor{};
-  texture_descriptor.storage_mode = StorageMode::kHostVisible;
+  TextureDescriptor texture_descriptor;
+  texture_descriptor.storage_mode = StorageMode::kDevicePrivate;
   texture_descriptor.type = TextureType::kTextureCube;
   texture_descriptor.format = PixelFormat::kR8G8B8A8UNormInt;
   texture_descriptor.size = images[0].GetSize();

--- a/impeller/renderer/backend/vulkan/render_pass_builder_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_builder_vk.cc
@@ -6,7 +6,9 @@
 
 #include <vector>
 
+#include "impeller/core/formats.h"
 #include "impeller/renderer/backend/vulkan/formats_vk.h"
+#include "vulkan/vulkan_enums.hpp"
 
 namespace impeller {
 
@@ -31,7 +33,8 @@ RenderPassBuilderVK& RenderPassBuilderVK::SetColorAttachment(
     PixelFormat format,
     SampleCount sample_count,
     LoadAction load_action,
-    StoreAction store_action) {
+    StoreAction store_action,
+    vk::ImageLayout current_layout) {
   vk::AttachmentDescription desc;
   desc.format = ToVKImageFormat(format);
   desc.samples = ToVKSampleCount(sample_count);
@@ -39,7 +42,11 @@ RenderPassBuilderVK& RenderPassBuilderVK::SetColorAttachment(
   desc.storeOp = ToVKAttachmentStoreOp(store_action, false);
   desc.stencilLoadOp = vk::AttachmentLoadOp::eDontCare;
   desc.stencilStoreOp = vk::AttachmentStoreOp::eDontCare;
-  desc.initialLayout = vk::ImageLayout::eUndefined;
+  if (load_action == LoadAction::kLoad) {
+    desc.initialLayout = current_layout;
+  } else {
+    desc.initialLayout = vk::ImageLayout::eUndefined;
+  }
   desc.finalLayout = vk::ImageLayout::eGeneral;
   colors_[index] = desc;
 

--- a/impeller/renderer/backend/vulkan/render_pass_builder_vk.h
+++ b/impeller/renderer/backend/vulkan/render_pass_builder_vk.h
@@ -11,7 +11,6 @@
 #include "impeller/core/formats.h"
 #include "impeller/renderer/backend/vulkan/context_vk.h"
 #include "impeller/renderer/backend/vulkan/vk.h"
-#include "vulkan/vulkan_enums.hpp"
 
 namespace impeller {
 

--- a/impeller/renderer/backend/vulkan/render_pass_builder_vk.h
+++ b/impeller/renderer/backend/vulkan/render_pass_builder_vk.h
@@ -11,6 +11,7 @@
 #include "impeller/core/formats.h"
 #include "impeller/renderer/backend/vulkan/context_vk.h"
 #include "impeller/renderer/backend/vulkan/vk.h"
+#include "vulkan/vulkan_enums.hpp"
 
 namespace impeller {
 
@@ -24,11 +25,13 @@ class RenderPassBuilderVK {
 
   RenderPassBuilderVK& operator=(const RenderPassBuilderVK&) = delete;
 
-  RenderPassBuilderVK& SetColorAttachment(size_t index,
-                                          PixelFormat format,
-                                          SampleCount sample_count,
-                                          LoadAction load_action,
-                                          StoreAction store_action);
+  RenderPassBuilderVK& SetColorAttachment(
+      size_t index,
+      PixelFormat format,
+      SampleCount sample_count,
+      LoadAction load_action,
+      StoreAction store_action,
+      vk::ImageLayout current_layout = vk::ImageLayout::eUndefined);
 
   RenderPassBuilderVK& SetDepthStencilAttachment(PixelFormat format,
                                                  SampleCount sample_count,

--- a/impeller/renderer/backend/vulkan/render_pass_builder_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_builder_vk_unittests.cc
@@ -27,6 +27,30 @@ TEST(RenderPassBuilder, CreatesRenderPassWithNoDepthStencil) {
   EXPECT_FALSE(builder.GetDepthStencil().has_value());
 }
 
+TEST(RenderPassBuilder, RenderPassWithLoadOpUsesCurrentLayout) {
+  RenderPassBuilderVK builder = RenderPassBuilderVK();
+  auto const context = MockVulkanContextBuilder().Build();
+
+  // Create a single color attachment with a transient depth stencil.
+  builder.SetColorAttachment(0, PixelFormat::kR8G8B8A8UNormInt,
+                             SampleCount::kCount1, LoadAction::kLoad,
+                             StoreAction::kStore,
+                             vk::ImageLayout::eColorAttachmentOptimal);
+
+  auto render_pass = builder.Build(context->GetDevice());
+
+  EXPECT_TRUE(!!render_pass);
+
+  auto maybe_color = builder.GetColorAttachments().find(0u);
+  ASSERT_NE(maybe_color, builder.GetColorAttachments().end());
+  auto color = maybe_color->second;
+
+  EXPECT_EQ(color.initialLayout, vk::ImageLayout::eColorAttachmentOptimal);
+  EXPECT_EQ(color.finalLayout, vk::ImageLayout::eGeneral);
+  EXPECT_EQ(color.loadOp, vk::AttachmentLoadOp::eLoad);
+  EXPECT_EQ(color.storeOp, vk::AttachmentStoreOp::eStore);
+}
+
 TEST(RenderPassBuilder, CreatesRenderPassWithCombinedDepthStencil) {
   RenderPassBuilderVK builder = RenderPassBuilderVK();
   auto const context = MockVulkanContextBuilder().Build();
@@ -34,7 +58,7 @@ TEST(RenderPassBuilder, CreatesRenderPassWithCombinedDepthStencil) {
   // Create a single color attachment with a transient depth stencil.
   builder.SetColorAttachment(0, PixelFormat::kR8G8B8A8UNormInt,
                              SampleCount::kCount1, LoadAction::kClear,
-                             StoreAction::kStore);
+                             StoreAction::kStore, vk::ImageLayout::eGeneral);
   builder.SetDepthStencilAttachment(PixelFormat::kD24UnormS8Uint,
                                     SampleCount::kCount1, LoadAction::kDontCare,
                                     StoreAction::kDontCare);

--- a/impeller/renderer/backend/vulkan/render_pass_builder_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_builder_vk_unittests.cc
@@ -31,7 +31,6 @@ TEST(RenderPassBuilder, RenderPassWithLoadOpUsesCurrentLayout) {
   RenderPassBuilderVK builder = RenderPassBuilderVK();
   auto const context = MockVulkanContextBuilder().Build();
 
-  // Create a single color attachment with a transient depth stencil.
   builder.SetColorAttachment(0, PixelFormat::kR8G8B8A8UNormInt,
                              SampleCount::kCount1, LoadAction::kLoad,
                              StoreAction::kStore,

--- a/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -89,7 +89,8 @@ SharedHandleVK<vk::RenderPass> RenderPassVK::CreateVKRenderPass(
         color.texture->GetTextureDescriptor().format,        //
         color.texture->GetTextureDescriptor().sample_count,  //
         color.load_action,                                   //
-        color.store_action                                   //
+        color.store_action,                                  //
+        TextureVK::Cast(*color.texture).GetLayout()          //
     );
     TextureVK::Cast(*color.texture)
         .SetLayoutWithoutEncoding(vk::ImageLayout::eGeneral);


### PR DESCRIPTION
Both changes were required to get playground tests validation free with moltenvk. becuase an initial state of undefined means "I don't care what was in this texture before" but that doesn't make sense if we're setting "kLoad" since that explicitly asks vulkan to load the previous contents.

Fixes https://github.com/flutter/flutter/issues/157557