### PR TITLE
[Impeller] faster descriptor type mapping.

### DIFF
--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -192,6 +192,7 @@
 ../../../flutter/impeller/renderer/backend/vulkan/descriptor_pool_vk_unittests.cc
 ../../../flutter/impeller/renderer/backend/vulkan/driver_info_vk_unittests.cc
 ../../../flutter/impeller/renderer/backend/vulkan/fence_waiter_vk_unittests.cc
+../../../flutter/impeller/renderer/backend/vulkan/formats_vk_unittests.cc
 ../../../flutter/impeller/renderer/backend/vulkan/pipeline_cache_data_vk_unittests.cc
 ../../../flutter/impeller/renderer/backend/vulkan/render_pass_builder_vk_unittests.cc
 ../../../flutter/impeller/renderer/backend/vulkan/render_pass_cache_unittests.cc

--- a/impeller/core/shader_types.h
+++ b/impeller/core/shader_types.h
@@ -153,13 +153,15 @@ struct ShaderStageBufferLayout {
   }
 };
 
+// These enum values were chosen to match the same values
+// in the VK Descriptor Type enum.
 enum class DescriptorType {
-  kUniformBuffer,
-  kStorageBuffer,
-  kSampledImage,
-  kImage,
-  kSampler,
-  kInputAttachment,
+  kSampler = 0,
+  kSampledImage = 1,
+  kImage = 2,
+  kUniformBuffer = 6,
+  kStorageBuffer = 7,
+  kInputAttachment = 10,
 };
 
 struct DescriptorSetLayout {

--- a/impeller/renderer/backend/vulkan/BUILD.gn
+++ b/impeller/renderer/backend/vulkan/BUILD.gn
@@ -15,6 +15,7 @@ impeller_component("vulkan_unittests") {
     "descriptor_pool_vk_unittests.cc",
     "driver_info_vk_unittests.cc",
     "fence_waiter_vk_unittests.cc",
+    "formats_vk_unittests.cc",
     "pipeline_cache_data_vk_unittests.cc",
     "render_pass_builder_vk_unittests.cc",
     "render_pass_cache_unittests.cc",

--- a/impeller/renderer/backend/vulkan/formats_vk.h
+++ b/impeller/renderer/backend/vulkan/formats_vk.h
@@ -276,28 +276,21 @@ constexpr vk::ShaderStageFlags ToVkShaderStage(ShaderStage stage) {
   FML_UNREACHABLE();
 }
 
-constexpr vk::DescriptorType ToVKDescriptorType(DescriptorType type) {
-  switch (type) {
-    case DescriptorType::kSampledImage:
-      return vk::DescriptorType::eCombinedImageSampler;
-      break;
-    case DescriptorType::kUniformBuffer:
-      return vk::DescriptorType::eUniformBuffer;
-      break;
-    case DescriptorType::kStorageBuffer:
-      return vk::DescriptorType::eStorageBuffer;
-      break;
-    case DescriptorType::kImage:
-      return vk::DescriptorType::eSampledImage;
-      break;
-    case DescriptorType::kSampler:
-      return vk::DescriptorType::eSampler;
-      break;
-    case DescriptorType::kInputAttachment:
-      return vk::DescriptorType::eInputAttachment;
-  }
+static_assert(static_cast<int>(DescriptorType::kSampledImage) ==
+              static_cast<int>(vk::DescriptorType::eCombinedImageSampler));
+static_assert(static_cast<int>(DescriptorType::kUniformBuffer) ==
+              static_cast<int>(vk::DescriptorType::eUniformBuffer));
+static_assert(static_cast<int>(DescriptorType::kStorageBuffer) ==
+              static_cast<int>(vk::DescriptorType::eStorageBuffer));
+static_assert(static_cast<int>(DescriptorType::kImage) ==
+              static_cast<int>(vk::DescriptorType::eSampledImage));
+static_assert(static_cast<int>(DescriptorType::kSampler) ==
+              static_cast<int>(vk::DescriptorType::eSampler));
+static_assert(static_cast<int>(DescriptorType::kInputAttachment) ==
+              static_cast<int>(vk::DescriptorType::eInputAttachment));
 
-  FML_UNREACHABLE();
+constexpr vk::DescriptorType ToVKDescriptorType(DescriptorType type) {
+  return static_cast<vk::DescriptorType>(type);
 }
 
 constexpr vk::DescriptorSetLayoutBinding ToVKDescriptorSetLayoutBinding(

--- a/impeller/renderer/backend/vulkan/formats_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/formats_vk_unittests.cc
@@ -1,0 +1,27 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "gtest/gtest.h"  // IWYU pragma: keep
+#include "impeller/renderer/backend/vulkan/formats_vk.h"
+
+namespace impeller {
+namespace testing {
+
+TEST(FormatsVKTest, DescriptorMapping) {
+  EXPECT_EQ(ToVKDescriptorType(DescriptorType::kSampledImage),
+            vk::DescriptorType::eCombinedImageSampler);
+  EXPECT_EQ(ToVKDescriptorType(DescriptorType::kUniformBuffer),
+            vk::DescriptorType::eUniformBuffer);
+  EXPECT_EQ(ToVKDescriptorType(DescriptorType::kStorageBuffer),
+            vk::DescriptorType::eStorageBuffer);
+  EXPECT_EQ(ToVKDescriptorType(DescriptorType::kImage),
+            vk::DescriptorType::eSampledImage);
+  EXPECT_EQ(ToVKDescriptorType(DescriptorType::kSampler),
+            vk::DescriptorType::eSampler);
+  EXPECT_EQ(ToVKDescriptorType(DescriptorType::kInputAttachment),
+            vk::DescriptorType::eInputAttachment);
+}
+
+}  // namespace testing
+}  // namespace impeller


### PR DESCRIPTION
This is a dumb performance optimization. because we only use the DescriptorType enum to represent vk descriptor types, lets just make the enum values match. Then we can static cast instead of switch.

I do see this function showing up in profiles, though a very small slice.