### PR TITLE
Migrate Metal translation units to Obj-C++

### DIFF
--- a/display_list/testing/BUILD.gn
+++ b/display_list/testing/BUILD.gn
@@ -101,8 +101,8 @@ source_set("display_list_surface_provider") {
 
   if (surface_provider_include_metal) {
     sources += [
-      "dl_test_surface_metal.cc",
       "dl_test_surface_metal.h",
+      "dl_test_surface_metal.mm",
     ]
     deps += [
       "//flutter/impeller/display_list",

--- a/display_list/testing/dl_test_surface_metal.mm
+++ b/display_list/testing/dl_test_surface_metal.mm
@@ -15,22 +15,17 @@ namespace testing {
 
 class DlMetalSurfaceInstance : public DlSurfaceInstance {
  public:
-  explicit DlMetalSurfaceInstance(
-      std::unique_ptr<TestMetalSurface> metal_surface)
+  explicit DlMetalSurfaceInstance(std::unique_ptr<TestMetalSurface> metal_surface)
       : metal_surface_(std::move(metal_surface)) {}
   ~DlMetalSurfaceInstance() = default;
 
-  sk_sp<SkSurface> sk_surface() const override {
-    return metal_surface_->GetSurface();
-  }
+  sk_sp<SkSurface> sk_surface() const override { return metal_surface_->GetSurface(); }
 
  private:
   std::unique_ptr<TestMetalSurface> metal_surface_;
 };
 
-bool DlMetalSurfaceProvider::InitializeSurface(size_t width,
-                                               size_t height,
-                                               PixelFormat format) {
+bool DlMetalSurfaceProvider::InitializeSurface(size_t width, size_t height, PixelFormat format) {
   if (format != kN32PremulPixelFormat) {
     return false;
   }
@@ -39,8 +34,7 @@ bool DlMetalSurfaceProvider::InitializeSurface(size_t width,
   return true;
 }
 
-std::shared_ptr<DlSurfaceInstance> DlMetalSurfaceProvider::GetPrimarySurface()
-    const {
+std::shared_ptr<DlSurfaceInstance> DlMetalSurfaceProvider::GetPrimarySurface() const {
   if (!metal_surface_) {
     return nullptr;
   }
@@ -51,16 +45,14 @@ std::shared_ptr<DlSurfaceInstance> DlMetalSurfaceProvider::MakeOffscreenSurface(
     size_t width,
     size_t height,
     PixelFormat format) const {
-  auto surface =
-      TestMetalSurface::Create(*metal_context_, SkISize::Make(width, height));
+  auto surface = TestMetalSurface::Create(*metal_context_, SkISize::Make(width, height));
   surface->GetSurface()->getCanvas()->clear(SK_ColorTRANSPARENT);
   return std::make_shared<DlMetalSurfaceInstance>(std::move(surface));
 }
 
 class DlMetalPixelData : public DlPixelData {
  public:
-  explicit DlMetalPixelData(
-      std::unique_ptr<impeller::testing::Screenshot> screenshot)
+  explicit DlMetalPixelData(std::unique_ptr<impeller::testing::Screenshot> screenshot)
       : screenshot_(std::move(screenshot)),
         addr_(reinterpret_cast<const uint32_t*>(screenshot_->GetBytes())),
         ints_per_row_(screenshot_->GetBytesPerRow() / 4) {
@@ -68,14 +60,10 @@ class DlMetalPixelData : public DlPixelData {
   }
   ~DlMetalPixelData() override = default;
 
-  const uint32_t* addr32(int x, int y) const override {
-    return addr_ + (y * ints_per_row_) + x;
-  }
+  const uint32_t* addr32(int x, int y) const override { return addr_ + (y * ints_per_row_) + x; }
   size_t width() const override { return screenshot_->GetWidth(); }
   size_t height() const override { return screenshot_->GetHeight(); }
-  void write(const std::string& path) const override {
-    screenshot_->WriteToPNG(path);
-  }
+  void write(const std::string& path) const override { screenshot_->WriteToPNG(path); }
 
  private:
   std::unique_ptr<impeller::testing::Screenshot> screenshot_;
@@ -83,19 +71,16 @@ class DlMetalPixelData : public DlPixelData {
   const uint32_t ints_per_row_;
 };
 
-sk_sp<DlPixelData> DlMetalSurfaceProvider::ImpellerSnapshot(
-    const sk_sp<DisplayList>& list,
-    int width,
-    int height) const {
+sk_sp<DlPixelData> DlMetalSurfaceProvider::ImpellerSnapshot(const sk_sp<DisplayList>& list,
+                                                            int width,
+                                                            int height) const {
   auto texture = DisplayListToTexture(list, {width, height}, *aiks_context_);
-  return sk_make_sp<DlMetalPixelData>(
-      snapshotter_->MakeScreenshot(*aiks_context_, texture));
+  return sk_make_sp<DlMetalPixelData>(snapshotter_->MakeScreenshot(*aiks_context_, texture));
 }
 
-sk_sp<DlImage> DlMetalSurfaceProvider::MakeImpellerImage(
-    const sk_sp<DisplayList>& list,
-    int width,
-    int height) const {
+sk_sp<DlImage> DlMetalSurfaceProvider::MakeImpellerImage(const sk_sp<DisplayList>& list,
+                                                         int width,
+                                                         int height) const {
   InitScreenShotter();
   return impeller::DlImageImpeller::Make(
       DisplayListToTexture(list, {width, height}, *aiks_context_));
@@ -105,8 +90,8 @@ void DlMetalSurfaceProvider::InitScreenShotter() const {
   if (!snapshotter_) {
     snapshotter_.reset(new MetalScreenshotter(/*enable_wide_gamut=*/false));
     auto typographer = impeller::TypographerContextSkia::Make();
-    aiks_context_.reset(new impeller::AiksContext(
-        snapshotter_->GetPlayground().GetContext(), typographer));
+    aiks_context_.reset(
+        new impeller::AiksContext(snapshotter_->GetPlayground().GetContext(), typographer));
   }
 }
 

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -328,10 +328,10 @@ if (enable_unittests) {
 
     if (test_enable_metal) {
       sources += [
-        "tests/embedder_test_compositor_metal.cc",
         "tests/embedder_test_compositor_metal.h",
-        "tests/embedder_test_context_metal.cc",
+        "tests/embedder_test_compositor_metal.mm",
         "tests/embedder_test_context_metal.h",
+        "tests/embedder_test_context_metal.mm",
         "tests/embedder_test_metal.mm",
       ]
 

--- a/shell/platform/embedder/tests/embedder_test_compositor_metal.mm
+++ b/shell/platform/embedder/tests/embedder_test_compositor_metal.mm
@@ -14,29 +14,26 @@
 namespace flutter {
 namespace testing {
 
-EmbedderTestCompositorMetal::EmbedderTestCompositorMetal(
-    SkISize surface_size,
-    sk_sp<GrDirectContext> context)
+EmbedderTestCompositorMetal::EmbedderTestCompositorMetal(SkISize surface_size,
+                                                         sk_sp<GrDirectContext> context)
     : EmbedderTestCompositor(surface_size, std::move(context)) {}
 
 EmbedderTestCompositorMetal::~EmbedderTestCompositorMetal() = default;
 
-bool EmbedderTestCompositorMetal::UpdateOffscrenComposition(
-    const FlutterLayer** layers,
-    size_t layers_count) {
+bool EmbedderTestCompositorMetal::UpdateOffscrenComposition(const FlutterLayer** layers,
+                                                            size_t layers_count) {
   last_composition_ = nullptr;
 
   const auto image_info = SkImageInfo::MakeN32Premul(surface_size_);
 
-  auto surface =
-      SkSurfaces::RenderTarget(context_.get(),            // context
-                               skgpu::Budgeted::kNo,      // budgeted
-                               image_info,                // image info
-                               1,                         // sample count
-                               kTopLeft_GrSurfaceOrigin,  // surface origin
-                               nullptr,                   // surface properties
-                               false                      // create mipmaps
-      );
+  auto surface = SkSurfaces::RenderTarget(context_.get(),            // context
+                                          skgpu::Budgeted::kNo,      // budgeted
+                                          image_info,                // image info
+                                          1,                         // sample count
+                                          kTopLeft_GrSurfaceOrigin,  // surface origin
+                                          nullptr,                   // surface properties
+                                          false                      // create mipmaps
+  );
 
   if (!surface) {
     FML_LOG(ERROR) << "Could not update the off-screen composition.";
@@ -60,14 +57,12 @@ bool EmbedderTestCompositorMetal::UpdateOffscrenComposition(
     switch (layer->type) {
       case kFlutterLayerContentTypeBackingStore:
         layer_image =
-            reinterpret_cast<SkSurface*>(layer->backing_store->user_data)
-                ->makeImageSnapshot();
+            reinterpret_cast<SkSurface*>(layer->backing_store->user_data)->makeImageSnapshot();
         break;
       case kFlutterLayerContentTypePlatformView:
-        layer_image =
-            platform_view_renderer_callback_
-                ? platform_view_renderer_callback_(*layer, context_.get())
-                : nullptr;
+        layer_image = platform_view_renderer_callback_
+                          ? platform_view_renderer_callback_(*layer, context_.get())
+                          : nullptr;
         canvas_offset = SkIPoint::Make(layer->offset.x, layer->offset.y);
         break;
     };
@@ -75,8 +70,7 @@ bool EmbedderTestCompositorMetal::UpdateOffscrenComposition(
     // If the layer is not a platform view but the engine did not specify an
     // image for the backing store, it is an error.
     if (!layer_image && layer->type != kFlutterLayerContentTypePlatformView) {
-      FML_LOG(ERROR) << "Could not snapshot layer in test compositor: "
-                     << *layer;
+      FML_LOG(ERROR) << "Could not snapshot layer in test compositor: " << *layer;
       return false;
     }
 
@@ -85,8 +79,7 @@ bool EmbedderTestCompositorMetal::UpdateOffscrenComposition(
     if (layer_image) {
       // The image rendered by Flutter already has the correct offset and
       // transformation applied. The layers offset is meant for the platform.
-      canvas->drawImage(layer_image.get(), canvas_offset.x(),
-                        canvas_offset.y());
+      canvas->drawImage(layer_image.get(), canvas_offset.x(), canvas_offset.y());
     }
   }
 

--- a/shell/platform/embedder/tests/embedder_test_context_metal.mm
+++ b/shell/platform/embedder/tests/embedder_test_context_metal.mm
@@ -37,10 +37,9 @@ EmbedderTestContextType EmbedderTestContextMetal::GetContextType() const {
 
 void EmbedderTestContextMetal::SetupCompositor() {
   FML_CHECK(!compositor_) << "Already set up a compositor in this context.";
-  FML_CHECK(metal_surface_)
-      << "Set up the Metal surface before setting up a compositor.";
-  compositor_ = std::make_unique<EmbedderTestCompositorMetal>(
-      surface_size_, metal_surface_->GetGrContext());
+  FML_CHECK(metal_surface_) << "Set up the Metal surface before setting up a compositor.";
+  compositor_ =
+      std::make_unique<EmbedderTestCompositorMetal>(surface_size_, metal_surface_->GetGrContext());
 }
 
 TestMetalContext* EmbedderTestContextMetal::GetTestMetalContext() {
@@ -51,8 +50,7 @@ TestMetalSurface* EmbedderTestContextMetal::GetTestMetalSurface() {
   return metal_surface_.get();
 }
 
-void EmbedderTestContextMetal::SetPresentCallback(
-    PresentCallback present_callback) {
+void EmbedderTestContextMetal::SetPresentCallback(PresentCallback present_callback) {
   present_callback_ = std::move(present_callback);
 }
 
@@ -71,11 +69,10 @@ void EmbedderTestContextMetal::SetExternalTextureCallback(
   external_texture_frame_callback_ = std::move(external_texture_frame_callback);
 }
 
-bool EmbedderTestContextMetal::PopulateExternalTexture(
-    int64_t texture_id,
-    size_t w,
-    size_t h,
-    FlutterMetalExternalTexture* output) {
+bool EmbedderTestContextMetal::PopulateExternalTexture(int64_t texture_id,
+                                                       size_t w,
+                                                       size_t h,
+                                                       FlutterMetalExternalTexture* output) {
   if (external_texture_frame_callback_ != nullptr) {
     return external_texture_frame_callback_(texture_id, w, h, output);
   } else {
@@ -88,8 +85,7 @@ void EmbedderTestContextMetal::SetNextDrawableCallback(
   next_drawable_callback_ = std::move(next_drawable_callback);
 }
 
-FlutterMetalTexture EmbedderTestContextMetal::GetNextDrawable(
-    const FlutterFrameInfo* frame_info) {
+FlutterMetalTexture EmbedderTestContextMetal::GetNextDrawable(const FlutterFrameInfo* frame_info) {
   if (next_drawable_callback_ != nullptr) {
     return next_drawable_callback_(frame_info);
   }
@@ -98,8 +94,7 @@ FlutterMetalTexture EmbedderTestContextMetal::GetNextDrawable(
   FlutterMetalTexture texture = {};
   texture.struct_size = sizeof(FlutterMetalTexture);
   texture.texture_id = texture_info.texture_id;
-  texture.texture =
-      reinterpret_cast<FlutterMetalTextureHandle>(texture_info.texture);
+  texture.texture = reinterpret_cast<FlutterMetalTextureHandle>(texture_info.texture);
   return texture;
 }
 

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -199,8 +199,8 @@ if (is_mac || is_ios) {
       sources = [
         "test_metal_context.h",
         "test_metal_context.mm",
-        "test_metal_surface.cc",
         "test_metal_surface.h",
+        "test_metal_surface.mm",
         "test_metal_surface_impl.h",
         "test_metal_surface_impl.mm",
       ]
@@ -260,7 +260,7 @@ if (enable_unittests) {
       cflags_objc = flutter_cflags_objc_arc
       cflags_objcc = flutter_cflags_objcc_arc
 
-      sources += [ "test_metal_surface_unittests.cc" ]
+      sources += [ "test_metal_surface_unittests.mm" ]
       deps += [ ":metal" ]
     }
   }

--- a/testing/test_metal_surface.mm
+++ b/testing/test_metal_surface.mm
@@ -18,16 +18,14 @@ bool TestMetalSurface::PlatformSupportsMetal() {
 std::unique_ptr<TestMetalSurface> TestMetalSurface::Create(
     const TestMetalContext& test_metal_context,
     SkISize surface_size) {
-  return std::make_unique<TestMetalSurfaceImpl>(test_metal_context,
-                                                surface_size);
+  return std::make_unique<TestMetalSurfaceImpl>(test_metal_context, surface_size);
 }
 
 std::unique_ptr<TestMetalSurface> TestMetalSurface::Create(
     const TestMetalContext& test_metal_context,
     int64_t texture_id,
     SkISize surface_size) {
-  return std::make_unique<TestMetalSurfaceImpl>(test_metal_context, texture_id,
-                                                surface_size);
+  return std::make_unique<TestMetalSurfaceImpl>(test_metal_context, texture_id, surface_size);
 }
 
 TestMetalSurface::TestMetalSurface() = default;

--- a/testing/test_metal_surface_unittests.mm
+++ b/testing/test_metal_surface_unittests.mm
@@ -28,8 +28,7 @@ TEST(TestMetalSurface, CanCreateValidTestMetalSurface) {
   }
 
   TestMetalContext metal_context = TestMetalContext();
-  auto surface =
-      TestMetalSurface::Create(metal_context, SkISize::Make(100, 100));
+  auto surface = TestMetalSurface::Create(metal_context, SkISize::Make(100, 100));
   ASSERT_NE(surface, nullptr);
   ASSERT_TRUE(surface->IsValid());
   ASSERT_NE(surface->GetSurface(), nullptr);


### PR DESCRIPTION
Since Metal code frequently uses Objective-C types like id<MTLTexture> etc. this migrates Metal translation units to Obj-C++. In particular, this allows transitively including headers that include such types. This in turn helps with refactoring `EmbedderTest`, `TestMetalContext`, `TestMetalSurface` to avoid specifying `void*` types in headers and manually refcounting via ARC bridge casts.

Reformats the source, since Objective-C files are linted to 100 columns rather than the 80 column limit we impose on C++ files.

This change introduces no semantic changes.

Issue: https://github.com/flutter/flutter/issues/137801

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I did listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
