### PR TITLE
[CP][iOS] fix tracking of prev platform view items.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/platform_views_controller.mm
+++ b/shell/platform/darwin/ios/framework/Source/platform_views_controller.mm
@@ -796,6 +796,7 @@ void PlatformViewsController::BringLayersIntoView(const LayersMap& layer_map,
   previous_composition_order_.clear();
   NSMutableArray* desired_platform_subviews = [NSMutableArray array];
   for (int64_t platform_view_id : composition_order) {
+    previous_composition_order_.push_back(platform_view_id);
     UIView* platform_view_root = platform_views_[platform_view_id].root_view.get();
     if (platform_view_root != nil) {
       [desired_platform_subviews addObject:platform_view_root];
@@ -806,7 +807,6 @@ void PlatformViewsController::BringLayersIntoView(const LayersMap& layer_map,
       auto view = maybe_layer_data->second.layer->overlay_view_wrapper;
       if (view != nil) {
         [desired_platform_subviews addObject:view];
-        previous_composition_order_.push_back(platform_view_id);
       }
     }
   }


### PR DESCRIPTION
Ensures that all platform views items are tracked in the previous_composition_order_ set. Without this, they can occasionally be left on screen.