### PR TITLE
[Impeller] Remove the use of a subpixel minimum stroke size for MSAA

### DIFF
--- a/impeller/entity/geometry/circle_geometry.cc
+++ b/impeller/entity/geometry/circle_geometry.cc
@@ -42,11 +42,9 @@ GeometryResult CircleGeometry::GetPositionBuffer(const ContentContext& renderer,
                                                  RenderPass& pass) const {
   auto& transform = entity.GetTransform();
 
-  Scalar half_width = stroke_width_ < 0
-                          ? 0.0
-                          : LineGeometry::ComputePixelHalfWidth(
-                                transform, stroke_width_,
-                                pass.GetSampleCount() == SampleCount::kCount4);
+  Scalar half_width = stroke_width_ < 0 ? 0.0
+                                        : LineGeometry::ComputePixelHalfWidth(
+                                              transform, stroke_width_);
 
   const std::shared_ptr<Tessellator>& tessellator = renderer.GetTessellator();
 

--- a/impeller/entity/geometry/geometry.cc
+++ b/impeller/entity/geometry/geometry.cc
@@ -133,9 +133,7 @@ bool Geometry::CanApplyMaskFilter() const {
 Scalar Geometry::ComputeStrokeAlphaCoverage(const Matrix& transform,
                                             Scalar stroke_width) {
   Scalar scaled_stroke_width = transform.GetMaxBasisLengthXY() * stroke_width;
-  // If the stroke width is 0 or greater than kMinStrokeSizeMSAA, don't apply
-  // any additional alpha. This is intended to match Skia behavior.
-  if (scaled_stroke_width == 0.0 || scaled_stroke_width >= kMinStrokeSizeMSAA) {
+  if (scaled_stroke_width == 0.0 || scaled_stroke_width >= kMinStrokeSize) {
     return 1.0;
   }
   // This scalling is eyeballed from Skia.

--- a/impeller/entity/geometry/geometry.h
+++ b/impeller/entity/geometry/geometry.h
@@ -16,11 +16,6 @@ namespace impeller {
 
 class Tessellator;
 
-/// @brief The minimum stroke size can be less than one physical pixel because
-///        of MSAA, but no less that half a physical pixel otherwise we might
-///        not hit one of the sample positions.
-static constexpr Scalar kMinStrokeSizeMSAA = 0.5f;
-
 static constexpr Scalar kMinStrokeSize = 1.0f;
 
 struct GeometryResult {

--- a/impeller/entity/geometry/line_geometry.h
+++ b/impeller/entity/geometry/line_geometry.h
@@ -15,9 +15,7 @@ class LineGeometry final : public Geometry {
 
   ~LineGeometry() override;
 
-  static Scalar ComputePixelHalfWidth(const Matrix& transform,
-                                      Scalar width,
-                                      bool msaa);
+  static Scalar ComputePixelHalfWidth(const Matrix& transform, Scalar width);
 
   // |Geometry|
   bool CoversArea(const Matrix& transform, const Rect& rect) const override;
@@ -44,12 +42,10 @@ class LineGeometry final : public Geometry {
   // @return true if the transform and width were not degenerate
   bool ComputeCorners(Point corners[4],
                       const Matrix& transform,
-                      bool extend_endpoints,
-                      bool msaa) const;
+                      bool extend_endpoints) const;
 
   Vector2 ComputeAlongVector(const Matrix& transform,
-                             bool allow_zero_length,
-                             bool msaa) const;
+                             bool allow_zero_length) const;
 
   // |Geometry|
   GeometryResult GetPositionBuffer(const ContentContext& renderer,

--- a/impeller/entity/geometry/stroke_path_geometry.cc
+++ b/impeller/entity/geometry/stroke_path_geometry.cc
@@ -574,10 +574,7 @@ GeometryResult StrokePathGeometry::GetPositionBuffer(
     return {};
   }
 
-  Scalar min_size =
-      (pass.GetSampleCount() == SampleCount::kCount4 ? kMinStrokeSizeMSAA
-                                                     : kMinStrokeSize) /
-      max_basis;
+  Scalar min_size = kMinStrokeSize / max_basis;
   Scalar stroke_width = std::max(stroke_width_, min_size);
 
   auto& host_buffer = renderer.GetTransientsBuffer();


### PR DESCRIPTION
Based on https://github.com/flutter/engine/pull/55230

Fixes https://github.com/flutter/flutter/issues/156438