### PR TITLE
remove mock vulkan memory test.

### DIFF
--- a/impeller/renderer/backend/vulkan/allocator_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/allocator_vk_unittests.cc
@@ -73,19 +73,6 @@ TEST(AllocatorVKTest, MemoryTypeSelectionTwoHeap) {
   EXPECT_EQ(AllocatorVK::FindMemoryTypeIndex(4, properties), -1);
 }
 
-TEST(AllocatorVKTest, DeviceBufferCoherency) {
-  auto const context = MockVulkanContextBuilder().Build();
-  auto allocator = context->GetResourceAllocator();
-
-  std::shared_ptr<DeviceBuffer> buffer =
-      allocator->CreateBuffer(DeviceBufferDescriptor{
-          .storage_mode = StorageMode::kHostVisible,
-          .size = 1024,
-      });
-
-  EXPECT_TRUE(DeviceBufferVK::Cast(*buffer).IsHostCoherent());
-}
-
 #ifdef IMPELLER_DEBUG
 
 TEST(AllocatorVKTest, RecreateSwapchainWhenSizeChanges) {


### PR DESCRIPTION
This test is flakey despite using the mocked vulkan backend. This likely indicates that VMA is still performing some real initialization work in a way that is not consistently passing or failing.

It may not be safe to use VMA with mock vulkan.