### PR TITLE
Move TestMetalContext/Surface to testing namespace

### DIFF
--- a/testing/assertions.h
+++ b/testing/assertions.h
@@ -7,15 +7,13 @@
 
 #include <type_traits>
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 inline bool NumberNear(double a, double b) {
   static const double epsilon = 1e-3;
   return (a > (b - epsilon)) && (a < (b + epsilon));
 }
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_TESTING_ASSERTIONS_H_

--- a/testing/canvas_test.h
+++ b/testing/canvas_test.h
@@ -9,8 +9,7 @@
 #include "gtest/gtest.h"
 #include "third_party/skia/include/core/SkColorSpace.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 // This fixture allows creating tests that make use of a mock |SkCanvas|.
 template <typename BaseT>
@@ -27,7 +26,6 @@ class CanvasTestBase : public BaseT {
 };
 using CanvasTest = CanvasTestBase<::testing::Test>;
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_TESTING_CANVAS_TEST_H_

--- a/testing/dart_isolate_runner.cc
+++ b/testing/dart_isolate_runner.cc
@@ -8,8 +8,8 @@
 
 #include "flutter/runtime/isolate_configuration.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
+
 AutoIsolateShutdown::AutoIsolateShutdown(std::shared_ptr<DartIsolate> isolate,
                                          fml::RefPtr<fml::TaskRunner> runner)
     : isolate_(std::move(isolate)), runner_(std::move(runner)) {}
@@ -173,5 +173,4 @@ std::unique_ptr<AutoIsolateShutdown> RunDartCodeInIsolate(
   return result;
 }
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing

--- a/testing/dart_isolate_runner.h
+++ b/testing/dart_isolate_runner.h
@@ -14,8 +14,7 @@
 #include "flutter/runtime/dart_vm.h"
 #include "flutter/runtime/dart_vm_lifecycle.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 class AutoIsolateShutdown {
  public:
@@ -66,7 +65,6 @@ std::unique_ptr<AutoIsolateShutdown> RunDartCodeInIsolate(
     fml::WeakPtr<IOManager> io_manager = {},
     std::unique_ptr<PlatformConfiguration> platform_configuration = nullptr);
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_TESTING_DART_ISOLATE_RUNNER_H_

--- a/testing/debugger_detection.cc
+++ b/testing/debugger_detection.cc
@@ -19,8 +19,7 @@
 #include <windows.h>
 #endif  // FML_OS_WIN
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 DebuggerStatus GetDebuggerStatus() {
 #if FML_OS_MACOSX
@@ -61,7 +60,6 @@ DebuggerStatus GetDebuggerStatus() {
 #else
   return DebuggerStatus::kDontKnow;
 #endif
-}  // namespace testing
+}
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing

--- a/testing/debugger_detection.h
+++ b/testing/debugger_detection.h
@@ -7,8 +7,7 @@
 
 #include "flutter/fml/macros.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 enum class DebuggerStatus {
   kDontKnow,
@@ -17,7 +16,6 @@ enum class DebuggerStatus {
 
 DebuggerStatus GetDebuggerStatus();
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_TESTING_DEBUGGER_DETECTION_H_

--- a/testing/display_list_testing.cc
+++ b/testing/display_list_testing.cc
@@ -10,8 +10,7 @@
 #include "flutter/display_list/display_list.h"
 #include "flutter/display_list/effects/dl_image_filter.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 // clang-format off
 bool DisplayListsEQ_Verbose(const DisplayList* a, const DisplayList* b) {
@@ -37,8 +36,7 @@ bool DisplayListsNE_Verbose(const DisplayList* a, const DisplayList* b) {
   return true;
 }
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing
 
 namespace std {
 
@@ -389,8 +387,7 @@ std::ostream& operator<<(std::ostream& os, const DlImage* image) {
 
 }  // namespace std
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 std::ostream& DisplayListStreamDispatcher::startl() {
   for (int i = 0; i < cur_indent_; i++) {
@@ -978,5 +975,4 @@ void DisplayListStreamDispatcher::drawShadow(const DlPath& path,
 }
 // clang-format on
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing

--- a/testing/display_list_testing.h
+++ b/testing/display_list_testing.h
@@ -11,8 +11,7 @@
 #include "flutter/display_list/display_list.h"
 #include "flutter/display_list/dl_op_receiver.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 [[nodiscard]] bool DisplayListsEQ_Verbose(const DisplayList* a,
                                           const DisplayList* b);
@@ -37,8 +36,7 @@ namespace testing {
   return DisplayListsNE_Verbose(a.get(), b.get());
 }
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing
 
 namespace std {
 
@@ -84,8 +82,7 @@ extern std::ostream& operator<<(std::ostream& os, const flutter::DlPath& path);
 
 }  // namespace std
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 class DisplayListStreamDispatcher final : public DlOpReceiver {
  public:
@@ -609,7 +606,6 @@ class DisplayListGeneralReceiver : public DlOpReceiver {
   uint32_t op_count_ = 0u;
 };
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_TESTING_DISPLAY_LIST_TESTING_H_

--- a/testing/elf_loader.cc
+++ b/testing/elf_loader.cc
@@ -11,8 +11,7 @@
 #include "flutter/runtime/dart_vm.h"
 #include "flutter/testing/testing.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 ELFAOTSymbols LoadELFSymbolFromFixturesIfNeccessary(std::string elf_filename) {
   if (!DartVM::IsRunningPrecompiledCode()) {
@@ -135,5 +134,4 @@ bool PrepareSettingsForAOTWithSymbols(Settings& settings,
   return true;
 }
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing

--- a/testing/elf_loader.h
+++ b/testing/elf_loader.h
@@ -11,8 +11,7 @@
 #include "flutter/fml/macros.h"
 #include "third_party/dart/runtime/bin/elf_loader.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 inline constexpr const char* kDefaultAOTAppELFFileName = "app_elf_snapshot.so";
 
@@ -81,7 +80,6 @@ ELFAOTSymbols LoadELFSplitSymbolFromFixturesIfNeccessary(
 bool PrepareSettingsForAOTWithSymbols(Settings& settings,
                                       const ELFAOTSymbols& symbols);
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_TESTING_ELF_LOADER_H_

--- a/testing/fixture_test.cc
+++ b/testing/fixture_test.cc
@@ -8,8 +8,7 @@
 
 #include "flutter/testing/dart_fixture.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 FixtureTest::FixtureTest() : DartFixture() {}
 
@@ -20,5 +19,4 @@ FixtureTest::FixtureTest(std::string kernel_filename,
                   std::move(elf_filename),
                   std::move(elf_split_filename)) {}
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing

--- a/testing/fixture_test.h
+++ b/testing/fixture_test.h
@@ -7,8 +7,7 @@
 
 #include "flutter/testing/dart_fixture.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 class FixtureTest : public DartFixture, public ThreadTest {
  public:
@@ -24,7 +23,6 @@ class FixtureTest : public DartFixture, public ThreadTest {
   FML_DISALLOW_COPY_AND_ASSIGN(FixtureTest);
 };
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_TESTING_FIXTURE_TEST_H_

--- a/testing/post_task_sync.cc
+++ b/testing/post_task_sync.cc
@@ -6,8 +6,7 @@
 
 #include "flutter/fml/synchronization/waitable_event.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 void PostTaskSync(const fml::RefPtr<fml::TaskRunner>& task_runner,
                   const std::function<void()>& function) {
@@ -19,5 +18,4 @@ void PostTaskSync(const fml::RefPtr<fml::TaskRunner>& task_runner,
   latch.Wait();
 }
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing

--- a/testing/post_task_sync.h
+++ b/testing/post_task_sync.h
@@ -7,13 +7,11 @@
 
 #include "flutter/fml/task_runner.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 void PostTaskSync(const fml::RefPtr<fml::TaskRunner>& task_runner,
                   const std::function<void()>& function);
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_TESTING_POST_TASK_SYNC_H_

--- a/testing/stream_capture.cc
+++ b/testing/stream_capture.cc
@@ -4,8 +4,7 @@
 
 #include "flutter/testing/stream_capture.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 StreamCapture::StreamCapture(std::ostream* ostream)
     : ostream_(ostream), old_buffer_(ostream_->rdbuf()) {
@@ -27,5 +26,4 @@ std::string StreamCapture::GetOutput() const {
   return buffer_.str();
 }
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing

--- a/testing/stream_capture.h
+++ b/testing/stream_capture.h
@@ -9,8 +9,7 @@
 #include <sstream>
 #include <string>
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 // Temporarily replaces the specified stream's output buffer to capture output.
 //
@@ -41,7 +40,6 @@ class StreamCapture {
   std::streambuf* old_buffer_;
 };
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_TESTING_STREAM_CAPTURE_H_

--- a/testing/test_args.cc
+++ b/testing/test_args.cc
@@ -4,8 +4,7 @@
 
 #include "flutter/testing/test_args.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 static fml::CommandLine gProcessArgs;
 
@@ -17,5 +16,4 @@ void SetArgsForProcess(int argc, char** argv) {
   gProcessArgs = fml::CommandLineFromArgcArgv(argc, argv);
 }
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing

--- a/testing/test_args.h
+++ b/testing/test_args.h
@@ -7,14 +7,12 @@
 
 #include "flutter/fml/command_line.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 const fml::CommandLine& GetArgsForProcess();
 
 void SetArgsForProcess(int argc, char** argv);
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_TESTING_TEST_ARGS_H_

--- a/testing/test_dart_native_resolver.cc
+++ b/testing/test_dart_native_resolver.cc
@@ -11,8 +11,7 @@
 #include "third_party/tonic/logging/dart_error.h"
 #include "tonic/converter/dart_converter.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 TestDartNativeResolver::TestDartNativeResolver() = default;
 
@@ -124,5 +123,4 @@ void TestDartNativeResolver::SetNativeResolverForIsolate() {
   }
 }
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing

--- a/testing/test_dart_native_resolver.h
+++ b/testing/test_dart_native_resolver.h
@@ -23,8 +23,7 @@
     return entrypoint;                                                      \
   })()
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 using NativeEntry = std::function<void(Dart_NativeArguments)>;
 
@@ -56,7 +55,6 @@ class TestDartNativeResolver
   FML_DISALLOW_COPY_AND_ASSIGN(TestDartNativeResolver);
 };
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_TESTING_TEST_DART_NATIVE_RESOLVER_H_

--- a/testing/test_gl_surface.cc
+++ b/testing/test_gl_surface.cc
@@ -24,8 +24,7 @@
 #include "third_party/skia/include/gpu/ganesh/gl/GrGLDirectContext.h"
 #include "third_party/skia/include/gpu/ganesh/gl/GrGLTypes.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 static std::string GetEGLError() {
   std::stringstream stream;
@@ -433,5 +432,4 @@ bool TestGLSurface::MakeResourceCurrent() {
   return result == EGL_TRUE;
 }
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing

--- a/testing/test_gl_surface.h
+++ b/testing/test_gl_surface.h
@@ -12,8 +12,7 @@
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/ganesh/GrDirectContext.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 struct TestEGLContext {
   explicit TestEGLContext();
@@ -96,7 +95,6 @@ class TestGLSurface : public TestGLOnscreenOnlySurface {
   FML_DISALLOW_COPY_AND_ASSIGN(TestGLSurface);
 };
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_TESTING_TEST_GL_SURFACE_H_

--- a/testing/test_metal_context.h
+++ b/testing/test_metal_context.h
@@ -12,7 +12,7 @@
 #include "third_party/skia/include/gpu/ganesh/GrDirectContext.h"
 #include "third_party/skia/include/ports/SkCFObject.h"
 
-namespace flutter {
+namespace flutter::testing {
 
 struct MetalObjCFields;
 
@@ -48,6 +48,6 @@ class TestMetalContext {
   std::map<int64_t, sk_cfp<void*>> textures_;  // guarded by textures_mutex
 };
 
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_TESTING_TEST_METAL_CONTEXT_H_

--- a/testing/test_metal_context.mm
+++ b/testing/test_metal_context.mm
@@ -15,7 +15,7 @@
 
 static_assert(__has_feature(objc_arc), "ARC must be enabled.");
 
-namespace flutter {
+namespace flutter::testing {
 
 // TOOD(cbracken): https://github.com/flutter/flutter/issues/157942
 struct MetalObjCFields {
@@ -133,4 +133,4 @@ TestMetalContext::TextureInfo TestMetalContext::GetTextureInfo(int64_t texture_i
   }
 }
 
-}  // namespace flutter
+}  // namespace flutter::testing

--- a/testing/test_metal_surface.h
+++ b/testing/test_metal_surface.h
@@ -11,7 +11,7 @@
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/ganesh/GrDirectContext.h"
 
-namespace flutter {
+namespace flutter::testing {
 
 //------------------------------------------------------------------------------
 /// @brief      Creates a MTLTexture backed SkSurface and context that can be
@@ -53,6 +53,6 @@ class TestMetalSurface {
   FML_DISALLOW_COPY_AND_ASSIGN(TestMetalSurface);
 };
 
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_TESTING_TEST_METAL_SURFACE_H_

--- a/testing/test_metal_surface.mm
+++ b/testing/test_metal_surface.mm
@@ -9,7 +9,7 @@
 
 #include "third_party/skia/include/core/SkSurface.h"
 
-namespace flutter {
+namespace flutter::testing {
 
 bool TestMetalSurface::PlatformSupportsMetal() {
   return true;
@@ -52,4 +52,4 @@ TestMetalContext::TextureInfo TestMetalSurface::GetTextureInfo() {
   return impl_ ? impl_->GetTextureInfo() : TestMetalContext::TextureInfo();
 }
 
-}  // namespace flutter
+}  // namespace flutter::testing

--- a/testing/test_metal_surface_impl.h
+++ b/testing/test_metal_surface_impl.h
@@ -11,7 +11,7 @@
 
 #include "third_party/skia/include/core/SkSurface.h"
 
-namespace flutter {
+namespace flutter::testing {
 
 class TestMetalSurfaceImpl : public TestMetalSurface {
  public:
@@ -52,6 +52,6 @@ class TestMetalSurfaceImpl : public TestMetalSurface {
   FML_DISALLOW_COPY_AND_ASSIGN(TestMetalSurfaceImpl);
 };
 
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_TESTING_TEST_METAL_SURFACE_IMPL_H_

--- a/testing/test_metal_surface_impl.mm
+++ b/testing/test_metal_surface_impl.mm
@@ -22,7 +22,7 @@
 
 static_assert(__has_feature(objc_arc), "ARC must be enabled.");
 
-namespace flutter {
+namespace flutter::testing {
 
 void TestMetalSurfaceImpl::Init(const TestMetalContext::TextureInfo& texture_info,
                                 const SkISize& surface_size) {
@@ -121,4 +121,4 @@ TestMetalContext::TextureInfo TestMetalSurfaceImpl::GetTextureInfo() {
   return IsValid() ? texture_info_ : TestMetalContext::TextureInfo();
 }
 
-}  // namespace flutter
+}  // namespace flutter::testing

--- a/testing/test_metal_surface_unittests.mm
+++ b/testing/test_metal_surface_unittests.mm
@@ -6,8 +6,7 @@
 #include "flutter/testing/test_metal_surface.h"
 #include "flutter/testing/testing.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 #ifdef SHELL_ENABLE_METAL
 
@@ -37,5 +36,4 @@ TEST(TestMetalSurface, CanCreateValidTestMetalSurface) {
 
 #endif
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing

--- a/testing/test_timeout_listener.cc
+++ b/testing/test_timeout_listener.cc
@@ -7,8 +7,7 @@
 #include <map>
 #include <sstream>
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 class PendingTests : public std::enable_shared_from_this<PendingTests> {
  public:
@@ -120,5 +119,4 @@ void TestTimeoutListener::OnTestEnd(const ::testing::TestInfo& test_info) {
       });
 }
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing

--- a/testing/test_timeout_listener.h
+++ b/testing/test_timeout_listener.h
@@ -12,8 +12,7 @@
 #include "flutter/fml/thread.h"
 #include "flutter/testing/testing.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 class PendingTests;
 
@@ -38,7 +37,6 @@ class TestTimeoutListener : public ::testing::EmptyTestEventListener {
   FML_DISALLOW_COPY_AND_ASSIGN(TestTimeoutListener);
 };
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_TESTING_TEST_TIMEOUT_LISTENER_H_

--- a/testing/test_vulkan_context.cc
+++ b/testing/test_vulkan_context.cc
@@ -22,8 +22,7 @@
 #include "third_party/skia/include/gpu/vk/VulkanExtensions.h"
 #include "vulkan/vulkan_core.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 TestVulkanContext::TestVulkanContext() {
   // ---------------------------------------------------------------------------
@@ -185,5 +184,4 @@ sk_sp<GrDirectContext> TestVulkanContext::GetGrDirectContext() const {
   return context_;
 }
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing

--- a/testing/test_vulkan_context.h
+++ b/testing/test_vulkan_context.h
@@ -15,8 +15,7 @@
 #include "third_party/skia/include/core/SkSize.h"
 #include "third_party/skia/include/gpu/ganesh/GrDirectContext.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 class TestVulkanContext : public fml::RefCountedThreadSafe<TestVulkanContext> {
  public:
@@ -42,7 +41,6 @@ class TestVulkanContext : public fml::RefCountedThreadSafe<TestVulkanContext> {
   FML_DISALLOW_COPY_AND_ASSIGN(TestVulkanContext);
 };
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_TESTING_TEST_VULKAN_CONTEXT_H_

--- a/testing/test_vulkan_image.cc
+++ b/testing/test_vulkan_image.cc
@@ -6,8 +6,7 @@
 
 #include "flutter/testing/test_vulkan_context.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 TestVulkanImage::TestVulkanImage() = default;
 
@@ -20,5 +19,4 @@ VkImage TestVulkanImage::GetImage() {
   return image_;
 }
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing

--- a/testing/test_vulkan_image.h
+++ b/testing/test_vulkan_image.h
@@ -11,8 +11,7 @@
 #include "flutter/vulkan/procs/vulkan_handle.h"
 #include "third_party/skia/include/core/SkSize.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 class TestVulkanContext;
 
@@ -40,7 +39,6 @@ class TestVulkanImage {
   friend TestVulkanContext;
 };
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_TESTING_TEST_VULKAN_IMAGE_H_

--- a/testing/test_vulkan_surface.cc
+++ b/testing/test_vulkan_surface.cc
@@ -16,8 +16,7 @@
 #include "third_party/skia/include/gpu/ganesh/vk/GrVkBackendSurface.h"
 #include "third_party/skia/include/gpu/ganesh/vk/GrVkTypes.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 TestVulkanSurface::TestVulkanSurface(TestVulkanImage&& image)
     : image_(std::move(image)){};
@@ -110,5 +109,4 @@ VkImage TestVulkanSurface::GetImage() {
   return image_.GetImage();
 }
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing

--- a/testing/test_vulkan_surface.h
+++ b/testing/test_vulkan_surface.h
@@ -13,9 +13,7 @@
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/ganesh/GrDirectContext.h"
 
-namespace flutter {
-
-namespace testing {
+namespace flutter::testing {
 
 class TestVulkanSurface {
  public:
@@ -36,7 +34,6 @@ class TestVulkanSurface {
   sk_sp<SkSurface> surface_;
 };
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_TESTING_TEST_VULKAN_SURFACE_H_

--- a/testing/testing.cc
+++ b/testing/testing.cc
@@ -9,8 +9,7 @@
 #include "flutter/fml/file.h"
 #include "flutter/fml/paths.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 std::string GetCurrentTestName() {
   return ::testing::UnitTest::GetInstance()->current_test_info()->name();
@@ -121,5 +120,4 @@ bool MemsetPatternSetOrCheck(std::vector<uint8_t>& buffer, MemsetPatternOp op) {
   return MemsetPatternSetOrCheck(buffer.data(), buffer.size(), op);
 }
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing

--- a/testing/testing.h
+++ b/testing/testing.h
@@ -14,8 +14,7 @@
 #include "gtest/gtest.h"
 #include "third_party/skia/include/core/SkData.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 const char* GetSourcePath();
 
@@ -115,7 +114,6 @@ bool MemsetPatternSetOrCheck(uint8_t* buffer, size_t size, MemsetPatternOp op);
 
 bool MemsetPatternSetOrCheck(std::vector<uint8_t>& buffer, MemsetPatternOp op);
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_TESTING_TESTING_H_

--- a/testing/thread_test.cc
+++ b/testing/thread_test.cc
@@ -6,8 +6,8 @@
 
 #include "flutter/testing/thread_test.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
+
 namespace {
 
 fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
@@ -31,5 +31,4 @@ fml::RefPtr<fml::TaskRunner> ThreadTest::CreateNewThread(
   return runner;
 }
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing

--- a/testing/thread_test.h
+++ b/testing/thread_test.h
@@ -14,8 +14,7 @@
 #include "flutter/fml/thread.h"
 #include "gtest/gtest.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 //------------------------------------------------------------------------------
 /// @brief      A fixture that creates threads with running message loops that
@@ -65,7 +64,6 @@ class ThreadTest : public ::testing::Test {
   FML_DISALLOW_COPY_AND_ASSIGN(ThreadTest);
 };
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_TESTING_THREAD_TEST_H_


### PR DESCRIPTION
The Metal context/surface code was only in the `flutter` namespace but should have been in `flutter::testing` for consistency with everything else in the `testing` directory.

Also squashes the declarations in the rest of that directory to match the style guide while I've got the macro still handy.


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I did not list at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
