### PR TITLE
[Impeller] check if memory type is host coherent, avoid flush.

### DIFF
--- a/impeller/renderer/backend/vulkan/allocator_vk.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk.cc
@@ -506,7 +506,6 @@ std::shared_ptr<DeviceBuffer> AllocatorVK::OnCreateBuffer(
       !desc.readback) {
     allocation_info.pool = staging_buffer_pool_.get().pool;
   }
-
   VkBuffer buffer = {};
   VmaAllocation buffer_allocation = {};
   VmaAllocationInfo buffer_allocation_info = {};
@@ -517,6 +516,10 @@ std::shared_ptr<DeviceBuffer> AllocatorVK::OnCreateBuffer(
                                              &buffer_allocation,      //
                                              &buffer_allocation_info  //
                                              )};
+
+  auto type = memory_properties_.memoryTypes[buffer_allocation_info.memoryType];
+  bool is_host_coherent =
+      !!(type.propertyFlags & vk::MemoryPropertyFlagBits::eHostCoherent);
 
   if (result != vk::Result::eSuccess) {
     VALIDATION_LOG << "Unable to allocate a device buffer: "
@@ -530,8 +533,8 @@ std::shared_ptr<DeviceBuffer> AllocatorVK::OnCreateBuffer(
       UniqueBufferVMA{BufferVMA{allocator_.get(),      //
                                 buffer_allocation,     //
                                 vk::Buffer{buffer}}},  //
-      buffer_allocation_info                           //
-  );
+      buffer_allocation_info,                          //
+      is_host_coherent);
 }
 
 Bytes AllocatorVK::DebugGetHeapUsage() const {

--- a/impeller/renderer/backend/vulkan/allocator_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk_unittests.cc
@@ -5,9 +5,11 @@
 #include "flutter/testing/testing.h"  // IWYU pragma: keep
 #include "gtest/gtest.h"
 #include "impeller/base/allocation_size.h"
+#include "impeller/core/device_buffer.h"
 #include "impeller/core/device_buffer_descriptor.h"
 #include "impeller/core/formats.h"
 #include "impeller/renderer/backend/vulkan/allocator_vk.h"
+#include "impeller/renderer/backend/vulkan/device_buffer_vk.h"
 #include "impeller/renderer/backend/vulkan/test/mock_vulkan.h"
 #include "vulkan/vulkan_enums.hpp"
 
@@ -69,6 +71,19 @@ TEST(AllocatorVKTest, MemoryTypeSelectionTwoHeap) {
   EXPECT_EQ(AllocatorVK::FindMemoryTypeIndex(2, properties), 1);
   EXPECT_EQ(AllocatorVK::FindMemoryTypeIndex(3, properties), 1);
   EXPECT_EQ(AllocatorVK::FindMemoryTypeIndex(4, properties), -1);
+}
+
+TEST(AllocatorVKTest, DeviceBufferCoherency) {
+  auto const context = MockVulkanContextBuilder().Build();
+  auto allocator = context->GetResourceAllocator();
+
+  std::shared_ptr<DeviceBuffer> buffer =
+      allocator->CreateBuffer(DeviceBufferDescriptor{
+          .storage_mode = StorageMode::kHostVisible,
+          .size = 1024,
+      });
+
+  EXPECT_TRUE(DeviceBufferVK::Cast(*buffer).IsHostCoherent());
 }
 
 #ifdef IMPELLER_DEBUG

--- a/impeller/renderer/backend/vulkan/allocator_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk_unittests.cc
@@ -77,19 +77,6 @@ TEST(AllocatorVKTest, MemoryTypeSelectionTwoHeap) {
   EXPECT_EQ(AllocatorVK::FindMemoryTypeIndex(4, properties), -1);
 }
 
-TEST(AllocatorVKTest, DeviceBufferCoherency) {
-  auto const context = MockVulkanContextBuilder().Build();
-  auto allocator = context->GetResourceAllocator();
-
-  std::shared_ptr<DeviceBuffer> buffer =
-      allocator->CreateBuffer(DeviceBufferDescriptor{
-          .storage_mode = StorageMode::kHostVisible,
-          .size = 1024,
-      });
-
-  EXPECT_TRUE(DeviceBufferVK::Cast(*buffer).IsHostCoherent());
-}
-
 TEST_P(AllocatorVKTest, DeviceBufferNonCoherency) {
   auto allocator = GetContext()->GetResourceAllocator();
 
@@ -100,6 +87,14 @@ TEST_P(AllocatorVKTest, DeviceBufferNonCoherency) {
       });
 
   EXPECT_TRUE(DeviceBufferVK::Cast(*buffer).IsHostCoherent());
+
+  std::shared_ptr<DeviceBuffer> buffer_2 =
+      allocator->CreateBuffer(DeviceBufferDescriptor{
+          .storage_mode = StorageMode::kDevicePrivate,
+          .size = 1024,
+      });
+
+  EXPECT_FALSE(DeviceBufferVK::Cast(*buffer_2).IsHostCoherent());
 }
 
 #ifdef IMPELLER_DEBUG

--- a/impeller/renderer/backend/vulkan/allocator_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk_unittests.cc
@@ -8,6 +8,7 @@
 #include "impeller/core/device_buffer.h"
 #include "impeller/core/device_buffer_descriptor.h"
 #include "impeller/core/formats.h"
+#include "impeller/playground/playground_test.h"
 #include "impeller/renderer/backend/vulkan/allocator_vk.h"
 #include "impeller/renderer/backend/vulkan/device_buffer_vk.h"
 #include "impeller/renderer/backend/vulkan/test/mock_vulkan.h"
@@ -15,6 +16,9 @@
 
 namespace impeller {
 namespace testing {
+
+using AllocatorVKTest = PlaygroundTest;
+INSTANTIATE_VULKAN_PLAYGROUND_SUITE(AllocatorVKTest);
 
 TEST(AllocatorVKTest, ToVKImageUsageFlags) {
   EXPECT_EQ(AllocatorVK::ToVKImageUsageFlags(
@@ -76,6 +80,18 @@ TEST(AllocatorVKTest, MemoryTypeSelectionTwoHeap) {
 TEST(AllocatorVKTest, DeviceBufferCoherency) {
   auto const context = MockVulkanContextBuilder().Build();
   auto allocator = context->GetResourceAllocator();
+
+  std::shared_ptr<DeviceBuffer> buffer =
+      allocator->CreateBuffer(DeviceBufferDescriptor{
+          .storage_mode = StorageMode::kHostVisible,
+          .size = 1024,
+      });
+
+  EXPECT_TRUE(DeviceBufferVK::Cast(*buffer).IsHostCoherent());
+}
+
+TEST_P(AllocatorVKTest, DeviceBufferNonCoherency) {
+  auto allocator = GetContext()->GetResourceAllocator();
 
   std::shared_ptr<DeviceBuffer> buffer =
       allocator->CreateBuffer(DeviceBufferDescriptor{

--- a/impeller/renderer/backend/vulkan/allocator_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk_unittests.cc
@@ -77,6 +77,19 @@ TEST(AllocatorVKTest, MemoryTypeSelectionTwoHeap) {
   EXPECT_EQ(AllocatorVK::FindMemoryTypeIndex(4, properties), -1);
 }
 
+TEST(AllocatorVKTest, DeviceBufferCoherency) {
+  auto const context = MockVulkanContextBuilder().Build();
+  auto allocator = context->GetResourceAllocator();
+
+  std::shared_ptr<DeviceBuffer> buffer =
+      allocator->CreateBuffer(DeviceBufferDescriptor{
+          .storage_mode = StorageMode::kHostVisible,
+          .size = 1024,
+      });
+
+  EXPECT_TRUE(DeviceBufferVK::Cast(*buffer).IsHostCoherent());
+}
+
 TEST_P(AllocatorVKTest, DeviceBufferNonCoherency) {
   auto allocator = GetContext()->GetResourceAllocator();
 
@@ -87,14 +100,6 @@ TEST_P(AllocatorVKTest, DeviceBufferNonCoherency) {
       });
 
   EXPECT_TRUE(DeviceBufferVK::Cast(*buffer).IsHostCoherent());
-
-  std::shared_ptr<DeviceBuffer> buffer_2 =
-      allocator->CreateBuffer(DeviceBufferDescriptor{
-          .storage_mode = StorageMode::kDevicePrivate,
-          .size = 1024,
-      });
-
-  EXPECT_FALSE(DeviceBufferVK::Cast(*buffer_2).IsHostCoherent());
 }
 
 #ifdef IMPELLER_DEBUG

--- a/impeller/renderer/backend/vulkan/allocator_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk_unittests.cc
@@ -8,7 +8,6 @@
 #include "impeller/core/device_buffer.h"
 #include "impeller/core/device_buffer_descriptor.h"
 #include "impeller/core/formats.h"
-#include "impeller/playground/playground_test.h"
 #include "impeller/renderer/backend/vulkan/allocator_vk.h"
 #include "impeller/renderer/backend/vulkan/device_buffer_vk.h"
 #include "impeller/renderer/backend/vulkan/test/mock_vulkan.h"
@@ -16,9 +15,6 @@
 
 namespace impeller {
 namespace testing {
-
-using AllocatorVKTest = PlaygroundTest;
-INSTANTIATE_VULKAN_PLAYGROUND_SUITE(AllocatorVKTest);
 
 TEST(AllocatorVKTest, ToVKImageUsageFlags) {
   EXPECT_EQ(AllocatorVK::ToVKImageUsageFlags(
@@ -80,18 +76,6 @@ TEST(AllocatorVKTest, MemoryTypeSelectionTwoHeap) {
 TEST(AllocatorVKTest, DeviceBufferCoherency) {
   auto const context = MockVulkanContextBuilder().Build();
   auto allocator = context->GetResourceAllocator();
-
-  std::shared_ptr<DeviceBuffer> buffer =
-      allocator->CreateBuffer(DeviceBufferDescriptor{
-          .storage_mode = StorageMode::kHostVisible,
-          .size = 1024,
-      });
-
-  EXPECT_TRUE(DeviceBufferVK::Cast(*buffer).IsHostCoherent());
-}
-
-TEST_P(AllocatorVKTest, DeviceBufferNonCoherency) {
-  auto allocator = GetContext()->GetResourceAllocator();
 
   std::shared_ptr<DeviceBuffer> buffer =
       allocator->CreateBuffer(DeviceBufferDescriptor{

--- a/impeller/renderer/backend/vulkan/device_buffer_vk.cc
+++ b/impeller/renderer/backend/vulkan/device_buffer_vk.cc
@@ -5,23 +5,23 @@
 #include "impeller/renderer/backend/vulkan/device_buffer_vk.h"
 
 #include "flutter/flutter_vma/flutter_vma.h"
-#include "flutter/fml/trace_event.h"
 #include "impeller/renderer/backend/vulkan/context_vk.h"
-#include "vulkan/vulkan_core.h"
 
 namespace impeller {
 
 DeviceBufferVK::DeviceBufferVK(DeviceBufferDescriptor desc,
                                std::weak_ptr<Context> context,
                                UniqueBufferVMA buffer,
-                               VmaAllocationInfo info)
+                               VmaAllocationInfo info,
+                               bool is_host_coherent)
     : DeviceBuffer(desc),
       context_(std::move(context)),
       resource_(ContextVK::Cast(*context_.lock().get()).GetResourceManager(),
                 BufferResource{
                     std::move(buffer),  //
                     info                //
-                }) {}
+                }),
+      is_host_coherent_(is_host_coherent) {}
 
 DeviceBufferVK::~DeviceBufferVK() = default;
 
@@ -69,10 +69,18 @@ bool DeviceBufferVK::SetLabel(std::string_view label) {
 }
 
 void DeviceBufferVK::Flush(std::optional<Range> range) const {
+  if (is_host_coherent_) {
+    return;
+  }
   auto flush_range = range.value_or(Range{0, GetDeviceBufferDescriptor().size});
   ::vmaFlushAllocation(resource_->buffer.get().allocator,
                        resource_->buffer.get().allocation, flush_range.offset,
                        flush_range.length);
+}
+
+// Visible for testing.
+bool DeviceBufferVK::IsHostCoherent() const {
+  return is_host_coherent_;
 }
 
 void DeviceBufferVK::Invalidate(std::optional<Range> range) const {

--- a/impeller/renderer/backend/vulkan/device_buffer_vk.h
+++ b/impeller/renderer/backend/vulkan/device_buffer_vk.h
@@ -20,12 +20,16 @@ class DeviceBufferVK final : public DeviceBuffer,
   DeviceBufferVK(DeviceBufferDescriptor desc,
                  std::weak_ptr<Context> context,
                  UniqueBufferVMA buffer,
-                 VmaAllocationInfo info);
+                 VmaAllocationInfo info,
+                 bool is_host_coherent);
 
   // |DeviceBuffer|
   ~DeviceBufferVK() override;
 
   vk::Buffer GetBuffer() const;
+
+  // Visible for testing.
+  bool IsHostCoherent() const;
 
  private:
   friend class AllocatorVK;
@@ -51,6 +55,7 @@ class DeviceBufferVK final : public DeviceBuffer,
 
   std::weak_ptr<Context> context_;
   UniqueResourceVKT<BufferResource> resource_;
+  bool is_host_coherent_ = false;
 
   // |DeviceBuffer|
   uint8_t* OnGetContents() const override;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/137454

Host coherent memory does not need to be flushed. Almost all mobile devices will have host coherent memory for us to write to, but we still need check because of swiftshader and/or desktop at some point.