### PR TITLE
Remove the quiet flag from invocations of run_tests.py on macOS CI builders

### DIFF
--- a/ci/builders/mac_unopt.json
+++ b/ci/builders/mac_unopt.json
@@ -44,7 +44,6 @@
                     "name": "Host Tests for host_debug",
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
-                        "--quiet",
                         "--variant",
                         "ci/host_debug_arm64_tests",
                         "--type",
@@ -96,7 +95,6 @@
                     "name": "Host Tests for host_profile",
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
-                        "--quiet",
                         "--variant",
                         "ci/host_profile_arm64_tests",
                         "--type",
@@ -149,7 +147,6 @@
                     "name": "Dart and engine tests for host_release",
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
-                        "--quiet",
                         "--variant",
                         "ci/host_release_arm64_tests",
                         "--type",
@@ -207,7 +204,6 @@
                     "name": "Impeller-golden for host_release",
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
-                        "--quiet",
                         "--variant",
                         "ci/mac_release_arm64_tests",
                         "--type",
@@ -263,7 +259,6 @@
                     "name": "Tests for ios_debug_unopt_sim",
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
-                        "--quiet",
                         "--variant",
                         "ci/ios_debug_unopt_sim",
                         "--type",
@@ -328,7 +323,6 @@
                     "name": "Host Tests for host_debug_unopt_arm64",
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
-                        "--quiet",
                         "--variant",
                         "ci/host_debug_unopt_arm64",
                         "--type",
@@ -393,7 +387,6 @@
                     "name": "Tests for ios_debug_unopt_sim_arm64",
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
-                        "--quiet",
                         "--variant",
                         "ci/ios_debug_unopt_sim_arm64",
                         "--type",
@@ -463,7 +456,6 @@
                     "name": "Tests for ios_debug_unopt_sim_arm64_extension_safe",
                     "script": "flutter/testing/run_tests.py",
                     "parameters": [
-                        "--quiet",
                         "--variant",
                         "ci/ios_debug_unopt_sim_arm64_extension_safe",
                         "--type",


### PR DESCRIPTION
The quiet flag filters out most of the script's output.  In particular, it excludes the output of child processes launched by the script.