### PR TITLE
[Impeller] keep imgui hostbuffer alive.

### DIFF
--- a/impeller/playground/imgui/imgui_impl_impeller.cc
+++ b/impeller/playground/imgui/imgui_impl_impeller.cc
@@ -138,13 +138,11 @@ void ImGui_ImplImpeller_Shutdown() {
 }
 
 void ImGui_ImplImpeller_RenderDrawData(ImDrawData* draw_data,
-                                       impeller::RenderPass& render_pass) {
+                                       impeller::RenderPass& render_pass,
+                                       impeller::HostBuffer& host_buffer) {
   if (draw_data->CmdListsCount == 0) {
     return;  // Nothing to render.
   }
-  auto host_buffer = impeller::HostBuffer::Create(
-      render_pass.GetContext()->GetResourceAllocator(),
-      render_pass.GetContext()->GetIdleWaiter());
 
   using VS = impeller::ImguiRasterVertexShader;
   using FS = impeller::ImguiRasterFragmentShader;
@@ -178,7 +176,7 @@ void ImGui_ImplImpeller_RenderDrawData(ImDrawData* draw_data,
   VS::UniformBuffer uniforms;
   uniforms.mvp = impeller::Matrix::MakeOrthographic(display_rect.GetSize())
                      .Translate(-display_rect.GetOrigin());
-  auto vtx_uniforms = host_buffer->EmplaceUniform(uniforms);
+  auto vtx_uniforms = host_buffer.EmplaceUniform(uniforms);
 
   size_t vertex_buffer_offset = 0;
   size_t index_buffer_offset = total_vtx_bytes;
@@ -284,5 +282,5 @@ void ImGui_ImplImpeller_RenderDrawData(ImDrawData* draw_data,
     vertex_buffer_offset += draw_list_vtx_bytes;
     index_buffer_offset += draw_list_idx_bytes;
   }
-  host_buffer->Reset();
+  host_buffer.Reset();
 }

--- a/impeller/playground/imgui/imgui_impl_impeller.h
+++ b/impeller/playground/imgui/imgui_impl_impeller.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "impeller/core/host_buffer.h"
 #include "third_party/imgui/imgui.h"
 
 namespace impeller {
@@ -23,6 +24,7 @@ IMGUI_IMPL_API void ImGui_ImplImpeller_Shutdown();
 
 IMGUI_IMPL_API void ImGui_ImplImpeller_RenderDrawData(
     ImDrawData* draw_data,
-    impeller::RenderPass& renderpass);
+    impeller::RenderPass& renderpass,
+    impeller::HostBuffer& host_buffer);
 
 #endif  // FLUTTER_IMPELLER_PLAYGROUND_IMGUI_IMGUI_IMPL_IMPELLER_H_

--- a/impeller/playground/playground.cc
+++ b/impeller/playground/playground.cc
@@ -133,8 +133,6 @@ void Playground::SetupContext(PlaygroundBackend backend,
   }
 
   context_ = impl_->GetContext();
-  host_buffer_ = HostBuffer::Create(context_->GetResourceAllocator(),
-                                    context_->GetIdleWaiter());
 }
 
 void Playground::SetupWindow() {
@@ -151,7 +149,9 @@ bool Playground::IsPlaygroundEnabled() const {
 }
 
 void Playground::TeardownWindow() {
-  host_buffer_.reset();
+  if (host_buffer_) {
+    host_buffer_.reset();
+  }
   if (context_) {
     context_->Shutdown();
   }
@@ -307,6 +307,10 @@ bool Playground::OpenPlaygroundHere(
         return false;
       }
       pass->SetLabel("ImGui Render Pass");
+      if (!host_buffer_) {
+        host_buffer_ = HostBuffer::Create(context_->GetResourceAllocator(),
+                                          context_->GetIdleWaiter());
+      }
 
       ImGui_ImplImpeller_RenderDrawData(ImGui::GetDrawData(), *pass,
                                         *host_buffer_);

--- a/impeller/playground/playground.cc
+++ b/impeller/playground/playground.cc
@@ -9,6 +9,7 @@
 
 #include "fml/closure.h"
 #include "fml/time/time_point.h"
+#include "impeller/core/host_buffer.h"
 #include "impeller/playground/image/backends/skia/compressed_image_skia.h"
 #include "impeller/playground/image/decompressed_image.h"
 #include "impeller/renderer/command_buffer.h"
@@ -132,6 +133,8 @@ void Playground::SetupContext(PlaygroundBackend backend,
   }
 
   context_ = impl_->GetContext();
+  host_buffer_ = HostBuffer::Create(context_->GetResourceAllocator(),
+                                    context_->GetIdleWaiter());
 }
 
 void Playground::SetupWindow() {
@@ -148,6 +151,7 @@ bool Playground::IsPlaygroundEnabled() const {
 }
 
 void Playground::TeardownWindow() {
+  host_buffer_.reset();
   if (context_) {
     context_->Shutdown();
   }
@@ -304,7 +308,8 @@ bool Playground::OpenPlaygroundHere(
       }
       pass->SetLabel("ImGui Render Pass");
 
-      ImGui_ImplImpeller_RenderDrawData(ImGui::GetDrawData(), *pass);
+      ImGui_ImplImpeller_RenderDrawData(ImGui::GetDrawData(), *pass,
+                                        *host_buffer_);
 
       pass->EncodeCommands();
 

--- a/impeller/playground/playground.h
+++ b/impeller/playground/playground.h
@@ -10,6 +10,7 @@
 
 #include "flutter/fml/status.h"
 #include "flutter/fml/time/time_delta.h"
+#include "impeller/core/host_buffer.h"
 #include "impeller/core/runtime_types.h"
 #include "impeller/core/texture.h"
 #include "impeller/geometry/point.h"
@@ -130,6 +131,7 @@ class Playground {
   std::shared_ptr<Context> context_;
   Point cursor_position_;
   ISize window_size_ = ISize{1024, 768};
+  std::shared_ptr<HostBuffer> host_buffer_;
 
   void SetCursorPosition(Point pos);
 

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -553,7 +553,7 @@ def run_cc_tests(build_dir, executable_filter, coverage, capture_core_dump):
             '--enable_vulkan_validation',
             '--enable_playground',
             '--playground_timeout_ms=4000',
-            '--gtest_filter="*ColorWheel/Vulkan"',
+            '--gtest_filter="*ColorWheel*"',
         ],
         coverage=coverage,
         extra_env=extra_env,


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/158275

We are now counting on the content context to keep the host buffer alive. the imgui overlay does not use a content context, so it has to manage the lifetime of the host buffer correctly, keeping it alive for as many frames as needed and destroying it in the correct order (before context destruction).