### PR TITLE
[Impeller] prevent no-op backend from throwing exceptions during image  decoding

### DIFF
--- a/lib/ui/painting/image_decoder_impeller.cc
+++ b/lib/ui/painting/image_decoder_impeller.cc
@@ -519,6 +519,13 @@ void ImageDecoderImpeller::Decode(fml::RefPtr<ImageDescriptor> descriptor,
        result,
        supports_wide_gamut = supports_wide_gamut_,  //
        gpu_disabled_switch = gpu_disabled_switch_]() {
+#if FML_OS_IOS_SIMULATOR
+        // No-op backend.
+        if (!context) {
+          return;
+        }
+#endif  // FML_OS_IOS_SIMULATOR
+
         if (!context) {
           result(nullptr, "No Impeller context is available");
           return;

--- a/lib/ui/painting/multi_frame_codec.cc
+++ b/lib/ui/painting/multi_frame_codec.cc
@@ -190,6 +190,17 @@ void MultiFrameCodec::State::GetNextFrameAndInvokeCallback(
     const std::shared_ptr<const fml::SyncSwitch>& gpu_disable_sync_switch,
     size_t trace_id,
     const std::shared_ptr<impeller::Context>& impeller_context) {
+#if FML_OS_IOS_SIMULATOR
+  // Noop backend.
+  if (!resourceContext && !impeller_context) {
+    ui_task_runner->PostTask(
+        fml::MakeCopyable([callback = std::move(callback)]() {
+          // must be destroyed on UI thread.
+        }));
+    return;
+  }
+#endif  // FML_OS_IOS_SIMULATOR
+
   fml::RefPtr<CanvasImage> image = nullptr;
   int duration = 0;
   sk_sp<DlImage> dlImage;


### PR DESCRIPTION
This preveents errors reported in some g3 test cases.