### PR TITLE
[ci] use env for format and support arm64 hosts

### DIFF
--- a/ci/bin/format.dart
+++ b/ci/bin/format.dart
@@ -6,6 +6,7 @@
 //
 // Run with --help for usage.
 
+import 'dart:ffi';
 import 'dart:io';
 
 import 'package:args/args.dart';
@@ -312,17 +313,15 @@ class ClangFormatChecker extends FormatChecker {
     super.allFiles,
     super.messageCallback,
   }) {
-    /*late*/ String clangOs;
-    if (Platform.isLinux) {
-      clangOs = 'linux-x64';
-    } else if (Platform.isMacOS) {
-      clangOs = 'mac-x64';
-    } else if (Platform.isWindows) {
-      clangOs = 'windows-x64';
-    } else {
-      throw FormattingException(
-          "Unknown operating system: don't know how to run clang-format here.");
-    }
+    final clangOs = switch (Abi.current()) {
+      Abi.linuxArm64 => 'linux-arm64',
+      Abi.linuxX64 => 'linux-x64',
+      Abi.macosArm64 => 'mac-arm64',
+      Abi.macosX64 => 'mac-x64',
+      Abi.windowsX64 => 'windows-x64',
+      (_) => throw FormattingException(
+          "Unknown operating system: don't know how to run clang-format here.")
+    };
     clangFormat = File(
       path.join(
         srcDir.absolute.path,

--- a/ci/format.sh
+++ b/ci/format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be


### PR DESCRIPTION
Fixes running x64 binaries on arm64 hosts, this fixes systems like Raspberry Pi's, Apple Silicon, and Ampere.

Before, I would get something like:
```
Checking GN formatting...
Completed checking 0 GN files with no formatting problems.
Checking Java formatting...
No Java files with changes, skipping Java format check.
Checking Python formatting...
All python files formatted correctly.
Checking for trailing whitespace on 1 source file...
No trailing whitespace found.
No header files with changes, skipping header guard check.
Checking C++/ObjC/Shader formatting...
ERROR: Formatter command '/home/ross/flutter-engine/src/flutter/buildtools/linux-x64/clang/bin/clang-format --style=file shell/platform/linux/fl_application_test.cc' failed with exit code 255. Command output follows:

qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory

Completed checking 0 C++/ObjC/Shader files with no formatting problems
```

Now it just works, I also changed the shell script to use env since `/bin/bash` doesn't exist on NixOS so using env is a more portable solution.

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
