### PR TITLE
[skwasm] Make sure to include the transfer list when using postMessage.

### DIFF
--- a/lib/web_ui/skwasm/library_skwasm_multi_threaded.js
+++ b/lib/web_ui/skwasm/library_skwasm_multi_threaded.js
@@ -43,7 +43,7 @@ mergeInto(LibraryManager.library, {
       if (threadId) {
         PThread.pthreads[threadId].postMessage(message, transfers);
       } else {
-        postMessage(message);
+        postMessage(message, transfers);
       }
     };
   },


### PR DESCRIPTION
This change doesn't have unit tests, because it doesn't actually change the functional behavior of the renderer, it only changes its performance characteristics. If the transfer list is not included, the browser copies the image bitmaps instead of transfers them, which is slow, but does actually work. I am going to be adding some additional benchmarking in the framework to ensure that we detect if we regress something like this again.