### PR TITLE
Fix crash when closing a window with `Alt+F4` in multi-win Flutter on Windows

### DIFF
--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -536,12 +536,15 @@ void FlutterWindowsView::SendKey(int key,
                                  KeyEventCallback callback) {
   engine_->keyboard_key_handler()->KeyboardHook(
       key, scancode, action, character, extended, was_down,
-      [=, callback = std::move(callback)](bool handled) {
-        if (!handled) {
-          engine_->text_input_plugin()->KeyboardHook(
-              key, scancode, action, character, extended, was_down);
+      [=, engine = engine_, view_id = view_id_,
+       callback = std::move(callback)](bool handled) {
+        if (engine->view(view_id)) {
+          if (!handled) {
+            engine->text_input_plugin()->KeyboardHook(
+                key, scancode, action, character, extended, was_down);
+          }
+          callback(handled);
         }
-        callback(handled);
       });
 }
 


### PR DESCRIPTION
Fixes [#158450](https://github.com/flutter/flutter/issues/158450).

As mentioned in [#158450](https://github.com/flutter/flutter/issues/158450), the crash occurs because a destroyed object may be accessed if the window and view have already been destroyed by the time `KeyEventCallback` is called. This issue is not limited to the `Alt+F4` system key; it may also occur if the window is closed using other key presses, such as pressing `Enter` after navigating to a dialog's "Close" button.

This PR proposes a fix that checks whether the view ID is still valid when the callback is invoked. If the view is invalid, the event is skipped for that view.

A unit test has been added to assert that the `KeyEventCallback` is invoked when the associated view is valid, and not invoked when the view is destroyed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
