### PR TITLE
[Impeller] Don't enable KHR_debug on Angle.

### DIFF
--- a/impeller/renderer/backend/gles/description_gles.cc
+++ b/impeller/renderer/backend/gles/description_gles.cc
@@ -178,7 +178,10 @@ bool DescriptionGLES::HasExtension(const std::string& ext) const {
 }
 
 bool DescriptionGLES::HasDebugExtension() const {
-  return HasExtension("GL_KHR_debug");
+  // Angle just logs calls instead of forwarding debug information to the
+  // backend. This just overwhelms the logs and is of limited use. Disable on
+  // Angle.
+  return HasExtension("GL_KHR_debug") && !IsANGLE();
 }
 
 }  // namespace impeller


### PR DESCRIPTION
All it does it log the calls and overwhelms the output for no utility.

<img width="651" alt="Screenshot 2024-11-14 at 3 53 54 PM" src="https://github.com/user-attachments/assets/b2de0d71-6263-4f00-94a0-73a5c0d0135d">
