### PR TITLE
[Impeller] fix downsample with decal tile mode.

### DIFF
--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -337,8 +337,8 @@ ContentContext::ContentContext(
     clip_pipelines_.SetDefault(
         options,
         std::make_unique<ClipPipeline>(*context_, clip_pipeline_descriptor));
-    texture_downsample_pipelines_.CreateDefault(*context_,
-                                                options_trianglestrip);
+    texture_downsample_pipelines_.CreateDefault(
+        *context_, options_trianglestrip, {supports_decal});
     rrect_blur_pipelines_.CreateDefault(*context_, options_trianglestrip);
     texture_strict_src_pipelines_.CreateDefault(*context_, options);
     tiled_texture_pipelines_.CreateDefault(*context_, options,

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -407,7 +407,8 @@ fml::StatusOr<RenderTarget> MakeDownsampleSubpass(
           frag_info.edge = edge;
           frag_info.ratio = ratio;
           frag_info.pixel_size = Vector2(1.0f / Size(input_texture->GetSize()));
-          frag_info.decal = (tile_mode == Entity::TileMode::kDecal) ? 1.0 : 0.0;
+          frag_info.use_decal =
+              (tile_mode == Entity::TileMode::kDecal) ? 1.0 : 0.0;
 
           const Quad& uvs = pass_args.uvs;
           std::array<VS::PerVertexData, 4> vertices = {

--- a/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
+++ b/impeller/entity/contents/filters/gaussian_blur_filter_contents.cc
@@ -9,6 +9,7 @@
 #include "flutter/fml/make_copyable.h"
 #include "impeller/entity/contents/clip_contents.h"
 #include "impeller/entity/contents/content_context.h"
+#include "impeller/entity/entity.h"
 #include "impeller/entity/texture_downsample.frag.h"
 #include "impeller/entity/texture_fill.frag.h"
 #include "impeller/entity/texture_fill.vert.h"
@@ -406,6 +407,7 @@ fml::StatusOr<RenderTarget> MakeDownsampleSubpass(
           frag_info.edge = edge;
           frag_info.ratio = ratio;
           frag_info.pixel_size = Vector2(1.0f / Size(input_texture->GetSize()));
+          frag_info.decal = (tile_mode == Entity::TileMode::kDecal) ? 1.0 : 0.0;
 
           const Quad& uvs = pass_args.uvs;
           std::array<VS::PerVertexData, 4> vertices = {

--- a/impeller/entity/shaders/texture_downsample.frag
+++ b/impeller/entity/shaders/texture_downsample.frag
@@ -14,7 +14,7 @@ uniform f16sampler2D texture_sampler;
 uniform FragInfo {
   float edge;
   float ratio;
-  float decal;
+  float use_decal;
   vec2 pixel_size;
 }
 frag_info;
@@ -27,7 +27,7 @@ vec4 Sample(vec2 uv) {
   if (supports_decal == 1.0) {
     return texture(texture_sampler, uv, float16_t(kDefaultMipBias));
   } else {
-    if (frag_info.decal == 1.0 &&
+    if (frag_info.use_decal == 1.0 &&
         (uv.x < 0 || uv.y < 0 || uv.x > 1 || uv.y > 1)) {
       return vec4(0);
     } else {

--- a/impeller/entity/shaders/texture_downsample.frag
+++ b/impeller/entity/shaders/texture_downsample.frag
@@ -7,11 +7,14 @@ precision mediump float;
 #include <impeller/constants.glsl>
 #include <impeller/types.glsl>
 
+layout(constant_id = 0) const float supports_decal = 1.0;
+
 uniform f16sampler2D texture_sampler;
 
 uniform FragInfo {
   float edge;
   float ratio;
+  float decal;
   vec2 pixel_size;
 }
 frag_info;
@@ -20,13 +23,24 @@ in highp vec2 v_texture_coords;
 
 out vec4 frag_color;
 
+vec4 Sample(vec2 uv) {
+  if (supports_decal == 1.0) {
+    return texture(texture_sampler, uv, float16_t(kDefaultMipBias));
+  } else {
+    if (frag_info.decal == 1.0 &&
+        (uv.x < 0 || uv.y < 0 || uv.x > 1 || uv.y > 1)) {
+      return vec4(0);
+    } else {
+      return texture(texture_sampler, uv, float16_t(kDefaultMipBias));
+    }
+  }
+}
+
 void main() {
   vec4 total = vec4(0.0);
   for (float i = -frag_info.edge; i <= frag_info.edge; i += 2) {
     for (float j = -frag_info.edge; j <= frag_info.edge; j += 2) {
-      total += (texture(texture_sampler,
-                        v_texture_coords + frag_info.pixel_size * vec2(i, j),
-                        float16_t(kDefaultMipBias)) *
+      total += (Sample(v_texture_coords + frag_info.pixel_size * vec2(i, j)) *
                 frag_info.ratio);
     }
   }

--- a/impeller/tools/malioc.json
+++ b/impeller/tools/malioc.json
@@ -4845,7 +4845,7 @@
           },
           "thread_occupancy": 100,
           "uniform_registers_used": 1,
-          "work_registers_used": 4
+          "work_registers_used": 3
         }
       }
     }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/157956
Fixes https://github.com/flutter/flutter/issues/157959

Decal tile mode needs to be emulated on platforms that don't support it.