### PR TITLE
[Flutter GPU] Fix MSAA sample size and HostBuffer alignment.

### DIFF
--- a/lib/gpu/lib/src/buffer.dart
+++ b/lib/gpu/lib/src/buffer.dart
@@ -212,7 +212,11 @@ base class HostBuffer {
           offsetInBytes: 0, lengthInBytes: bytes.lengthInBytes);
     }
 
-    int padding = _offsetCursor % _gpuContext.minimumUniformByteAlignment;
+    int padding = _gpuContext.minimumUniformByteAlignment -
+        (_offsetCursor % _gpuContext.minimumUniformByteAlignment);
+    // If the padding is the full alignment size, then we're already aligned.
+    // So reset the padding to zero.
+    padding %= _gpuContext.minimumUniformByteAlignment;
     if (_offsetCursor + padding >= blockLengthInBytes) {
       DeviceBuffer buffer = _allocateNewBlock(blockLengthInBytes);
       _buffers[_frameCursor].add(buffer);

--- a/lib/gpu/lib/src/render_pass.dart
+++ b/lib/gpu/lib/src/render_pass.dart
@@ -250,6 +250,14 @@ base class RenderPass extends NativeFieldWrapperClass1 {
       sampler = SamplerOptions();
     }
 
+    assert(() {
+      if (texture.storageMode == StorageMode.deviceTransient) {
+        throw Exception(
+            "Textures with StorageMode.deviceTransient cannot be bound to a RenderPass");
+      }
+      return true;
+    }());
+
     bool success = _bindTexture(
         slot.shader,
         slot.uniformName,

--- a/lib/gpu/render_pass.cc
+++ b/lib/gpu/render_pass.cc
@@ -102,6 +102,9 @@ std::shared_ptr<impeller::Pipeline<impeller::PipelineDescriptor>>
 RenderPass::GetOrCreatePipeline() {
   // Infer the pipeline layout based on the shape of the RenderTarget.
   auto pipeline_desc = pipeline_descriptor_;
+
+  pipeline_desc.SetSampleCount(render_target_.GetSampleCount());
+
   for (const auto& it : render_target_.GetColorAttachments()) {
     auto& color = GetColorAttachmentDescriptor(it.first);
     color.format = render_target_.GetRenderTargetPixelFormat();


### PR DESCRIPTION
- Align HostBuffer emplacements properly (fix Metal validation failures).
- Correctly set the pipeline sample size.
- Throw an error when attempting to bind `deviceTransient` textures.