### PR TITLE
[Impeller] dont apply opacity peephole to runtime effect.

### DIFF
--- a/impeller/display_list/paint.cc
+++ b/impeller/display_list/paint.cc
@@ -11,6 +11,7 @@
 #include "display_list/geometry/dl_path.h"
 #include "fml/logging.h"
 #include "impeller/display_list/color_filter.h"
+#include "impeller/display_list/image_filter.h"
 #include "impeller/display_list/skia_conversions.h"
 #include "impeller/entity/contents/color_source_contents.h"
 #include "impeller/entity/contents/conical_gradient_contents.h"
@@ -33,6 +34,22 @@ using DlPoint = flutter::DlPoint;
 using DlRect = flutter::DlRect;
 using DlIRect = flutter::DlIRect;
 using DlPath = flutter::DlPath;
+
+// static
+bool Paint::CanApplyOpacityPeephole(const Paint& paint) {
+  if (paint.blend_mode != BlendMode::kSourceOver) {
+    return false;
+  }
+  if (paint.invert_colors || paint.mask_blur_descriptor.has_value() ||
+      paint.image_filter || paint.color_filter) {
+    return false;
+  }
+  if (paint.color_source && paint.color_source->type() ==
+                                flutter::DlColorSourceType::kRuntimeEffect) {
+    return false;
+  }
+  return true;
+}
 
 std::shared_ptr<ColorSourceContents> Paint::CreateContents() const {
   if (color_source == nullptr) {

--- a/impeller/display_list/paint.h
+++ b/impeller/display_list/paint.h
@@ -10,15 +10,12 @@
 #include "display_list/effects/dl_color_filter.h"
 #include "display_list/effects/dl_color_source.h"
 #include "display_list/effects/dl_image_filter.h"
-#include "impeller/display_list/color_filter.h"
-#include "impeller/display_list/image_filter.h"
 #include "impeller/entity/contents/color_source_contents.h"
 #include "impeller/entity/contents/contents.h"
 #include "impeller/entity/contents/filters/color_filter_contents.h"
 #include "impeller/entity/contents/filters/filter_contents.h"
 #include "impeller/entity/contents/texture_contents.h"
 #include "impeller/entity/entity.h"
-#include "impeller/entity/geometry/geometry.h"
 #include "impeller/geometry/color.h"
 
 namespace impeller {
@@ -36,12 +33,7 @@ struct Paint {
 
   /// @brief Whether or not a save layer with the provided paint can perform the
   ///        opacity peephole optimization.
-  static bool CanApplyOpacityPeephole(const Paint& paint) {
-    return paint.blend_mode == BlendMode::kSourceOver &&
-           paint.invert_colors == false &&
-           !paint.mask_blur_descriptor.has_value() &&
-           paint.image_filter == nullptr && paint.color_filter == nullptr;
-  }
+  static bool CanApplyOpacityPeephole(const Paint& paint);
 
   enum class Style {
     kFill,

--- a/impeller/entity/contents/solid_color_contents.h
+++ b/impeller/entity/contents/solid_color_contents.h
@@ -44,10 +44,6 @@ class SolidColorContents final : public ColorSourceContents {
 
  private:
   Color color_;
-
-  SolidColorContents(const SolidColorContents&) = delete;
-
-  SolidColorContents& operator=(const SolidColorContents&) = delete;
 };
 
 }  // namespace impeller

--- a/impeller/entity/contents/solid_color_contents.h
+++ b/impeller/entity/contents/solid_color_contents.h
@@ -44,6 +44,10 @@ class SolidColorContents final : public ColorSourceContents {
 
  private:
   Color color_;
+
+  SolidColorContents(const SolidColorContents&) = delete;
+
+  SolidColorContents& operator=(const SolidColorContents&) = delete;
 };
 
 }  // namespace impeller


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/158500

Runtime effect cannot accept opacity.
