### PR TITLE
iOS: Eliminate strong retain loop in Scenario tests

### DIFF
--- a/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterViewControllerTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterViewControllerTest.m
@@ -91,9 +91,7 @@ FLUTTER_ASSERT_ARC
   [rootVC presentViewController:self.flutterViewController animated:NO completion:nil];
 
   CGColorSpaceRef color_space = CGColorSpaceCreateDeviceRGB();
-
-  __block dispatch_block_t callback;
-  callback = ^{
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC), dispatch_get_main_queue(), ^{
     size_t width = 300u;
     CGContextRef context =
         CGBitmapContextCreate(nil, width, width, 8, 4 * width, color_space,
@@ -104,14 +102,8 @@ FLUTTER_ASSERT_ARC
       [imageRendered fulfill];
       return;
     }
-
     CGContextRelease(context);
-
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC), dispatch_get_main_queue(),
-                   callback);
-  };
-  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC), dispatch_get_main_queue(),
-                 callback);
+  });
 
   [self waitForExpectationsWithTimeout:30.0 handler:nil];
 


### PR DESCRIPTION
`FlutterViewControllerTest testDrawLayer` created a callback which strongly referenced itself in its own body as part of an asynchronous recursive loop. The recursion was unnecessary and the test consistently passes, even if run on repeat > 100 times without it.

Now that there's only one call, eliminates the unnecessary local and inlines it into the `dispatch_after` call.

This was originally introduced in https://github.com/flutter/engine/pull/50072.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I didn't list at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
