### PR TITLE
[Impeller] enable OpenGL fallback on Android.

### DIFF
--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -240,7 +240,7 @@ AndroidRenderingAPI FlutterMain::SelectedRenderingAPI(
     return AndroidRenderingAPI::kSoftware;
   }
   constexpr AndroidRenderingAPI kVulkanUnsupportedFallback =
-      AndroidRenderingAPI::kSkiaOpenGLES;
+      AndroidRenderingAPI::kImpellerOpenGLES;
 
   // Debug/Profile only functionality for testing a specific
   // backend configuration.

--- a/shell/platform/android/platform_view_android_unittests.cc
+++ b/shell/platform/android/platform_view_android_unittests.cc
@@ -22,7 +22,7 @@ TEST(AndroidPlatformView, SelectsVulkanBasedOnApiLevel) {
               AndroidRenderingAPI::kImpellerVulkan);
   } else {
     EXPECT_EQ(FlutterMain::SelectedRenderingAPI(settings),
-              AndroidRenderingAPI::kSkiaOpenGLES);
+              AndroidRenderingAPI::kImpellerOpenGLES);
   }
 }
 


### PR DESCRIPTION
Ship impeller OpenGLES on non-vulkan android devices

Fixes https://github.com/flutter/flutter/issues/158361
