### PR TITLE
iOS: Use standard Obj-C cflags for ios_test_flutter

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -199,9 +199,9 @@ shared_library("ios_test_flutter") {
   testonly = true
   visibility = [ "*" ]
 
-  # XCode 15 beta has a bug where iOS 17 API usage is not guarded.
+  # Xcode 15 beta has a bug where iOS 17 API usage is not guarded.
   # This bug results engine build failure since the engine treats warnings as errors.
-  # The `-Wno-unguarded-availability-new` can be removed when the XCode bug is fixed.
+  # The `-Wno-unguarded-availability-new` can be removed when the Xcode bug is fixed.
   # See details in https://github.com/flutter/flutter/issues/128958.
   cflags_objc = flutter_cflags_objc_arc
   cflags_objcc =

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -198,18 +198,20 @@ platform_frameworks_path =
 shared_library("ios_test_flutter") {
   testonly = true
   visibility = [ "*" ]
-  cflags = [
-    "-fvisibility=default",
-    "-F$platform_frameworks_path",
-    "-fobjc-arc",
-    "-mios-simulator-version-min=$ios_testing_deployment_target",
-  ]
 
   # XCode 15 beta has a bug where iOS 17 API usage is not guarded.
   # This bug results engine build failure since the engine treats warnings as errors.
   # The `-Wno-unguarded-availability-new` can be removed when the XCode bug is fixed.
   # See details in https://github.com/flutter/flutter/issues/128958.
-  cflags_objcc = [ "-Wno-unguarded-availability-new" ]
+  cflags_objc = flutter_cflags_objc_arc
+  cflags_objcc =
+      flutter_cflags_objcc_arc + [ "-Wno-unguarded-availability-new" ]
+  cflags = [
+    "-fvisibility=default",
+    "-F$platform_frameworks_path",
+    "-mios-simulator-version-min=$ios_testing_deployment_target",
+  ]
+
   ldflags = [
     "-F$platform_frameworks_path",
     "-Wl,-install_name,@rpath/Frameworks/libios_test_flutter.dylib",

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -834,8 +834,10 @@ FLUTTER_ASSERT_ARC
 
 - (void)testFlutterTextInputViewOnlyRespondsToInsertionPointColorBelowIOS17 {
   FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
-  BOOL respondsToInsertionPointColor =
-      [inputView respondsToSelector:@selector(insertionPointColor)];
+  // [UITextInputTraits insertionPointColor] is non-public API, so @selector(insertionPointColor)
+  // would generate a compile-time warning.
+  SEL insertionPointColor = NSSelectorFromString(@"insertionPointColor");
+  BOOL respondsToInsertionPointColor = [inputView respondsToSelector:insertionPointColor];
   if (@available(iOS 17, *)) {
     XCTAssertFalse(respondsToInsertionPointColor);
   } else {

--- a/shell/platform/darwin/ios/framework/Source/FlutterUndoManagerPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterUndoManagerPluginTest.mm
@@ -8,36 +8,23 @@
 #import <XCTest/XCTest.h>
 
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h"
 
 FLUTTER_ASSERT_ARC
-
-/// OCMock does not allow mocking both class and protocol. Use this to mock the methods used on
-/// `UIView<UITextInput>*` in the plugin.
-@interface TextInputViewTest : NSObject
-
-@property(nonatomic, weak) id<UITextInputDelegate> inputDelegate;
-@property(nonatomic, readonly) UITextInputAssistantItem* inputAssistantItem;
-
-@end
-
-@implementation TextInputViewTest
-@end
 
 @interface FakeFlutterUndoManagerDelegate : NSObject <FlutterUndoManagerDelegate>
 
 @property(readonly) NSUInteger undoCount;
 @property(readonly) NSUInteger redoCount;
 @property(nonatomic, nullable) NSUndoManager* undoManager;
+@property(nonatomic, nullable) UIView<UITextInput>* activeTextInputView;
 
 - (instancetype)initWithUndoManager:(NSUndoManager*)undoManager
-                activeTextInputView:(TextInputViewTest*)activeTextInputView;
+                activeTextInputView:(UIView<UITextInput>*)activeTextInputView;
 
 @end
 
 @implementation FakeFlutterUndoManagerDelegate
-
-@synthesize undoManager = _undoManager;
-@synthesize activeTextInputView = _activeTextInputView;
 
 - (instancetype)initWithUndoManager:(NSUndoManager*)undoManager
                 activeTextInputView:(UIView<UITextInput>*)activeTextInputView {
@@ -62,7 +49,7 @@ FLUTTER_ASSERT_ARC
 @interface FlutterUndoManagerPluginTest : XCTestCase
 @property(nonatomic) FakeFlutterUndoManagerDelegate* undoManagerDelegate;
 @property(nonatomic) FlutterUndoManagerPlugin* undoManagerPlugin;
-@property(nonatomic) TextInputViewTest* activeTextInputView;
+@property(nonatomic) UIView<UITextInput>* activeTextInputView;
 @property(nonatomic) NSUndoManager* undoManager;
 @end
 
@@ -72,7 +59,7 @@ FLUTTER_ASSERT_ARC
   [super setUp];
 
   self.undoManager = OCMClassMock([NSUndoManager class]);
-  self.activeTextInputView = OCMClassMock([TextInputViewTest class]);
+  self.activeTextInputView = OCMClassMock([FlutterTextInputView class]);
 
   self.undoManagerDelegate =
       [[FakeFlutterUndoManagerDelegate alloc] initWithUndoManager:self.undoManager
@@ -170,7 +157,7 @@ FLUTTER_ASSERT_ARC
   // Use a real undo manager.
   NSUndoManager* undoManager = [[NSUndoManager alloc] init];
   @autoreleasepool {
-    id activeTextInputView = OCMClassMock([TextInputViewTest class]);
+    id activeTextInputView = OCMClassMock([FlutterTextInputView class]);
 
     FakeFlutterUndoManagerDelegate* undoManagerDelegate =
         [[FakeFlutterUndoManagerDelegate alloc] initWithUndoManager:undoManager


### PR DESCRIPTION
Previously, we had not enabled standard iOS cflags for `ios_test_flutter`, though ARC had been manually added to the cflags. This meant that the following flags were not enabled:

* -Werror=overriding-method-mismatch
* -Werror=undeclared-selector

Both of these existed in the code within this target:

* undeclared-selector: `insertionPointColor` was a non-public selector on UITextInput prior to iOS 17.
* overriding-method-mismatch: `FakeFlutterUndoManagerDelegate`, which implements the `FlutterUndoManagerDelegate` protocol, declared `initWithUndoManager:activeInputView:` with a different type for `activeInputView`. This was a hack to jam in a test mock object that didn't match the required type for the property. Conveniently we have a class (`FlutterTextInputView`) that implements the required type and protocol (`UIView<UITextInput>`).

Issue: https://github.com/flutter/flutter/issues/137801

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
