### PR TITLE
[Impeller] make sure binding nullptr texture does not crash.

### DIFF
--- a/impeller/renderer/backend/metal/render_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/render_pass_mtl.mm
@@ -408,6 +408,9 @@ bool RenderPassMTL::BindResource(
     const ShaderMetadata& metadata,
     std::shared_ptr<const Texture> texture,
     const std::unique_ptr<const Sampler>& sampler) {
+  if (!texture) {
+    return false;
+  }
   return Bind(pass_bindings_, stage, slot.texture_index, sampler, *texture);
 }
 

--- a/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -602,7 +602,7 @@ bool RenderPassVK::BindResource(ShaderStage stage,
   if (bound_buffer_offset_ >= kMaxBindings) {
     return false;
   }
-  if (!texture->IsValid() || !sampler) {
+  if (!texture || !texture->IsValid() || !sampler) {
     return false;
   }
   const TextureVK& texture_vk = TextureVK::Cast(*texture);

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -31,7 +31,6 @@
 #include "impeller/fixtures/swizzle.frag.h"
 #include "impeller/fixtures/texture.frag.h"
 #include "impeller/fixtures/texture.vert.h"
-#include "impeller/geometry/path_builder.h"
 #include "impeller/playground/playground.h"
 #include "impeller/playground/playground_test.h"
 #include "impeller/renderer/command_buffer.h"
@@ -1624,6 +1623,21 @@ TEST_P(RendererTest, CanSepiaToneThenSwizzleWithSubpasses) {
     return true;
   };
   OpenPlaygroundHere(callback);
+}
+
+TEST_P(RendererTest, BindingNullTexturesDoesNotCrash) {
+  using FS = BoxFadeFragmentShader;
+
+  auto context = GetContext();
+  const std::unique_ptr<const Sampler>& sampler =
+      context->GetSamplerLibrary()->GetSampler({});
+  auto command_buffer = context->CreateCommandBuffer();
+
+  RenderTargetAllocator allocator(context->GetResourceAllocator());
+  RenderTarget target = allocator.CreateOffscreen(*context, {1, 1}, 1);
+
+  auto pass = command_buffer->CreateRenderPass(target);
+  EXPECT_FALSE(FS::BindContents2(*pass, nullptr, sampler));
 }
 
 }  // namespace testing


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/158074

binding a nullptr texture should fail but not crash.