### PR TITLE
Embedder: Refactor EmbedderTestContext creation

### DIFF
--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -317,6 +317,7 @@ if (enable_unittests) {
         "tests/embedder_test_compositor_gl.h",
         "tests/embedder_test_context_gl.cc",
         "tests/embedder_test_context_gl.h",
+        "tests/embedder_test_gl.cc",
       ]
 
       public_deps += [
@@ -331,6 +332,7 @@ if (enable_unittests) {
         "tests/embedder_test_compositor_metal.h",
         "tests/embedder_test_context_metal.cc",
         "tests/embedder_test_context_metal.h",
+        "tests/embedder_test_metal.mm",
       ]
 
       public_deps += [ "//flutter/testing:metal" ]
@@ -342,6 +344,7 @@ if (enable_unittests) {
         "tests/embedder_test_compositor_vulkan.h",
         "tests/embedder_test_context_vulkan.cc",
         "tests/embedder_test_context_vulkan.h",
+        "tests/embedder_test_vulkan.cc",
       ]
 
       public_deps += [

--- a/shell/platform/embedder/tests/embedder_test.cc
+++ b/shell/platform/embedder/tests/embedder_test.cc
@@ -5,18 +5,6 @@
 #include "flutter/shell/platform/embedder/tests/embedder_test.h"
 #include "flutter/shell/platform/embedder/tests/embedder_test_context_software.h"
 
-#ifdef SHELL_ENABLE_GL
-#include "flutter/shell/platform/embedder/tests/embedder_test_context_gl.h"
-#endif
-
-#ifdef SHELL_ENABLE_METAL
-#include "flutter/shell/platform/embedder/tests/embedder_test_context_metal.h"
-#endif
-
-#ifdef SHELL_ENABLE_VULKAN
-#include "flutter/shell/platform/embedder/tests/embedder_test_context_vulkan.h"
-#endif
-
 namespace flutter {
 namespace testing {
 
@@ -33,28 +21,17 @@ EmbedderTestContext& EmbedderTest::GetEmbedderContext(
   if (!embedder_contexts_[type]) {
     switch (type) {
       case EmbedderTestContextType::kSoftwareContext:
-        embedder_contexts_[type] =
-            std::make_unique<EmbedderTestContextSoftware>(
-                GetFixturesDirectory());
+        embedder_contexts_[type] = CreateSoftwareContext();
         break;
-#ifdef SHELL_ENABLE_VULKAN
-      case EmbedderTestContextType::kVulkanContext:
-        embedder_contexts_[type] =
-            std::make_unique<EmbedderTestContextVulkan>(GetFixturesDirectory());
-        break;
-#endif
-#ifdef SHELL_ENABLE_GL
       case EmbedderTestContextType::kOpenGLContext:
-        embedder_contexts_[type] =
-            std::make_unique<EmbedderTestContextGL>(GetFixturesDirectory());
+        embedder_contexts_[type] = CreateGLContext();
         break;
-#endif
-#ifdef SHELL_ENABLE_METAL
+      case EmbedderTestContextType::kVulkanContext:
+        embedder_contexts_[type] = CreateVulkanContext();
+        break;
       case EmbedderTestContextType::kMetalContext:
-        embedder_contexts_[type] =
-            std::make_unique<EmbedderTestContextMetal>(GetFixturesDirectory());
+        embedder_contexts_[type] = CreateMetalContext();
         break;
-#endif
       default:
         FML_DCHECK(false) << "Invalid context type specified.";
         break;
@@ -63,6 +40,37 @@ EmbedderTestContext& EmbedderTest::GetEmbedderContext(
 
   return *embedder_contexts_[type];
 }
+
+std::unique_ptr<EmbedderTestContext> EmbedderTest::CreateSoftwareContext() {
+  return std::make_unique<EmbedderTestContextSoftware>(GetFixturesDirectory());
+}
+
+#ifndef SHELL_ENABLE_GL
+// Fallback implementation.
+// See: flutter/shell/platform/embedder/tests/embedder_test_gl.cc.
+std::unique_ptr<EmbedderTestContext> EmbedderTest::CreateGLContext() {
+  FML_LOG(FATAL) << "OpenGL is not supported in this build";
+  return nullptr;
+}
+#endif
+
+#ifndef SHELL_ENABLE_METAL
+// Fallback implementation.
+// See: flutter/shell/platform/embedder/tests/embedder_test_metal.mm.
+std::unique_ptr<EmbedderTestContext> EmbedderTest::CreateMetalContext() {
+  FML_LOG(FATAL) << "Metal is not supported in this build";
+  return nullptr;
+}
+#endif
+
+#ifndef SHELL_ENABLE_VULKAN
+// Fallback implementation.
+// See: flutter/shell/platform/embedder/tests/embedder_test_vulkan.cc.
+std::unique_ptr<EmbedderTestContext> EmbedderTest::CreateVulkanContext() {
+  FML_LOG(FATAL) << "Vulkan is not supported in this build";
+  return nullptr;
+}
+#endif
 
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/embedder/tests/embedder_test.cc
+++ b/shell/platform/embedder/tests/embedder_test.cc
@@ -5,8 +5,7 @@
 #include "flutter/shell/platform/embedder/tests/embedder_test.h"
 #include "flutter/shell/platform/embedder/tests/embedder_test_context_software.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 EmbedderTest::EmbedderTest() = default;
 
@@ -72,5 +71,4 @@ std::unique_ptr<EmbedderTestContext> EmbedderTest::CreateVulkanContext() {
 }
 #endif
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing

--- a/shell/platform/embedder/tests/embedder_test.h
+++ b/shell/platform/embedder/tests/embedder_test.h
@@ -29,6 +29,11 @@ class EmbedderTest : public ThreadTest {
   std::map<EmbedderTestContextType, std::unique_ptr<EmbedderTestContext>>
       embedder_contexts_;
 
+  std::unique_ptr<EmbedderTestContext> CreateSoftwareContext();
+  std::unique_ptr<EmbedderTestContext> CreateGLContext();
+  std::unique_ptr<EmbedderTestContext> CreateMetalContext();
+  std::unique_ptr<EmbedderTestContext> CreateVulkanContext();
+
   FML_DISALLOW_COPY_AND_ASSIGN(EmbedderTest);
 };
 

--- a/shell/platform/embedder/tests/embedder_test.h
+++ b/shell/platform/embedder/tests/embedder_test.h
@@ -14,8 +14,7 @@
 #include "flutter/testing/thread_test.h"
 #include "gtest/gtest.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 class EmbedderTest : public ThreadTest {
  public:
@@ -41,7 +40,6 @@ class EmbedderTestMultiBackend
     : public EmbedderTest,
       public ::testing::WithParamInterface<EmbedderTestContextType> {};
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_SHELL_PLATFORM_EMBEDDER_TESTS_EMBEDDER_TEST_H_

--- a/shell/platform/embedder/tests/embedder_test_gl.cc
+++ b/shell/platform/embedder/tests/embedder_test_gl.cc
@@ -1,0 +1,17 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/embedder/tests/embedder_test.h"
+
+#include "flutter/shell/platform/embedder/tests/embedder_test_context_gl.h"
+
+namespace flutter {
+namespace testing {
+
+std::unique_ptr<EmbedderTestContext> EmbedderTest::CreateGLContext() {
+  return std::make_unique<EmbedderTestContextGL>(GetFixturesDirectory());
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/shell/platform/embedder/tests/embedder_test_gl.cc
+++ b/shell/platform/embedder/tests/embedder_test_gl.cc
@@ -6,12 +6,10 @@
 
 #include "flutter/shell/platform/embedder/tests/embedder_test_context_gl.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 std::unique_ptr<EmbedderTestContext> EmbedderTest::CreateGLContext() {
   return std::make_unique<EmbedderTestContextGL>(GetFixturesDirectory());
 }
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing

--- a/shell/platform/embedder/tests/embedder_test_metal.mm
+++ b/shell/platform/embedder/tests/embedder_test_metal.mm
@@ -1,0 +1,17 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/embedder/tests/embedder_test.h"
+
+#include "flutter/shell/platform/embedder/tests/embedder_test_context_metal.h"
+
+namespace flutter {
+namespace testing {
+
+std::unique_ptr<EmbedderTestContext> EmbedderTest::CreateMetalContext() {
+  return std::make_unique<EmbedderTestContextMetal>(GetFixturesDirectory());
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/shell/platform/embedder/tests/embedder_test_metal.mm
+++ b/shell/platform/embedder/tests/embedder_test_metal.mm
@@ -6,12 +6,10 @@
 
 #include "flutter/shell/platform/embedder/tests/embedder_test_context_metal.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 std::unique_ptr<EmbedderTestContext> EmbedderTest::CreateMetalContext() {
   return std::make_unique<EmbedderTestContextMetal>(GetFixturesDirectory());
 }
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing

--- a/shell/platform/embedder/tests/embedder_test_vulkan.cc
+++ b/shell/platform/embedder/tests/embedder_test_vulkan.cc
@@ -1,0 +1,17 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/embedder/tests/embedder_test.h"
+
+#include "flutter/shell/platform/embedder/tests/embedder_test_context_vulkan.h"
+
+namespace flutter {
+namespace testing {
+
+std::unique_ptr<EmbedderTestContext> EmbedderTest::CreateVulkanContext() {
+  return std::make_unique<EmbedderTestContextVulkan>(GetFixturesDirectory());
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/shell/platform/embedder/tests/embedder_test_vulkan.cc
+++ b/shell/platform/embedder/tests/embedder_test_vulkan.cc
@@ -6,12 +6,10 @@
 
 #include "flutter/shell/platform/embedder/tests/embedder_test_context_vulkan.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 std::unique_ptr<EmbedderTestContext> EmbedderTest::CreateVulkanContext() {
   return std::make_unique<EmbedderTestContextVulkan>(GetFixturesDirectory());
 }
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing


### PR DESCRIPTION
Extracts creation of graphics backend specfic EmbedderTestContext creation to their own translation units. In particular, this allows for less conditional header includes, and more specifically, for code relating to the Metal backend to include headers that include Objective-C types -- today we cast these all to void* to avoid declaring them in headers, which requires special handling for ARC.

An alternative approach would have been to extract backend-specific subclasses, but there are test suites such as `EmbedderTestMultiBackend` that are executed against multiple backends, which make that approach impractical.

No test changes since this patch makes no semantic changes.

Issue: https://github.com/flutter/flutter/issues/137801

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
