### PR TITLE
Remove the unsafe_html analysis rule

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -221,7 +221,6 @@ linter:
     - unnecessary_to_list_in_spreads
     - unreachable_from_main
     - unrelated_type_equality_checks
-    - unsafe_html
     - use_build_context_synchronously
     - use_colored_box
     # - use_decorated_box # leads to bugs: DecoratedBox and Container are not equivalent (Container inserts extra padding)


### PR DESCRIPTION
This rule was deleted from the Dart SDK.

See https://dart.googlesource.com/sdk/+/cb5c73e06fba5f9a795df532480e3d02028696bd