### PR TITLE
[Impeller] Add OpenGL debugging utilities.

### DIFF
--- a/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/impeller/renderer/backend/gles/proc_table_gles.h
@@ -45,6 +45,31 @@ struct AutoErrorCheck {
   }
 };
 
+template <class Type>
+void BuildGLArgumentsStream(std::stringstream& stream, Type arg) {
+  stream << arg;
+}
+
+constexpr void BuildGLArgumentsStream(std::stringstream& stream) {}
+
+template <class Type, class... Rest>
+void BuildGLArgumentsStream(std::stringstream& stream,
+                            Type arg,
+                            Rest... other_args) {
+  BuildGLArgumentsStream(stream, arg);
+  stream << ", ";
+  BuildGLArgumentsStream(stream, other_args...);
+}
+
+template <class... Type>
+[[nodiscard]] std::string BuildGLArguments(Type... args) {
+  std::stringstream stream;
+  stream << "(";
+  BuildGLArgumentsStream(stream, args...);
+  stream << ")";
+  return stream.str();
+}
+
 template <class T>
 struct GLProc {
   using GLFunctionType = T;
@@ -67,6 +92,14 @@ struct GLProc {
   PFNGLGETERRORPROC error_fn = nullptr;
 
   //----------------------------------------------------------------------------
+  /// Whether the OpenGL call and its arguments should be logged.
+  ///
+  /// Only works in IMPELLER_DEBUG and for environments where traditional
+  /// tracing is hard. Expect log spam and only use during development.
+  ///
+  bool log_calls = false;
+
+  //----------------------------------------------------------------------------
   /// @brief      Call the GL function with the appropriate parameters. Lookup
   ///             the documentation for the GL function being called to
   ///             understand the arguments and return types. The arguments
@@ -81,6 +114,10 @@ struct GLProc {
     // validation log will at least give us a hint as to what's going on.
     FML_CHECK(IsAvailable()) << "GL function " << name << " is not available. "
                              << "This is likely due to a missing extension.";
+    if (log_calls) {
+      FML_LOG(IMPORTANT) << name
+                         << BuildGLArguments(std::forward<Args>(args)...);
+    }
 #endif  // defined(IMPELLER_DEBUG) && !defined(NDEBUG)
     return function(std::forward<Args>(args)...);
   }


### PR DESCRIPTION
* CheckFramebufferStatus needs to be called with the enum for the target type and not the target itself.
* Fix dumping the framebuffer type and object name.

The results should be the following for the default FBO0.
```
[IMPORTANT:flutter/impeller/renderer/backend/gles/render_pass_gles.cc(281)] The default framebuffer (FBO0) was bound.
```

and the following for an offscreen framebuffer:
```
[IMPORTANT:flutter/impeller/renderer/backend/gles/render_pass_gles.cc(281)] The default framebuffer (FBO0) was bound.
[IMPORTANT:flutter/impeller/renderer/backend/gles/render_pass_gles.cc(281)] FBO 1: GL_FRAMEBUFFER_COMPLETE
Framebuffer is complete.
Description: 
Color Attachment: GL_TEXTURE(5)
Depth Attachment: GL_RENDERBUFFER(1)
Stencil Attachment: GL_RENDERBUFFER(1)

```

cc @lyceel