### PR TITLE
yapf: Add more detailed error message and TODO

### DIFF
--- a/tools/yapf.sh
+++ b/tools/yapf.sh
@@ -36,14 +36,22 @@ function follow_links() (
 SCRIPT_DIR=$(follow_links "$(dirname -- "${BASH_SOURCE[0]}")")
 SRC_DIR="$(cd "$SCRIPT_DIR/../.."; pwd -P)"
 YAPF_DIR="$(cd "$SRC_DIR/flutter/third_party/yapf"; pwd -P)"
+
+# TODO: https://github.com/flutter/flutter/issues/158384
+# Migrate to a supported Python formatter.
 if command -v python3.10 &> /dev/null; then
   PYTHON_EXEC="python3.10"
+elif command -v python3.11 &> /dev/null; then
+  PYTHON_EXEC="python3.11"
 else
   python3 -c "
 import sys
 version = sys.version_info
 if (version.major, version.minor) > (3, 11):
-    print(f'Error: python3 version {version.major}.{version.minor} is greater than 3.11.', file=sys.stderr)
+    print(f'Error: The yapf Python formatter requires Python version 3.11 or '
+          f'earlier. The installed python3 version is '
+          f'{version.major}.{version.minor}.',
+          file=sys.stderr)
     sys.exit(1)
 else:
     print(f'Using python3 version {version.major}.{version.minor}.')


### PR DESCRIPTION
The yapf Python formatter is abandoned and only works with Python versions up to and including Python 3.11. upgraded, this will become more and more problematic. On some Linux distributions side-by-side python installations are unsupported, for example.

Issue: https://github.com/flutter/flutter/issues/158384

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
