### PR TITLE
[Linux] Replace deprecated macros in fl_application_test.cc

### DIFF
--- a/shell/platform/linux/fl_application_test.cc
+++ b/shell/platform/linux/fl_application_test.cc
@@ -7,11 +7,23 @@
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_application.h"
 
 TEST(FlApplicationTest, ConstructorArgs) {
-  g_autoptr(FlApplication) app = fl_application_new(
-      "com.example.TestApplication", G_APPLICATION_FLAGS_NONE);
+  g_autoptr(FlApplication) app =
+      fl_application_new("com.example.TestApplication",
+#ifdef GLIB_VERSION_2_74
+                         G_APPLICATION_DEFAULT_FLAGS
+#else
+                         G_APPLICATION_FLAGS_NONE
+#endif
+      );
 
   EXPECT_STREQ(g_application_get_application_id(G_APPLICATION(app)),
                "com.example.TestApplication");
+
+#ifdef GLIB_VERSION_2_74
+  EXPECT_EQ(g_application_get_flags(G_APPLICATION(app)),
+            G_APPLICATION_DEFAULT_FLAGS);
+#else
   EXPECT_EQ(g_application_get_flags(G_APPLICATION(app)),
             G_APPLICATION_FLAGS_NONE);
+#endif
 }


### PR DESCRIPTION
Fixes this compile error:
```
[211/451] CXX obj/flutter/shell/platform/linux/flutter_linux_unittests.fl_application_test.o
FAILED: obj/flutter/shell/platform/linux/flutter_linux_unittests.fl_application_test.o
../../flutter/buildtools/linux-arm64/clang/bin/clang++ -MMD -MFobj/flutter/shell/platform/linux/flutter_linux_unittests.fl_application_test.o.d -DFLUTTER_ENGINE_NO_PROTOTYPES -DFLUTTER_LINUX_COMPILATION -DUSE_OPENSSL=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D_LIBCPP_DISABLE_AVAILABILITY=1 -D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DSK_FONTMGR_ANDROID_AVAILABLE -DSK_TYPEFACE_FACTORY_FREETYPE -DSK_FONTMGR_FREETYPE_DIRECTORY_AVAILABLE -DSK_FONTMGR_FREETYPE_EMBEDDED_AVAILABLE -DSK_FONTMGR_FREETYPE_EMPTY_AVAILABLE -DSK_GL -DSK_VULKAN -DSK_CODEC_DECODES_JPEG -DSK_CODEC_DECODES_PNG -DSK_CODEC_DECODES_ICO -DSK_CODEC_DECODES_WEBP -DSK_HAS_WUFFS_LIBRARY -DSK_CODEC_DECODES_GIF -DSK_XML -DFLUTTER_RUNTIME_MODE_DEBUG=1 -DFLUTTER_RUNTIME_MODE_PROFILE=2 -DFLUTTER_RUNTIME_MODE_RELEASE=3 -DFLUTTER_RUNTIME_MODE_JIT_RELEASE=4 -DDART_LEGACY_API=\[\[deprecated\]\] -DFLUTTER_RUNTIME_MODE=1 -DFLUTTER_JIT_RUNTIME=1 -DIMPELLER_DEBUG=1 -DIMPELLER_SUPPORTS_RENDERING=1 -DIMPELLER_ENABLE_OPENGLES=1 -DIMPELLER_ENABLE_VULKAN=1 -DSK_CODEC_DECODES_BMP -DSK_CODEC_DECODES_WBMP -DSK_ENABLE_DUMP_GPU -DSK_FORCE_AAA -DSK_LEGACY_IGNORE_DRAW_VERTICES_BLEND_WITH_NO_SHADER -DSK_DISABLE_LEGACY_METAL_BACKEND_SURFACE -DSK_DISABLE_LEGACY_PARAGRAPH_UNICODE -DSK_USE_LEGACY_BLUR_RASTER -DSK_DISABLE_LEGACY_SHADERCONTEXT -DSK_DISABLE_LOWP_RASTER_PIPELINE -DSK_FORCE_RASTER_PIPELINE_BLITTER -DSK_METAL_WAIT_UNTIL_SCHEDULED -DSK_DISABLE_EFFECT_DESERIALIZATION -DSK_R32_SHIFT=16 -DSK_ENABLE_PRECOMPILE -DSK_GANESH -DSK_USE_PERFETTO -I../.. -Igen -I../../flutter/third_party/libcxx/include -I../../flutter/third_party/libcxxabi/include -I../../flutter/build/secondary/flutter/third_party/libcxx/config -I../../flutter -I../../flutter/third_party/dart/runtime -I../../flutter/third_party/dart/runtime/include -Igen/flutter -Igen/flutter/impeller/runtime_stage -I../../flutter/third_party/flatbuffers/include -I../../flutter/third_party/skia -I../../flutter/third_party/googletest/googlemock/include -I../../flutter/third_party/googletest/googletest/include -fno-strict-aliasing -fstack-protector --param=ssp-buffer-size=8 -fPIC -pipe -pthread --target=aarch64-linux-gnu -DBORINGSSL_CLANG_SUPPORTS_DOT_ARCH -fcolor-diagnostics -Wall -Wextra -Wendif-labels -Werror -Wno-missing-field-initializers -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-unused-but-set-variable -Wno-implicit-int-float-conversion -Wno-deprecated-copy -Wno-psabi -Wno-deprecated-literal-operator -Wno-unqualified-std-cast-call -Wno-non-c-typedef-for-linkage -Wno-range-loop-construct -fdebug-prefix-map=/home/ross/flutter-engine/src/= -no-canonical-prefixes -fvisibility=hidden --sysroot=/nix/store/l8f409nhbvgl4xgd3ka5bvqjqdr39l6w-flutter-engine-toolchain-af0f0d559c8a87d912a20971bbd84afc80a54b0f -Wstring-conversion -Wnewline-eof -O2 -fno-ident -fdata-sections -ffunction-sections -g0 -isystem../../../../../../nix/store/l8f409nhbvgl4xgd3ka5bvqjqdr39l6w-flutter-engine-toolchain-af0f0d559c8a87d912a20971bbd84afc80a54b0f/nix/store/x56wmsqb0cwv09iqivb7i9fx9iy5zlkf-gtk+3-3.24.43-dev/include/gtk-3.0 -isystem../../../../../../nix/store/l8f409nhbvgl4xgd3ka5bvqjqdr39l6w-flutter-engine-toolchain-af0f0d559c8a87d912a20971bbd84afc80a54b0f/nix/store/as8vpbnch4a9n70x0v22pbmdp0zy0bj5-pango-1.52.2-dev/include/pango-1.0 -isystem../../../../../../nix/store/l8f409nhbvgl4xgd3ka5bvqjqdr39l6w-flutter-engine-toolchain-af0f0d559c8a87d912a20971bbd84afc80a54b0f/nix/store/9n0d1issr9pmaqix7jgzp214mlnz4sw7-harfbuzz-9.0.0-dev/include/harfbuzz -isystem../../../../../../nix/store/l8f409nhbvgl4xgd3ka5bvqjqdr39l6w-flutter-engine-toolchain-af0f0d559c8a87d912a20971bbd84afc80a54b0f/nix/store/22xgw9djkc5jrmm08f8qx8ki8a3yghy5-at-spi2-core-2.52.0-dev/include/atk-1.0 -isystem../../../../../../nix/store/l8f409nhbvgl4xgd3ka5bvqjqdr39l6w-flutter-engine-toolchain-af0f0d559c8a87d912a20971bbd84afc80a54b0f/nix/store/xya3gcnd2ald7yqw1chvfsbrvfdivykh-cairo-1.18.2-dev/include/cairo -isystem../../../../../../nix/store/l8f409nhbvgl4xgd3ka5bvqjqdr39l6w-flutter-engine-toolchain-af0f0d559c8a87d912a20971bbd84afc80a54b0f/nix/store/sd61i6hj14jvf83brrih1irmg7r0vb3v-freetype-2.13.3-dev/include/freetype2 -isystem../../../../../../nix/store/l8f409nhbvgl4xgd3ka5bvqjqdr39l6w-flutter-engine-toolchain-af0f0d559c8a87d912a20971bbd84afc80a54b0f/nix/store/sd61i6hj14jvf83brrih1irmg7r0vb3v-freetype-2.13.3-dev/include -isystem../../../../../../nix/store/l8f409nhbvgl4xgd3ka5bvqjqdr39l6w-flutter-engine-toolchain-af0f0d559c8a87d912a20971bbd84afc80a54b0f/nix/store/i2n1y998igf66wlz6b5yyc5fg1mjp5g7-gdk-pixbuf-2.42.12-dev/include/gdk-pixbuf-2.0 -isystem../../../../../../nix/store/l8f409nhbvgl4xgd3ka5bvqjqdr39l6w-flutter-engine-toolchain-af0f0d559c8a87d912a20971bbd84afc80a54b0f/nix/store/5bhcbbcl7p77zv5hx5bdnfggjlpmqzbq-glib-2.80.4-dev/include -isystem../../../../../../nix/store/l8f409nhbvgl4xgd3ka5bvqjqdr39l6w-flutter-engine-toolchain-af0f0d559c8a87d912a20971bbd84afc80a54b0f/nix/store/5bhcbbcl7p77zv5hx5bdnfggjlpmqzbq-glib-2.80.4-dev/include/glib-2.0 -isystem../../../../../../nix/store/l8f409nhbvgl4xgd3ka5bvqjqdr39l6w-flutter-engine-toolchain-af0f0d559c8a87d912a20971bbd84afc80a54b0f/nix/store/cw9qz08zwd1li8vd8lm0laywa6rsi3gs-glib-2.80.4/lib/glib-2.0/include -isystem../../../../../../nix/store/l8f409nhbvgl4xgd3ka5bvqjqdr39l6w-flutter-engine-toolchain-af0f0d559c8a87d912a20971bbd84afc80a54b0f/nix/store/60vanm346k9kjx9adzpsqgci7m0z1b3n-libepoxy-1.5.10-dev/include -Wunreachable-code -Wno-newline-eof -fvisibility-inlines-hidden -std=c++17 -fno-rtti -nostdinc++ -nostdinc++ -fvisibility=hidden -fno-exceptions -Wno-inconsistent-missing-override   -c ../../flutter/shell/platform/linux/fl_application_test.cc -o obj/flutter/shell/platform/linux/flutter_linux_unittests.fl_application_test.o
../../flutter/shell/platform/linux/fl_application_test.cc:11:38: error: 'G_APPLICATION_FLAGS_NONE' is deprecated: Use 'G_APPLICATION_DEFAULT_FLAGS' instead [-Werror,-Wdeprecated-declarations]
   11 |       "com.example.TestApplication", G_APPLICATION_FLAGS_NONE);
      |                                      ^
../../../../../../nix/store/l8f409nhbvgl4xgd3ka5bvqjqdr39l6w-flutter-engine-toolchain-af0f0d559c8a87d912a20971bbd84afc80a54b0f/nix/store/5bhcbbcl7p77zv5hx5bdnfggjlpmqzbq-glib-2.80.4-dev/include/glib-2.0/gio/gioenums.h:1545:28: note: 'G_APPLICATION_FLAGS_NONE' has been explicitly marked deprecated here
 1545 |   G_APPLICATION_FLAGS_NONE GIO_DEPRECATED_ENUMERATOR_IN_2_74_FOR(G_APPLICATION_DEFAULT_FLAGS),
      |                            ^
../../../../../../nix/store/l8f409nhbvgl4xgd3ka5bvqjqdr39l6w-flutter-engine-toolchain-af0f0d559c8a87d912a20971bbd84afc80a54b0f/nix/store/5bhcbbcl7p77zv5hx5bdnfggjlpmqzbq-glib-2.80.4-dev/include/glib-2.0/gio/gio-visibility.h:858:50: note: expanded from macro 'GIO_DEPRECATED_ENUMERATOR_IN_2_74_FOR'
  858 | #define GIO_DEPRECATED_ENUMERATOR_IN_2_74_FOR(f) GLIB_DEPRECATED_ENUMERATOR_FOR (f)
      |                                                  ^
../../../../../../nix/store/l8f409nhbvgl4xgd3ka5bvqjqdr39l6w-flutter-engine-toolchain-af0f0d559c8a87d912a20971bbd84afc80a54b0f/nix/store/5bhcbbcl7p77zv5hx5bdnfggjlpmqzbq-glib-2.80.4-dev/include/glib-2.0/glib/gmacros.h:1313:43: note: expanded from macro 'GLIB_DEPRECATED_ENUMERATOR_FOR'
 1313 | #define GLIB_DEPRECATED_ENUMERATOR_FOR(f) G_DEPRECATED_FOR(f)
      |                                           ^
../../../../../../nix/store/l8f409nhbvgl4xgd3ka5bvqjqdr39l6w-flutter-engine-toolchain-af0f0d559c8a87d912a20971bbd84afc80a54b0f/nix/store/5bhcbbcl7p77zv5hx5bdnfggjlpmqzbq-glib-2.80.4-dev/include/glib-2.0/glib/gmacros.h:1273:44: note: expanded from macro 'G_DEPRECATED_FOR'
 1273 | #define G_DEPRECATED_FOR(f) __attribute__((__deprecated__("Use '" #f "' instead")))
      |                                            ^
../../flutter/shell/platform/linux/fl_application_test.cc:16:13: error: 'G_APPLICATION_FLAGS_NONE' is deprecated: Use 'G_APPLICATION_DEFAULT_FLAGS' instead [-Werror,-Wdeprecated-declarations]
   16 |             G_APPLICATION_FLAGS_NONE);
      |             ^
../../../../../../nix/store/l8f409nhbvgl4xgd3ka5bvqjqdr39l6w-flutter-engine-toolchain-af0f0d559c8a87d912a20971bbd84afc80a54b0f/nix/store/5bhcbbcl7p77zv5hx5bdnfggjlpmqzbq-glib-2.80.4-dev/include/glib-2.0/gio/gioenums.h:1545:28: note: 'G_APPLICATION_FLAGS_NONE' has been explicitly marked deprecated here
 1545 |   G_APPLICATION_FLAGS_NONE GIO_DEPRECATED_ENUMERATOR_IN_2_74_FOR(G_APPLICATION_DEFAULT_FLAGS),
      |                            ^
../../../../../../nix/store/l8f409nhbvgl4xgd3ka5bvqjqdr39l6w-flutter-engine-toolchain-af0f0d559c8a87d912a20971bbd84afc80a54b0f/nix/store/5bhcbbcl7p77zv5hx5bdnfggjlpmqzbq-glib-2.80.4-dev/include/glib-2.0/gio/gio-visibility.h:858:50: note: expanded from macro 'GIO_DEPRECATED_ENUMERATOR_IN_2_74_FOR'
  858 | #define GIO_DEPRECATED_ENUMERATOR_IN_2_74_FOR(f) GLIB_DEPRECATED_ENUMERATOR_FOR (f)
      |                                                  ^
../../../../../../nix/store/l8f409nhbvgl4xgd3ka5bvqjqdr39l6w-flutter-engine-toolchain-af0f0d559c8a87d912a20971bbd84afc80a54b0f/nix/store/5bhcbbcl7p77zv5hx5bdnfggjlpmqzbq-glib-2.80.4-dev/include/glib-2.0/glib/gmacros.h:1313:43: note: expanded from macro 'GLIB_DEPRECATED_ENUMERATOR_FOR'
 1313 | #define GLIB_DEPRECATED_ENUMERATOR_FOR(f) G_DEPRECATED_FOR(f)
      |                                           ^
../../../../../../nix/store/l8f409nhbvgl4xgd3ka5bvqjqdr39l6w-flutter-engine-toolchain-af0f0d559c8a87d912a20971bbd84afc80a54b0f/nix/store/5bhcbbcl7p77zv5hx5bdnfggjlpmqzbq-glib-2.80.4-dev/include/glib-2.0/glib/gmacros.h:1273:44: note: expanded from macro 'G_DEPRECATED_FOR'
 1273 | #define G_DEPRECATED_FOR(f) __attribute__((__deprecated__("Use '" #f "' instead")))
      |                                            ^
2 errors generated.
[218/451] CXX obj/flutter/shell/platform/embedder/tests/embedder_unittests.embedder_gl_unittests.o
ninja: build stopped: subcommand failed.
```

*List which issues are fixed by this PR. You must list at least one issue.*

- https://github.com/flutter/flutter/issues/157906

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
