### PR TITLE
iOS: Refactor ShellTestPlatformViewMetal

### DIFF
--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -301,6 +301,9 @@ if (enable_unittests) {
         "shell_test_platform_view_metal.mm",
       ]
 
+      cflags_objc = flutter_cflags_objc_arc
+      cflags_objcc = flutter_cflags_objcc_arc
+
       public_deps += [ "//flutter/shell/platform/darwin/graphics" ]
     }
   }

--- a/shell/common/shell_test_platform_view_metal.h
+++ b/shell/common/shell_test_platform_view_metal.h
@@ -12,7 +12,7 @@
 namespace flutter {
 namespace testing {
 
-class DarwinContextMetal;
+struct DarwinContextMetal;
 
 class ShellTestPlatformViewMetal final : public ShellTestPlatformView,
                                          public GPUSurfaceMetalDelegate {


### PR DESCRIPTION
Migrates DarwinContextMetal to a plain C struct, eliminating the need for constructor, getters, etc. since it's only used in this translation unit. The fields themselves cannot be inlined as fields on ShellTestPlatformViewMetal because the header in which that class is defined is included in plain C++ (non-Obj-C++) translation units and therefore cannot contain Obj-C types.

This simplifies the code and simultaneously fixes complicated ARC behaviour in which the const "DarwinContextMetal::context()" getter caused retainCount to be incremented on the underlying context_ pointer, but not decremented even if never unassigned. In particular the line
```objc
FML_CHECK([metal_context->context() mainContext]));
```
appeared to cause refcount to be incremented but never decremented.

Regardless of the ARC issue, this significantly simplifies the code.

This also eliminates the last remaining use of fml::scoped_nsobject in Flutter's codebase. That class will be removed in a followup PR.

No test changes since there is no change to semantics.

Issue: https://github.com/flutter/flutter/issues/137801

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
