### PR TITLE
[Impeller] disable Maleoon GPU from using Vulkan.

### DIFF
--- a/impeller/renderer/backend/vulkan/driver_info_vk.cc
+++ b/impeller/renderer/backend/vulkan/driver_info_vk.cc
@@ -350,6 +350,11 @@ bool DriverInfoVK::IsKnownBadDriver() const {
         return false;
     }
   }
+  // Disable Maleoon series GPUs, see:
+  // https://github.com/flutter/flutter/issues/156623
+  if (vendor_ == VendorVK::kHuawei) {
+    return true;
+  }
   return false;
 }
 

--- a/impeller/renderer/backend/vulkan/driver_info_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/driver_info_vk_unittests.cc
@@ -36,6 +36,19 @@ TEST_P(DriverInfoVKTest, CanDumpToLog) {
   EXPECT_TRUE(log.str().find("Driver Information") != std::string::npos);
 }
 
+TEST(DriverInfoVKTest, CanIdentifyBadMaleoonDriver) {
+  auto const context =
+      MockVulkanContextBuilder()
+          .SetPhysicalPropertiesCallback(
+              [](VkPhysicalDevice device, VkPhysicalDeviceProperties* prop) {
+                prop->vendorID = 0x19E5;  // Huawei
+                prop->deviceType = VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU;
+              })
+          .Build();
+
+  EXPECT_TRUE(context->GetDriverInfo()->IsKnownBadDriver());
+}
+
 bool IsBadVersionTest(std::string_view driver_name, bool qc = true) {
   auto const context =
       MockVulkanContextBuilder()


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/156623

using info from https://vulkan.gpuinfo.org/displayreport.php?id=23730 . I dont believe these vulkan drivers are working correctly.
