### PR TITLE
[CP][Impeller] disable AHBs on devices that were upgraded to 29. (#56202)

### DIFF
--- a/impeller/toolkit/android/shadow_realm.cc
+++ b/impeller/toolkit/android/shadow_realm.cc
@@ -15,13 +15,23 @@ bool ShadowRealm::ShouldDisableAHB() {
   __system_property_get("ro.com.google.clientidbase", clientidbase);
 
   auto api_level = android_get_device_api_level();
+  char first_api_level[PROP_VALUE_MAX];
+  __system_property_get("ro.product.first_api_level", first_api_level);
 
-  return ShouldDisableAHBInternal(clientidbase, api_level);
+  return ShouldDisableAHBInternal(clientidbase, first_api_level, api_level);
 }
 
 // static
 bool ShadowRealm::ShouldDisableAHBInternal(std::string_view clientidbase,
+                                           std::string_view first_api_level,
                                            uint32_t api_level) {
+  // Most devices that have updated to API 29 don't seem to correctly
+  // support AHBs: https://github.com/flutter/flutter/issues/157113
+  if (first_api_level == "28" || first_api_level == "27" ||
+      first_api_level == "26" || first_api_level == "25" ||
+      first_api_level == "24") {
+    return false;
+  }
   // From local testing, neither the swapchain nor AHB import works, see also:
   // https://github.com/flutter/flutter/issues/154068
   if (clientidbase == kAndroidHuawei && api_level <= 29) {

--- a/impeller/toolkit/android/shadow_realm.cc
+++ b/impeller/toolkit/android/shadow_realm.cc
@@ -30,7 +30,7 @@ bool ShadowRealm::ShouldDisableAHBInternal(std::string_view clientidbase,
   if (first_api_level == "28" || first_api_level == "27" ||
       first_api_level == "26" || first_api_level == "25" ||
       first_api_level == "24") {
-    return false;
+    return true;
   }
   // From local testing, neither the swapchain nor AHB import works, see also:
   // https://github.com/flutter/flutter/issues/154068

--- a/impeller/toolkit/android/shadow_realm.h
+++ b/impeller/toolkit/android/shadow_realm.h
@@ -18,6 +18,7 @@ class ShadowRealm {
 
   // For testing.
   static bool ShouldDisableAHBInternal(std::string_view clientidbase,
+                                       std::string_view first_api_level,
                                        uint32_t api_level);
 };
 

--- a/impeller/toolkit/android/toolkit_android_unittests.cc
+++ b/impeller/toolkit/android/toolkit_android_unittests.cc
@@ -138,9 +138,17 @@ TEST(ToolkitAndroidTest, CanPostAndWaitForFrameCallbacks) {
 TEST(ToolkitAndroidTest, ShouldDisableAHB) {
   EXPECT_FALSE(ShadowRealm::ShouldDisableAHB());
 
-  EXPECT_TRUE(ShadowRealm::ShouldDisableAHBInternal("android-huawei", 29));
-  EXPECT_FALSE(ShadowRealm::ShouldDisableAHBInternal("android-huawei", 30));
-  EXPECT_FALSE(ShadowRealm::ShouldDisableAHBInternal("something made up", 29));
+  EXPECT_FALSE(
+      ShadowRealm::ShouldDisableAHBInternal("android-huawei", "30", 30));
+  EXPECT_FALSE(
+      ShadowRealm::ShouldDisableAHBInternal("something made up", "29", 29));
+
+  EXPECT_TRUE(
+      ShadowRealm::ShouldDisableAHBInternal("android-huawei", "29", 29));
+  EXPECT_TRUE(
+      ShadowRealm::ShouldDisableAHBInternal("something made up", "27", 29));
+  EXPECT_TRUE(
+      ShadowRealm::ShouldDisableAHBInternal("android-huawei", "garbage", 29));
 }
 
 }  // namespace impeller::android::testing

--- a/impeller/toolkit/android/toolkit_android_unittests.cc
+++ b/impeller/toolkit/android/toolkit_android_unittests.cc
@@ -136,8 +136,6 @@ TEST(ToolkitAndroidTest, CanPostAndWaitForFrameCallbacks) {
 }
 
 TEST(ToolkitAndroidTest, ShouldDisableAHB) {
-  EXPECT_FALSE(ShadowRealm::ShouldDisableAHB());
-
   EXPECT_FALSE(
       ShadowRealm::ShouldDisableAHBInternal("android-huawei", "30", 30));
   EXPECT_FALSE(


### PR DESCRIPTION
Uses `ro.product.first_api_level` to disable AHBs on devices that began life pre 29.

Fixes https://github.com/flutter/flutter/issues/157113
