### PR TITLE
iOS: Eliminate fml::scoped_nsobject pointer use

### DIFF
--- a/shell/common/shell_test_platform_view_metal.mm
+++ b/shell/common/shell_test_platform_view_metal.mm
@@ -8,7 +8,6 @@
 
 #include <utility>
 
-#include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/shell/gpu/gpu_surface_metal_impeller.h"
 #include "flutter/shell/gpu/gpu_surface_metal_skia.h"
 #include "flutter/shell/platform/darwin/graphics/FlutterDarwinContextMetalImpeller.h"
@@ -17,14 +16,14 @@
 namespace flutter {
 namespace testing {
 
-static fml::scoped_nsprotocol<id<MTLTexture>> CreateOffscreenTexture(id<MTLDevice> device) {
+static id<MTLTexture> CreateOffscreenTexture(id<MTLDevice> device) {
   auto descriptor =
       [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
                                                          width:800
                                                         height:600
                                                      mipmapped:NO];
   descriptor.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
-  return fml::scoped_nsprotocol<id<MTLTexture>>{[device newTextureWithDescriptor:descriptor]};
+  return [device newTextureWithDescriptor:descriptor];
 }
 
 // This is out of the header so that shell_test_platform_view_metal.h can be included in
@@ -43,25 +42,23 @@ class DarwinContextMetal {
 
   ~DarwinContextMetal() = default;
 
-  fml::scoped_nsobject<FlutterDarwinContextMetalImpeller> impeller_context() const {
-    return impeller_context_;
-  }
+  const FlutterDarwinContextMetalImpeller* impeller_context() const { return impeller_context_; }
 
-  fml::scoped_nsobject<FlutterDarwinContextMetalSkia> context() const { return context_; }
+  const FlutterDarwinContextMetalSkia* context() const { return context_; }
 
-  fml::scoped_nsprotocol<id<MTLTexture>> offscreen_texture() const { return offscreen_texture_; }
+  id<MTLTexture> offscreen_texture() const { return offscreen_texture_; }
 
   GPUMTLTextureInfo offscreen_texture_info() const {
     GPUMTLTextureInfo info = {};
     info.texture_id = 0;
-    info.texture = reinterpret_cast<GPUMTLTextureHandle>(offscreen_texture_.get());
+    info.texture = (__bridge GPUMTLTextureHandle)offscreen_texture_;
     return info;
   }
 
  private:
-  const fml::scoped_nsobject<FlutterDarwinContextMetalSkia> context_;
-  const fml::scoped_nsobject<FlutterDarwinContextMetalImpeller> impeller_context_;
-  const fml::scoped_nsprotocol<id<MTLTexture>> offscreen_texture_;
+  const FlutterDarwinContextMetalSkia* context_;
+  const FlutterDarwinContextMetalImpeller* impeller_context_;
+  const id<MTLTexture> offscreen_texture_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(DarwinContextMetal);
 };

--- a/shell/gpu/gpu_surface_metal_impeller.h
+++ b/shell/gpu/gpu_surface_metal_impeller.h
@@ -9,7 +9,6 @@
 
 #include "flutter/flow/surface.h"
 #include "flutter/fml/macros.h"
-#include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/impeller/display_list/aiks_context.h"
 #include "flutter/impeller/renderer/backend/metal/context_mtl.h"
 #include "flutter/shell/gpu/gpu_surface_metal_delegate.h"

--- a/shell/gpu/gpu_surface_metal_skia.mm
+++ b/shell/gpu/gpu_surface_metal_skia.mm
@@ -15,7 +15,6 @@
 #include "flutter/common/graphics/persistent_cache.h"
 #include "flutter/fml/make_copyable.h"
 #include "flutter/fml/platform/darwin/cf_utils.h"
-#include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/fml/trace_event.h"
 #include "flutter/shell/gpu/gpu_surface_metal_delegate.h"
 #include "third_party/skia/include/core/SkCanvas.h"

--- a/shell/platform/darwin/common/buffer_conversions.mm
+++ b/shell/platform/darwin/common/buffer_conversions.mm
@@ -5,7 +5,6 @@
 #import "flutter/shell/platform/darwin/common/buffer_conversions.h"
 
 #include "flutter/fml/macros.h"
-#include "flutter/fml/platform/darwin/scoped_nsobject.h"
 
 static_assert(__has_feature(objc_arc), "ARC must be enabled.");
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartVMServicePublisher.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartVMServicePublisher.mm
@@ -41,7 +41,6 @@
 
 #include "flutter/fml/logging.h"
 #include "flutter/fml/message_loop.h"
-#include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/runtime/dart_service_isolate.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -14,7 +14,6 @@
 
 #include "flutter/flow/surface.h"
 #include "flutter/fml/memory/weak_ptr.h"
-#include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/fml/trace_event.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterChannels.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h"

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -714,7 +714,7 @@ static BOOL _preparedOnce = NO;
   // This gesture recognizer retains the `FlutterViewController` until the
   // end of a gesture sequence, that is all the touches in touchesBegan are concluded
   // with |touchesCancelled| or |touchesEnded|.
-  fml::scoped_nsobject<UIViewController<FlutterViewResponder>> _flutterViewController;
+  UIViewController<FlutterViewResponder>* _flutterViewController;
 }
 
 - (instancetype)initWithTarget:(id)target
@@ -741,18 +741,18 @@ static BOOL _preparedOnce = NO;
     // At the start of each gesture sequence, we reset the `_flutterViewController`,
     // so that all the touch events in the same sequence are forwarded to the same
     // `_flutterViewController`.
-    _flutterViewController.reset(_platformViewsController->GetFlutterViewController());
+    _flutterViewController = _platformViewsController->GetFlutterViewController();
   }
-  [_flutterViewController.get() touchesBegan:touches withEvent:event];
+  [_flutterViewController touchesBegan:touches withEvent:event];
   _currentTouchPointersCount += touches.count;
 }
 
 - (void)touchesMoved:(NSSet*)touches withEvent:(UIEvent*)event {
-  [_flutterViewController.get() touchesMoved:touches withEvent:event];
+  [_flutterViewController touchesMoved:touches withEvent:event];
 }
 
 - (void)touchesEnded:(NSSet*)touches withEvent:(UIEvent*)event {
-  [_flutterViewController.get() touchesEnded:touches withEvent:event];
+  [_flutterViewController touchesEnded:touches withEvent:event];
   _currentTouchPointersCount -= touches.count;
   // Touches in one touch sequence are sent to the touchesEnded method separately if different
   // fingers stop touching the screen at different time. So one touchesEnded method triggering does
@@ -760,7 +760,7 @@ static BOOL _preparedOnce = NO;
   // UIGestureRecognizerStateFailed when all the touches in the current touch sequence is ended.
   if (_currentTouchPointersCount == 0) {
     self.state = UIGestureRecognizerStateFailed;
-    _flutterViewController.reset(nil);
+    _flutterViewController = nil;
     [self forceResetStateIfNeeded];
   }
 }
@@ -771,11 +771,11 @@ static BOOL _preparedOnce = NO;
   // Flutter needs all the cancelled touches to be "cancelled" change types in order to correctly
   // handle gesture sequence.
   // We always override the change type to "cancelled".
-  [_flutterViewController.get() forceTouchesCancelled:touches];
+  [_flutterViewController forceTouchesCancelled:touches];
   _currentTouchPointersCount -= touches.count;
   if (_currentTouchPointersCount == 0) {
     self.state = UIGestureRecognizerStateFailed;
-    _flutterViewController.reset(nil);
+    _flutterViewController = nil;
     [self forceResetStateIfNeeded];
   }
 }

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -14,7 +14,6 @@
 
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/weak_ptr.h"
-#include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/lib/ui/semantics/custom_accessibility_action.h"
 #include "flutter/lib/ui/semantics/semantics_node.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterChannels.h"
@@ -98,10 +97,8 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
   // (i.e. the status bar or keyboard)
   int32_t last_focused_semantics_object_id_;
 
-  // TODO(cbracken): https://github.com/flutter/flutter/issues/137801
-  // Eliminate use of fml::scoped_* wrappers here.
-  fml::scoped_nsobject<NSMutableDictionary<NSNumber*, SemanticsObject*>> objects_;
-  fml::scoped_nsprotocol<FlutterBasicMessageChannel*> accessibility_channel_;
+  NSMutableDictionary<NSNumber*, SemanticsObject*>* objects_;
+  FlutterBasicMessageChannel* accessibility_channel_;
   int32_t previous_route_id_ = 0;
   std::unordered_map<int32_t, flutter::CustomAccessibilityAction> actions_;
   std::vector<int32_t> previous_routes_;

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -53,17 +53,17 @@ AccessibilityBridge::AccessibilityBridge(
       ios_delegate_(ios_delegate ? std::move(ios_delegate)
                                  : std::make_unique<DefaultIosDelegate>()),
       weak_factory_(this) {
-  accessibility_channel_.reset([[FlutterBasicMessageChannel alloc]
+  accessibility_channel_ = [[FlutterBasicMessageChannel alloc]
          initWithName:@"flutter/accessibility"
       binaryMessenger:platform_view->GetOwnerViewController().engine.binaryMessenger
-                codec:[FlutterStandardMessageCodec sharedInstance]]);
-  [accessibility_channel_.get() setMessageHandler:^(id message, FlutterReply reply) {
+                codec:[FlutterStandardMessageCodec sharedInstance]];
+  [accessibility_channel_ setMessageHandler:^(id message, FlutterReply reply) {
     HandleEvent((NSDictionary*)message);
   }];
 }
 
 AccessibilityBridge::~AccessibilityBridge() {
-  [accessibility_channel_.get() setMessageHandler:nil];
+  [accessibility_channel_ setMessageHandler:nil];
   clearState();
   view_controller_.viewIfLoaded.accessibilityElements = nil;
 }
@@ -74,7 +74,7 @@ UIView<UITextInput>* AccessibilityBridge::textInputView() {
 
 void AccessibilityBridge::AccessibilityObjectDidBecomeFocused(int32_t id) {
   last_focused_semantics_object_id_ = id;
-  [accessibility_channel_.get() sendMessage:@{@"type" : @"didGainFocus", @"nodeId" : @(id)}];
+  [accessibility_channel_ sendMessage:@{@"type" : @"didGainFocus", @"nodeId" : @(id)}];
 }
 
 void AccessibilityBridge::AccessibilityObjectDidLoseFocus(int32_t id) {
@@ -152,7 +152,7 @@ void AccessibilityBridge::UpdateSemantics(
     }
   }
 
-  SemanticsObject* root = objects_.get()[@(kRootNodeId)];
+  SemanticsObject* root = objects_[@(kRootNodeId)];
 
   bool routeChanged = false;
   SemanticsObject* lastAdded = nil;
@@ -196,13 +196,13 @@ void AccessibilityBridge::UpdateSemantics(
     view_controller_.viewIfLoaded.accessibilityElements = nil;
   }
 
-  NSMutableArray<NSNumber*>* doomed_uids = [NSMutableArray arrayWithArray:[objects_ allKeys]];
+  NSMutableArray<NSNumber*>* doomed_uids = [NSMutableArray arrayWithArray:objects_.allKeys];
   if (root) {
     VisitObjectsRecursivelyAndRemove(root, doomed_uids);
   }
   [objects_ removeObjectsForKeys:doomed_uids];
 
-  for (SemanticsObject* object in [objects_ allValues]) {
+  for (SemanticsObject* object in objects_.allValues) {
     [object accessibilityBridgeDidFinishUpdate];
   }
 
@@ -217,8 +217,7 @@ void AccessibilityBridge::UpdateSemantics(
 
     if (layoutChanged) {
       SemanticsObject* next = FindNextFocusableIfNecessary();
-      SemanticsObject* lastFocused =
-          [objects_.get() objectForKey:@(last_focused_semantics_object_id_)];
+      SemanticsObject* lastFocused = [objects_ objectForKey:@(last_focused_semantics_object_id_)];
       // Only specify the focus item if the new focus is different, avoiding double focuses on the
       // same item. See: https://github.com/flutter/flutter/issues/104176. If there is a route
       // change, we always refocus.
@@ -290,10 +289,10 @@ static bool DidFlagChange(const flutter::SemanticsNode& oldNode,
 
 SemanticsObject* AccessibilityBridge::GetOrCreateObject(int32_t uid,
                                                         flutter::SemanticsNodeUpdates& updates) {
-  SemanticsObject* object = objects_.get()[@(uid)];
+  SemanticsObject* object = objects_[@(uid)];
   if (!object) {
     object = CreateObject(updates[uid], GetWeakPtr());
-    objects_.get()[@(uid)] = object;
+    objects_[@(uid)] = object;
   } else {
     // Existing node case
     auto nodeEntry = updates.find(object.node.id);
@@ -309,7 +308,7 @@ SemanticsObject* AccessibilityBridge::GetOrCreateObject(int32_t uid,
         // SemanticsObject implementation. Instead, we replace it with a new
         // instance.
         SemanticsObject* newSemanticsObject = CreateObject(node, GetWeakPtr());
-        ReplaceSemanticsObject(object, newSemanticsObject, objects_.get());
+        ReplaceSemanticsObject(object, newSemanticsObject, objects_);
         object = newSemanticsObject;
       }
     }
@@ -332,11 +331,11 @@ SemanticsObject* AccessibilityBridge::FindNextFocusableIfNecessary() {
   }
 
   // Tries to refocus the previous focused semantics object to avoid random jumps.
-  return FindFirstFocusable([objects_.get() objectForKey:@(last_focused_semantics_object_id_)]);
+  return FindFirstFocusable([objects_ objectForKey:@(last_focused_semantics_object_id_)]);
 }
 
 SemanticsObject* AccessibilityBridge::FindFirstFocusable(SemanticsObject* parent) {
-  SemanticsObject* currentObject = parent ?: objects_.get()[@(kRootNodeId)];
+  SemanticsObject* currentObject = parent ?: objects_[@(kRootNodeId)];
   if (!currentObject) {
     return nil;
   }
@@ -360,7 +359,7 @@ void AccessibilityBridge::HandleEvent(NSDictionary<NSString*, id>* annotatedEven
     ios_delegate_->PostAccessibilityNotification(UIAccessibilityAnnouncementNotification, message);
   }
   if ([type isEqualToString:@"focus"]) {
-    SemanticsObject* node = objects_.get()[annotatedEvent[@"nodeId"]];
+    SemanticsObject* node = objects_[annotatedEvent[@"nodeId"]];
     ios_delegate_->PostAccessibilityNotification(UIAccessibilityLayoutChangedNotification, node);
   }
 }

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -331,7 +331,7 @@ SemanticsObject* AccessibilityBridge::FindNextFocusableIfNecessary() {
   }
 
   // Tries to refocus the previous focused semantics object to avoid random jumps.
-  return FindFirstFocusable([objects_ objectForKey:@(last_focused_semantics_object_id_)]);
+  return FindFirstFocusable(objects_[@(last_focused_semantics_object_id_)]);
 }
 
 SemanticsObject* AccessibilityBridge::FindFirstFocusable(SemanticsObject* parent) {

--- a/shell/platform/darwin/ios/framework/Source/overlay_layer_pool.h
+++ b/shell/platform/darwin/ios/framework/Source/overlay_layer_pool.h
@@ -11,7 +11,6 @@
 #import <UIKit/UIKit.h>
 
 #include "flow/surface.h"
-#include "fml/platform/darwin/scoped_nsobject.h"
 
 #import "flutter/shell/platform/darwin/ios/ios_context.h"
 
@@ -21,15 +20,15 @@ class IOSSurface;
 
 /// @brief State holder for a Flutter overlay layer.
 struct OverlayLayer {
-  OverlayLayer(const fml::scoped_nsobject<UIView>& overlay_view,
-               const fml::scoped_nsobject<UIView>& overlay_view_wrapper,
+  OverlayLayer(UIView* overlay_view,
+               UIView* overlay_view_wrapper,
                std::unique_ptr<IOSSurface> ios_surface,
                std::unique_ptr<Surface> surface);
 
   ~OverlayLayer() = default;
 
-  fml::scoped_nsobject<UIView> overlay_view;
-  fml::scoped_nsobject<UIView> overlay_view_wrapper;
+  UIView* overlay_view;
+  UIView* overlay_view_wrapper;
   std::unique_ptr<IOSSurface> ios_surface;
   std::unique_ptr<Surface> surface;
 

--- a/shell/platform/darwin/ios/framework/Source/platform_views_controller.h
+++ b/shell/platform/darwin/ios/framework/Source/platform_views_controller.h
@@ -11,7 +11,6 @@
 
 #include "flutter/flow/surface.h"
 #include "flutter/fml/memory/weak_ptr.h"
-#include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/fml/task_runner.h"
 #include "flutter/fml/trace_event.h"
 #include "impeller/base/thread_safety.h"
@@ -242,12 +241,10 @@ class PlatformViewsController {
   // The Slices are deleted by the PlatformViewsController.reset().
   std::unordered_map<int64_t, std::unique_ptr<EmbedderViewSlice>> slices_;
 
-  fml::scoped_nsobject<FlutterMethodChannel> channel_;
-  fml::scoped_nsobject<UIView> flutter_view_;
-  fml::scoped_nsobject<UIViewController<FlutterViewResponder>> flutter_view_controller_;
-  fml::scoped_nsobject<FlutterClippingMaskViewPool> mask_view_pool_;
-  std::unordered_map<std::string, fml::scoped_nsobject<NSObject<FlutterPlatformViewFactory>>>
-      factories_;
+  UIView* flutter_view_;
+  UIViewController<FlutterViewResponder>* flutter_view_controller_;
+  FlutterClippingMaskViewPool* mask_view_pool_;
+  std::unordered_map<std::string, NSObject<FlutterPlatformViewFactory>*> factories_;
 
   // The FlutterPlatformViewGestureRecognizersBlockingPolicy for each type of platform view.
   std::unordered_map<std::string, FlutterPlatformViewGestureRecognizersBlockingPolicy>
@@ -264,9 +261,9 @@ class PlatformViewsController {
   ///
   /// This data must only be accessed on the platform thread.
   struct PlatformViewData {
-    fml::scoped_nsobject<NSObject<FlutterPlatformView>> view;
-    fml::scoped_nsobject<FlutterTouchInterceptingView> touch_interceptor;
-    fml::scoped_nsobject<UIView> root_view;
+    NSObject<FlutterPlatformView>* view;
+    FlutterTouchInterceptingView* touch_interceptor;
+    UIView* root_view;
   };
 
   /// This data must only be accessed on the platform thread.

--- a/shell/platform/darwin/ios/framework/Source/platform_views_controller.mm
+++ b/shell/platform/darwin/ios/framework/Source/platform_views_controller.mm
@@ -386,7 +386,7 @@ FlutterTouchInterceptingView* PlatformViewsController::GetFlutterTouchIntercepti
 
 long PlatformViewsController::FindFirstResponderPlatformViewId() {
   for (auto const& [id, platform_view_data] : platform_views_) {
-    UIView* root_view = (UIView*)platform_view_data.root_view;
+    UIView* root_view = platform_view_data.root_view;
     if (root_view.flt_hasFirstResponderInViewHierarchySubtree) {
       return id;
     }

--- a/shell/platform/darwin/ios/framework/Source/platform_views_controller.mm
+++ b/shell/platform/darwin/ios/framework/Source/platform_views_controller.mm
@@ -113,8 +113,8 @@ BOOL canApplyBlurBackdrop = YES;
 PlatformViewsController::PlatformViewsController()
     : layer_pool_(std::make_unique<OverlayLayerPool>()),
       weak_factory_(std::make_unique<fml::WeakPtrFactory<PlatformViewsController>>(this)) {
-  mask_view_pool_.reset(
-      [[FlutterClippingMaskViewPool alloc] initWithCapacity:kFlutterClippingMaskViewPoolCapacity]);
+  mask_view_pool_ =
+      [[FlutterClippingMaskViewPool alloc] initWithCapacity:kFlutterClippingMaskViewPoolCapacity];
 };
 
 void PlatformViewsController::SetTaskRunner(
@@ -127,16 +127,16 @@ fml::WeakPtr<flutter::PlatformViewsController> PlatformViewsController::GetWeakP
 }
 
 void PlatformViewsController::SetFlutterView(UIView* flutter_view) {
-  flutter_view_.reset(flutter_view);
+  flutter_view_ = flutter_view;
 }
 
 void PlatformViewsController::SetFlutterViewController(
     UIViewController<FlutterViewResponder>* flutter_view_controller) {
-  flutter_view_controller_.reset(flutter_view_controller);
+  flutter_view_controller_ = flutter_view_controller;
 }
 
 UIViewController<FlutterViewResponder>* PlatformViewsController::GetFlutterViewController() {
-  return flutter_view_controller_.get();
+  return flutter_view_controller_;
 }
 
 void PlatformViewsController::OnMethodCall(FlutterMethodCall* call, FlutterResult result) {
@@ -167,7 +167,7 @@ void PlatformViewsController::OnCreate(FlutterMethodCall* call, FlutterResult re
     return;
   }
 
-  NSObject<FlutterPlatformViewFactory>* factory = factories_[viewType].get();
+  NSObject<FlutterPlatformViewFactory>* factory = factories_[viewType];
   if (factory == nil) {
     result([FlutterError
         errorWithCode:@"unregistered_view_type"
@@ -209,13 +209,11 @@ void PlatformViewsController::OnCreate(FlutterMethodCall* call, FlutterResult re
   ChildClippingView* clipping_view = [[ChildClippingView alloc] initWithFrame:CGRectZero];
   [clipping_view addSubview:touch_interceptor];
 
-  platform_views_.emplace(
-      viewId, PlatformViewData{
-                  .view = fml::scoped_nsobject<NSObject<FlutterPlatformView>>(embedded_view),  //
-                  .touch_interceptor =
-                      fml::scoped_nsobject<FlutterTouchInterceptingView>(touch_interceptor),  //
-                  .root_view = fml::scoped_nsobject<UIView>(clipping_view)                    //
-              });
+  platform_views_.emplace(viewId, PlatformViewData{
+                                      .view = embedded_view,                   //
+                                      .touch_interceptor = touch_interceptor,  //
+                                      .root_view = clipping_view               //
+                                  });
 
   result(nil);
 }
@@ -246,7 +244,7 @@ void PlatformViewsController::OnAcceptGesture(FlutterMethodCall* call, FlutterRe
     return;
   }
 
-  FlutterTouchInterceptingView* view = platform_views_[viewId].touch_interceptor.get();
+  FlutterTouchInterceptingView* view = platform_views_[viewId].touch_interceptor;
   [view releaseGesture];
 
   result(nil);
@@ -263,7 +261,7 @@ void PlatformViewsController::OnRejectGesture(FlutterMethodCall* call, FlutterRe
     return;
   }
 
-  FlutterTouchInterceptingView* view = platform_views_[viewId].touch_interceptor.get();
+  FlutterTouchInterceptingView* view = platform_views_[viewId].touch_interceptor;
   [view blockGesture];
 
   result(nil);
@@ -275,7 +273,7 @@ void PlatformViewsController::RegisterViewFactory(
     FlutterPlatformViewGestureRecognizersBlockingPolicy gestureRecognizerBlockingPolicy) {
   std::string idString([factoryId UTF8String]);
   FML_CHECK(factories_.count(idString) == 0);
-  factories_[idString] = fml::scoped_nsobject<NSObject<FlutterPlatformViewFactory>>(factory);
+  factories_[idString] = factory;
   gesture_recognizers_blocking_policies_[idString] = gestureRecognizerBlockingPolicy;
 }
 
@@ -383,12 +381,12 @@ FlutterTouchInterceptingView* PlatformViewsController::GetFlutterTouchIntercepti
   if (platform_views_.empty()) {
     return nil;
   }
-  return platform_views_[view_id].touch_interceptor.get();
+  return platform_views_[view_id].touch_interceptor;
 }
 
 long PlatformViewsController::FindFirstResponderPlatformViewId() {
   for (auto const& [id, platform_view_data] : platform_views_) {
-    UIView* root_view = (UIView*)platform_view_data.root_view.get();
+    UIView* root_view = (UIView*)platform_view_data.root_view;
     if (root_view.flt_hasFirstResponderInViewHierarchySubtree) {
       return id;
     }
@@ -401,11 +399,10 @@ void PlatformViewsController::ClipViewSetMaskView(UIView* clipView) {
   if (clipView.maskView) {
     return;
   }
-  UIView* flutterView = flutter_view_.get();
   CGRect frame =
       CGRectMake(-clipView.frame.origin.x, -clipView.frame.origin.y,
-                 CGRectGetWidth(flutterView.bounds), CGRectGetHeight(flutterView.bounds));
-  clipView.maskView = [mask_view_pool_.get() getMaskViewWithFrame:frame];
+                 CGRectGetWidth(flutter_view_.bounds), CGRectGetHeight(flutter_view_.bounds));
+  clipView.maskView = [mask_view_pool_ getMaskViewWithFrame:frame];
 }
 
 // This method is only called when the `embedded_view` needs to be re-composited at the current
@@ -425,7 +422,7 @@ void PlatformViewsController::ApplyMutators(const MutatorsStack& mutators_stack,
   FML_DCHECK(!clipView.maskView ||
              [clipView.maskView isKindOfClass:[FlutterClippingMaskView class]]);
   if (clipView.maskView) {
-    [mask_view_pool_.get() insertViewToPoolIfNeeded:(FlutterClippingMaskView*)(clipView.maskView)];
+    [mask_view_pool_ insertViewToPoolIfNeeded:(FlutterClippingMaskView*)(clipView.maskView)];
     clipView.maskView = nil;
   }
   CGFloat screenScale = [UIScreen mainScreen].scale;
@@ -484,7 +481,7 @@ void PlatformViewsController::ApplyMutators(const MutatorsStack& mutators_stack,
           break;
         }
         CGRect intersection = CGRectIntersection(filterRect, clipView.frame);
-        CGRect frameInClipView = [flutter_view_.get() convertRect:intersection toView:clipView];
+        CGRect frameInClipView = [flutter_view_ convertRect:intersection toView:clipView];
         // sigma_x is arbitrarily chosen as the radius value because Quartz sets
         // sigma_x and sigma_y equal to each other. DlBlurImageFilter's Tile Mode
         // is not supported in Quartz's gaussianBlur CAFilter, so it is not used
@@ -540,7 +537,7 @@ void PlatformViewsController::ApplyMutators(const MutatorsStack& mutators_stack,
 void PlatformViewsController::CompositeWithParams(int64_t view_id,
                                                   const EmbeddedViewParams& params) {
   CGRect frame = CGRectMake(0, 0, params.sizePoints().width(), params.sizePoints().height());
-  FlutterTouchInterceptingView* touchInterceptor = platform_views_[view_id].touch_interceptor.get();
+  FlutterTouchInterceptingView* touchInterceptor = platform_views_[view_id].touch_interceptor;
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
   FML_DCHECK(CGPointEqualToPoint([touchInterceptor embeddedView].frame.origin, CGPointZero));
   if (non_zero_origin_views_.find(view_id) == non_zero_origin_views_.end() &&
@@ -564,7 +561,7 @@ void PlatformViewsController::CompositeWithParams(int64_t view_id,
   touchInterceptor.alpha = 1;
 
   const MutatorsStack& mutatorStack = params.mutatorsStack();
-  UIView* clippingView = platform_views_[view_id].root_view.get();
+  UIView* clippingView = platform_views_[view_id].root_view;
   // The frame of the clipping view should be the final bounding rect.
   // Because the translate matrix in the Mutator Stack also includes the offset,
   // when we apply the transforms matrix in |ApplyMutators|, we need
@@ -584,13 +581,13 @@ void PlatformViewsController::Reset() {
   // Reset will only be called from the raster thread or a merged raster/platform thread.
   // platform_views_ must only be modified on the platform thread, and any operations that
   // read or modify platform views should occur there.
-  fml::TaskRunner::RunNowOrPostTask(
-      platform_task_runner_, [&, composition_order = composition_order_]() {
-        for (int64_t view_id : composition_order_) {
-          [platform_views_[view_id].root_view.get() removeFromSuperview];
-        }
-        platform_views_.clear();
-      });
+  fml::TaskRunner::RunNowOrPostTask(platform_task_runner_,
+                                    [&, composition_order = composition_order_]() {
+                                      for (int64_t view_id : composition_order_) {
+                                        [platform_views_[view_id].root_view removeFromSuperview];
+                                      }
+                                      platform_views_.clear();
+                                    });
 
   composition_order_.clear();
   slices_.clear();
@@ -729,9 +726,9 @@ void PlatformViewsController::CreateMissingOverlays(GrDirectContext* gr_context,
   auto latch = std::make_shared<fml::CountDownLatch>(1u);
   fml::TaskRunner::RunNowOrPostTask(platform_task_runner_, [&]() {
     for (auto i = 0u; i < missing_layer_count; i++) {
-      CreateLayer(gr_context,                                      //
-                  ios_context,                                     //
-                  ((FlutterView*)flutter_view_.get()).pixelFormat  //
+      CreateLayer(gr_context,                                //
+                  ios_context,                               //
+                  ((FlutterView*)flutter_view_).pixelFormat  //
       );
     }
     latch->CountDown();
@@ -791,12 +788,12 @@ void PlatformViewsController::PerformSubmit(
 void PlatformViewsController::BringLayersIntoView(const LayersMap& layer_map,
                                                   const std::vector<int64_t>& composition_order) {
   FML_DCHECK(flutter_view_);
-  UIView* flutter_view = flutter_view_.get();
+  UIView* flutter_view = flutter_view_;
 
   previous_composition_order_.clear();
   NSMutableArray* desired_platform_subviews = [NSMutableArray array];
   for (int64_t platform_view_id : composition_order) {
-    UIView* platform_view_root = platform_views_[platform_view_id].root_view.get();
+    UIView* platform_view_root = platform_views_[platform_view_id].root_view;
     if (platform_view_root != nil) {
       [desired_platform_subviews addObject:platform_view_root];
     }
@@ -854,7 +851,7 @@ void PlatformViewsController::RemoveUnusedLayers(
   // Remove unused platform views.
   for (int64_t view_id : previous_composition_order_) {
     if (composition_order_set.find(view_id) == composition_order_set.end()) {
-      UIView* platform_view_root = platform_views_[view_id].root_view.get();
+      UIView* platform_view_root = platform_views_[view_id].root_view;
       [platform_view_root removeFromSuperview];
     }
   }
@@ -874,7 +871,7 @@ std::vector<UIView*> PlatformViewsController::GetViewsToDispose() {
       views_to_delay_dispose.insert(viewId);
       continue;
     }
-    UIView* root_view = platform_views_[viewId].root_view.get();
+    UIView* root_view = platform_views_[viewId].root_view;
     views.push_back(root_view);
     current_composition_params_.erase(viewId);
     views_to_recomposite_.erase(viewId);

--- a/shell/platform/darwin/ios/ios_context.h
+++ b/shell/platform/darwin/ios/ios_context.h
@@ -11,7 +11,6 @@
 #include "flutter/common/graphics/texture.h"
 #include "flutter/fml/concurrent_message_loop.h"
 #include "flutter/fml/macros.h"
-#include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/fml/synchronization/sync_switch.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterTexture.h"
 #import "flutter/shell/platform/darwin/ios/rendering_api_selection.h"
@@ -121,9 +120,8 @@ class IOSContext {
   /// @return     The texture proxy if the rendering backend supports embedder
   ///             provided external textures.
   ///
-  virtual std::unique_ptr<Texture> CreateExternalTexture(
-      int64_t texture_id,
-      fml::scoped_nsobject<NSObject<FlutterTexture>> texture) = 0;
+  virtual std::unique_ptr<Texture> CreateExternalTexture(int64_t texture_id,
+                                                         NSObject<FlutterTexture>* texture) = 0;
 
   //----------------------------------------------------------------------------
   /// @brief      Accessor for the Skia context associated with IOSSurfaces and

--- a/shell/platform/darwin/ios/ios_context_metal_impeller.h
+++ b/shell/platform/darwin/ios/ios_context_metal_impeller.h
@@ -34,7 +34,7 @@ class IOSContextMetalImpeller final : public IOSContext {
   sk_sp<GrDirectContext> GetResourceContext() const;
 
  private:
-  fml::scoped_nsobject<FlutterDarwinContextMetalImpeller> darwin_context_metal_impeller_;
+  FlutterDarwinContextMetalImpeller* darwin_context_metal_impeller_;
   std::shared_ptr<impeller::AiksContext> aiks_context_;
 
   // |IOSContext|
@@ -44,9 +44,8 @@ class IOSContextMetalImpeller final : public IOSContext {
   std::unique_ptr<GLContextResult> MakeCurrent() override;
 
   // |IOSContext|
-  std::unique_ptr<Texture> CreateExternalTexture(
-      int64_t texture_id,
-      fml::scoped_nsobject<NSObject<FlutterTexture>> texture) override;
+  std::unique_ptr<Texture> CreateExternalTexture(int64_t texture_id,
+                                                 NSObject<FlutterTexture>* texture) override;
 
   // |IOSContext|
   std::shared_ptr<impeller::Context> GetImpellerContext() const override;

--- a/shell/platform/darwin/ios/ios_context_metal_impeller.mm
+++ b/shell/platform/darwin/ios/ios_context_metal_impeller.mm
@@ -15,11 +15,11 @@ namespace flutter {
 
 IOSContextMetalImpeller::IOSContextMetalImpeller(
     const std::shared_ptr<const fml::SyncSwitch>& is_gpu_disabled_sync_switch)
-    : darwin_context_metal_impeller_(fml::scoped_nsobject<FlutterDarwinContextMetalImpeller>{
-          [[FlutterDarwinContextMetalImpeller alloc] init:is_gpu_disabled_sync_switch]}) {
-  if (darwin_context_metal_impeller_.get().context) {
+    : darwin_context_metal_impeller_(
+          [[FlutterDarwinContextMetalImpeller alloc] init:is_gpu_disabled_sync_switch]) {
+  if (darwin_context_metal_impeller_.context) {
     aiks_context_ = std::make_shared<impeller::AiksContext>(
-        darwin_context_metal_impeller_.get().context, impeller::TypographerContextSkia::Make());
+        darwin_context_metal_impeller_.context, impeller::TypographerContextSkia::Make());
   }
 }
 
@@ -44,7 +44,7 @@ sk_sp<GrDirectContext> IOSContextMetalImpeller::CreateResourceContext() {
 
 // |IOSContext|
 std::shared_ptr<impeller::Context> IOSContextMetalImpeller::GetImpellerContext() const {
-  return darwin_context_metal_impeller_.get().context;
+  return darwin_context_metal_impeller_.context;
 }
 
 // |IOSContext|
@@ -61,11 +61,10 @@ std::unique_ptr<GLContextResult> IOSContextMetalImpeller::MakeCurrent() {
 // |IOSContext|
 std::unique_ptr<Texture> IOSContextMetalImpeller::CreateExternalTexture(
     int64_t texture_id,
-    fml::scoped_nsobject<NSObject<FlutterTexture>> texture) {
-  return std::make_unique<IOSExternalTextureMetal>(
-      fml::scoped_nsobject<FlutterDarwinExternalTextureMetal>{[darwin_context_metal_impeller_
-          createExternalTextureWithIdentifier:texture_id
-                                      texture:texture]});
+    NSObject<FlutterTexture>* texture) {
+  return std::make_unique<IOSExternalTextureMetal>([darwin_context_metal_impeller_
+      createExternalTextureWithIdentifier:texture_id
+                                  texture:texture]);
 }
 
 }  // namespace flutter

--- a/shell/platform/darwin/ios/ios_context_metal_skia.h
+++ b/shell/platform/darwin/ios/ios_context_metal_skia.h
@@ -11,7 +11,6 @@
 
 #include "flutter/fml/macros.h"
 #include "flutter/fml/platform/darwin/cf_utils.h"
-#include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #import "flutter/shell/platform/darwin/graphics/FlutterDarwinContextMetalSkia.h"
 #import "flutter/shell/platform/darwin/ios/ios_context.h"
 #include "third_party/skia/include/gpu/ganesh/GrDirectContext.h"
@@ -24,7 +23,7 @@ class IOSContextMetalSkia final : public IOSContext {
 
   ~IOSContextMetalSkia();
 
-  fml::scoped_nsobject<FlutterDarwinContextMetalSkia> GetDarwinContext() const;
+  FlutterDarwinContextMetalSkia* GetDarwinContext() const;
 
   // |IOSContext|
   IOSRenderingBackend GetBackend() const override;
@@ -35,7 +34,7 @@ class IOSContextMetalSkia final : public IOSContext {
   sk_sp<GrDirectContext> GetResourceContext() const;
 
  private:
-  fml::scoped_nsobject<FlutterDarwinContextMetalSkia> darwin_context_metal_;
+  FlutterDarwinContextMetalSkia* darwin_context_metal_;
 
   // |IOSContext|
   sk_sp<GrDirectContext> CreateResourceContext() override;
@@ -44,9 +43,8 @@ class IOSContextMetalSkia final : public IOSContext {
   std::unique_ptr<GLContextResult> MakeCurrent() override;
 
   // |IOSContext|
-  std::unique_ptr<Texture> CreateExternalTexture(
-      int64_t texture_id,
-      fml::scoped_nsobject<NSObject<FlutterTexture>> texture) override;
+  std::unique_ptr<Texture> CreateExternalTexture(int64_t texture_id,
+                                                 NSObject<FlutterTexture>* texture) override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(IOSContextMetalSkia);
 };

--- a/shell/platform/darwin/ios/ios_context_metal_skia.mm
+++ b/shell/platform/darwin/ios/ios_context_metal_skia.mm
@@ -17,13 +17,12 @@ FLUTTER_ASSERT_ARC
 namespace flutter {
 
 IOSContextMetalSkia::IOSContextMetalSkia() {
-  darwin_context_metal_ = fml::scoped_nsobject<FlutterDarwinContextMetalSkia>{
-      [[FlutterDarwinContextMetalSkia alloc] initWithDefaultMTLDevice]};
+  darwin_context_metal_ = [[FlutterDarwinContextMetalSkia alloc] initWithDefaultMTLDevice];
 }
 
 IOSContextMetalSkia::~IOSContextMetalSkia() = default;
 
-fml::scoped_nsobject<FlutterDarwinContextMetalSkia> IOSContextMetalSkia::GetDarwinContext() const {
+FlutterDarwinContextMetalSkia* IOSContextMetalSkia::GetDarwinContext() const {
   return darwin_context_metal_;
 }
 
@@ -32,16 +31,16 @@ IOSRenderingBackend IOSContextMetalSkia::GetBackend() const {
 }
 
 sk_sp<GrDirectContext> IOSContextMetalSkia::GetMainContext() const {
-  return darwin_context_metal_.get().mainContext;
+  return darwin_context_metal_.mainContext;
 }
 
 sk_sp<GrDirectContext> IOSContextMetalSkia::GetResourceContext() const {
-  return darwin_context_metal_.get().resourceContext;
+  return darwin_context_metal_.resourceContext;
 }
 
 // |IOSContext|
 sk_sp<GrDirectContext> IOSContextMetalSkia::CreateResourceContext() {
-  return darwin_context_metal_.get().resourceContext;
+  return darwin_context_metal_.resourceContext;
 }
 
 // |IOSContext|
@@ -53,10 +52,9 @@ std::unique_ptr<GLContextResult> IOSContextMetalSkia::MakeCurrent() {
 // |IOSContext|
 std::unique_ptr<Texture> IOSContextMetalSkia::CreateExternalTexture(
     int64_t texture_id,
-    fml::scoped_nsobject<NSObject<FlutterTexture>> texture) {
+    NSObject<FlutterTexture>* texture) {
   return std::make_unique<IOSExternalTextureMetal>(
-      fml::scoped_nsobject<FlutterDarwinExternalTextureMetal>{
-          [darwin_context_metal_ createExternalTextureWithIdentifier:texture_id texture:texture]});
+      [darwin_context_metal_ createExternalTextureWithIdentifier:texture_id texture:texture]);
 }
 
 }  // namespace flutter

--- a/shell/platform/darwin/ios/ios_context_noop.h
+++ b/shell/platform/darwin/ios/ios_context_noop.h
@@ -27,9 +27,8 @@ class IOSContextNoop final : public IOSContext {
   std::unique_ptr<GLContextResult> MakeCurrent() override;
 
   // |IOSContext|
-  std::unique_ptr<Texture> CreateExternalTexture(
-      int64_t texture_id,
-      fml::scoped_nsobject<NSObject<FlutterTexture>> texture) override;
+  std::unique_ptr<Texture> CreateExternalTexture(int64_t texture_id,
+                                                 NSObject<FlutterTexture>* texture) override;
 
   IOSRenderingBackend GetBackend() const override;
 

--- a/shell/platform/darwin/ios/ios_context_noop.mm
+++ b/shell/platform/darwin/ios/ios_context_noop.mm
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 #import "flutter/shell/platform/darwin/ios/ios_context_noop.h"
+#include "flutter/shell/platform/darwin/ios/rendering_api_selection.h"
 #include "ios_context.h"
-#include "shell/platform/darwin/ios/rendering_api_selection.h"
 
 FLUTTER_ASSERT_ARC
 
@@ -37,9 +37,8 @@ std::unique_ptr<GLContextResult> IOSContextNoop::MakeCurrent() {
 }
 
 // |IOSContext|
-std::unique_ptr<Texture> IOSContextNoop::CreateExternalTexture(
-    int64_t texture_id,
-    fml::scoped_nsobject<NSObject<FlutterTexture>> texture) {
+std::unique_ptr<Texture> IOSContextNoop::CreateExternalTexture(int64_t texture_id,
+                                                               NSObject<FlutterTexture>* texture) {
   // Don't use FML for logging as it will contain engine specific details. This is a user facing
   // message.
   NSLog(@"Flutter: Attempted to composite external texture sources using the noop backend. "

--- a/shell/platform/darwin/ios/ios_context_software.h
+++ b/shell/platform/darwin/ios/ios_context_software.h
@@ -27,9 +27,8 @@ class IOSContextSoftware final : public IOSContext {
   std::unique_ptr<GLContextResult> MakeCurrent() override;
 
   // |IOSContext|
-  std::unique_ptr<Texture> CreateExternalTexture(
-      int64_t texture_id,
-      fml::scoped_nsobject<NSObject<FlutterTexture>> texture) override;
+  std::unique_ptr<Texture> CreateExternalTexture(int64_t texture_id,
+                                                 NSObject<FlutterTexture>* texture) override;
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(IOSContextSoftware);

--- a/shell/platform/darwin/ios/ios_context_software.mm
+++ b/shell/platform/darwin/ios/ios_context_software.mm
@@ -33,7 +33,7 @@ std::unique_ptr<GLContextResult> IOSContextSoftware::MakeCurrent() {
 // |IOSContext|
 std::unique_ptr<Texture> IOSContextSoftware::CreateExternalTexture(
     int64_t texture_id,
-    fml::scoped_nsobject<NSObject<FlutterTexture>> texture) {
+    NSObject<FlutterTexture>* texture) {
   // Don't use FML for logging as it will contain engine specific details. This is a user facing
   // message.
   NSLog(@"Flutter: Attempted to composite external texture sources using the software backend. "

--- a/shell/platform/darwin/ios/ios_external_texture_metal.h
+++ b/shell/platform/darwin/ios/ios_external_texture_metal.h
@@ -7,7 +7,6 @@
 
 #include "flutter/common/graphics/texture.h"
 #include "flutter/fml/macros.h"
-#include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #import "flutter/shell/platform/darwin/graphics/FlutterDarwinExternalTextureMetal.h"
 
 namespace flutter {
@@ -15,15 +14,13 @@ namespace flutter {
 class IOSExternalTextureMetal final : public Texture {
  public:
   explicit IOSExternalTextureMetal(
-      const fml::scoped_nsobject<FlutterDarwinExternalTextureMetal>&
-          darwin_external_texture_metal);
+      FlutterDarwinExternalTextureMetal* darwin_external_texture_metal);
 
   // |Texture|
   ~IOSExternalTextureMetal();
 
  private:
-  fml::scoped_nsobject<FlutterDarwinExternalTextureMetal>
-      darwin_external_texture_metal_;
+  FlutterDarwinExternalTextureMetal* darwin_external_texture_metal_;
 
   // |Texture|
   void Paint(PaintContext& context,

--- a/shell/platform/darwin/ios/ios_external_texture_metal.mm
+++ b/shell/platform/darwin/ios/ios_external_texture_metal.mm
@@ -10,7 +10,7 @@ FLUTTER_ASSERT_ARC
 namespace flutter {
 
 IOSExternalTextureMetal::IOSExternalTextureMetal(
-    const fml::scoped_nsobject<FlutterDarwinExternalTextureMetal>& darwin_external_texture_metal)
+    FlutterDarwinExternalTextureMetal* darwin_external_texture_metal)
     : Texture([darwin_external_texture_metal textureID]),
       darwin_external_texture_metal_(darwin_external_texture_metal) {}
 

--- a/shell/platform/darwin/ios/ios_surface.h
+++ b/shell/platform/darwin/ios/ios_surface.h
@@ -12,7 +12,6 @@
 #include "flutter/flow/embedded_views.h"
 #include "flutter/flow/surface.h"
 #include "flutter/fml/macros.h"
-#include "flutter/fml/platform/darwin/scoped_nsobject.h"
 
 @class CALayer;
 
@@ -20,8 +19,7 @@ namespace flutter {
 
 class IOSSurface {
  public:
-  static std::unique_ptr<IOSSurface> Create(std::shared_ptr<IOSContext> context,
-                                            const fml::scoped_nsobject<CALayer>& layer);
+  static std::unique_ptr<IOSSurface> Create(std::shared_ptr<IOSContext> context, CALayer* layer);
 
   std::shared_ptr<IOSContext> GetContext() const;
 

--- a/shell/platform/darwin/ios/ios_surface.mm
+++ b/shell/platform/darwin/ios/ios_surface.mm
@@ -26,8 +26,9 @@ std::unique_ptr<IOSSurface> IOSSurface::Create(std::shared_ptr<IOSContext> conte
       switch (context->GetBackend()) {
         case IOSRenderingBackend::kSkia:
 #if !SLIMPELLER
-          return std::make_unique<IOSSurfaceMetalSkia>((CAMetalLayer*)layer,  // Metal layer
-                                                       std::move(context)     // context
+          return std::make_unique<IOSSurfaceMetalSkia>(
+              static_cast<CAMetalLayer*>(layer),  // Metal layer
+              std::move(context)                  // context
           );
 #else   //  !SLIMPELLER
           FML_LOG(FATAL) << "Impeller opt-out unavailable.";
@@ -35,8 +36,9 @@ std::unique_ptr<IOSSurface> IOSSurface::Create(std::shared_ptr<IOSContext> conte
 #endif  //  !SLIMPELLER
           break;
         case IOSRenderingBackend::kImpeller:
-          return std::make_unique<IOSSurfaceMetalImpeller>((CAMetalLayer*)layer,  // Metal layer
-                                                           std::move(context)     // context
+          return std::make_unique<IOSSurfaceMetalImpeller>(
+              static_cast<CAMetalLayer*>(layer),  // Metal layer
+              std::move(context)                  // context
           );
       }
     }

--- a/shell/platform/darwin/ios/ios_surface.mm
+++ b/shell/platform/darwin/ios/ios_surface.mm
@@ -17,18 +17,17 @@ FLUTTER_ASSERT_ARC
 namespace flutter {
 
 std::unique_ptr<IOSSurface> IOSSurface::Create(std::shared_ptr<IOSContext> context,
-                                               const fml::scoped_nsobject<CALayer>& layer) {
+                                               CALayer* layer) {
   FML_DCHECK(layer);
   FML_DCHECK(context);
 
   if (@available(iOS METAL_IOS_VERSION_BASELINE, *)) {
-    if ([layer.get() isKindOfClass:[CAMetalLayer class]]) {
+    if ([layer isKindOfClass:[CAMetalLayer class]]) {
       switch (context->GetBackend()) {
         case IOSRenderingBackend::kSkia:
 #if !SLIMPELLER
-          return std::make_unique<IOSSurfaceMetalSkia>(
-              fml::scoped_nsobject<CAMetalLayer>((CAMetalLayer*)layer.get()),  // Metal layer
-              std::move(context)                                               // context
+          return std::make_unique<IOSSurfaceMetalSkia>((CAMetalLayer*)layer,  // Metal layer
+                                                       std::move(context)     // context
           );
 #else   //  !SLIMPELLER
           FML_LOG(FATAL) << "Impeller opt-out unavailable.";
@@ -36,9 +35,8 @@ std::unique_ptr<IOSSurface> IOSSurface::Create(std::shared_ptr<IOSContext> conte
 #endif  //  !SLIMPELLER
           break;
         case IOSRenderingBackend::kImpeller:
-          return std::make_unique<IOSSurfaceMetalImpeller>(
-              fml::scoped_nsobject<CAMetalLayer>((CAMetalLayer*)layer.get()),  // Metal layer
-              std::move(context)                                               // context
+          return std::make_unique<IOSSurfaceMetalImpeller>((CAMetalLayer*)layer,  // Metal layer
+                                                           std::move(context)     // context
           );
       }
     }

--- a/shell/platform/darwin/ios/ios_surface_metal_impeller.h
+++ b/shell/platform/darwin/ios/ios_surface_metal_impeller.h
@@ -21,14 +21,13 @@ class SK_API_AVAILABLE_CA_METAL_LAYER IOSSurfaceMetalImpeller final
     : public IOSSurface,
       public GPUSurfaceMetalDelegate {
  public:
-  IOSSurfaceMetalImpeller(const fml::scoped_nsobject<CAMetalLayer>& layer,
-                          const std::shared_ptr<IOSContext>& context);
+  IOSSurfaceMetalImpeller(CAMetalLayer* layer, const std::shared_ptr<IOSContext>& context);
 
   // |IOSSurface|
   ~IOSSurfaceMetalImpeller();
 
  private:
-  fml::scoped_nsobject<CAMetalLayer> layer_;
+  CAMetalLayer* layer_;
   const std::shared_ptr<impeller::Context> impeller_context_;
   std::shared_ptr<impeller::AiksContext> aiks_context_;
   bool is_valid_ = false;

--- a/shell/platform/darwin/ios/ios_surface_metal_impeller.mm
+++ b/shell/platform/darwin/ios/ios_surface_metal_impeller.mm
@@ -15,7 +15,7 @@ FLUTTER_ASSERT_ARC
 
 namespace flutter {
 
-IOSSurfaceMetalImpeller::IOSSurfaceMetalImpeller(const fml::scoped_nsobject<CAMetalLayer>& layer,
+IOSSurfaceMetalImpeller::IOSSurfaceMetalImpeller(CAMetalLayer* layer,
                                                  const std::shared_ptr<IOSContext>& context)
     : IOSSurface(context),
       GPUSurfaceMetalDelegate(MTLRenderTargetType::kCAMetalLayer),
@@ -44,7 +44,7 @@ void IOSSurfaceMetalImpeller::UpdateStorageSizeIfNecessary() {
 // |IOSSurface|
 std::unique_ptr<Surface> IOSSurfaceMetalImpeller::CreateGPUSurface(GrDirectContext*) {
   impeller_context_->UpdateOffscreenLayerPixelFormat(
-      impeller::FromMTLPixelFormat(layer_.get().pixelFormat));
+      impeller::FromMTLPixelFormat(layer_.pixelFormat));
   return std::make_unique<GPUSurfaceMetalImpeller>(this,          //
                                                    aiks_context_  //
   );
@@ -52,10 +52,10 @@ std::unique_ptr<Surface> IOSSurfaceMetalImpeller::CreateGPUSurface(GrDirectConte
 
 // |GPUSurfaceMetalDelegate|
 GPUCAMetalLayerHandle IOSSurfaceMetalImpeller::GetCAMetalLayer(const SkISize& frame_info) const {
-  CAMetalLayer* layer = layer_.get();
+  CAMetalLayer* layer = layer_;
   const auto drawable_size = CGSizeMake(frame_info.width(), frame_info.height());
-  if (!CGSizeEqualToSize(drawable_size, layer.drawableSize)) {
-    layer.drawableSize = drawable_size;
+  if (!CGSizeEqualToSize(drawable_size, layer_.drawableSize)) {
+    layer_.drawableSize = drawable_size;
   }
 
   // Flutter needs to read from the color attachment in cases where there are effects such as

--- a/shell/platform/darwin/ios/ios_surface_metal_impeller.mm
+++ b/shell/platform/darwin/ios/ios_surface_metal_impeller.mm
@@ -52,7 +52,6 @@ std::unique_ptr<Surface> IOSSurfaceMetalImpeller::CreateGPUSurface(GrDirectConte
 
 // |GPUSurfaceMetalDelegate|
 GPUCAMetalLayerHandle IOSSurfaceMetalImpeller::GetCAMetalLayer(const SkISize& frame_info) const {
-  CAMetalLayer* layer = layer_;
   const auto drawable_size = CGSizeMake(frame_info.width(), frame_info.height());
   if (!CGSizeEqualToSize(drawable_size, layer_.drawableSize)) {
     layer_.drawableSize = drawable_size;
@@ -60,9 +59,9 @@ GPUCAMetalLayerHandle IOSSurfaceMetalImpeller::GetCAMetalLayer(const SkISize& fr
 
   // Flutter needs to read from the color attachment in cases where there are effects such as
   // backdrop filters. Flutter plugins that create platform views may also read from the layer.
-  layer.framebufferOnly = NO;
+  layer_.framebufferOnly = NO;
 
-  return (__bridge GPUCAMetalLayerHandle)layer;
+  return (__bridge GPUCAMetalLayerHandle)layer_;
 }
 
 // |GPUSurfaceMetalDelegate|

--- a/shell/platform/darwin/ios/ios_surface_metal_skia.h
+++ b/shell/platform/darwin/ios/ios_surface_metal_skia.h
@@ -19,14 +19,13 @@ namespace flutter {
 class SK_API_AVAILABLE_CA_METAL_LAYER IOSSurfaceMetalSkia final : public IOSSurface,
                                                                   public GPUSurfaceMetalDelegate {
  public:
-  IOSSurfaceMetalSkia(const fml::scoped_nsobject<CAMetalLayer>& layer,
-                      std::shared_ptr<IOSContext> context);
+  IOSSurfaceMetalSkia(CAMetalLayer* layer, std::shared_ptr<IOSContext> context);
 
   // |IOSSurface|
   ~IOSSurfaceMetalSkia();
 
  private:
-  fml::scoped_nsobject<CAMetalLayer> layer_;
+  CAMetalLayer* layer_;
   id<MTLDevice> device_;
   id<MTLCommandQueue> command_queue_;
   bool is_valid_ = false;

--- a/shell/platform/darwin/ios/ios_surface_metal_skia.mm
+++ b/shell/platform/darwin/ios/ios_surface_metal_skia.mm
@@ -23,14 +23,13 @@ static IOSContextMetalSkia* CastToMetalContext(const std::shared_ptr<IOSContext>
   return (IOSContextMetalSkia*)context.get();
 }
 
-IOSSurfaceMetalSkia::IOSSurfaceMetalSkia(const fml::scoped_nsobject<CAMetalLayer>& layer,
-                                         std::shared_ptr<IOSContext> context)
+IOSSurfaceMetalSkia::IOSSurfaceMetalSkia(CAMetalLayer* layer, std::shared_ptr<IOSContext> context)
     : IOSSurface(std::move(context)),
       GPUSurfaceMetalDelegate(MTLRenderTargetType::kCAMetalLayer),
       layer_(layer) {
   is_valid_ = layer_;
   auto metal_context = CastToMetalContext(GetContext());
-  auto darwin_context = metal_context->GetDarwinContext().get();
+  auto darwin_context = metal_context->GetDarwinContext();
   command_queue_ = darwin_context.commandQueue;
   device_ = darwin_context.device;
 }
@@ -58,7 +57,7 @@ std::unique_ptr<Surface> IOSSurfaceMetalSkia::CreateGPUSurface(GrDirectContext* 
 
 // |GPUSurfaceMetalDelegate|
 GPUCAMetalLayerHandle IOSSurfaceMetalSkia::GetCAMetalLayer(const SkISize& frame_info) const {
-  CAMetalLayer* layer = layer_.get();
+  CAMetalLayer* layer = layer_;
   layer.device = device_;
 
   layer.pixelFormat = MTLPixelFormatBGRA8Unorm;

--- a/shell/platform/darwin/ios/ios_surface_metal_skia.mm
+++ b/shell/platform/darwin/ios/ios_surface_metal_skia.mm
@@ -18,18 +18,13 @@ FLUTTER_ASSERT_ARC
 
 namespace flutter {
 
-static IOSContextMetalSkia* CastToMetalContext(const std::shared_ptr<IOSContext>& context)
-    __attribute__((cf_audited_transfer)) {
-  return (IOSContextMetalSkia*)context.get();
-}
-
 IOSSurfaceMetalSkia::IOSSurfaceMetalSkia(CAMetalLayer* layer, std::shared_ptr<IOSContext> context)
     : IOSSurface(std::move(context)),
       GPUSurfaceMetalDelegate(MTLRenderTargetType::kCAMetalLayer),
       layer_(layer) {
   is_valid_ = layer_;
-  auto metal_context = CastToMetalContext(GetContext());
-  auto darwin_context = metal_context->GetDarwinContext();
+  IOSContextMetalSkia* metal_context = static_cast<IOSContextMetalSkia*>(GetContext().get());
+  FlutterDarwinContextMetalSkia* darwin_context = metal_context->GetDarwinContext();
   command_queue_ = darwin_context.commandQueue;
   device_ = darwin_context.device;
 }
@@ -57,25 +52,24 @@ std::unique_ptr<Surface> IOSSurfaceMetalSkia::CreateGPUSurface(GrDirectContext* 
 
 // |GPUSurfaceMetalDelegate|
 GPUCAMetalLayerHandle IOSSurfaceMetalSkia::GetCAMetalLayer(const SkISize& frame_info) const {
-  CAMetalLayer* layer = layer_;
-  layer.device = device_;
+  layer_.device = device_;
 
-  layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
+  layer_.pixelFormat = MTLPixelFormatBGRA8Unorm;
   // Flutter needs to read from the color attachment in cases where there are effects such as
   // backdrop filters. Flutter plugins that create platform views may also read from the layer.
-  layer.framebufferOnly = NO;
+  layer_.framebufferOnly = NO;
 
   const auto drawable_size = CGSizeMake(frame_info.width(), frame_info.height());
-  if (!CGSizeEqualToSize(drawable_size, layer.drawableSize)) {
-    layer.drawableSize = drawable_size;
+  if (!CGSizeEqualToSize(drawable_size, layer_.drawableSize)) {
+    layer_.drawableSize = drawable_size;
   }
 
   // When there are platform views in the scene, the drawable needs to be presented in the same
   // transaction as the one created for platform views. When the drawable are being presented from
   // the raster thread, there is no such transaction.
-  layer.presentsWithTransaction = [[NSThread currentThread] isMainThread];
+  layer_.presentsWithTransaction = [[NSThread currentThread] isMainThread];
 
-  return (__bridge GPUCAMetalLayerHandle)layer;
+  return (__bridge GPUCAMetalLayerHandle)layer_;
 }
 
 // |GPUSurfaceMetalDelegate|

--- a/shell/platform/darwin/ios/ios_surface_noop.h
+++ b/shell/platform/darwin/ios/ios_surface_noop.h
@@ -5,7 +5,6 @@
 #ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_IOS_SURFACE_NOOP_H_
 #define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_IOS_SURFACE_NOOP_H_
 
-#include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #import "flutter/shell/platform/darwin/ios/ios_context.h"
 #import "flutter/shell/platform/darwin/ios/ios_surface.h"
 

--- a/shell/platform/darwin/ios/ios_surface_software.h
+++ b/shell/platform/darwin/ios/ios_surface_software.h
@@ -7,7 +7,6 @@
 
 #include "flutter/flow/embedded_views.h"
 #include "flutter/fml/macros.h"
-#include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/shell/gpu/gpu_surface_software.h"
 #import "flutter/shell/platform/darwin/ios/ios_context.h"
 #import "flutter/shell/platform/darwin/ios/ios_surface.h"
@@ -20,8 +19,7 @@ namespace flutter {
 
 class IOSSurfaceSoftware final : public IOSSurface, public GPUSurfaceSoftwareDelegate {
  public:
-  IOSSurfaceSoftware(const fml::scoped_nsobject<CALayer>& layer,
-                     std::shared_ptr<IOSContext> context);
+  IOSSurfaceSoftware(CALayer* layer, std::shared_ptr<IOSContext> context);
 
   ~IOSSurfaceSoftware() override;
 
@@ -41,7 +39,7 @@ class IOSSurfaceSoftware final : public IOSSurface, public GPUSurfaceSoftwareDel
   bool PresentBackingStore(sk_sp<SkSurface> backing_store) override;
 
  private:
-  fml::scoped_nsobject<CALayer> layer_;
+  CALayer* layer_;
   sk_sp<SkSurface> sk_surface_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(IOSSurfaceSoftware);

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -19,8 +19,7 @@ FLUTTER_ASSERT_ARC
 
 namespace flutter {
 
-IOSSurfaceSoftware::IOSSurfaceSoftware(const fml::scoped_nsobject<CALayer>& layer,
-                                       std::shared_ptr<IOSContext> context)
+IOSSurfaceSoftware::IOSSurfaceSoftware(CALayer* layer, std::shared_ptr<IOSContext> context)
     : IOSSurface(std::move(context)), layer_(layer) {}
 
 IOSSurfaceSoftware::~IOSSurfaceSoftware() = default;
@@ -120,7 +119,7 @@ bool IOSSurfaceSoftware::PresentBackingStore(sk_sp<SkSurface> backing_store) {
     return false;
   }
 
-  layer_.get().contents = (__bridge id)(static_cast<CGImageRef>(pixmap_image));
+  layer_.contents = (__bridge id)(static_cast<CGImageRef>(pixmap_image));
 
   return true;
 }

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -119,7 +119,7 @@ bool IOSSurfaceSoftware::PresentBackingStore(sk_sp<SkSurface> backing_store) {
     return false;
   }
 
-  layer_.contents = (__bridge id)(static_cast<CGImageRef>(pixmap_image));
+  layer_.contents = (__bridge id) static_cast<CGImageRef>(pixmap_image);
 
   return true;
 }

--- a/shell/platform/darwin/ios/platform_message_handler_ios.h
+++ b/shell/platform/darwin/ios/platform_message_handler_ios.h
@@ -6,7 +6,6 @@
 #define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_PLATFORM_MESSAGE_HANDLER_IOS_H_
 
 #include "flutter/fml/platform/darwin/scoped_block.h"
-#include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/fml/task_runner.h"
 #include "flutter/shell/common/platform_message_handler.h"
 #import "flutter/shell/platform/darwin/ios/flutter_task_queue_dispatch.h"
@@ -33,7 +32,7 @@ class PlatformMessageHandlerIos : public PlatformMessageHandler {
                          NSObject<FlutterTaskQueue>* task_queue);
 
   struct HandlerInfo {
-    fml::scoped_nsprotocol<NSObject<FlutterTaskQueueDispatch>*> task_queue;
+    NSObject<FlutterTaskQueueDispatch>* task_queue;
     fml::ScopedBlock<FlutterBinaryMessageHandler> handler;
   };
 

--- a/shell/platform/darwin/ios/platform_message_handler_ios.mm
+++ b/shell/platform/darwin/ios/platform_message_handler_ios.mm
@@ -80,8 +80,8 @@ void PlatformMessageHandlerIos::HandlePlatformMessage(std::unique_ptr<PlatformMe
         });
       };
 
-      if (handler_info.task_queue.get()) {
-        [handler_info.task_queue.get() dispatch:run_handler];
+      if (handler_info.task_queue) {
+        [handler_info.task_queue dispatch:run_handler];
       } else {
         dispatch_async(dispatch_get_main_queue(), run_handler);
       }
@@ -124,8 +124,7 @@ void PlatformMessageHandlerIos::SetMessageHandler(const std::string& channel,
   message_handlers_.erase(channel);
   if (handler) {
     message_handlers_[channel] = {
-        .task_queue =
-            fml::scoped_nsprotocol(static_cast<NSObject<FlutterTaskQueueDispatch>*>(task_queue)),
+        .task_queue = (NSObject<FlutterTaskQueueDispatch>*)task_queue,
         .handler =
             fml::ScopedBlock<FlutterBinaryMessageHandler>{
                 handler, fml::scoped_policy::OwnershipPolicy::kRetain},

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -116,7 +116,7 @@ void PlatformViewIOS::attachView() {
   FML_DCHECK(owner_controller_.isViewLoaded) << "FlutterViewController's view should be loaded "
                                                 "before attaching to PlatformViewIOS.";
   FlutterView* flutter_view = static_cast<FlutterView*>(owner_controller_.view);
-  auto ca_layer = fml::scoped_nsobject<CALayer>{[flutter_view layer]};
+  CALayer* ca_layer = flutter_view.layer;
   ios_surface_ = IOSSurface::Create(ios_context_, ca_layer);
   FML_DCHECK(ios_surface_ != nullptr);
 
@@ -134,8 +134,7 @@ PointerDataDispatcherMaker PlatformViewIOS::GetDispatcherMaker() {
 
 void PlatformViewIOS::RegisterExternalTexture(int64_t texture_id,
                                               NSObject<FlutterTexture>* texture) {
-  RegisterTexture(ios_context_->CreateExternalTexture(
-      texture_id, fml::scoped_nsobject<NSObject<FlutterTexture>>{texture}));
+  RegisterTexture(ios_context_->CreateExternalTexture(texture_id, texture));
 }
 
 // |PlatformView|

--- a/testing/test_metal_context.mm
+++ b/testing/test_metal_context.mm
@@ -8,7 +8,6 @@
 #include <iostream>
 
 #include "flutter/fml/logging.h"
-#include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/ganesh/GrDirectContext.h"
 #include "third_party/skia/include/gpu/ganesh/mtl/GrMtlBackendContext.h"

--- a/testing/test_metal_surface_impl.mm
+++ b/testing/test_metal_surface_impl.mm
@@ -7,7 +7,6 @@
 #include <Metal/Metal.h>
 
 #include "flutter/fml/logging.h"
-#include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/testing/test_metal_context.h"
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkColorSpace.h"


### PR DESCRIPTION
Eliminates use of `fml::scoped_nsobject` now that the codebase has been migrated to ARC.

Issue: https://github.com/flutter/flutter/issues/137801

No changes to tests since this patch makes no semantic changes.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
