### PR TITLE
Remove superfluous dart2wasm test suites/bundles.

### DIFF
--- a/ci/builders/linux_web_engine.json
+++ b/ci/builders/linux_web_engine.json
@@ -202,94 +202,6 @@
       }
     },
     {
-      "name": "web_tests/test_bundles/dart2wasm-html-html",
-      "drone_dimensions": [
-        "device_type=none",
-        "os=Linux"
-      ],
-      "generators": {
-        "tasks": [
-          {
-            "name": "compile bundle dart2wasm-html-html",
-            "parameters": [
-              "test",
-              "--compile",
-              "--bundle=dart2wasm-html-html"
-            ],
-            "scripts": [
-              "flutter/lib/web_ui/dev/felt"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "web_tests/test_bundles/dart2wasm-html-ui",
-      "drone_dimensions": [
-        "device_type=none",
-        "os=Linux"
-      ],
-      "generators": {
-        "tasks": [
-          {
-            "name": "compile bundle dart2wasm-html-ui",
-            "parameters": [
-              "test",
-              "--compile",
-              "--bundle=dart2wasm-html-ui"
-            ],
-            "scripts": [
-              "flutter/lib/web_ui/dev/felt"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "web_tests/test_bundles/dart2wasm-canvaskit-canvaskit",
-      "drone_dimensions": [
-        "device_type=none",
-        "os=Linux"
-      ],
-      "generators": {
-        "tasks": [
-          {
-            "name": "compile bundle dart2wasm-canvaskit-canvaskit",
-            "parameters": [
-              "test",
-              "--compile",
-              "--bundle=dart2wasm-canvaskit-canvaskit"
-            ],
-            "scripts": [
-              "flutter/lib/web_ui/dev/felt"
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "web_tests/test_bundles/dart2wasm-canvaskit-ui",
-      "drone_dimensions": [
-        "device_type=none",
-        "os=Linux"
-      ],
-      "generators": {
-        "tasks": [
-          {
-            "name": "compile bundle dart2wasm-canvaskit-ui",
-            "parameters": [
-              "test",
-              "--compile",
-              "--bundle=dart2wasm-canvaskit-ui"
-            ],
-            "scripts": [
-              "flutter/lib/web_ui/dev/felt"
-            ]
-          }
-        ]
-      }
-    },
-    {
       "name": "web_tests/test_bundles/dart2wasm-skwasm-ui",
       "drone_dimensions": [
         "device_type=none",
@@ -354,10 +266,6 @@
         "web_tests/test_bundles/dart2js-canvaskit-canvaskit",
         "web_tests/test_bundles/dart2js-canvaskit-ui",
         "web_tests/test_bundles/dart2wasm-html-engine",
-        "web_tests/test_bundles/dart2wasm-html-html",
-        "web_tests/test_bundles/dart2wasm-html-ui",
-        "web_tests/test_bundles/dart2wasm-canvaskit-canvaskit",
-        "web_tests/test_bundles/dart2wasm-canvaskit-ui",
         "web_tests/test_bundles/dart2wasm-skwasm-ui",
         "web_tests/test_bundles/fallbacks"
       ],
@@ -445,42 +353,6 @@
           "script": "flutter/lib/web_ui/dev/felt"
         },
         {
-          "name": "run suite chrome-dart2wasm-html-html",
-          "parameters": [
-            "test",
-            "--run",
-            "--suite=chrome-dart2wasm-html-html"
-          ],
-          "script": "flutter/lib/web_ui/dev/felt"
-        },
-        {
-          "name": "run suite chrome-dart2wasm-html-ui",
-          "parameters": [
-            "test",
-            "--run",
-            "--suite=chrome-dart2wasm-html-ui"
-          ],
-          "script": "flutter/lib/web_ui/dev/felt"
-        },
-        {
-          "name": "run suite chrome-dart2wasm-canvaskit-canvaskit",
-          "parameters": [
-            "test",
-            "--run",
-            "--suite=chrome-dart2wasm-canvaskit-canvaskit"
-          ],
-          "script": "flutter/lib/web_ui/dev/felt"
-        },
-        {
-          "name": "run suite chrome-dart2wasm-canvaskit-ui",
-          "parameters": [
-            "test",
-            "--run",
-            "--suite=chrome-dart2wasm-canvaskit-ui"
-          ],
-          "script": "flutter/lib/web_ui/dev/felt"
-        },
-        {
           "name": "run suite chrome-coi-dart2wasm-skwasm-ui",
           "parameters": [
             "test",
@@ -495,24 +367,6 @@
             "test",
             "--run",
             "--suite=chrome-force-st-dart2wasm-skwasm-ui"
-          ],
-          "script": "flutter/lib/web_ui/dev/felt"
-        },
-        {
-          "name": "run suite chrome-full-dart2wasm-canvaskit-canvaskit",
-          "parameters": [
-            "test",
-            "--run",
-            "--suite=chrome-full-dart2wasm-canvaskit-canvaskit"
-          ],
-          "script": "flutter/lib/web_ui/dev/felt"
-        },
-        {
-          "name": "run suite chrome-full-dart2wasm-canvaskit-ui",
-          "parameters": [
-            "test",
-            "--run",
-            "--suite=chrome-full-dart2wasm-canvaskit-ui"
           ],
           "script": "flutter/lib/web_ui/dev/felt"
         },
@@ -735,10 +589,6 @@
         "web_tests/test_bundles/dart2js-canvaskit-canvaskit",
         "web_tests/test_bundles/dart2js-canvaskit-ui",
         "web_tests/test_bundles/dart2wasm-html-engine",
-        "web_tests/test_bundles/dart2wasm-html-html",
-        "web_tests/test_bundles/dart2wasm-html-ui",
-        "web_tests/test_bundles/dart2wasm-canvaskit-canvaskit",
-        "web_tests/test_bundles/dart2wasm-canvaskit-ui",
         "web_tests/test_bundles/dart2wasm-skwasm-ui",
         "web_tests/test_bundles/fallbacks"
       ],
@@ -826,42 +676,6 @@
           "script": "flutter/lib/web_ui/dev/felt"
         },
         {
-          "name": "run suite chrome-dart2wasm-html-html",
-          "parameters": [
-            "test",
-            "--run",
-            "--suite=chrome-dart2wasm-html-html"
-          ],
-          "script": "flutter/lib/web_ui/dev/felt"
-        },
-        {
-          "name": "run suite chrome-dart2wasm-html-ui",
-          "parameters": [
-            "test",
-            "--run",
-            "--suite=chrome-dart2wasm-html-ui"
-          ],
-          "script": "flutter/lib/web_ui/dev/felt"
-        },
-        {
-          "name": "run suite chrome-dart2wasm-canvaskit-canvaskit",
-          "parameters": [
-            "test",
-            "--run",
-            "--suite=chrome-dart2wasm-canvaskit-canvaskit"
-          ],
-          "script": "flutter/lib/web_ui/dev/felt"
-        },
-        {
-          "name": "run suite chrome-dart2wasm-canvaskit-ui",
-          "parameters": [
-            "test",
-            "--run",
-            "--suite=chrome-dart2wasm-canvaskit-ui"
-          ],
-          "script": "flutter/lib/web_ui/dev/felt"
-        },
-        {
           "name": "run suite chrome-coi-dart2wasm-skwasm-ui",
           "parameters": [
             "test",
@@ -876,24 +690,6 @@
             "test",
             "--run",
             "--suite=chrome-force-st-dart2wasm-skwasm-ui"
-          ],
-          "script": "flutter/lib/web_ui/dev/felt"
-        },
-        {
-          "name": "run suite chrome-full-dart2wasm-canvaskit-canvaskit",
-          "parameters": [
-            "test",
-            "--run",
-            "--suite=chrome-full-dart2wasm-canvaskit-canvaskit"
-          ],
-          "script": "flutter/lib/web_ui/dev/felt"
-        },
-        {
-          "name": "run suite chrome-full-dart2wasm-canvaskit-ui",
-          "parameters": [
-            "test",
-            "--run",
-            "--suite=chrome-full-dart2wasm-canvaskit-ui"
           ],
           "script": "flutter/lib/web_ui/dev/felt"
         },

--- a/lib/web_ui/test/felt_config.yaml
+++ b/lib/web_ui/test/felt_config.yaml
@@ -17,10 +17,6 @@ compile-configs:
     compiler: dart2wasm
     renderer: html
 
-  - name: dart2wasm-canvaskit
-    compiler: dart2wasm
-    renderer: canvaskit
-
   - name: dart2wasm-skwasm
     compiler: dart2wasm
     renderer: skwasm
@@ -70,22 +66,6 @@ test-bundles:
   - name: dart2wasm-html-engine
     test-set: engine
     compile-configs: dart2wasm-html
-
-  - name: dart2wasm-html-html
-    test-set: html
-    compile-configs: dart2wasm-html
-
-  - name: dart2wasm-html-ui
-    test-set: ui
-    compile-configs: dart2wasm-html
-
-  - name: dart2wasm-canvaskit-canvaskit
-    test-set: canvaskit
-    compile-configs: dart2wasm-canvaskit
-
-  - name: dart2wasm-canvaskit-ui
-    test-set: ui
-    compile-configs: dart2wasm-canvaskit
 
   - name: dart2wasm-skwasm-ui
     test-set: ui
@@ -246,24 +226,6 @@ test-suites:
     test-bundle: dart2wasm-html-engine
     run-config: chrome
 
-  - name: chrome-dart2wasm-html-html
-    test-bundle: dart2wasm-html-html
-    run-config: chrome
-
-  - name: chrome-dart2wasm-html-ui
-    test-bundle: dart2wasm-html-ui
-    run-config: chrome
-
-  - name: chrome-dart2wasm-canvaskit-canvaskit
-    test-bundle: dart2wasm-canvaskit-canvaskit
-    run-config: chrome
-    artifact-deps: [ canvaskit_chromium ]
-
-  - name: chrome-dart2wasm-canvaskit-ui
-    test-bundle: dart2wasm-canvaskit-ui
-    run-config: chrome
-    artifact-deps: [ canvaskit_chromium ]
-
   - name: chrome-coi-dart2wasm-skwasm-ui
     test-bundle: dart2wasm-skwasm-ui
     run-config: chrome-coi
@@ -273,16 +235,6 @@ test-suites:
     test-bundle: dart2wasm-skwasm-ui
     run-config: chrome-force-st
     artifact-deps: [ skwasm ]
-
-  - name: chrome-full-dart2wasm-canvaskit-canvaskit
-    test-bundle: dart2wasm-canvaskit-canvaskit
-    run-config: chrome-full
-    artifact-deps: [ canvaskit ]
-
-  - name: chrome-full-dart2wasm-canvaskit-ui
-    test-bundle: dart2wasm-canvaskit-ui
-    run-config: chrome-full
-    artifact-deps: [ canvaskit ]
 
   - name: chrome-fallbacks
     test-bundle: fallbacks


### PR DESCRIPTION
When dart2wasm was still in early stages and unstable, we wanted to run dart2wasm on as many unit tests and code paths as possible. However, dart2wasm is much more stable now, and there are some configurations that users simply cannot not use and are not worth testing. Specifically, users cannot use renderers other than skwasm with dart2wasm, so we should avoid running test suites specific to those renderers.

* `dart2wasm-html-html` and `dart2wasm-canvaskit-canvaskit` bundles and their associated suites are removed. These are tests specifically for the `html` and `canvaskit` renderers, which are run with those renderers. Users can't use these renderers in dart2wasm mode, so it's not useful to run these tests.
* `dart2wasm-html-ui` and `dart2wasm-canvaskit-ui` and their associated suites are also removed. These are tests that can run on any renderer, and they are being run with the `html` and `canvaskit` renderers. We don't need to run against these renderers on `dart2wasm` since users can't actually use these renderers in dart2wasm mode.
* Notably, `dart2wasm-html-engine` and associated suites are staying. These run against the `html` renderer, but only incidentally. These tests are supposed to be exercising logic that doesn't actually pertain to rendering, and it's logic that will be running for the end user in dart2wasm mode. So it makes sense to continue running these tests against dart2wasm.