### PR TITLE
[Android] choose 24 bit depth buffer.

### DIFF
--- a/impeller/toolkit/egl/config.h
+++ b/impeller/toolkit/egl/config.h
@@ -35,6 +35,7 @@ enum class StencilBits {
 enum class DepthBits {
   kZero = 0,
   kEight = 8,
+  kTwentyFour = 24,
 };
 
 enum class SurfaceType {

--- a/shell/platform/android/android_context_gl_impeller.cc
+++ b/shell/platform/android/android_context_gl_impeller.cc
@@ -94,7 +94,7 @@ AndroidContextGLImpeller::AndroidContextGLImpeller(
   impeller::egl::ConfigDescriptor desc;
   desc.api = impeller::egl::API::kOpenGLES2;
   desc.color_format = impeller::egl::ColorFormat::kRGBA8888;
-  desc.depth_bits = impeller::egl::DepthBits::kZero;
+  desc.depth_bits = impeller::egl::DepthBits::kTwentyFour;
   desc.stencil_bits = impeller::egl::StencilBits::kEight;
   desc.samples = impeller::egl::Samples::kFour;
 

--- a/shell/platform/android/android_context_gl_impeller_unittests.cc
+++ b/shell/platform/android/android_context_gl_impeller_unittests.cc
@@ -5,6 +5,7 @@
 #include "flutter/shell/platform/android/android_context_gl_impeller.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "third_party/angle/include/EGL/egl.h"
 
 namespace flutter {
 namespace testing {
@@ -38,6 +39,8 @@ bool GetEGLConfigForSurface(EGLint surface_bit, EGLConfig* result) {
       EGL_GREEN_SIZE,      8,
       EGL_BLUE_SIZE,       8,
       EGL_ALPHA_SIZE,      8,
+      EGL_DEPTH_SIZE,      24,
+      EGL_STENCIL_SIZE,    8,
       EGL_NONE,
       // clang-format on
   };

--- a/shell/platform/android/android_context_gl_impeller_unittests.cc
+++ b/shell/platform/android/android_context_gl_impeller_unittests.cc
@@ -5,7 +5,6 @@
 #include "flutter/shell/platform/android/android_context_gl_impeller.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "third_party/angle/include/EGL/egl.h"
 
 namespace flutter {
 namespace testing {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/158531

Make sure the onscreen framebuffer has a depth attachment that matches the depth24_s8 format expected.