### PR TITLE
[Impeller] emulate gl blitframebuffer for GLES 2.0

### DIFF
--- a/impeller/renderer/backend/gles/blit_command_gles.cc
+++ b/impeller/renderer/backend/gles/blit_command_gles.cc
@@ -103,10 +103,15 @@ static bool EmulatedBlit(const ProcTableGLES& gl,
   gl.UseProgram(program);
   gl.BindTexture(GL_TEXTURE_2D, src_handle.value());
   if (linear) {
-    gl.TexParameteri(src_handle.value(), GL_TEXTURE_MIN_FILTER,
-                     GL_LINEAR_MIPMAP_LINEAR);
-    gl.TexParameteri(src_handle.value(), GL_TEXTURE_MAG_FILTER,
-                     GL_LINEAR_MIPMAP_LINEAR);
+    if (source->GetMipCount() > 1 && !source->NeedsMipmapGeneration()) {
+      gl.TexParameteri(src_handle.value(), GL_TEXTURE_MIN_FILTER,
+                       GL_LINEAR_MIPMAP_LINEAR);
+      gl.TexParameteri(src_handle.value(), GL_TEXTURE_MAG_FILTER,
+                       GL_LINEAR_MIPMAP_LINEAR);
+    } else {
+      gl.TexParameteri(src_handle.value(), GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+      gl.TexParameteri(src_handle.value(), GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    }
   }
 
   // Translate into OpenGL coordinates

--- a/impeller/renderer/backend/gles/blit_command_gles.cc
+++ b/impeller/renderer/backend/gles/blit_command_gles.cc
@@ -102,15 +102,18 @@ static bool EmulatedBlit(const ProcTableGLES& gl,
 
   gl.UseProgram(program);
   gl.BindTexture(GL_TEXTURE_2D, src_handle.value());
+
+  gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
   if (linear) {
     if (source->GetMipCount() > 1 && !source->NeedsMipmapGeneration()) {
-      gl.TexParameteri(src_handle.value(), GL_TEXTURE_MIN_FILTER,
+      gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
                        GL_LINEAR_MIPMAP_LINEAR);
-      gl.TexParameteri(src_handle.value(), GL_TEXTURE_MAG_FILTER,
+      gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
                        GL_LINEAR_MIPMAP_LINEAR);
     } else {
-      gl.TexParameteri(src_handle.value(), GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-      gl.TexParameteri(src_handle.value(), GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+      gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+      gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     }
   }
 

--- a/impeller/renderer/backend/gles/blit_command_gles.cc
+++ b/impeller/renderer/backend/gles/blit_command_gles.cc
@@ -5,10 +5,10 @@
 #include "impeller/renderer/backend/gles/blit_command_gles.h"
 
 #include "flutter/fml/closure.h"
-#include "fml/trace_event.h"
 #include "impeller/base/validation.h"
 #include "impeller/geometry/point.h"
 #include "impeller/renderer/backend/gles/device_buffer_gles.h"
+#include "impeller/renderer/backend/gles/proc_table_gles.h"
 #include "impeller/renderer/backend/gles/reactor_gles.h"
 #include "impeller/renderer/backend/gles/texture_gles.h"
 
@@ -66,6 +66,12 @@ std::string BlitCopyTextureToTextureCommandGLES::GetLabel() const {
   return label;
 }
 
+namespace {
+static GLfloat pixels_to_gl_coords(GLfloat position, GLfloat pixels) {
+  return (2.0 * position / pixels) - 1.0;
+}
+}  // namespace
+
 bool BlitCopyTextureToTextureCommandGLES::Encode(
     const ReactorGLES& reactor) const {
   const auto& gl = reactor.GetProcTable();
@@ -73,9 +79,65 @@ bool BlitCopyTextureToTextureCommandGLES::Encode(
   // glBlitFramebuffer is a GLES3 proc. Since we target GLES2, we need to
   // emulate the blit when it's not available in the driver.
   if (!gl.BlitFramebuffer.IsAvailable()) {
-    // TODO(157064): Emulate the blit using a raster draw call here.
-    VALIDATION_LOG << "Texture blit fallback not implemented yet for GLES2.";
-    return false;
+    if (!blit_program.has_value()) {
+      return false;
+    }
+    GLint program = blit_program.value().name->id;
+
+    GLuint draw_fbo = GL_NONE;
+    fml::ScopedCleanupClosure delete_fbos(
+        [&gl, &draw_fbo]() { DeleteFBO(gl, draw_fbo, GL_DRAW_FRAMEBUFFER); });
+
+    auto src_handle = TextureGLES::Cast(source.get())->GetGLHandle();
+    if (!src_handle.has_value()) {
+      return false;
+    }
+
+    auto dst_handle = ConfigureFBO(gl, destination, GL_DRAW_FRAMEBUFFER);
+    if (!dst_handle.has_value()) {
+      return false;
+    }
+    draw_fbo = dst_handle.value();
+
+    gl.Disable(GL_BLEND);
+    gl.Disable(GL_SCISSOR_TEST);
+    gl.Disable(GL_DITHER);
+    gl.Disable(GL_CULL_FACE);
+    gl.ColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+
+    gl.ClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    gl.Clear(GL_COLOR_BUFFER_BIT);
+
+    gl.UseProgram(program);
+    gl.BindTexture(GL_TEXTURE_2D, src_handle.value());
+
+    // Translate into OpenGL co-ordinates
+    int64_t texture_width = destination->GetSize().width;
+    int64_t texture_height = destination->GetSize().height;
+    GLfloat x0 = pixels_to_gl_coords(0, texture_width);
+    GLfloat y0 = pixels_to_gl_coords(0, texture_height);
+    GLfloat x1 = pixels_to_gl_coords(texture_width, texture_width);
+    GLfloat y1 = pixels_to_gl_coords(texture_height, texture_height);
+    GLfloat vertex_data[] = {x0, y0, 0, 0, x1, y1, 1, 1, x0, y1, 0, 1,
+                             x0, y0, 0, 0, x1, y0, 1, 0, x1, y1, 1, 1};
+
+    GLuint vertex_buffer;
+    gl.GenBuffers(1, &vertex_buffer);
+    gl.BindBuffer(GL_ARRAY_BUFFER, vertex_buffer);
+    gl.BufferData(GL_ARRAY_BUFFER, sizeof(vertex_data), vertex_data,
+                  GL_STATIC_DRAW);
+    GLint position_index = 0;
+    gl.EnableVertexAttribArray(position_index);
+    gl.VertexAttribPointer(position_index, 2, GL_FLOAT, GL_FALSE,
+                           sizeof(GLfloat) * 4, (void*)0);
+    GLint texcoord_index = 1;
+    gl.EnableVertexAttribArray(texcoord_index);
+    gl.VertexAttribPointer(texcoord_index, 2, GL_FLOAT, GL_FALSE,
+                           sizeof(GLfloat) * 4, (void*)(sizeof(GLfloat) * 2));
+
+    gl.DrawArrays(GL_TRIANGLES, 0, 6);
+    gl.DeleteBuffers(1, &vertex_buffer);
+    return true;
   }
 
   GLuint read_fbo = GL_NONE;

--- a/impeller/renderer/backend/gles/blit_command_gles.cc
+++ b/impeller/renderer/backend/gles/blit_command_gles.cc
@@ -173,7 +173,7 @@ std::string BlitCopyTextureToTextureCommandGLES::GetLabel() const {
 
 bool BlitCopyTextureToTextureCommandGLES::Encode(
     const ReactorGLES& reactor) const {
-  const auto& gl = reactor.GetProcTable();
+  auto& gl = reactor.GetProcTable();
 
 // glBlitFramebuffer is a GLES3 proc. Since we target GLES2, we need to
 // emulate the blit when it's not available in the driver.

--- a/impeller/renderer/backend/gles/blit_command_gles.h
+++ b/impeller/renderer/backend/gles/blit_command_gles.h
@@ -66,8 +66,6 @@ struct BlitResizeTextureCommandGLES : public BlitEncodeGLES,
                                       public BlitResizeTextureCommand {
   ~BlitResizeTextureCommandGLES() override;
 
-  std::optional<HandleGLES> blit_program;
-
   std::string GetLabel() const override;
 
   [[nodiscard]] bool Encode(const ReactorGLES& reactor) const override;

--- a/impeller/renderer/backend/gles/blit_command_gles.h
+++ b/impeller/renderer/backend/gles/blit_command_gles.h
@@ -68,6 +68,8 @@ struct BlitResizeTextureCommandGLES : public BlitEncodeGLES,
 
   std::string GetLabel() const override;
 
+  std::optional<HandleGLES> blit_program;
+
   [[nodiscard]] bool Encode(const ReactorGLES& reactor) const override;
 };
 

--- a/impeller/renderer/backend/gles/blit_command_gles.h
+++ b/impeller/renderer/backend/gles/blit_command_gles.h
@@ -6,6 +6,7 @@
 #define FLUTTER_IMPELLER_RENDERER_BACKEND_GLES_BLIT_COMMAND_GLES_H_
 
 #include "impeller/base/backend_cast.h"
+#include "impeller/renderer/backend/gles/handle_gles.h"
 #include "impeller/renderer/backend/gles/reactor_gles.h"
 #include "impeller/renderer/blit_command.h"
 
@@ -35,6 +36,8 @@ struct BlitCopyTextureToTextureCommandGLES
       public BlitCopyTextureToTextureCommand {
   ~BlitCopyTextureToTextureCommandGLES() override;
 
+  std::optional<HandleGLES> blit_program;
+
   std::string GetLabel() const override;
 
   [[nodiscard]] bool Encode(const ReactorGLES& reactor) const override;
@@ -62,6 +65,8 @@ struct BlitGenerateMipmapCommandGLES : public BlitEncodeGLES,
 struct BlitResizeTextureCommandGLES : public BlitEncodeGLES,
                                       public BlitResizeTextureCommand {
   ~BlitResizeTextureCommandGLES() override;
+
+  std::optional<HandleGLES> blit_program;
 
   std::string GetLabel() const override;
 

--- a/impeller/renderer/backend/gles/blit_pass_gles.cc
+++ b/impeller/renderer/backend/gles/blit_pass_gles.cc
@@ -10,12 +10,15 @@
 #include "fml/closure.h"
 #include "impeller/core/formats.h"
 #include "impeller/renderer/backend/gles/blit_command_gles.h"
+#include "impeller/renderer/backend/gles/handle_gles.h"
 #include "impeller/renderer/backend/gles/proc_table_gles.h"
 
 namespace impeller {
 
-BlitPassGLES::BlitPassGLES(ReactorGLES::Ref reactor)
+BlitPassGLES::BlitPassGLES(ReactorGLES::Ref reactor,
+                           std::optional<HandleGLES> blit_program)
     : reactor_(std::move(reactor)),
+      blit_program_(blit_program),
       is_valid_(reactor_ && reactor_->IsValid()) {}
 
 // |BlitPass|
@@ -103,6 +106,7 @@ bool BlitPassGLES::OnCopyTextureToTextureCommand(
   command->destination = std::move(destination);
   command->source_region = source_region;
   command->destination_origin = destination_origin;
+  command->blit_program = blit_program_;
 
   commands_.push_back(std::move(command));
   return true;

--- a/impeller/renderer/backend/gles/blit_pass_gles.cc
+++ b/impeller/renderer/backend/gles/blit_pass_gles.cc
@@ -169,6 +169,7 @@ bool BlitPassGLES::ResizeTexture(const std::shared_ptr<Texture>& source,
   auto command = std::make_unique<BlitResizeTextureCommandGLES>();
   command->source = source;
   command->destination = destination;
+  command->blit_program = blit_program_;
 
   commands_.push_back(std::move(command));
   return true;

--- a/impeller/renderer/backend/gles/blit_pass_gles.h
+++ b/impeller/renderer/backend/gles/blit_pass_gles.h
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <memory>
 
-#include "GLES/gl.h"
 #include "flutter/impeller/base/config.h"
 #include "flutter/impeller/renderer/backend/gles/reactor_gles.h"
 #include "flutter/impeller/renderer/blit_pass.h"

--- a/impeller/renderer/backend/gles/blit_pass_gles.h
+++ b/impeller/renderer/backend/gles/blit_pass_gles.h
@@ -8,10 +8,12 @@
 #include <cstdint>
 #include <memory>
 
+#include "GLES/gl.h"
 #include "flutter/impeller/base/config.h"
 #include "flutter/impeller/renderer/backend/gles/reactor_gles.h"
 #include "flutter/impeller/renderer/blit_pass.h"
 #include "impeller/renderer/backend/gles/blit_command_gles.h"
+#include "impeller/renderer/backend/gles/handle_gles.h"
 
 namespace impeller {
 
@@ -27,15 +29,20 @@ class BlitPassGLES final : public BlitPass,
   std::vector<std::unique_ptr<BlitEncodeGLES>> commands_;
   ReactorGLES::Ref reactor_;
   std::string label_;
+  std::optional<HandleGLES> blit_program_;
   bool is_valid_ = false;
 
-  explicit BlitPassGLES(ReactorGLES::Ref reactor);
+  explicit BlitPassGLES(ReactorGLES::Ref reactor,
+                        std::optional<HandleGLES> blit_program);
 
   // |BlitPass|
   bool IsValid() const override;
 
   // |BlitPass|
   void OnSetLabel(std::string_view label) override;
+
+  // |BlitPass|
+  bool SupportsBlitResolve() const override { return true; }
 
   // |BlitPass|
   bool EncodeCommands(

--- a/impeller/renderer/backend/gles/capabilities_gles.cc
+++ b/impeller/renderer/backend/gles/capabilities_gles.cc
@@ -158,7 +158,7 @@ bool CapabilitiesGLES::SupportsSSBO() const {
 }
 
 bool CapabilitiesGLES::SupportsTextureToTextureBlits() const {
-  return false;
+  return true;
 }
 
 bool CapabilitiesGLES::SupportsFramebufferFetch() const {

--- a/impeller/renderer/backend/gles/command_buffer_gles.cc
+++ b/impeller/renderer/backend/gles/command_buffer_gles.cc
@@ -80,7 +80,7 @@ std::shared_ptr<BlitPass> CommandBufferGLES::OnCreateBlitPass() {
 #else
   if (!reactor_->GetProcTable().BlitFramebuffer.IsAvailable()) {
 #endif  // IMPELLER_DEBUG
-    blit_handle = ContextGLES::Cast(*context).GetEmulatedBlitProgram();
+    blit_handle = ContextGLES::Cast(*context).GetEmulatedBlit();
   }
   auto pass =
       std::shared_ptr<BlitPassGLES>(new BlitPassGLES(reactor_, blit_handle));

--- a/impeller/renderer/backend/gles/command_buffer_gles.cc
+++ b/impeller/renderer/backend/gles/command_buffer_gles.cc
@@ -73,7 +73,13 @@ std::shared_ptr<BlitPass> CommandBufferGLES::OnCreateBlitPass() {
     return nullptr;
   }
   std::optional<HandleGLES> blit_handle;
+
+#ifdef IMPELLER_DEBUG
+  if (!reactor_->GetProcTable().BlitFramebuffer.IsAvailable() ||
+      forceEmulatedBlitFramebufferForTesting) {
+#else
   if (!reactor_->GetProcTable().BlitFramebuffer.IsAvailable()) {
+#endif  // IMPELLER_DEBUG
     blit_handle = ContextGLES::Cast(*context).GetEmulatedBlitProgram();
   }
   auto pass =

--- a/impeller/renderer/backend/gles/command_buffer_gles.cc
+++ b/impeller/renderer/backend/gles/command_buffer_gles.cc
@@ -4,7 +4,6 @@
 
 #include "impeller/renderer/backend/gles/command_buffer_gles.h"
 
-#include "GLES/gl.h"
 #include "impeller/base/config.h"
 #include "impeller/renderer/backend/gles/blit_pass_gles.h"
 #include "impeller/renderer/backend/gles/context_gles.h"

--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -74,8 +74,8 @@ ContextGLES::ContextGLES(
 #else
   if (!reactor_->GetProcTable().BlitFramebuffer.IsAvailable()) {
 #endif  // IMPELLER_DEBUG
-    HandleGLES blit_program = reactor_->CreateHandle(HandleType::kProgram);
-    bool created = reactor_->AddOperation([&, blit_program](
+    blit_program_ = reactor_->CreateHandle(HandleType::kProgram);
+    bool created = reactor_->AddOperation([&, blit_program = blit_program_](
                                               const ReactorGLES& reactor) {
       std::optional<GLint> handle = reactor.GetGLHandle(blit_program);
       if (!handle.has_value()) {

--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -68,16 +68,16 @@ ContextGLES::ContextGLES(
             device_capabilities_->SupportsDecalSamplerAddressMode()));
   }
 #ifdef IMPELLER_DEBUG
-  if (!gl->BlitFramebuffer.IsAvailable() ||
+  if (!reactor_->GetProcTable().BlitFramebuffer.IsAvailable() ||
       forceEmulatedBlitFramebufferForTesting) {
 #else
-  if (!gl.BlitFramebuffer.IsAvailable()) {
+  if (!reactor_->GetProcTable().BlitFramebuffer.IsAvailable()) {
 #endif  // IMPELLER_DEBUG
     HandleGLES blit_program = reactor_->CreateHandle(HandleType::kProgram);
-    bool created = reactor_->AddOperation([&, blit_program](
-                                              const ReactorGLES& reactor) {
-      return reactor_->GetProcTable().CreateEmulatedBlitProgram(blit_program);
-    });
+    bool created =
+        reactor_->AddOperation([&, blit_program](const ReactorGLES& reactor) {
+          return reactor.GetProcTable().CreateEmulatedBlitProgram(blit_program);
+        });
     if (!created) {
       VALIDATION_LOG << "Failed to set up proc table emulated blit.";
     }

--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -74,8 +74,9 @@ ContextGLES::ContextGLES(
 #else
   if (!reactor_->GetProcTable().BlitFramebuffer.IsAvailable()) {
 #endif  // IMPELLER_DEBUG
-    blit_program_ = reactor_->CreateHandle(HandleType::kProgram);
-    bool created = reactor_->AddOperation([&, blit_program = blit_program_](
+    HandleGLES blit_program = reactor_->CreateHandle(HandleType::kProgram);
+    blit_program_ = blit_program;
+    bool created = reactor_->AddOperation([&, blit_program](
                                               const ReactorGLES& reactor) {
       std::optional<GLint> handle = reactor.GetGLHandle(blit_program);
       if (!handle.has_value()) {

--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -9,6 +9,7 @@
 #include "impeller/base/validation.h"
 #include "impeller/renderer/backend/gles/command_buffer_gles.h"
 #include "impeller/renderer/backend/gles/gpu_tracer_gles.h"
+#include "impeller/renderer/backend/gles/handle_gles.h"
 #include "impeller/renderer/command_queue.h"
 
 namespace impeller {
@@ -143,6 +144,128 @@ const std::shared_ptr<const Capabilities>& ContextGLES::GetCapabilities()
 // |Context|
 std::shared_ptr<CommandQueue> ContextGLES::GetCommandQueue() const {
   return command_queue_;
+}
+
+namespace {
+static const std::string_view kVertexShaderSource =
+    "#version 100\n"
+    "attribute vec2 position;\n"
+    "attribute vec2 in_texcoord;\n"
+    "varying vec2 texcoord;\n"
+    "\n"
+    "void main() {\n"
+    "  gl_Position = vec4(position, 0, 1);\n"
+    "  texcoord = in_texcoord;\n"
+    "}\n";
+
+static const std::string_view kFragmentShaderSource =
+    "#version 100\n"
+    "precision mediump float;\n"
+    "\n"
+    "uniform sampler2D texture;\n"
+    "varying vec2 texcoord;\n"
+    "\n"
+    "void main() {\n"
+    "  gl_FragColor = texture2D(texture, texcoord);\n"
+    "}\n";
+}  // namespace
+
+// |Context|
+std::optional<HandleGLES> ContextGLES::GetEmulatedBlitProgram() const {
+  if (emulated_blit_program_.has_value()) {
+    return emulated_blit_program_;
+  }
+
+  const auto& gl = reactor_->GetProcTable();
+  auto vert_shader = gl.CreateShader(GL_VERTEX_SHADER);
+  auto frag_shader = gl.CreateShader(GL_FRAGMENT_SHADER);
+
+  if (vert_shader == 0 || frag_shader == 0) {
+    VALIDATION_LOG << "Could not create shader handles.";
+    return std::nullopt;
+  }
+
+  gl.SetDebugLabel(DebugResourceType::kShader, vert_shader,
+                   SPrintF("Blit Vertex Shader"));
+  gl.SetDebugLabel(DebugResourceType::kShader, frag_shader,
+                   SPrintF("Blit Fragment Shader"));
+
+  fml::ScopedCleanupClosure delete_vert_shader(
+      [&gl, vert_shader]() { gl.DeleteShader(vert_shader); });
+  fml::ScopedCleanupClosure delete_frag_shader(
+      [&gl, frag_shader]() { gl.DeleteShader(frag_shader); });
+
+  {
+    const GLchar* sources[] = {kVertexShaderSource.data()};
+    const GLint lengths[] = {static_cast<GLint>(kVertexShaderSource.size())};
+
+    gl.ShaderSource(vert_shader, 1u, sources, lengths);
+  }
+  {
+    const GLchar* sources[] = {kFragmentShaderSource.data()};
+    const GLint lengths[] = {static_cast<GLint>(kFragmentShaderSource.size())};
+
+    gl.ShaderSource(frag_shader, 1u, sources, lengths);
+  }
+
+  gl.CompileShader(vert_shader);
+  gl.CompileShader(frag_shader);
+
+  GLint vert_status = GL_FALSE;
+  GLint frag_status = GL_FALSE;
+
+  gl.GetShaderiv(vert_shader, GL_COMPILE_STATUS, &vert_status);
+  gl.GetShaderiv(frag_shader, GL_COMPILE_STATUS, &frag_status);
+
+  if (vert_status != GL_TRUE) {
+    VALIDATION_LOG << "Failed to compile blit framebuffer emulation shader.";
+    return std::nullopt;
+  }
+
+  if (frag_status != GL_TRUE) {
+    VALIDATION_LOG << "Failed to compile blit framebuffer emulation shader.";
+    return std::nullopt;
+  }
+
+  HandleGLES program_handle = reactor_->CreateHandle(HandleType::kProgram);
+  if (program_handle.IsDead()) {
+    return std::nullopt;
+  }
+  GLint program = program_handle.name->id;
+
+  gl.AttachShader(program, vert_shader);
+  gl.AttachShader(program, frag_shader);
+
+  fml::ScopedCleanupClosure detach_vert_shader(
+      [&gl, program = program, vert_shader]() {
+        gl.DetachShader(program, vert_shader);
+      });
+  fml::ScopedCleanupClosure detach_frag_shader(
+      [&gl, program = program, frag_shader]() {
+        gl.DetachShader(program, frag_shader);
+      });
+
+  gl.BindAttribLocation(program,                 //
+                        static_cast<GLuint>(0),  //
+                        "position"               //
+  );
+  gl.BindAttribLocation(program,                 //
+                        static_cast<GLuint>(1),  //
+                        "in_texcoord"            //
+  );
+
+  gl.LinkProgram(program);
+
+  GLint link_status = GL_FALSE;
+  gl.GetProgramiv(program, GL_LINK_STATUS, &link_status);
+
+  if (link_status != GL_TRUE) {
+    VALIDATION_LOG << "Could not link shader program: "
+                   << gl.GetProgramInfoLogString(program);
+    return std::nullopt;
+  }
+  emulated_blit_program_ = program_handle;
+  return emulated_blit_program_;
 }
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/context_gles.h
+++ b/impeller/renderer/backend/gles/context_gles.h
@@ -5,7 +5,6 @@
 #ifndef FLUTTER_IMPELLER_RENDERER_BACKEND_GLES_CONTEXT_GLES_H_
 #define FLUTTER_IMPELLER_RENDERER_BACKEND_GLES_CONTEXT_GLES_H_
 
-#include "GLES/gl.h"
 #include "impeller/base/backend_cast.h"
 #include "impeller/renderer/backend/gles/allocator_gles.h"
 #include "impeller/renderer/backend/gles/capabilities_gles.h"

--- a/impeller/renderer/backend/gles/context_gles.h
+++ b/impeller/renderer/backend/gles/context_gles.h
@@ -44,7 +44,7 @@ class ContextGLES final : public Context,
 
   std::shared_ptr<GPUTracerGLES> GetGPUTracer() const { return gpu_tracer_; }
 
-  std::optional<HandleGLES> GetEmulatedBlitProgram() const;
+  std::optional<HandleGLES> GetEmulatedBlit() const { return blit_program_; }
 
  private:
   ReactorGLES::Ref reactor_;
@@ -54,7 +54,7 @@ class ContextGLES final : public Context,
   std::shared_ptr<AllocatorGLES> resource_allocator_;
   std::shared_ptr<CommandQueue> command_queue_;
   std::shared_ptr<GPUTracerGLES> gpu_tracer_;
-  mutable std::optional<HandleGLES> emulated_blit_program_;
+  std::optional<HandleGLES> blit_program_;
 
   // Note: This is stored separately from the ProcTableGLES CapabilitiesGLES
   // in order to satisfy the Context::GetCapabilities signature which returns

--- a/impeller/renderer/backend/gles/context_gles.h
+++ b/impeller/renderer/backend/gles/context_gles.h
@@ -5,10 +5,12 @@
 #ifndef FLUTTER_IMPELLER_RENDERER_BACKEND_GLES_CONTEXT_GLES_H_
 #define FLUTTER_IMPELLER_RENDERER_BACKEND_GLES_CONTEXT_GLES_H_
 
+#include "GLES/gl.h"
 #include "impeller/base/backend_cast.h"
 #include "impeller/renderer/backend/gles/allocator_gles.h"
 #include "impeller/renderer/backend/gles/capabilities_gles.h"
 #include "impeller/renderer/backend/gles/gpu_tracer_gles.h"
+#include "impeller/renderer/backend/gles/handle_gles.h"
 #include "impeller/renderer/backend/gles/pipeline_library_gles.h"
 #include "impeller/renderer/backend/gles/reactor_gles.h"
 #include "impeller/renderer/backend/gles/sampler_library_gles.h"
@@ -43,6 +45,8 @@ class ContextGLES final : public Context,
 
   std::shared_ptr<GPUTracerGLES> GetGPUTracer() const { return gpu_tracer_; }
 
+  std::optional<HandleGLES> GetEmulatedBlitProgram() const;
+
  private:
   ReactorGLES::Ref reactor_;
   std::shared_ptr<ShaderLibraryGLES> shader_library_;
@@ -51,6 +55,7 @@ class ContextGLES final : public Context,
   std::shared_ptr<AllocatorGLES> resource_allocator_;
   std::shared_ptr<CommandQueue> command_queue_;
   std::shared_ptr<GPUTracerGLES> gpu_tracer_;
+  mutable std::optional<HandleGLES> emulated_blit_program_;
 
   // Note: This is stored separately from the ProcTableGLES CapabilitiesGLES
   // in order to satisfy the Context::GetCapabilities signature which returns

--- a/impeller/renderer/backend/gles/proc_table_gles.cc
+++ b/impeller/renderer/backend/gles/proc_table_gles.cc
@@ -435,7 +435,9 @@ static const std::string_view kVertexShaderSource =
 
 static const std::string_view kFragmentShaderSource =
     "#version 100\n"
+    "#ifdef GL_ES\n"
     "precision mediump float;\n"
+    "#endif\n"
     "\n"
     "uniform sampler2D texture;\n"
     "varying vec2 texcoord;\n"
@@ -445,7 +447,7 @@ static const std::string_view kFragmentShaderSource =
     "}\n";
 }  // namespace
 
-bool ProcTableGLES::CreateEmulatedBlitProgram(HandleGLES program_handle) const {
+bool ProcTableGLES::CreateEmulatedBlitProgram(GLint program) const {
   const auto& gl = *this;
   auto vert_shader = gl.CreateShader(GL_VERTEX_SHADER);
   auto frag_shader = gl.CreateShader(GL_FRAGMENT_SHADER);
@@ -496,11 +498,6 @@ bool ProcTableGLES::CreateEmulatedBlitProgram(HandleGLES program_handle) const {
     VALIDATION_LOG << "Failed to compile blit framebuffer emulation shader.";
     return false;
   }
-
-  if (program_handle.IsDead() || !program_handle.name.has_value()) {
-    return false;
-  }
-  GLint program = program_handle.name->id;
 
   gl.AttachShader(program, vert_shader);
   gl.AttachShader(program, frag_shader);

--- a/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/impeller/renderer/backend/gles/proc_table_gles.h
@@ -6,6 +6,7 @@
 #define FLUTTER_IMPELLER_RENDERER_BACKEND_GLES_PROC_TABLE_GLES_H_
 
 #include <functional>
+#include <optional>
 #include <string>
 
 #include "flutter/fml/logging.h"
@@ -13,6 +14,7 @@
 #include "impeller/renderer/backend/gles/capabilities_gles.h"
 #include "impeller/renderer/backend/gles/description_gles.h"
 #include "impeller/renderer/backend/gles/gles.h"
+#include "impeller/renderer/backend/gles/handle_gles.h"
 
 namespace impeller {
 
@@ -282,6 +284,8 @@ class ProcTableGLES {
   std::optional<std::string> ComputeShaderWithDefines(
       const fml::Mapping& mapping,
       const std::vector<Scalar>& defines) const;
+
+  bool CreateEmulatedBlitProgram(HandleGLES program_handle) const;
 
  private:
   bool is_valid_ = false;

--- a/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/impeller/renderer/backend/gles/proc_table_gles.h
@@ -16,6 +16,10 @@
 
 namespace impeller {
 
+#ifdef IMPELLER_DEBUG
+static bool forceEmulatedBlitFramebufferForTesting = true;
+#endif  // IMPELLER_DEBUG
+
 const char* GLErrorToString(GLenum value);
 bool GLErrorIsFatal(GLenum value);
 

--- a/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/impeller/renderer/backend/gles/proc_table_gles.h
@@ -285,7 +285,7 @@ class ProcTableGLES {
       const fml::Mapping& mapping,
       const std::vector<Scalar>& defines) const;
 
-  bool CreateEmulatedBlitProgram(HandleGLES program_handle) const;
+  bool CreateEmulatedBlitProgram(GLint program) const;
 
  private:
   bool is_valid_ = false;

--- a/impeller/renderer/blit_pass.cc
+++ b/impeller/renderer/blit_pass.cc
@@ -37,8 +37,9 @@ bool BlitPass::AddCopy(std::shared_ptr<Texture> source,
     return false;
   }
 
-  if (source->GetTextureDescriptor().sample_count !=
-      destination->GetTextureDescriptor().sample_count) {
+  if ((source->GetTextureDescriptor().sample_count !=
+       destination->GetTextureDescriptor().sample_count) &&
+      !SupportsBlitResolve()) {
     VALIDATION_LOG << SPrintF(
         "The source sample count (%d) must match the destination sample count "
         "(%d) for blits.",

--- a/impeller/renderer/blit_pass.h
+++ b/impeller/renderer/blit_pass.h
@@ -157,6 +157,10 @@ class BlitPass {
  protected:
   explicit BlitPass();
 
+  /// @brief Whether the backend blit pass implementation supports using
+  ///        a blit pass to resolve MSAA.
+  virtual bool SupportsBlitResolve() const { return false; }
+
   virtual void OnSetLabel(std::string_view label) = 0;
 
   virtual bool OnCopyTextureToTextureCommand(


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/157064
Fixes https://github.com/flutter/flutter/issues/135764

Emulates gl.BlitFramebuffer with a draw call. manual testing with gl.BlitFramebuffer disabled works for me locally...
