### PR TITLE
[Impeller] Fixes for GLES framebuffer status helper functions

### DIFF
--- a/impeller/renderer/backend/gles/proc_table_gles.cc
+++ b/impeller/renderer/backend/gles/proc_table_gles.cc
@@ -250,6 +250,7 @@ static std::string DescribeFramebufferAttachment(const ProcTableGLES& gl,
   );
 
   if (param != GL_NONE) {
+    std::string type = AttachmentTypeString(param);
     param = GL_NONE;
     gl.GetFramebufferAttachmentParameteriv(
         GL_FRAMEBUFFER,                         // target
@@ -258,7 +259,7 @@ static std::string DescribeFramebufferAttachment(const ProcTableGLES& gl,
         &param                                  // parameter
     );
     std::stringstream stream;
-    stream << AttachmentTypeString(param) << "(" << param << ")";
+    stream << type << "(" << param << ")";
     return stream.str();
   }
 
@@ -267,12 +268,12 @@ static std::string DescribeFramebufferAttachment(const ProcTableGLES& gl,
 
 std::string ProcTableGLES::DescribeCurrentFramebuffer() const {
   GLint framebuffer = GL_NONE;
-  GetIntegerv(GL_FRAMEBUFFER_BINDING, &framebuffer);
+  GetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &framebuffer);
   if (IsFramebuffer(framebuffer) == GL_FALSE) {
     return "No framebuffer or the default window framebuffer is bound.";
   }
 
-  GLenum status = CheckFramebufferStatus(framebuffer);
+  GLenum status = CheckFramebufferStatus(GL_DRAW_FRAMEBUFFER);
   std::stringstream stream;
   stream << "FBO "
          << ((framebuffer == GL_NONE) ? "(Default)"
@@ -287,10 +288,10 @@ std::string ProcTableGLES::DescribeCurrentFramebuffer() const {
   stream << "Color Attachment: "
          << DescribeFramebufferAttachment(*this, GL_COLOR_ATTACHMENT0)
          << std::endl;
-  stream << "Color Attachment: "
+  stream << "Depth Attachment: "
          << DescribeFramebufferAttachment(*this, GL_DEPTH_ATTACHMENT)
          << std::endl;
-  stream << "Color Attachment: "
+  stream << "Stencil Attachment: "
          << DescribeFramebufferAttachment(*this, GL_STENCIL_ATTACHMENT)
          << std::endl;
   return stream.str();
@@ -298,12 +299,12 @@ std::string ProcTableGLES::DescribeCurrentFramebuffer() const {
 
 bool ProcTableGLES::IsCurrentFramebufferComplete() const {
   GLint framebuffer = GL_NONE;
-  GetIntegerv(GL_FRAMEBUFFER_BINDING, &framebuffer);
+  GetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &framebuffer);
   if (IsFramebuffer(framebuffer) == GL_FALSE) {
     // The default framebuffer is always complete.
     return true;
   }
-  GLenum status = CheckFramebufferStatus(framebuffer);
+  GLenum status = CheckFramebufferStatus(GL_DRAW_FRAMEBUFFER);
   return status == GL_FRAMEBUFFER_COMPLETE;
 }
 

--- a/impeller/renderer/backend/gles/test/proc_table_gles_unittests.cc
+++ b/impeller/renderer/backend/gles/test/proc_table_gles_unittests.cc
@@ -5,7 +5,10 @@
 #include <optional>
 
 #include "flutter/testing/testing.h"  // IWYU pragma: keep
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "impeller/playground/playground_test.h"
+#include "impeller/renderer/backend/gles/context_gles.h"
 #include "impeller/renderer/backend/gles/proc_table_gles.h"
 #include "impeller/renderer/backend/gles/test/mock_gles.h"
 
@@ -16,6 +19,9 @@ namespace testing {
   EXPECT_TRUE(mock_gles->GetProcTable().proc_ivar.IsAvailable());
 #define EXPECT_UNAVAILABLE(proc_ivar) \
   EXPECT_FALSE(mock_gles->GetProcTable().proc_ivar.IsAvailable());
+
+using ProcTablePlaygroundTest = PlaygroundTest;
+INSTANTIATE_OPENGLES_PLAYGROUND_SUITE(ProcTablePlaygroundTest);
 
 TEST(ProcTableGLES, ResolvesCorrectClearDepthProcOnES) {
   auto mock_gles = MockGLES::Init(std::nullopt, "OpenGL ES 3.0");
@@ -31,6 +37,38 @@ TEST(ProcTableGLES, ResolvesCorrectClearDepthProcOnDesktopGL) {
 
   FOR_EACH_IMPELLER_DESKTOP_ONLY_PROC(EXPECT_AVAILABLE);
   FOR_EACH_IMPELLER_ES_ONLY_PROC(EXPECT_UNAVAILABLE);
+}
+
+TEST_P(ProcTablePlaygroundTest, DescribeFramebuffer) {
+  FML_LOG(ERROR) << "*** " << __PRETTY_FUNCTION__;
+  auto context = GetContext();
+  ASSERT_TRUE(context);
+
+  const auto& gl_context = ContextGLES::Cast(*context);
+  const auto& gl = gl_context.GetReactor()->GetProcTable();
+
+  GLuint fbo;
+  gl.GenFramebuffers(1, &fbo);
+  gl.BindFramebuffer(GL_FRAMEBUFFER, fbo);
+
+  GLuint texture;
+  gl.GenTextures(1, &texture);
+  gl.BindTexture(GL_TEXTURE_2D, texture);
+  gl.TexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 100, 100, 0, GL_RGBA,
+                GL_UNSIGNED_BYTE, nullptr);
+  gl.BindTexture(GL_TEXTURE_2D, 0);
+
+  gl.FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                          texture, 0);
+
+  std::string description = gl.DescribeCurrentFramebuffer();
+  FML_LOG(ERROR) << "[" << description << "]";
+
+  EXPECT_THAT(description,
+              ::testing::MatchesRegex("FBO.*GL_FRAMEBUFFER_COMPLETE.*"
+                                      "Color Attachment: GL_TEXTURE.*"
+                                      "Depth Attachment: No Attachment.*"
+                                      "Stencil Attachment: No Attachment.*"));
 }
 
 }  // namespace testing


### PR DESCRIPTION
* Pass a target instead of a framebuffer name to glCheckFramebufferStatus
* Fix output of framebuffer attachment object types
* Fix labels of depth and stencil attachments