### PR TITLE
Move Vulkan context to EmbedderTestContextVulkan

### DIFF
--- a/shell/platform/embedder/tests/embedder_test_context.h
+++ b/shell/platform/embedder/tests/embedder_test_context.h
@@ -116,12 +116,6 @@ class EmbedderTestContext {
 
   using NextSceneCallback = std::function<void(sk_sp<SkImage> image)>;
 
-#ifdef SHELL_ENABLE_VULKAN
-  // The TestVulkanContext destructor must be called _after_ the compositor is
-  // freed.
-  fml::RefPtr<TestVulkanContext> vulkan_context_ = nullptr;
-#endif
-
 #ifdef SHELL_ENABLE_GL
   std::shared_ptr<TestEGLContext> egl_context_ = nullptr;
 #endif

--- a/shell/platform/embedder/tests/embedder_test_context_vulkan.h
+++ b/shell/platform/embedder/tests/embedder_test_context_vulkan.h
@@ -38,6 +38,10 @@ class EmbedderTestContextVulkan : public EmbedderTestContext {
                                 const char* name);
 
  private:
+  // The TestVulkanContext destructor must be called _after_ the compositor is
+  // freed.
+  fml::RefPtr<TestVulkanContext> vulkan_context_ = nullptr;
+
   std::unique_ptr<TestVulkanSurface> surface_;
 
   SkISize surface_size_ = SkISize::MakeEmpty();


### PR DESCRIPTION
In flutter/engine#29391 we extracted EmbedderTestContextVulkan, but didn't move the vulkan_context_ to that class. Since it's no longer used in the base class, we push it down to avoid the ifdef guards.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
