### PR TITLE
iOS,macOS: Refactor TestMetalContext for ARC

### DIFF
--- a/testing/test_metal_context.h
+++ b/testing/test_metal_context.h
@@ -6,12 +6,15 @@
 #define FLUTTER_TESTING_TEST_METAL_CONTEXT_H_
 
 #include <map>
+#include <memory>
 #include <mutex>
 
 #include "third_party/skia/include/gpu/ganesh/GrDirectContext.h"
 #include "third_party/skia/include/ports/SkCFObject.h"
 
 namespace flutter {
+
+struct MetalObjCFields;
 
 class TestMetalContext {
  public:
@@ -38,9 +41,7 @@ class TestMetalContext {
   TextureInfo GetTextureInfo(int64_t texture_id);
 
  private:
-  // TODO(cbracken): https://github.com/flutter/flutter/issues/157942
-  void* device_;         // id<MTLDevice>
-  void* command_queue_;  // id<MTLCommandQueue>
+  std::unique_ptr<MetalObjCFields> metal_;
   sk_sp<GrDirectContext> skia_context_;
   std::mutex textures_mutex_;
   int64_t texture_id_ctr_ = 1;                 // guarded by textures_mutex


### PR DESCRIPTION
`TestMetalContext` cannot include any Objective-C types in its header file since that header is included in pure C++ translation units. Previously, we declared these fields as `void*`, which then requires manual `__bridge_retained` and `__bridge_transfer` casts to perform the necessary retain/relase manipulation while opting the object in and out of ARC management.

Instead, we extract these to a struct in the implementation file and allow the fields to be managed by ARC. This is an interim measure consistent with the approach we've taken [elsewhere][1] until we implement the proper long-term solution.

The proper long-term solution is to refactor `EmbedderTest` (see: https://github.com/flutter/flutter/issues/157942) and other related code to split out backends into separate translation units, with the Metal backend code in Objective-C++ implementation files, which would then mean the headers could include Objective-C ivars.

No changes to tests, since this change introduces no behaviour changes.

[1]: https://github.com/flutter/engine/blob/950e240eb7a6bd52124d8efda6806a9eb3a18a83/shell/common/shell_test_platform_view_metal.mm#L21-L27

Issue: https://github.com/flutter/flutter/issues/157942

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
