### PR TITLE
[iOS] Fix slider semantics node answer to accessibility activate

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -692,6 +692,8 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
     return NO;
   }
   if (!self.node.HasAction(flutter::SemanticsAction::kTap)) {
+    // Prevent Slider to receive a regular tap which will change the value.
+    // This is needed because Slider does not have a semantics tap.
     if (self.node.HasFlag(flutter::SemanticsFlags::kIsSlider)) {
       return YES;
     }

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -692,6 +692,9 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
     return NO;
   }
   if (!self.node.HasAction(flutter::SemanticsAction::kTap)) {
+    if (self.node.HasFlag(flutter::SemanticsFlags::kIsSlider)) {
+      return YES;
+    }
     return NO;
   }
   self.bridge->DispatchSemanticsAction(self.uid, flutter::SemanticsAction::kTap);

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -692,8 +692,10 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
     return NO;
   }
   if (!self.node.HasAction(flutter::SemanticsAction::kTap)) {
-    // Prevent Slider to receive a regular tap which will change the value.
-    // This is needed because Slider does not have a semantics tap.
+    // Prevent sliders to receive a regular tap which will change the value.
+    //
+    // This is needed because it causes slider to select to middle if it
+    // does not have a semantics tap.
     if (self.node.HasFlag(flutter::SemanticsFlags::kIsSlider)) {
       return YES;
     }

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -1206,4 +1206,18 @@ const float kFloatCompareEpsilon = 0.001;
   XCTAssertTrue([itemsInRect containsObject:child1]);
   XCTAssertTrue([itemsInRect containsObject:child2]);
 }
+
+- (void)testSliderSemanticsObject {
+  fml::WeakPtrFactory<flutter::AccessibilityBridgeIos> factory(
+      new flutter::testing::MockAccessibilityBridge());
+  fml::WeakPtr<flutter::AccessibilityBridgeIos> bridge = factory.GetWeakPtr();
+
+  flutter::SemanticsNode node;
+  node.flags = static_cast<int32_t>(flutter::SemanticsFlags::kIsSlider);
+  SemanticsObject* object = [[SemanticsObject alloc] initWithBridge:bridge uid:0];
+  [object setSemanticsNode:&node];
+  [object accessibilityBridgeDidFinishUpdate];
+  XCTAssertEqual([object accessibilityActivate], YES);
+}
+
 @end


### PR DESCRIPTION
## Description

iOS fix [[A11y] Double Tap brings the Slider thumb to the center of the widget.](https://github.com/flutter/flutter/issues/156427) per instruction from https://github.com/flutter/flutter/pull/157601#discussion_r1829992890

I don't have a physical iOS device to double check, but using the iOS Simulator and accessibility tools, the behavior seems ok. Without this PR, the slider thumb goes to the center when clicking 'Activate', with this PR it does not :

https://github.com/user-attachments/assets/697acadd-7fb1-40a5-ba5a-b549cac381a1


## Related Issue

iOS fix for [[A11y] Double Tap brings the Slider thumb to the center of the widget.](https://github.com/flutter/flutter/issues/156427)

## Tests

Adds 1 test.