### PR TITLE
[fuchsia] MaybeRunInitialVsyncCallback should only called once (#56429)

### DIFF
--- a/shell/platform/fuchsia/flutter/flatland_connection.h
+++ b/shell/platform/fuchsia/flutter/flatland_connection.h
@@ -137,7 +137,7 @@ class FlatlandConnection final {
     fml::TimePoint last_presentation_time_;
     FireCallbackCallback pending_fire_callback_;
     uint32_t present_credits_ = 1;
-    bool first_feedback_received_ = false;
+    bool initial_vsync_callback_ran_ = false;
   } threadsafe_state_;
 
   // Acquire fences sent to Flatland.


### PR DESCRIPTION
Currently, flutter keeps calling MaybeRunInitialVsyncCallback() until 1 OnNextFrameBegin() called from Fuchsia which maybe problem when display is off.

Tested manually.

Bug: http://fxbug.dev/376079469

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*
b/376079469

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
