### PR TITLE
[Impeller] combine translate* scale mat mul when computing shader transform.

### DIFF
--- a/impeller/entity/entity.cc
+++ b/impeller/entity/entity.cc
@@ -52,7 +52,7 @@ Matrix Entity::GetShaderTransform(const RenderPass& pass) const {
 Matrix Entity::GetShaderTransform(Scalar shader_clip_depth,
                                   const RenderPass& pass,
                                   const Matrix& transform) {
-  return Matrix::MakeScaleTranslate({1, 1, Entity::kDepthEpsilon},
+  return Matrix::MakeTranslateScale({1, 1, Entity::kDepthEpsilon},
                                     {0, 0, shader_clip_depth}) *
          pass.GetOrthographicTransform() * transform;
 }

--- a/impeller/entity/entity.cc
+++ b/impeller/entity/entity.cc
@@ -52,8 +52,8 @@ Matrix Entity::GetShaderTransform(const RenderPass& pass) const {
 Matrix Entity::GetShaderTransform(Scalar shader_clip_depth,
                                   const RenderPass& pass,
                                   const Matrix& transform) {
-  return Matrix::MakeTranslation({0, 0, shader_clip_depth}) *
-         Matrix::MakeScale({1, 1, Entity::kDepthEpsilon}) *
+  return Matrix::MakeScaleTranslate({1, 1, Entity::kDepthEpsilon},
+                                    {0, 0, shader_clip_depth}) *
          pass.GetOrthographicTransform() * transform;
 }
 

--- a/impeller/geometry/matrix.h
+++ b/impeller/geometry/matrix.h
@@ -110,6 +110,16 @@ struct Matrix {
     // clang-format on
   }
 
+  static constexpr Matrix MakeScaleTranslate(const Vector3& s,
+                                             const Vector3& t) {
+    // clang-format off
+    return Matrix(s.x, 0.0f, 0.0f, 0.0f,
+                  0.0f, s.y, 0.0f, 0.0f,
+                  0.0f, 0.0f, s.z, 0.0f,
+                  t.x * s.x, t.y * s.y, t.z * s.z, 1.0f);
+    // clang-format on
+  }
+
   static constexpr Matrix MakeScale(const Vector2& s) {
     return MakeScale(Vector3(s.x, s.y, 1.0f));
   }

--- a/impeller/geometry/matrix.h
+++ b/impeller/geometry/matrix.h
@@ -110,13 +110,13 @@ struct Matrix {
     // clang-format on
   }
 
-  static constexpr Matrix MakeScaleTranslate(const Vector3& s,
+  static constexpr Matrix MakeTranslateScale(const Vector3& s,
                                              const Vector3& t) {
     // clang-format off
     return Matrix(s.x, 0.0f, 0.0f, 0.0f,
                   0.0f, s.y, 0.0f, 0.0f,
                   0.0f, 0.0f, s.z, 0.0f,
-                  t.x * s.x, t.y * s.y, t.z * s.z, 1.0f);
+                  t.x , t.y, t.z, 1.0f);
     // clang-format on
   }
 

--- a/impeller/geometry/matrix_unittests.cc
+++ b/impeller/geometry/matrix_unittests.cc
@@ -211,5 +211,20 @@ TEST(MatrixTest, TranslateWithPerspective) {
                                                  0.0, 2.0, 0.0, 430.0)));
 }
 
+TEST(MatrixTest, MakeScaleTranslate) {
+  EXPECT_TRUE(MatrixNear(
+      Matrix::MakeScaleTranslate({1, 1, 1.0 / 1024}, {10, 10, 1.0 / 1024}),
+      Matrix::MakeScale({1, 1, 1.0 / 1024}) *
+          Matrix::MakeTranslation({10, 10, 1.0 / 1024})));
+
+  EXPECT_TRUE(MatrixNear(
+      Matrix::MakeScaleTranslate({2, 2, 2}, {10, 10, 0}),
+      Matrix::MakeScale({2, 2, 2}) * Matrix::MakeTranslation({10, 10, 0})));
+
+  EXPECT_TRUE(MatrixNear(
+      Matrix::MakeScaleTranslate({0, 0, 0}, {0, 0, 0}),
+      Matrix::MakeScale({0, 0, 0}) * Matrix::MakeTranslation({0, 0, 0})));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/geometry/matrix_unittests.cc
+++ b/impeller/geometry/matrix_unittests.cc
@@ -213,17 +213,17 @@ TEST(MatrixTest, TranslateWithPerspective) {
 
 TEST(MatrixTest, MakeScaleTranslate) {
   EXPECT_TRUE(MatrixNear(
-      Matrix::MakeScaleTranslate({1, 1, 1.0 / 1024}, {10, 10, 1.0 / 1024}),
-      Matrix::MakeScale({1, 1, 1.0 / 1024}) *
-          Matrix::MakeTranslation({10, 10, 1.0 / 1024})));
+      Matrix::MakeTranslateScale({1, 1, 1.0 / 1024}, {10, 10, 1.0 / 1024}),
+      Matrix::MakeTranslation({10, 10, 1.0 / 1024}) *
+          Matrix::MakeScale({1, 1, 1.0 / 1024})));
 
   EXPECT_TRUE(MatrixNear(
-      Matrix::MakeScaleTranslate({2, 2, 2}, {10, 10, 0}),
-      Matrix::MakeScale({2, 2, 2}) * Matrix::MakeTranslation({10, 10, 0})));
+      Matrix::MakeTranslateScale({2, 2, 2}, {10, 10, 0}),
+      Matrix::MakeTranslation({10, 10, 0}) * Matrix::MakeScale({2, 2, 2})));
 
   EXPECT_TRUE(MatrixNear(
-      Matrix::MakeScaleTranslate({0, 0, 0}, {0, 0, 0}),
-      Matrix::MakeScale({0, 0, 0}) * Matrix::MakeTranslation({0, 0, 0})));
+      Matrix::MakeTranslateScale({0, 0, 0}, {0, 0, 0}),
+      Matrix::MakeTranslation({0, 0, 0}) * Matrix::MakeScale({0, 0, 0})));
 }
 
 }  // namespace testing


### PR DESCRIPTION
For each draw we do 4 matrix multiplications, which isn't slow but does show up in CPU profiles at a few % of a frame. We can cut the number of multiplications down to 3 by constructing the translate*scale matrix in one go. The translate * scale matrix construction is much simpler than a full multiplication as we can ignore all of the known zero values.