### PR TITLE
iOS: migrate Metal testing types to ARC

### DIFF
--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -211,6 +211,9 @@ if (is_mac || is_ios) {
       }
     }
 
+    cflags_objc = flutter_cflags_objc_arc
+    cflags_objcc = flutter_cflags_objcc_arc
+
     testonly = true
   }
 }

--- a/testing/test_metal_context.h
+++ b/testing/test_metal_context.h
@@ -38,8 +38,9 @@ class TestMetalContext {
   TextureInfo GetTextureInfo(int64_t texture_id);
 
  private:
-  void* device_;
-  void* command_queue_;
+  // TODO(cbracken): https://github.com/flutter/flutter/issues/157942
+  void* device_;         // id<MTLDevice>
+  void* command_queue_;  // id<MTLCommandQueue>
   sk_sp<GrDirectContext> skia_context_;
   std::mutex textures_mutex_;
   int64_t texture_id_ctr_ = 1;                 // guarded by textures_mutex

--- a/testing/test_metal_context.mm
+++ b/testing/test_metal_context.mm
@@ -14,46 +14,55 @@
 #include "third_party/skia/include/gpu/ganesh/mtl/GrMtlBackendContext.h"
 #include "third_party/skia/include/gpu/ganesh/mtl/GrMtlDirectContext.h"
 
+static_assert(__has_feature(objc_arc), "ARC must be enabled.");
+
 namespace flutter {
 
 TestMetalContext::TestMetalContext() {
-  auto device = fml::scoped_nsprotocol{MTLCreateSystemDefaultDevice()};
+  id<MTLDevice> device = MTLCreateSystemDefaultDevice();
   if (!device) {
     FML_LOG(ERROR) << "Could not acquire Metal device.";
     return;
   }
 
-  auto command_queue = fml::scoped_nsobject{[device.get() newCommandQueue]};
+  id<MTLCommandQueue> command_queue = [device newCommandQueue];
   if (!command_queue) {
     FML_LOG(ERROR) << "Could not create the default command queue.";
     return;
   }
 
-  [command_queue.get() setLabel:@"Flutter Test Queue"];
+  [command_queue setLabel:@"Flutter Test Queue"];
 
   GrMtlBackendContext backendContext = {};
   // Skia expect arguments to `MakeMetal` transfer ownership of the reference in for release later
   // when the GrDirectContext is collected.
-  backendContext.fDevice.reset([device.get() retain]);
-  backendContext.fQueue.reset([command_queue.get() retain]);
+  backendContext.fDevice.retain((__bridge GrMTLHandle)device);
+  backendContext.fQueue.retain((__bridge GrMTLHandle)command_queue);
   skia_context_ = GrDirectContexts::MakeMetal(backendContext);
   if (!skia_context_) {
     FML_LOG(ERROR) << "Could not create the GrDirectContext from the Metal Device "
                       "and command queue.";
   }
 
-  device_ = [device.get() retain];
-  command_queue_ = [command_queue.get() retain];
+  // Retain and transfer to non-ARC-managed pointers.
+  device_ = (__bridge_retained void*)device;
+  command_queue_ = (__bridge_retained void*)command_queue;
 }
 
 TestMetalContext::~TestMetalContext() {
   std::scoped_lock lock(textures_mutex_);
   textures_.clear();
   if (device_) {
-    [(__bridge id)device_ release];
+    // Release and transfer to ARC-managed pointer.
+    id<MTLDevice> device =  // NOLINT(clang-analyzer-deadcode.DeadStores)
+        (__bridge_transfer id<MTLDevice>)device_;
+    device = nil;
   }
   if (command_queue_) {
-    [(__bridge id)command_queue_ release];
+    // Release and transfer to ARC-managed pointer.
+    id<MTLCommandQueue> command_queue =  // NOLINT(clang-analyzer-deadcode.DeadStores)
+        (__bridge_transfer id<MTLCommandQueue>)command_queue_;
+    command_queue = nil;
   }
 }
 
@@ -71,16 +80,16 @@ sk_sp<GrDirectContext> TestMetalContext::GetSkiaContext() const {
 
 TestMetalContext::TextureInfo TestMetalContext::CreateMetalTexture(const SkISize& size) {
   std::scoped_lock lock(textures_mutex_);
-  auto texture_descriptor = fml::scoped_nsobject{
-      [[MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
-                                                          width:size.width()
-                                                         height:size.height()
-                                                      mipmapped:NO] retain]};
+  MTLTextureDescriptor* texture_descriptor =
+      [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
+                                                         width:size.width()
+                                                        height:size.height()
+                                                     mipmapped:NO];
 
   // The most pessimistic option and disables all optimizations but allows tests
   // the most flexible access to the surface. They may read and write to the
   // surface from shaders or use as a pixel view.
-  texture_descriptor.get().usage = MTLTextureUsageUnknown;
+  texture_descriptor.usage = MTLTextureUsageUnknown;
 
   if (!texture_descriptor) {
     FML_CHECK(false) << "Invalid texture descriptor.";
@@ -88,19 +97,20 @@ TestMetalContext::TextureInfo TestMetalContext::CreateMetalTexture(const SkISize
   }
 
   id<MTLDevice> device = (__bridge id<MTLDevice>)GetMetalDevice();
-  sk_cfp<void*> texture = sk_cfp<void*>{[device newTextureWithDescriptor:texture_descriptor.get()]};
-
+  id<MTLTexture> texture = [device newTextureWithDescriptor:texture_descriptor];
   if (!texture) {
     FML_CHECK(false) << "Could not create texture from texture descriptor.";
     return {.texture_id = -1, .texture = nullptr};
   }
 
   const int64_t texture_id = texture_id_ctr_++;
-  textures_[texture_id] = texture;
+  sk_cfp<void*> texture_ptr;
+  texture_ptr.reset((__bridge_retained void*)texture);
+  textures_[texture_id] = texture_ptr;
 
   return {
       .texture_id = texture_id,
-      .texture = texture.get(),
+      .texture = (__bridge void*)texture,
   };
 }
 

--- a/testing/test_metal_context.mm
+++ b/testing/test_metal_context.mm
@@ -45,6 +45,7 @@ TestMetalContext::TestMetalContext() {
   }
 
   // Retain and transfer to non-ARC-managed pointers.
+  // TODO(cbracken): https://github.com/flutter/flutter/issues/157942
   device_ = (__bridge_retained void*)device;
   command_queue_ = (__bridge_retained void*)command_queue;
 }
@@ -54,12 +55,14 @@ TestMetalContext::~TestMetalContext() {
   textures_.clear();
   if (device_) {
     // Release and transfer to ARC-managed pointer.
+    // TODO(cbracken): https://github.com/flutter/flutter/issues/157942
     id<MTLDevice> device =  // NOLINT(clang-analyzer-deadcode.DeadStores)
         (__bridge_transfer id<MTLDevice>)device_;
     device = nil;
   }
   if (command_queue_) {
     // Release and transfer to ARC-managed pointer.
+    // TODO(cbracken): https://github.com/flutter/flutter/issues/157942
     id<MTLCommandQueue> command_queue =  // NOLINT(clang-analyzer-deadcode.DeadStores)
         (__bridge_transfer id<MTLCommandQueue>)command_queue_;
     command_queue = nil;
@@ -105,7 +108,7 @@ TestMetalContext::TextureInfo TestMetalContext::CreateMetalTexture(const SkISize
 
   const int64_t texture_id = texture_id_ctr_++;
   sk_cfp<void*> texture_ptr;
-  texture_ptr.reset((__bridge_retained void*)texture);
+  texture_ptr.retain((__bridge void*)texture);
   textures_[texture_id] = texture_ptr;
 
   return {

--- a/testing/test_metal_surface_impl.mm
+++ b/testing/test_metal_surface_impl.mm
@@ -21,6 +21,8 @@
 #include "third_party/skia/include/gpu/ganesh/mtl/GrMtlBackendSurface.h"
 #include "third_party/skia/include/gpu/ganesh/mtl/GrMtlTypes.h"
 
+static_assert(__has_feature(objc_arc), "ARC must be enabled.");
+
 namespace flutter {
 
 void TestMetalSurfaceImpl::Init(const TestMetalContext::TextureInfo& texture_info,
@@ -28,7 +30,7 @@ void TestMetalSurfaceImpl::Init(const TestMetalContext::TextureInfo& texture_inf
   id<MTLTexture> texture = (__bridge id<MTLTexture>)texture_info.texture;
 
   GrMtlTextureInfo skia_texture_info;
-  skia_texture_info.fTexture.reset([texture retain]);
+  skia_texture_info.fTexture.retain((__bridge GrMTLHandle)texture);
   GrBackendTexture backend_texture = GrBackendTextures::MakeMtl(
       surface_size.width(), surface_size.height(), skgpu::Mipmapped::kNo, skia_texture_info);
 


### PR DESCRIPTION
This migrates Flutter's TestMetalContext and TestMetalSurface to ARC.

Also migrates to using `sk_cfp::retain` (which retains the passed in pointer) rather than `sk_cfp::reset`, which only releases the previous pointer but doesn't retain the incoming pointer.

No changes to tests since no semantic changes.

Issue: https://github.com/flutter/flutter/issues/137801

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
