### PR TITLE
[Impeller] Put test components in the testing namespace.

### DIFF
--- a/impeller/entity/contents/test/contents_test_helpers.cc
+++ b/impeller/entity/contents/test/contents_test_helpers.cc
@@ -4,8 +4,8 @@
 
 #include "impeller/entity/contents/test/contents_test_helpers.h"
 
-namespace impeller {
+namespace impeller::testing {
 
 //
 
-}
+}  // namespace impeller::testing

--- a/impeller/entity/contents/test/contents_test_helpers.h
+++ b/impeller/entity/contents/test/contents_test_helpers.h
@@ -7,7 +7,7 @@
 
 #include "impeller/renderer/command.h"
 
-namespace impeller {
+namespace impeller::testing {
 
 /// @brief Retrieve the [VertInfo] struct data from the provided [command].
 template <typename T>
@@ -44,6 +44,6 @@ typename T::FragInfo* GetFragInfo(const Command& command) {
   return reinterpret_cast<typename T::FragInfo*>(data);
 }
 
-}  // namespace impeller
+}  // namespace impeller::testing
 
 #endif  // FLUTTER_IMPELLER_ENTITY_CONTENTS_TEST_CONTENTS_TEST_HELPERS_H_

--- a/impeller/entity/contents/test/recording_render_pass.cc
+++ b/impeller/entity/contents/test/recording_render_pass.cc
@@ -6,7 +6,7 @@
 
 #include <utility>
 
-namespace impeller {
+namespace impeller::testing {
 
 RecordingRenderPass::RecordingRenderPass(
     std::shared_ptr<RenderPass> delegate,
@@ -147,4 +147,4 @@ bool RecordingRenderPass::BindResource(
   return true;
 }
 
-}  // namespace impeller
+}  // namespace impeller::testing

--- a/impeller/entity/contents/test/recording_render_pass.h
+++ b/impeller/entity/contents/test/recording_render_pass.h
@@ -7,7 +7,7 @@
 
 #include "impeller/renderer/render_pass.h"
 
-namespace impeller {
+namespace impeller::testing {
 
 class RecordingRenderPass : public RenderPass {
  public:
@@ -82,6 +82,6 @@ class RecordingRenderPass : public RenderPass {
   std::vector<Command> commands_;
 };
 
-}  // namespace impeller
+}  // namespace impeller::testing
 
 #endif  // FLUTTER_IMPELLER_ENTITY_CONTENTS_TEST_RECORDING_RENDER_PASS_H_


### PR DESCRIPTION
Minor change for clarity. I went looking for how we used the recording render pass since it was not in the testing namespace.