### PR TITLE
[macos] early return to suppress clang-tidy warning

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponder.mm
@@ -134,6 +134,8 @@
     default: {
       NSAssert(false, @"Unexpected key event type (got %lu).", event.type);
       callback(false);
+      // This should not happen. Return to suppress clang-tidy warning on `type` being nil.
+      return;
     }
   }
   _previouslyPressedFlags = modifierFlags;

--- a/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponder.mm
@@ -131,12 +131,13 @@
         return;
       }
       break;
-    default: [[unlikely]] {
-      NSAssert(false, @"Unexpected key event type (got %lu).", event.type);
-      callback(false);
-      // This should not happen. Return to suppress clang-tidy warning on `type` being nil.
-      return;
-    }
+    default:
+      [[unlikely]] {
+        NSAssert(false, @"Unexpected key event type (got %lu).", event.type);
+        callback(false);
+        // This should not happen. Return to suppress clang-tidy warning on `type` being nil.
+        return;
+      }
   }
   _previouslyPressedFlags = modifierFlags;
   NSMutableDictionary* keyMessage = [@{

--- a/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponder.mm
@@ -131,7 +131,7 @@
         return;
       }
       break;
-    default: {
+    default: [[unlikely]] {
       NSAssert(false, @"Unexpected key event type (got %lu).", event.type);
       callback(false);
       // This should not happen. Return to suppress clang-tidy warning on `type` being nil.


### PR DESCRIPTION
If we disable the NSAssert during release mode, this code will continue after NSAssert failure, which will then pass a `nil` value into a dictionary (which cannot have a nil value), hence the clang-tidy warning here https://github.com/flutter/engine/pull/53005#issuecomment-2140975126

*List which issues are fixed by this PR. You must list at least one issue.*
https://github.com/flutter/flutter/issues/148279
https://github.com/flutter/flutter/issues/157837

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
