### PR TITLE
[Android] Fix Slider semantics double tap behaviors

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -802,6 +802,13 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         result.addAction(AccessibilityNodeInfo.ACTION_CLICK);
         result.setClickable(true);
       }
+    } else {
+      // Prevent Slider to receive a regular tap which will change its value.
+      // This is needed because Slider does not have a semantics tap.
+      if (semanticsNode.hasFlag(Flag.IS_SLIDER)) {
+        result.addAction(AccessibilityNodeInfo.ACTION_CLICK);
+        result.setClickable(true);
+      }
     }
     if (semanticsNode.hasAction(Action.LONG_PRESS)) {
       if (semanticsNode.onLongPressOverride != null) {

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -2165,6 +2165,21 @@ public class AccessibilityBridgeTest {
     verify(mockEvent).setSource(eq(mockRootView), eq(123));
   }
 
+  @Test
+  public void itAddsClickActionToSliderNodeInfo() {
+    AccessibilityBridge accessibilityBridge = setUpBridge();
+
+    TestSemanticsNode testSemanticsNode = new TestSemanticsNode();
+    testSemanticsNode.addFlag(AccessibilityBridge.Flag.IS_SLIDER);
+    TestSemanticsUpdate testSemanticsUpdate = testSemanticsNode.toUpdate();
+    testSemanticsUpdate.sendUpdateToBridge(accessibilityBridge);
+    AccessibilityNodeInfo nodeInfo = accessibilityBridge.createAccessibilityNodeInfo(0);
+
+    assertEquals(nodeInfo.isClickable(), true);
+    List<AccessibilityNodeInfo.AccessibilityAction> actions = nodeInfo.getActionList();
+    assertTrue(actions.contains(AccessibilityNodeInfo.AccessibilityAction.ACTION_CLICK));
+  }
+
   AccessibilityBridge setUpBridge() {
     return setUpBridge(null, null, null, null, null, null);
   }


### PR DESCRIPTION
## Description

Android fix for [[A11y] Double Tap brings the Slider thumb to the center of the widget.](https://github.com/flutter/flutter/issues/156427#top). Similar to [the iOS engine fix](https://github.com/flutter/engine/pull/56427).

Slider widget doesn't define a Semantics.onTap handler, so a double-click while in accessibility mode defaults to a regular tap down event to which _RenderSlider reacts by changing the slider value.

Adding a onTap callback on the framework side was tried in https://github.com/flutter/flutter/pull/157601 but it breaks one accessibility guideline test, see https://github.com/flutter/flutter/pull/157601#discussion_r1821650120). 

See https://github.com/flutter/flutter/pull/157601#discussion_r1829992890 for the reasoning to make the change at the engine level.

## Related Issue

Android fix for [[A11y] Double Tap brings the Slider thumb to the center of the widget.](https://github.com/flutter/flutter/issues/156427#top)

## Tests

Adds 1 test.