### PR TITLE
[Impeller] expose reference to tessellator instead of shared_ptr.

### DIFF
--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -543,8 +543,8 @@ fml::StatusOr<RenderTarget> ContentContext::MakeSubpass(
   return subpass_target;
 }
 
-std::shared_ptr<Tessellator> ContentContext::GetTessellator() const {
-  return tessellator_;
+Tessellator& ContentContext::GetTessellator() const {
+  return *tessellator_;
 }
 
 std::shared_ptr<Context> ContentContext::GetContext() const {

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -374,7 +374,7 @@ class ContentContext {
 
   bool IsValid() const;
 
-  std::shared_ptr<Tessellator> GetTessellator() const;
+  Tessellator& GetTessellator() const;
 
   std::shared_ptr<Pipeline<PipelineDescriptor>> GetFastGradientPipeline(
       ContentContextOptions opts) const {

--- a/impeller/entity/geometry/circle_geometry.cc
+++ b/impeller/entity/geometry/circle_geometry.cc
@@ -48,12 +48,10 @@ GeometryResult CircleGeometry::GetPositionBuffer(const ContentContext& renderer,
                                 transform, stroke_width_,
                                 pass.GetSampleCount() == SampleCount::kCount4);
 
-  const std::shared_ptr<Tessellator>& tessellator = renderer.GetTessellator();
-
   // We call the StrokedCircle method which will simplify to a
   // FilledCircleGenerator if the inner_radius is <= 0.
-  auto generator =
-      tessellator->StrokedCircle(transform, center_, radius_, half_width);
+  auto generator = renderer.GetTessellator().StrokedCircle(transform, center_,
+                                                           radius_, half_width);
 
   return ComputePositionGeometry(renderer, generator, entity, pass);
 }

--- a/impeller/entity/geometry/ellipse_geometry.cc
+++ b/impeller/entity/geometry/ellipse_geometry.cc
@@ -18,7 +18,7 @@ GeometryResult EllipseGeometry::GetPositionBuffer(
     RenderPass& pass) const {
   return ComputePositionGeometry(
       renderer,
-      renderer.GetTessellator()->FilledEllipse(entity.GetTransform(), bounds_),
+      renderer.GetTessellator().FilledEllipse(entity.GetTransform(), bounds_),
       entity, pass);
 }
 

--- a/impeller/entity/geometry/fill_path_geometry.cc
+++ b/impeller/entity/geometry/fill_path_geometry.cc
@@ -38,7 +38,7 @@ GeometryResult FillPathGeometry::GetPositionBuffer(
     };
   }
 
-  VertexBuffer vertex_buffer = renderer.GetTessellator()->TessellateConvex(
+  VertexBuffer vertex_buffer = renderer.GetTessellator().TessellateConvex(
       path_, host_buffer, entity.GetTransform().GetMaxBasisLengthXY());
 
   return GeometryResult{

--- a/impeller/entity/geometry/line_geometry.cc
+++ b/impeller/entity/geometry/line_geometry.cc
@@ -84,8 +84,8 @@ GeometryResult LineGeometry::GetPositionBuffer(const ContentContext& renderer,
       transform, width_, pass.GetSampleCount() == SampleCount::kCount4);
 
   if (cap_ == Cap::kRound) {
-    std::shared_ptr<Tessellator> tessellator = renderer.GetTessellator();
-    auto generator = tessellator->RoundCapLine(transform, p0_, p1_, radius);
+    auto generator =
+        renderer.GetTessellator().RoundCapLine(transform, p0_, p1_, radius);
     return ComputePositionGeometry(renderer, generator, entity, pass);
   }
 

--- a/impeller/entity/geometry/point_field_geometry.cc
+++ b/impeller/entity/geometry/point_field_geometry.cc
@@ -42,7 +42,7 @@ GeometryResult PointFieldGeometry::GetPositionBuffer(
     // Get triangulation relative to {0, 0} so we can translate it to each
     // point in turn.
     Tessellator::EllipticalVertexGenerator generator =
-        renderer.GetTessellator()->FilledCircle(transform, {}, radius);
+        renderer.GetTessellator().FilledCircle(transform, {}, radius);
     FML_DCHECK(generator.GetTriangleType() == PrimitiveType::kTriangleStrip);
 
     std::vector<Point> circle_vertices;

--- a/impeller/entity/geometry/round_rect_geometry.cc
+++ b/impeller/entity/geometry/round_rect_geometry.cc
@@ -16,7 +16,7 @@ GeometryResult RoundRectGeometry::GetPositionBuffer(
     const Entity& entity,
     RenderPass& pass) const {
   return ComputePositionGeometry(renderer,
-                                 renderer.GetTessellator()->FilledRoundRect(
+                                 renderer.GetTessellator().FilledRoundRect(
                                      entity.GetTransform(), bounds_, radii_),
                                  entity, pass);
 }

--- a/impeller/entity/geometry/stroke_path_geometry.cc
+++ b/impeller/entity/geometry/stroke_path_geometry.cc
@@ -584,7 +584,7 @@ GeometryResult StrokePathGeometry::GetPositionBuffer(
   auto scale = entity.GetTransform().GetMaxBasisLengthXY();
 
   PositionWriter position_writer;
-  auto polyline = renderer.GetTessellator()->CreateTempPolyline(path_, scale);
+  auto polyline = renderer.GetTessellator().CreateTempPolyline(path_, scale);
   CreateSolidStrokeVertices(position_writer, polyline, stroke_width,
                             miter_limit_ * stroke_width_ * 0.5f,
                             GetJoinProc<PositionWriter>(stroke_join_),


### PR DESCRIPTION
All geometries were incrementing the shared_ptr usage count which shows up in profiles. Instead expose a Tessellator reference like we do with HostBuffer.
