### PR TITLE
[Impeller] dont increment shared_ptr when tracked object is already tracked.

### DIFF
--- a/impeller/renderer/backend/vulkan/command_buffer_vk.cc
+++ b/impeller/renderer/backend/vulkan/command_buffer_vk.cc
@@ -116,11 +116,11 @@ vk::CommandBuffer CommandBufferVK::GetCommandBuffer() const {
   return {};
 }
 
-bool CommandBufferVK::Track(std::shared_ptr<SharedObjectVK> object) {
+bool CommandBufferVK::Track(const std::shared_ptr<SharedObjectVK>& object) {
   if (!IsValid()) {
     return false;
   }
-  tracked_objects_->Track(std::move(object));
+  tracked_objects_->Track(object);
   return true;
 }
 
@@ -132,11 +132,12 @@ bool CommandBufferVK::Track(const std::shared_ptr<const DeviceBuffer>& buffer) {
   return true;
 }
 
-bool CommandBufferVK::Track(std::shared_ptr<const TextureSourceVK> texture) {
+bool CommandBufferVK::Track(
+    const std::shared_ptr<const TextureSourceVK>& texture) {
   if (!IsValid()) {
     return false;
   }
-  tracked_objects_->Track(std::move(texture));
+  tracked_objects_->Track(texture);
   return true;
 }
 

--- a/impeller/renderer/backend/vulkan/command_buffer_vk.h
+++ b/impeller/renderer/backend/vulkan/command_buffer_vk.h
@@ -33,7 +33,7 @@ class CommandBufferVK final
 
   /// @brief Ensure that [object] is kept alive until this command buffer
   ///        completes execution.
-  bool Track(std::shared_ptr<SharedObjectVK> object);
+  bool Track(const std::shared_ptr<SharedObjectVK>& object);
 
   /// @brief Ensure that [buffer] is kept alive until this command buffer
   ///        completes execution.
@@ -45,7 +45,7 @@ class CommandBufferVK final
 
   /// @brief Ensure that [texture] is kept alive until this command buffer
   ///        completes execution.
-  bool Track(std::shared_ptr<const TextureSourceVK> texture);
+  bool Track(const std::shared_ptr<const TextureSourceVK>& texture);
 
   /// @brief Retrieve the native command buffer from this object.
   vk::CommandBuffer GetCommandBuffer() const;

--- a/impeller/renderer/backend/vulkan/tracked_objects_vk.cc
+++ b/impeller/renderer/backend/vulkan/tracked_objects_vk.cc
@@ -43,28 +43,30 @@ bool TrackedObjectsVK::IsValid() const {
   return is_valid_;
 }
 
-void TrackedObjectsVK::Track(std::shared_ptr<SharedObjectVK> object) {
+void TrackedObjectsVK::Track(const std::shared_ptr<SharedObjectVK>& object) {
   if (!object || (!tracked_objects_.empty() &&
                   object.get() == tracked_objects_.back().get())) {
     return;
   }
-  tracked_objects_.emplace_back(std::move(object));
+  tracked_objects_.emplace_back(object);
 }
 
-void TrackedObjectsVK::Track(std::shared_ptr<const DeviceBuffer> buffer) {
+void TrackedObjectsVK::Track(
+    const std::shared_ptr<const DeviceBuffer>& buffer) {
   if (!buffer || (!tracked_buffers_.empty() &&
                   buffer.get() == tracked_buffers_.back().get())) {
     return;
   }
-  tracked_buffers_.emplace_back(std::move(buffer));
+  tracked_buffers_.emplace_back(buffer);
 }
 
-void TrackedObjectsVK::Track(std::shared_ptr<const TextureSourceVK> texture) {
+void TrackedObjectsVK::Track(
+    const std::shared_ptr<const TextureSourceVK>& texture) {
   if (!texture || (!tracked_textures_.empty() &&
                    texture.get() == tracked_textures_.back().get())) {
     return;
   }
-  tracked_textures_.emplace_back(std::move(texture));
+  tracked_textures_.emplace_back(texture);
 }
 
 vk::CommandBuffer TrackedObjectsVK::GetCommandBuffer() const {

--- a/impeller/renderer/backend/vulkan/tracked_objects_vk.h
+++ b/impeller/renderer/backend/vulkan/tracked_objects_vk.h
@@ -27,11 +27,11 @@ class TrackedObjectsVK {
 
   bool IsValid() const;
 
-  void Track(std::shared_ptr<SharedObjectVK> object);
+  void Track(const std::shared_ptr<SharedObjectVK>& object);
 
-  void Track(std::shared_ptr<const DeviceBuffer> buffer);
+  void Track(const std::shared_ptr<const DeviceBuffer>& buffer);
 
-  void Track(std::shared_ptr<const TextureSourceVK> texture);
+  void Track(const std::shared_ptr<const TextureSourceVK>& texture);
 
   vk::CommandBuffer GetCommandBuffer() const;
 


### PR DESCRIPTION
By passing the shared_ptrs to TrackedObjectsVK by value, we will always require at least a decrement of the shared_ptr count, and possibly an increment too. 

Since for most cases the tracked object has already been tracked, passing by const ref results in no increment or decrement.


Ignoring the time value, since this is a flamegraph, we can see almost all time spent tracking is spent on shared_ptr decrement:

![image](https://github.com/user-attachments/assets/aeae405b-1e5a-4d97-a9a3-b7668cec0714)
