### PR TITLE
[fuchsia] MaybeRunInitialVsyncCallback should only called once

### DIFF
--- a/shell/platform/fuchsia/flutter/flatland_connection.cc
+++ b/shell/platform/fuchsia/flutter/flatland_connection.cc
@@ -222,7 +222,6 @@ void FlatlandConnection::OnNextFrameBegin(
   const auto now = fml::TimePoint::Now();
 
   std::scoped_lock<std::mutex> lock(threadsafe_state_.mutex_);
-  threadsafe_state_.first_feedback_received_ = true;
   threadsafe_state_.present_credits_ += values.additional_present_credits();
   TRACE_DURATION("flutter", "FlatlandConnection::OnNextFrameBegin",
                  "present_credits", threadsafe_state_.present_credits_);
@@ -319,15 +318,16 @@ fml::TimePoint FlatlandConnection::GetNextPresentationTime(
 bool FlatlandConnection::MaybeRunInitialVsyncCallback(
     const fml::TimePoint& now,
     FireCallbackCallback& callback) {
-  if (!threadsafe_state_.first_feedback_received_) {
-    TRACE_DURATION("flutter",
-                   "FlatlandConnection::MaybeRunInitialVsyncCallback");
-    const auto frame_end = now + kInitialFlatlandVsyncOffset;
-    threadsafe_state_.last_presentation_time_ = frame_end;
-    callback(now, frame_end);
-    return true;
+  // Only sent maybe_run_initial_vsync once.
+  if (threadsafe_state_.maybe_run_initial_vsync_callback_sent_) {
+    return false;
   }
-  return false;
+  TRACE_DURATION("flutter", "FlatlandConnection::MaybeRunInitialVsyncCallback");
+  const auto frame_end = now + kInitialFlatlandVsyncOffset;
+  threadsafe_state_.last_presentation_time_ = frame_end;
+  threadsafe_state_.maybe_run_initial_vsync_callback_sent_ = true;
+  callback(now, frame_end);
+  return true;
 }
 
 // This method may be called from the raster or UI thread, but it is safe

--- a/shell/platform/fuchsia/flutter/flatland_connection.cc
+++ b/shell/platform/fuchsia/flutter/flatland_connection.cc
@@ -319,13 +319,13 @@ bool FlatlandConnection::MaybeRunInitialVsyncCallback(
     const fml::TimePoint& now,
     FireCallbackCallback& callback) {
   // Only sent maybe_run_initial_vsync once.
-  if (threadsafe_state_.maybe_run_initial_vsync_callback_sent_) {
+  if (threadsafe_state_.initial_vsync_callback_ran_) {
     return false;
   }
   TRACE_DURATION("flutter", "FlatlandConnection::MaybeRunInitialVsyncCallback");
   const auto frame_end = now + kInitialFlatlandVsyncOffset;
   threadsafe_state_.last_presentation_time_ = frame_end;
-  threadsafe_state_.maybe_run_initial_vsync_callback_sent_ = true;
+  threadsafe_state_.initial_vsync_callback_ran_ = true;
   callback(now, frame_end);
   return true;
 }

--- a/shell/platform/fuchsia/flutter/flatland_connection.h
+++ b/shell/platform/fuchsia/flutter/flatland_connection.h
@@ -137,7 +137,7 @@ class FlatlandConnection final {
     fml::TimePoint last_presentation_time_;
     FireCallbackCallback pending_fire_callback_;
     uint32_t present_credits_ = 1;
-    bool first_feedback_received_ = false;
+    bool maybe_run_initial_vsync_callback_sent_ = false;
   } threadsafe_state_;
 
   // Acquire fences sent to Flatland.

--- a/shell/platform/fuchsia/flutter/flatland_connection.h
+++ b/shell/platform/fuchsia/flutter/flatland_connection.h
@@ -137,7 +137,7 @@ class FlatlandConnection final {
     fml::TimePoint last_presentation_time_;
     FireCallbackCallback pending_fire_callback_;
     uint32_t present_credits_ = 1;
-    bool maybe_run_initial_vsync_callback_sent_ = false;
+    bool initial_vsync_callback_ran_ = false;
   } threadsafe_state_;
 
   // Acquire fences sent to Flatland.


### PR DESCRIPTION
Currently, flutter keeps calling MaybeRunInitialVsyncCallback() until 1 OnNextFrameBegin() called from Fuchsia which maybe problem when display is off.

Tested manually.

Bug: http://fxbug.dev/376079469

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
