### PR TITLE
[Impeller] libImpeller: Reset the GL state when transitioning control back to the embedder.

### DIFF
--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -9,6 +9,7 @@
 #include "impeller/base/validation.h"
 #include "impeller/renderer/backend/gles/command_buffer_gles.h"
 #include "impeller/renderer/backend/gles/gpu_tracer_gles.h"
+#include "impeller/renderer/backend/gles/render_pass_gles.h"
 #include "impeller/renderer/command_queue.h"
 
 namespace impeller {
@@ -143,6 +144,17 @@ const std::shared_ptr<const Capabilities>& ContextGLES::GetCapabilities()
 // |Context|
 std::shared_ptr<CommandQueue> ContextGLES::GetCommandQueue() const {
   return command_queue_;
+}
+
+// |Context|
+void ContextGLES::ResetThreadLocalState() const {
+  if (!IsValid()) {
+    return;
+  }
+  [[maybe_unused]] auto result =
+      reactor_->AddOperation([](const ReactorGLES& reactor) {
+        RenderPassGLES::ResetGLState(reactor.GetProcTable());
+      });
 }
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/context_gles.h
+++ b/impeller/renderer/backend/gles/context_gles.h
@@ -93,6 +93,9 @@ class ContextGLES final : public Context,
   // |Context|
   void Shutdown() override;
 
+  // |Context|
+  void ResetThreadLocalState() const override;
+
   ContextGLES(const ContextGLES&) = delete;
 
   ContextGLES& operator=(const ContextGLES&) = delete;

--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -172,6 +172,19 @@ static bool BindVertexBuffer(const ProcTableGLES& gl,
   return true;
 }
 
+void RenderPassGLES::ResetGLState(const ProcTableGLES& gl) {
+  gl.Disable(GL_SCISSOR_TEST);
+  gl.Disable(GL_DEPTH_TEST);
+  gl.Disable(GL_STENCIL_TEST);
+  gl.Disable(GL_CULL_FACE);
+  gl.Disable(GL_BLEND);
+  gl.Disable(GL_DITHER);
+  gl.ColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+  gl.DepthMask(GL_TRUE);
+  gl.StencilMaskSeparate(GL_FRONT, 0xFFFFFFFF);
+  gl.StencilMaskSeparate(GL_BACK, 0xFFFFFFFF);
+}
+
 [[nodiscard]] bool EncodeCommandsInReactor(
     const RenderPassData& pass_data,
     const std::shared_ptr<Allocator>& transients_allocator,
@@ -267,16 +280,7 @@ static bool BindVertexBuffer(const ProcTableGLES& gl,
     clear_bits |= GL_STENCIL_BUFFER_BIT;
   }
 
-  gl.Disable(GL_SCISSOR_TEST);
-  gl.Disable(GL_DEPTH_TEST);
-  gl.Disable(GL_STENCIL_TEST);
-  gl.Disable(GL_CULL_FACE);
-  gl.Disable(GL_BLEND);
-  gl.Disable(GL_DITHER);
-  gl.ColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-  gl.DepthMask(GL_TRUE);
-  gl.StencilMaskSeparate(GL_FRONT, 0xFFFFFFFF);
-  gl.StencilMaskSeparate(GL_BACK, 0xFFFFFFFF);
+  RenderPassGLES::ResetGLState(gl);
 
   gl.Clear(clear_bits);
 

--- a/impeller/renderer/backend/gles/render_pass_gles.h
+++ b/impeller/renderer/backend/gles/render_pass_gles.h
@@ -19,6 +19,8 @@ class RenderPassGLES final
   // |RenderPass|
   ~RenderPassGLES() override;
 
+  static void ResetGLState(const ProcTableGLES& gl);
+
  private:
   friend class CommandBufferGLES;
 

--- a/impeller/renderer/context.cc
+++ b/impeller/renderer/context.cc
@@ -25,4 +25,12 @@ bool Context::FlushCommandBuffers() {
   return true;
 }
 
+std::shared_ptr<const IdleWaiter> Context::GetIdleWaiter() const {
+  return nullptr;
+}
+
+void Context::ResetThreadLocalState() const {
+  // Nothing to do.
+}
+
 }  // namespace impeller

--- a/impeller/renderer/context.h
+++ b/impeller/renderer/context.h
@@ -222,9 +222,17 @@ class Context {
   /// rendering a 2D workload.
   [[nodiscard]] virtual bool FlushCommandBuffers();
 
-  virtual std::shared_ptr<const IdleWaiter> GetIdleWaiter() const {
-    return nullptr;
-  }
+  virtual std::shared_ptr<const IdleWaiter> GetIdleWaiter() const;
+
+  //----------------------------------------------------------------------------
+  /// Resets any thread local state that may interfere with embedders.
+  ///
+  /// Today, only the OpenGL backend can trample on thread local state that the
+  /// embedder can access. This call puts the GL state in a sane "clean" state.
+  ///
+  /// Impeller itself is resilient to a dirty thread local state table.
+  ///
+  virtual void ResetThreadLocalState() const;
 
  protected:
   Context();

--- a/impeller/toolkit/interop/surface.cc
+++ b/impeller/toolkit/interop/surface.cc
@@ -62,8 +62,10 @@ bool Surface::DrawDisplayList(const DisplayList& dl) const {
   auto skia_cull_rect =
       SkIRect::MakeWH(cull_rect.GetWidth(), cull_rect.GetHeight());
 
-  return RenderToOnscreen(content_context, render_target, display_list,
-                          skia_cull_rect, /*reset_host_buffer=*/true);
+  auto result = RenderToOnscreen(content_context, render_target, display_list,
+                                 skia_cull_rect, /*reset_host_buffer=*/true);
+  context_->GetContext()->ResetThreadLocalState();
+  return result;
 }
 
 }  // namespace impeller::interop


### PR DESCRIPTION
Impeller is resilient to OpenGL state being trampled upon when accessing the GL context. But the embedder may not necessarily be. Ideally, we'd be using saving the state and restoring it. But that might be too involved. For now, this sets the GL state to a sane "clean" state.

We could, in theory, do this after each render pass but that unnecessarily increases API traffic. For now, I have added it at the transition of the embedder boundary.
