### PR TITLE
Add FlutterTaskRunnerDescription.destruction_callback

### DIFF
--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -1651,6 +1651,8 @@ typedef struct {
   /// A unique identifier for the task runner. If multiple task runners service
   /// tasks on the same thread, their identifiers must match.
   size_t identifier;
+  /// The callback invoked when the task runner is destroyed.
+  VoidCallback destruction_callback;
 } FlutterTaskRunnerDescription;
 
 typedef struct {

--- a/shell/platform/embedder/embedder_task_runner.cc
+++ b/shell/platform/embedder/embedder_task_runner.cc
@@ -18,9 +18,12 @@ EmbedderTaskRunner::EmbedderTaskRunner(DispatchTable table,
           fml::MessageLoopTaskQueues::GetInstance()->CreateTaskQueue()) {
   FML_DCHECK(dispatch_table_.post_task_callback);
   FML_DCHECK(dispatch_table_.runs_task_on_current_thread_callback);
+  FML_DCHECK(dispatch_table_.destruction_callback);
 }
 
-EmbedderTaskRunner::~EmbedderTaskRunner() = default;
+EmbedderTaskRunner::~EmbedderTaskRunner() {
+  dispatch_table_.destruction_callback();
+}
 
 size_t EmbedderTaskRunner::GetEmbedderIdentifier() const {
   return embedder_identifier_;

--- a/shell/platform/embedder/embedder_task_runner.h
+++ b/shell/platform/embedder/embedder_task_runner.h
@@ -39,6 +39,10 @@ class EmbedderTaskRunner final : public fml::TaskRunner {
     /// thread.
     ///
     std::function<bool(void)> runs_task_on_current_thread_callback;
+
+    //--------------------------------------------------------------------------
+    /// Performs user-designated cleanup on destruction.
+    std::function<void()> destruction_callback;
   };
 
   //----------------------------------------------------------------------------

--- a/shell/platform/embedder/tests/embedder_unittests_util.h
+++ b/shell/platform/embedder/tests/embedder_unittests_util.h
@@ -130,7 +130,12 @@ class EmbedderTestTaskRunner {
 
       real_task_runner->PostTaskForTime(invoke_task, target_time);
     };
+    task_runner_description_.destruction_callback = [](void* user_data) {};
     task_runner_description_.identifier = identifier_;
+  }
+
+  void SetDestructionCallback(VoidCallback callback) {
+    task_runner_description_.destruction_callback = callback;
   }
 
   const FlutterTaskRunnerDescription& GetFlutterTaskRunnerDescription() {


### PR DESCRIPTION
Adds a `destruction_callback` member to `FlutterTaskRunnerDescription` that provides embedder developers a means of performing any cleanup of resources tied to the lifetime of the task runner.

In the case of the macOS embedder, the task runner holds a reference to the engine itself that is used in the `post_task_callback` and whose lifetime needs to match/exceed that of the task runner. This refactoring allows us to centralise all related retain count manipulation around task runner setup.

This is a refactor of the lifecycle bits of https://github.com/flutter/engine/pull/13300.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
