### PR TITLE
temporarily make impeller unit tests run on ubuntu 20.04 only

### DIFF
--- a/ci/builders/linux_unopt.json
+++ b/ci/builders/linux_unopt.json
@@ -109,7 +109,7 @@
             "archives": [],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Linux",
+                "os=Ubuntu-20",
                 "cores=32"
             ],
             "gclient_variables": {


### PR DESCRIPTION
Work around https://github.com/flutter/flutter/issues/158521 until propagation of the fleet finishes.

Once all bots in https://chromium-swarm.appspot.com/botlist?c=id&c=task&c=os&c=status&d=asc&f=pool%3Aluci.flutter.prod&f=os%3ALinux&f=gcp%3Aflutter-machines-prod&k=gcp&s=id are back on Ubuntu 20.04, we can remove this.