### PR TITLE
Added assert for opengles thread safety

### DIFF
--- a/impeller/renderer/backend/gles/proc_table_gles.cc
+++ b/impeller/renderer/backend/gles/proc_table_gles.cc
@@ -140,6 +140,8 @@ ProcTableGLES::ProcTableGLES(  // NOLINT(google-readability-function-size)
 
   capabilities_ = std::make_shared<CapabilitiesGLES>(*this);
 
+  // This this will force glUseProgram to only be used on one thread in debug
+  // builds to identify threading violations in the engine.
   UseProgram.enforce_one_thread = true;
 
   is_valid_ = true;

--- a/impeller/renderer/backend/gles/proc_table_gles.cc
+++ b/impeller/renderer/backend/gles/proc_table_gles.cc
@@ -140,6 +140,8 @@ ProcTableGLES::ProcTableGLES(  // NOLINT(google-readability-function-size)
 
   capabilities_ = std::make_shared<CapabilitiesGLES>(*this);
 
+  UseProgram.enforce_one_thread = true;
+
   is_valid_ = true;
 }
 

--- a/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/impeller/renderer/backend/gles/proc_table_gles.h
@@ -6,7 +6,9 @@
 #define FLUTTER_IMPELLER_RENDERER_BACKEND_GLES_PROC_TABLE_GLES_H_
 
 #include <functional>
+#include <mutex>
 #include <string>
+#include <thread>
 
 #include "flutter/fml/logging.h"
 #include "flutter/fml/mapping.h"
@@ -100,6 +102,14 @@ struct GLProc {
   bool log_calls = false;
 
   //----------------------------------------------------------------------------
+  /// Whether the OpenGL call asserts it is only used from / one thread in
+  /// IMPELLER_DEBUG builds.
+  ///
+  /// This is used to block drawing calls from happening anywhere but the raster
+  /// thread.
+  bool enforce_one_thread = false;
+
+  //----------------------------------------------------------------------------
   /// @brief      Call the GL function with the appropriate parameters. Lookup
   ///             the documentation for the GL function being called to
   ///             understand the arguments and return types. The arguments
@@ -117,6 +127,16 @@ struct GLProc {
     if (log_calls) {
       FML_LOG(IMPORTANT) << name
                          << BuildGLArguments(std::forward<Args>(args)...);
+    }
+    if (enforce_one_thread) {
+      static std::thread::id allowed_thread;
+      static std::once_flag flag;
+      std::call_once(flag,
+                     []() { allowed_thread = std::this_thread::get_id(); });
+      FML_CHECK(std::this_thread::get_id() == allowed_thread)
+          << "This symbol is expected to be called from one thread, the raster "
+             "thread. As of this addition, the design of the engine should be "
+             "using non-raster threads only for uploading images.";
     }
 #endif  // defined(IMPELLER_DEBUG) && !defined(NDEBUG)
     return function(std::forward<Args>(args)...);


### PR DESCRIPTION
This assert would have blocked the following bug: https://github.com/flutter/flutter/issues/158535

This shouldn't be landed until https://github.com/flutter/engine/pull/56573 lands.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
