### PR TITLE
[ios][secure_paste]Show context items based on items sent from framework

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -1013,6 +1013,21 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
                            arguments:@[ @(client) ]];
 }
 
+- (void)flutterTextInputView:(FlutterTextInputView*)textInputView
+           shareSelectedText:(NSString*)selectedText {
+  [self.platformPlugin showShareViewController:selectedText];
+}
+
+- (void)flutterTextInputView:(FlutterTextInputView*)textInputView
+    searchWebWithSelectedText:(NSString*)selectedText {
+  [self.platformPlugin searchWeb:selectedText];
+}
+
+- (void)flutterTextInputView:(FlutterTextInputView*)textInputView
+          lookUpSelectedText:(NSString*)selectedText {
+  [self.platformPlugin showLookUpViewController:selectedText];
+}
+
 #pragma mark - FlutterViewEngineDelegate
 
 - (void)flutterTextInputView:(FlutterTextInputView*)textInputView showToolbar:(int)client {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h
@@ -14,6 +14,9 @@
 - (instancetype)initWithEngine:(FlutterEngine*)engine NS_DESIGNATED_INITIALIZER;
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result;
 
+- (void)showShareViewController:(NSString*)content;
+- (void)searchWeb:(NSString*)searchTerm;
+- (void)showLookUpViewController:(NSString*)term;
 @end
 
 namespace flutter {

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
@@ -67,6 +67,12 @@ typedef NS_ENUM(NSInteger, FlutterFloatingCursorDragState) {
     didResignFirstResponderWithTextInputClient:(int)client;
 - (void)flutterTextInputView:(FlutterTextInputView*)textInputView
     willDismissEditMenuWithTextInputClient:(int)client;
+- (void)flutterTextInputView:(FlutterTextInputView*)textInputView
+           shareSelectedText:(NSString*)selectedText;
+- (void)flutterTextInputView:(FlutterTextInputView*)textInputView
+    searchWebWithSelectedText:(NSString*)selectedText;
+- (void)flutterTextInputView:(FlutterTextInputView*)textInputView
+          lookUpSelectedText:(NSString*)selectedText;
 @end
 
 #endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERTEXTINPUTDELEGATE_H_

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -905,17 +905,19 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 }
 
 - (void)addBasicEditingCommandToItems:(NSMutableArray*)items
-                               action:(NSString*)action
+                                 type:(NSString*)type
                              selector:(SEL)selector
                         suggestedMenu:(UIMenu*)suggestedMenu {
   UICommand* command = [self searchCommandWithSelector:selector element:suggestedMenu];
   if (command) {
     [items addObject:command];
+  } else {
+    FML_LOG(ERROR) << "Cannot find context menu item of type \"" << type.UTF8String << "\".";
   }
 }
 
 - (void)addAdditionalBasicCommandToItems:(NSMutableArray*)items
-                                  action:(NSString*)action
+                                    type:(NSString*)type
                                 selector:(SEL)selector
                              encodedItem:(NSDictionary<NSString*, id>*)encodedItem {
   NSString* title = encodedItem[@"title"];
@@ -926,7 +928,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
                                         propertyList:nil];
     [items addObject:command];
   } else {
-    FML_LOG(ERROR) << "Missing title for context menu item action \"" << action.UTF8String << "\".";
+    FML_LOG(ERROR) << "Missing title for context menu item of type \"" << type.UTF8String << "\".";
   }
 }
 
@@ -940,49 +942,47 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 
   NSMutableArray* items = [NSMutableArray array];
   for (NSDictionary<NSString*, id>* encodedItem in _editMenuItems) {
-    if ([encodedItem[@"type"] isEqualToString:@"builtIn"]) {
-      NSString* action = encodedItem[@"action"];
-      if ([action isEqualToString:@"copy"]) {
-        [self addBasicEditingCommandToItems:items
-                                     action:action
-                                   selector:@selector(copy:)
-                              suggestedMenu:suggestedMenu];
-      } else if ([action isEqualToString:@"paste"]) {
-        [self addBasicEditingCommandToItems:items
-                                     action:action
-                                   selector:@selector(paste:)
-                              suggestedMenu:suggestedMenu];
-      } else if ([action isEqualToString:@"cut"]) {
-        [self addBasicEditingCommandToItems:items
-                                     action:action
-                                   selector:@selector(cut:)
-                              suggestedMenu:suggestedMenu];
-      } else if ([action isEqualToString:@"delete"]) {
-        [self addBasicEditingCommandToItems:items
-                                     action:action
-                                   selector:@selector(delete:)
-                              suggestedMenu:suggestedMenu];
-      } else if ([action isEqualToString:@"selectAll"]) {
-        [self addBasicEditingCommandToItems:items
-                                     action:action
-                                   selector:@selector(selectAll:)
-                              suggestedMenu:suggestedMenu];
-      } else if ([action isEqualToString:@"searchWeb"]) {
-        [self addAdditionalBasicCommandToItems:items
-                                        action:action
-                                      selector:@selector(handleSearchWebAction)
-                                   encodedItem:encodedItem];
-      } else if ([action isEqualToString:@"share"]) {
-        [self addAdditionalBasicCommandToItems:items
-                                        action:action
-                                      selector:@selector(handleShareAction)
-                                   encodedItem:encodedItem];
-      } else if ([action isEqualToString:@"lookUp"]) {
-        [self addAdditionalBasicCommandToItems:items
-                                        action:action
-                                      selector:@selector(handleLookUpAction)
-                                   encodedItem:encodedItem];
-      }
+    NSString* type = encodedItem[@"type"];
+    if ([type isEqualToString:@"copy"]) {
+      [self addBasicEditingCommandToItems:items
+                                     type:type
+                                 selector:@selector(copy:)
+                            suggestedMenu:suggestedMenu];
+    } else if ([type isEqualToString:@"paste"]) {
+      [self addBasicEditingCommandToItems:items
+                                     type:type
+                                 selector:@selector(paste:)
+                            suggestedMenu:suggestedMenu];
+    } else if ([type isEqualToString:@"cut"]) {
+      [self addBasicEditingCommandToItems:items
+                                     type:type
+                                 selector:@selector(cut:)
+                            suggestedMenu:suggestedMenu];
+    } else if ([type isEqualToString:@"delete"]) {
+      [self addBasicEditingCommandToItems:items
+                                     type:type
+                                 selector:@selector(delete:)
+                            suggestedMenu:suggestedMenu];
+    } else if ([type isEqualToString:@"selectAll"]) {
+      [self addBasicEditingCommandToItems:items
+                                     type:type
+                                 selector:@selector(selectAll:)
+                            suggestedMenu:suggestedMenu];
+    } else if ([type isEqualToString:@"searchWeb"]) {
+      [self addAdditionalBasicCommandToItems:items
+                                        type:type
+                                    selector:@selector(handleSearchWebAction)
+                                 encodedItem:encodedItem];
+    } else if ([type isEqualToString:@"share"]) {
+      [self addAdditionalBasicCommandToItems:items
+                                        type:type
+                                    selector:@selector(handleShareAction)
+                                 encodedItem:encodedItem];
+    } else if ([type isEqualToString:@"lookUp"]) {
+      [self addAdditionalBasicCommandToItems:items
+                                        type:type
+                                    selector:@selector(handleLookUpAction)
+                                 encodedItem:encodedItem];
     }
   }
   return [UIMenu menuWithChildren:items];

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -795,6 +795,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 // etc)
 @property(nonatomic, copy) NSString* temporarilyDeletedComposedCharacter;
 @property(nonatomic, assign) CGRect editMenuTargetRect;
+@property(nonatomic, strong) NSArray<NSDictionary*>* editMenuItems;
 
 - (void)setEditableTransform:(NSArray*)matrix;
 @end
@@ -868,10 +869,118 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
   return self;
 }
 
+- (void)handleSearchWebAction {
+  NSLog(@"put search web logic here");
+}
+
+- (void)handleLookUpAction {
+  NSLog(@"put look up logic here");
+}
+
+- (void)handleShareAction {
+  NSLog(@"put share logic here");
+}
+
+// DFS algorithm to search a UICommand from the menu tree.
+- (UICommand*)searchCommandWithSelector:(SEL)selector
+                                element:(UIMenuElement*)element API_AVAILABLE(ios(16.0)) {
+  if ([element isKindOfClass:UICommand.class]) {
+    UICommand* command = (UICommand*)element;
+    return command.action == selector ? command : nil;
+  } else if ([element isKindOfClass:UIMenu.class]) {
+    NSArray<UIMenuElement*>* children = ((UIMenu*)element).children;
+    for (UIMenuElement* child in children) {
+      UICommand* result = [self searchCommandWithSelector:selector element:child];
+      if (result) {
+        return result;
+      }
+    }
+    return nil;
+  } else {
+    return nil;
+  }
+}
+
+- (void)addBasicEditingCommandToItems:(NSMutableArray*)items
+                               action:(NSString*)action
+                             selector:(SEL)selector
+                        suggestedMenu:(UIMenu*)suggestedMenu {
+  UICommand* command = [self searchCommandWithSelector:selector element:suggestedMenu];
+  if (command) {
+    [items addObject:command];
+  }
+}
+
+- (void)addAdditionalBasicCommandToItems:(NSMutableArray*)items
+                                  action:(NSString*)action
+                                selector:(SEL)selector
+                             encodedItem:(NSDictionary<NSString*, id>*)encodedItem {
+  NSString* title = encodedItem[@"title"];
+  if (title) {
+    UICommand* command = [UICommand commandWithTitle:title
+                                               image:nil
+                                              action:selector
+                                        propertyList:nil];
+    [items addObject:command];
+  }
+}
+
 - (UIMenu*)editMenuInteraction:(UIEditMenuInteraction*)interaction
           menuForConfiguration:(UIEditMenuConfiguration*)configuration
               suggestedActions:(NSArray<UIMenuElement*>*)suggestedActions API_AVAILABLE(ios(16.0)) {
-  return [UIMenu menuWithChildren:suggestedActions];
+  UIMenu* suggestedMenu = [UIMenu menuWithChildren:suggestedActions];
+  if (!_editMenuItems) {
+    return suggestedMenu;
+  }
+
+  NSMutableArray* items = [NSMutableArray array];
+  for (NSDictionary<NSString*, id>* encodedItem in _editMenuItems) {
+    if ([encodedItem[@"type"] isEqualToString:@"default"]) {
+      NSString* action = encodedItem[@"action"];
+      if ([action isEqualToString:@"copy"]) {
+        [self addBasicEditingCommandToItems:items
+                                     action:action
+                                   selector:@selector(copy:)
+                              suggestedMenu:suggestedMenu];
+      } else if ([action isEqualToString:@"paste"]) {
+        [self addBasicEditingCommandToItems:items
+                                     action:action
+                                   selector:@selector(paste:)
+                              suggestedMenu:suggestedMenu];
+      } else if ([action isEqualToString:@"cut"]) {
+        [self addBasicEditingCommandToItems:items
+                                     action:action
+                                   selector:@selector(cut:)
+                              suggestedMenu:suggestedMenu];
+      } else if ([action isEqualToString:@"delete"]) {
+        [self addBasicEditingCommandToItems:items
+                                     action:action
+                                   selector:@selector(delete:)
+                              suggestedMenu:suggestedMenu];
+      } else if ([action isEqualToString:@"selectAll"]) {
+        [self addBasicEditingCommandToItems:items
+                                     action:action
+                                   selector:@selector(selectAll:)
+                              suggestedMenu:suggestedMenu];
+      } else if ([action isEqualToString:@"searchWeb"]) {
+        [self addAdditionalBasicCommandToItems:items
+                                        action:action
+                                      selector:@selector(handleSearchWebAction)
+                                   encodedItem:encodedItem];
+      } else if ([action isEqualToString:@"share"]) {
+        [self addAdditionalBasicCommandToItems:items
+                                        action:action
+                                      selector:@selector(handleShareAction)
+                                   encodedItem:encodedItem];
+      } else if ([action isEqualToString:@"lookUp"]) {
+        [self addAdditionalBasicCommandToItems:items
+                                        action:action
+                                      selector:@selector(handleLookUpAction)
+                                   encodedItem:encodedItem];
+      }
+    }
+  }
+  return [UIMenu menuWithChildren:items];
 }
 
 - (void)editMenuInteraction:(UIEditMenuInteraction*)interaction
@@ -887,8 +996,10 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
   return _editMenuTargetRect;
 }
 
-- (void)showEditMenuWithTargetRect:(CGRect)targetRect API_AVAILABLE(ios(16.0)) {
+- (void)showEditMenuWithTargetRect:(CGRect)targetRect
+                             items:(NSArray<NSDictionary*>*)items API_AVAILABLE(ios(16.0)) {
   _editMenuTargetRect = targetRect;
+  _editMenuItems = items;
   UIEditMenuConfiguration* config =
       [UIEditMenuConfiguration configurationWithIdentifier:nil sourcePoint:CGPointZero];
   [self.editMenuInteraction presentEditMenuWithConfiguration:config];
@@ -2560,7 +2671,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
       [encodedTargetRect[@"x"] doubleValue], [encodedTargetRect[@"y"] doubleValue],
       [encodedTargetRect[@"width"] doubleValue], [encodedTargetRect[@"height"] doubleValue]);
   CGRect localTargetRect = [self.hostView convertRect:globalTargetRect toView:self.activeView];
-  [self.activeView showEditMenuWithTargetRect:localTargetRect];
+  [self.activeView showEditMenuWithTargetRect:localTargetRect items:args[@"items"]];
   return YES;
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -925,6 +925,8 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
                                               action:selector
                                         propertyList:nil];
     [items addObject:command];
+  } else {
+    FML_LOG(ERROR) << "Missing title for context menu item action \"" << action.UTF8String << "\".";
   }
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -940,7 +940,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 
   NSMutableArray* items = [NSMutableArray array];
   for (NSDictionary<NSString*, id>* encodedItem in _editMenuItems) {
-    if ([encodedItem[@"type"] isEqualToString:@"default"]) {
+    if ([encodedItem[@"type"] isEqualToString:@"builtIn"]) {
       NSString* action = encodedItem[@"action"];
       if ([action isEqualToString:@"copy"]) {
         [self addBasicEditingCommandToItems:items

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -870,15 +870,18 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 }
 
 - (void)handleSearchWebAction {
-  NSLog(@"put search web logic here");
+  [self.textInputDelegate flutterTextInputView:self
+                     searchWebWithSelectedText:[self textInRange:_selectedTextRange]];
 }
 
 - (void)handleLookUpAction {
-  NSLog(@"put look up logic here");
+  [self.textInputDelegate flutterTextInputView:self
+                            lookUpSelectedText:[self textInRange:_selectedTextRange]];
 }
 
 - (void)handleShareAction {
-  NSLog(@"put share logic here");
+  [self.textInputDelegate flutterTextInputView:self
+                             shareSelectedText:[self textInRange:_selectedTextRange]];
 }
 
 // DFS algorithm to search a UICommand from the menu tree.

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -3064,9 +3064,8 @@ FLUTTER_ASSERT_ARC
     NSDictionary<NSString*, NSNumber*>* encodedTargetRect =
         @{@"x" : @(100), @"y" : @(200), @"width" : @(300), @"height" : @(400)};
 
-    NSArray<NSDictionary<NSString*, id>*>* encodedItems = @[
-      @{@"type" : @"builtIn", @"action" : @"paste"}, @{@"type" : @"builtIn", @"action" : @"copy"}
-    ];
+    NSArray<NSDictionary<NSString*, id>*>* encodedItems =
+        @[ @{@"type" : @"paste"}, @{@"type" : @"copy"} ];
 
     BOOL shownEditMenu =
         [myInputPlugin showEditMenu:@{@"targetRect" : encodedTargetRect, @"items" : encodedItems}];
@@ -3126,10 +3125,8 @@ FLUTTER_ASSERT_ARC
     NSDictionary<NSString*, NSNumber*>* encodedTargetRect =
         @{@"x" : @(100), @"y" : @(200), @"width" : @(300), @"height" : @(400)};
 
-    NSArray<NSDictionary<NSString*, id>*>* encodedItems = @[
-      @{@"type" : @"builtIn", @"action" : @"cut"}, @{@"type" : @"builtIn", @"action" : @"paste"},
-      @{@"type" : @"builtIn", @"action" : @"copy"}
-    ];
+    NSArray<NSDictionary<NSString*, id>*>* encodedItems =
+        @[ @{@"type" : @"cut"}, @{@"type" : @"paste"}, @{@"type" : @"copy"} ];
 
     BOOL shownEditMenu =
         [myInputPlugin showEditMenu:@{@"targetRect" : encodedTargetRect, @"items" : encodedItems}];
@@ -3208,9 +3205,8 @@ FLUTTER_ASSERT_ARC
         @{@"x" : @(100), @"y" : @(200), @"width" : @(300), @"height" : @(400)};
 
     NSArray<NSDictionary<NSString*, id>*>* encodedItems = @[
-      @{@"type" : @"builtIn", @"action" : @"searchWeb", @"title" : @"Search Web"},
-      @{@"type" : @"builtIn", @"action" : @"lookUp", @"title" : @"Look Up"},
-      @{@"type" : @"builtIn", @"action" : @"share", @"title" : @"Share"}
+      @{@"type" : @"searchWeb", @"title" : @"Search Web"},
+      @{@"type" : @"lookUp", @"title" : @"Look Up"}, @{@"type" : @"share", @"title" : @"Share"}
     ];
 
     BOOL shownEditMenu =

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -3065,7 +3065,7 @@ FLUTTER_ASSERT_ARC
         @{@"x" : @(100), @"y" : @(200), @"width" : @(300), @"height" : @(400)};
 
     NSArray<NSDictionary<NSString*, id>*>* encodedItems = @[
-      @{@"type" : @"default", @"action" : @"paste"}, @{@"type" : @"default", @"action" : @"copy"}
+      @{@"type" : @"builtIn", @"action" : @"paste"}, @{@"type" : @"builtIn", @"action" : @"copy"}
     ];
 
     BOOL shownEditMenu =
@@ -3127,8 +3127,8 @@ FLUTTER_ASSERT_ARC
         @{@"x" : @(100), @"y" : @(200), @"width" : @(300), @"height" : @(400)};
 
     NSArray<NSDictionary<NSString*, id>*>* encodedItems = @[
-      @{@"type" : @"default", @"action" : @"cut"}, @{@"type" : @"default", @"action" : @"paste"},
-      @{@"type" : @"default", @"action" : @"copy"}
+      @{@"type" : @"builtIn", @"action" : @"cut"}, @{@"type" : @"builtIn", @"action" : @"paste"},
+      @{@"type" : @"builtIn", @"action" : @"copy"}
     ];
 
     BOOL shownEditMenu =
@@ -3208,9 +3208,9 @@ FLUTTER_ASSERT_ARC
         @{@"x" : @(100), @"y" : @(200), @"width" : @(300), @"height" : @(400)};
 
     NSArray<NSDictionary<NSString*, id>*>* encodedItems = @[
-      @{@"type" : @"default", @"action" : @"searchWeb", @"title" : @"Search Web"},
-      @{@"type" : @"default", @"action" : @"lookUp", @"title" : @"Look Up"},
-      @{@"type" : @"default", @"action" : @"share", @"title" : @"Share"}
+      @{@"type" : @"builtIn", @"action" : @"searchWeb", @"title" : @"Search Web"},
+      @{@"type" : @"builtIn", @"action" : @"lookUp", @"title" : @"Look Up"},
+      @{@"type" : @"builtIn", @"action" : @"share", @"title" : @"Share"}
     ];
 
     BOOL shownEditMenu =

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -3008,20 +3008,28 @@ FLUTTER_ASSERT_ARC
     NSDictionary<NSString*, NSNumber*>* encodedTargetRect =
         @{@"x" : @(100), @"y" : @(200), @"width" : @(300), @"height" : @(400)};
 
-    NSArray<NSDictionary<NSString*, id>*>* encodedItems = @[@{@"type": @"default", @"action": @"paste"}, @{@"type": @"default", @"action": @"copy"}];
+    NSArray<NSDictionary<NSString*, id>*>* encodedItems = @[
+      @{@"type" : @"default", @"action" : @"paste"}, @{@"type" : @"default", @"action" : @"copy"}
+    ];
 
-    BOOL shownEditMenu = [myInputPlugin showEditMenu:@{@"targetRect" : encodedTargetRect, @"items": encodedItems}];
+    BOOL shownEditMenu =
+        [myInputPlugin showEditMenu:@{@"targetRect" : encodedTargetRect, @"items" : encodedItems}];
     XCTAssertTrue(shownEditMenu, @"Should show edit menu with correct configuration.");
     [self waitForExpectations:@[ expectation ] timeout:1.0];
 
-    UICommand* copyItem = [UICommand commandWithTitle:@"Copy" image: nil action: @selector(copy:) propertyList:nil];
-    UICommand* pasteItem = [UICommand commandWithTitle:@"Paste" image: nil action: @selector(paste:) propertyList:nil];
-    NSArray<UICommand*>* suggestedActions = @[
-      copyItem,
-      pasteItem
-    ];
+    UICommand* copyItem = [UICommand commandWithTitle:@"Copy"
+                                                image:nil
+                                               action:@selector(copy:)
+                                         propertyList:nil];
+    UICommand* pasteItem = [UICommand commandWithTitle:@"Paste"
+                                                 image:nil
+                                                action:@selector(paste:)
+                                          propertyList:nil];
+    NSArray<UICommand*>* suggestedActions = @[ copyItem, pasteItem ];
 
-    UIMenu* menu = [myInputView editMenuInteraction:mockInteraction menuForConfiguration: OCMClassMock([UIEditMenuConfiguration class]) suggestedActions:suggestedActions];
+    UIMenu* menu = [myInputView editMenuInteraction:mockInteraction
+                               menuForConfiguration:OCMClassMock([UIEditMenuConfiguration class])
+                                   suggestedActions:suggestedActions];
     XCTAssert(menu.children.count == 2, @"There must be 2 menu items");
     XCTAssertEqual(menu.children[0], pasteItem, @"Must be able to find paste item in the tree.");
     XCTAssertEqual(menu.children[1], copyItem, @"Must be able to find copy item in the tree.");
@@ -3062,22 +3070,32 @@ FLUTTER_ASSERT_ARC
     NSDictionary<NSString*, NSNumber*>* encodedTargetRect =
         @{@"x" : @(100), @"y" : @(200), @"width" : @(300), @"height" : @(400)};
 
-    NSArray<NSDictionary<NSString*, id>*>* encodedItems = @[@{@"type": @"default", @"action": @"searchWeb", @"title": @"Search Web"}, @{@"type": @"default", @"action": @"lookUp", @"title": @"Look Up"}, @{@"type": @"default", @"action": @"share", @"title": @"Share"}];
+    NSArray<NSDictionary<NSString*, id>*>* encodedItems = @[
+      @{@"type" : @"default", @"action" : @"searchWeb", @"title" : @"Search Web"},
+      @{@"type" : @"default", @"action" : @"lookUp", @"title" : @"Look Up"},
+      @{@"type" : @"default", @"action" : @"share", @"title" : @"Share"}
+    ];
 
-    BOOL shownEditMenu = [myInputPlugin showEditMenu:@{@"targetRect" : encodedTargetRect, @"items": encodedItems}];
+    BOOL shownEditMenu =
+        [myInputPlugin showEditMenu:@{@"targetRect" : encodedTargetRect, @"items" : encodedItems}];
     XCTAssertTrue(shownEditMenu, @"Should show edit menu with correct configuration.");
     [self waitForExpectations:@[ expectation ] timeout:1.0];
 
     NSArray<UICommand*>* suggestedActions = @[
-      [UICommand commandWithTitle:@"copy" image: nil action: @selector(copy:) propertyList:nil],
+      [UICommand commandWithTitle:@"copy" image:nil action:@selector(copy:) propertyList:nil],
     ];
 
-    UIMenu* menu = [myInputView editMenuInteraction:mockInteraction menuForConfiguration: OCMClassMock([UIEditMenuConfiguration class]) suggestedActions:suggestedActions];
+    UIMenu* menu = [myInputView editMenuInteraction:mockInteraction
+                               menuForConfiguration:OCMClassMock([UIEditMenuConfiguration class])
+                                   suggestedActions:suggestedActions];
     XCTAssert(menu.children.count == 3, @"There must be 3 menu items");
 
-    XCTAssert(((UICommand*) menu.children[0]).action == @selector(handleSearchWebAction), @"Must create search web item in the tree.");
-    XCTAssert(((UICommand*) menu.children[1]).action == @selector(handleLookUpAction), @"Must create look up item in the tree.");
-    XCTAssert(((UICommand*) menu.children[2]).action == @selector(handleShareAction), @"Must create share item in the tree.");
+    XCTAssert(((UICommand*)menu.children[0]).action == @selector(handleSearchWebAction),
+              @"Must create search web item in the tree.");
+    XCTAssert(((UICommand*)menu.children[1]).action == @selector(handleLookUpAction),
+              @"Must create look up item in the tree.");
+    XCTAssert(((UICommand*)menu.children[2]).action == @selector(handleShareAction),
+              @"Must create share item in the tree.");
   }
 }
 


### PR DESCRIPTION
This PR shows the context menu based on what's received from the framework via method channel. There are 2 cases: 

**1. For basic editing actions (e.g. copy/paste):** 

We perform a DFS search inside `suggestedActions`, so that we don't have to specify things like keyboard shortcut. 

**2. For additional actions (e.g. look up, share, search web):** 

We manually create `UICommand` because (1) some actions are not provided by `suggestedActions` (2) these are simply `UICommand` (rather than `UIKeyCommand`), so we just need title and action (3) the actions are private APIs. However this would require framework to send the item title. 


*List which issues are fixed by this PR. You must list at least one issue.*

Second milestone for https://github.com/flutter/flutter/issues/103163

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
