### PR TITLE
[Impeller] exploit content context options' perfect hash function.

### DIFF
--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -8,7 +8,6 @@
 #include <utility>
 
 #include "fml/trace_event.h"
-#include "impeller/base/strings.h"
 #include "impeller/base/validation.h"
 #include "impeller/core/formats.h"
 #include "impeller/core/texture_descriptor.h"

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -2170,16 +2170,16 @@ TEST_P(EntityTest, DecalSpecializationAppliedToMorphologyFilter) {
 // set of options, we can just compare benchmarks.
 TEST_P(EntityTest, ContentContextOptionsHasReasonableHashFunctions) {
   ContentContextOptions opts;
-  auto hash_a = ContentContextOptions::Hash{}(opts);
+  auto hash_a = opts.ToKey();
 
   opts.blend_mode = BlendMode::kColorBurn;
-  auto hash_b = ContentContextOptions::Hash{}(opts);
+  auto hash_b = opts.ToKey();
 
   opts.has_depth_stencil_attachments = false;
-  auto hash_c = ContentContextOptions::Hash{}(opts);
+  auto hash_c = opts.ToKey();
 
   opts.primitive_type = PrimitiveType::kPoint;
-  auto hash_d = ContentContextOptions::Hash{}(opts);
+  auto hash_d = opts.ToKey();
 
   EXPECT_NE(hash_a, hash_b);
   EXPECT_NE(hash_b, hash_c);


### PR DESCRIPTION
The content context options hash function is pefect - meaning a distinct hash guarantees a distinct value and vice versa. We can replace the hashing entirely with an equality check of the hash function.

Additionally, we can remove the hashmap. As most of these maps have fewer than a dozen entries (often just 2 or 3) and the linear search is much faster.
