### PR TITLE
Increase timeouts for Linux Fuchsia and Linux Web Framework Tests builders

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -233,7 +233,7 @@ targets:
 
   - name: Linux linux_fuchsia
     recipe: engine_v2/engine_v2
-    timeout: 90
+    timeout: 120
     properties:
       release_build: "true"
       config_name: linux_fuchsia
@@ -436,7 +436,7 @@ targets:
       shard: web_tests
       subshards: >-
               ["0", "1", "2", "3", "4", "5", "6", "7_last"]
-    timeout: 90
+    timeout: 120
     runIf:
       - DEPS
       - .ci.yaml

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -233,7 +233,7 @@ targets:
 
   - name: Linux linux_fuchsia
     recipe: engine_v2/engine_v2
-    timeout: 60
+    timeout: 90
     properties:
       release_build: "true"
       config_name: linux_fuchsia
@@ -436,7 +436,7 @@ targets:
       shard: web_tests
       subshards: >-
               ["0", "1", "2", "3", "4", "5", "6", "7_last"]
-    timeout: 60
+    timeout: 90
     runIf:
       - DEPS
       - .ci.yaml


### PR DESCRIPTION
These builders have recently been timing out due to LUCI scheduling delays.