### PR TITLE
Write run_tests console logs to stdout instead of stderr

### DIFF
--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -23,7 +23,7 @@ import subprocess
 # Explicitly import the parts of sys that are needed. This is to avoid using
 # sys.stdout and sys.stderr directly. Instead, only the logger defined below
 # should be used for output.
-from sys import exit as sys_exit, platform as sys_platform, path as sys_path
+from sys import exit as sys_exit, platform as sys_platform, path as sys_path, stdout as sys_stdout
 import tempfile
 import time
 import typing
@@ -45,7 +45,7 @@ ENCODING = 'UTF-8'
 
 LOG_FILE = os.path.join(OUT_DIR, 'run_tests.log')
 logger = logging.getLogger(__name__)
-console_logger_handler = logging.StreamHandler()
+console_logger_handler = logging.StreamHandler(sys_stdout)
 file_logger_handler = logging.FileHandler(LOG_FILE)
 
 

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -45,6 +45,7 @@ ENCODING = 'UTF-8'
 
 LOG_FILE = os.path.join(OUT_DIR, 'run_tests.log')
 logger = logging.getLogger(__name__)
+# Write console logs to stdout (by default StreamHandler uses stderr)
 console_logger_handler = logging.StreamHandler(sys_stdout)
 file_logger_handler = logging.FileHandler(LOG_FILE)
 


### PR DESCRIPTION
Users of this script typically expect that the normal output of the tests will be written to stdout.  However, the logging.StreamHandler writes to stderr by default unless another stream is specified.