### PR TITLE
Move SetRenderTargetType to EmbedderTestCompositor

### DIFF
--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -287,7 +287,7 @@ FlutterCompositor& EmbedderConfigBuilder::GetCompositor() {
 void EmbedderConfigBuilder::SetRenderTargetType(
     EmbedderTestBackingStoreProducer::RenderTargetType type,
     FlutterSoftwarePixelFormat software_pixfmt) {
-  context_.SetRenderTargetType(type, software_pixfmt);
+  context_.GetCompositor().SetRenderTargetType(type, software_pixfmt);
 }
 
 UniqueEngine EmbedderConfigBuilder::LaunchEngine() const {

--- a/shell/platform/embedder/tests/embedder_test_compositor.cc
+++ b/shell/platform/embedder/tests/embedder_test_compositor.cc
@@ -51,11 +51,6 @@ bool EmbedderTestCompositor::CollectBackingStore(
   return true;
 }
 
-void EmbedderTestCompositor::SetBackingStoreProducer(
-    std::unique_ptr<EmbedderTestBackingStoreProducer> backingstore_producer) {
-  backingstore_producer_ = std::move(backingstore_producer);
-}
-
 sk_sp<SkImage> EmbedderTestCompositor::GetLastComposition() {
   return last_composition_;
 }

--- a/shell/platform/embedder/tests/embedder_test_compositor.h
+++ b/shell/platform/embedder/tests/embedder_test_compositor.h
@@ -29,8 +29,9 @@ class EmbedderTestCompositor {
 
   virtual ~EmbedderTestCompositor();
 
-  void SetBackingStoreProducer(
-      std::unique_ptr<EmbedderTestBackingStoreProducer> backingstore_producer);
+  virtual void SetRenderTargetType(
+      EmbedderTestBackingStoreProducer::RenderTargetType type,
+      FlutterSoftwarePixelFormat software_pixfmt) = 0;
 
   bool CreateBackingStore(const FlutterBackingStoreConfig* config,
                           FlutterBackingStore* backing_store_out);

--- a/shell/platform/embedder/tests/embedder_test_compositor_gl.h
+++ b/shell/platform/embedder/tests/embedder_test_compositor_gl.h
@@ -5,21 +5,30 @@
 #ifndef FLUTTER_SHELL_PLATFORM_EMBEDDER_TESTS_EMBEDDER_TEST_COMPOSITOR_GL_H_
 #define FLUTTER_SHELL_PLATFORM_EMBEDDER_TESTS_EMBEDDER_TEST_COMPOSITOR_GL_H_
 
+#include <memory>
+
 #include "flutter/fml/macros.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/embedder/tests/embedder_test_compositor.h"
+#include "flutter/testing/test_gl_surface.h"
 
 namespace flutter {
 namespace testing {
 
 class EmbedderTestCompositorGL : public EmbedderTestCompositor {
  public:
-  EmbedderTestCompositorGL(SkISize surface_size,
+  EmbedderTestCompositorGL(std::shared_ptr<TestEGLContext> egl_context,
+                           SkISize surface_size,
                            sk_sp<GrDirectContext> context);
 
   ~EmbedderTestCompositorGL() override;
 
+  void SetRenderTargetType(
+      EmbedderTestBackingStoreProducer::RenderTargetType type,
+      FlutterSoftwarePixelFormat software_pixfmt) override;
+
  private:
+  std::shared_ptr<TestEGLContext> egl_context_;
   bool UpdateOffscrenComposition(const FlutterLayer** layers,
                                  size_t layers_count) override;
 

--- a/shell/platform/embedder/tests/embedder_test_compositor_metal.h
+++ b/shell/platform/embedder/tests/embedder_test_compositor_metal.h
@@ -19,6 +19,10 @@ class EmbedderTestCompositorMetal : public EmbedderTestCompositor {
 
   ~EmbedderTestCompositorMetal() override;
 
+  void SetRenderTargetType(
+      EmbedderTestBackingStoreProducer::RenderTargetType type,
+      FlutterSoftwarePixelFormat software_pixfmt) override;
+
  private:
   bool UpdateOffscrenComposition(const FlutterLayer** layers,
                                  size_t layers_count) override;

--- a/shell/platform/embedder/tests/embedder_test_compositor_metal.mm
+++ b/shell/platform/embedder/tests/embedder_test_compositor_metal.mm
@@ -20,6 +20,26 @@ EmbedderTestCompositorMetal::EmbedderTestCompositorMetal(SkISize surface_size,
 
 EmbedderTestCompositorMetal::~EmbedderTestCompositorMetal() = default;
 
+void EmbedderTestCompositorMetal::SetRenderTargetType(
+    EmbedderTestBackingStoreProducer::RenderTargetType type,
+    FlutterSoftwarePixelFormat software_pixfmt) {
+  switch (type) {
+    case EmbedderTestBackingStoreProducer::RenderTargetType::kMetalTexture:
+      // no-op.
+      break;
+    case EmbedderTestBackingStoreProducer::RenderTargetType::kOpenGLFramebuffer:
+    case EmbedderTestBackingStoreProducer::RenderTargetType::kOpenGLSurface:
+    case EmbedderTestBackingStoreProducer::RenderTargetType::kOpenGLTexture:
+    case EmbedderTestBackingStoreProducer::RenderTargetType::kSoftwareBuffer:
+    case EmbedderTestBackingStoreProducer::RenderTargetType::kSoftwareBuffer2:
+    case EmbedderTestBackingStoreProducer::RenderTargetType::kVulkanImage:
+      FML_LOG(FATAL) << "Unsupported render target type: " << static_cast<int>(type);
+      break;
+  }
+  backingstore_producer_ =
+      std::make_unique<EmbedderTestBackingStoreProducer>(context_, type, software_pixfmt);
+}
+
 bool EmbedderTestCompositorMetal::UpdateOffscrenComposition(const FlutterLayer** layers,
                                                             size_t layers_count) {
   last_composition_ = nullptr;

--- a/shell/platform/embedder/tests/embedder_test_compositor_software.cc
+++ b/shell/platform/embedder/tests/embedder_test_compositor_software.cc
@@ -17,6 +17,27 @@ EmbedderTestCompositorSoftware::EmbedderTestCompositorSoftware(
 
 EmbedderTestCompositorSoftware::~EmbedderTestCompositorSoftware() = default;
 
+void EmbedderTestCompositorSoftware::SetRenderTargetType(
+    EmbedderTestBackingStoreProducer::RenderTargetType type,
+    FlutterSoftwarePixelFormat software_pixfmt) {
+  switch (type) {
+    case EmbedderTestBackingStoreProducer::RenderTargetType::kSoftwareBuffer:
+    case EmbedderTestBackingStoreProducer::RenderTargetType::kSoftwareBuffer2:
+      // no-op.
+      break;
+    case EmbedderTestBackingStoreProducer::RenderTargetType::kMetalTexture:
+    case EmbedderTestBackingStoreProducer::RenderTargetType::kOpenGLFramebuffer:
+    case EmbedderTestBackingStoreProducer::RenderTargetType::kOpenGLSurface:
+    case EmbedderTestBackingStoreProducer::RenderTargetType::kOpenGLTexture:
+    case EmbedderTestBackingStoreProducer::RenderTargetType::kVulkanImage:
+      FML_LOG(FATAL) << "Unsupported render target type: "
+                     << static_cast<int>(type);
+      break;
+  }
+  backingstore_producer_ = std::make_unique<EmbedderTestBackingStoreProducer>(
+      context_, type, software_pixfmt);
+}
+
 bool EmbedderTestCompositorSoftware::UpdateOffscrenComposition(
     const FlutterLayer** layers,
     size_t layers_count) {

--- a/shell/platform/embedder/tests/embedder_test_compositor_software.h
+++ b/shell/platform/embedder/tests/embedder_test_compositor_software.h
@@ -16,6 +16,10 @@ class EmbedderTestCompositorSoftware : public EmbedderTestCompositor {
 
   ~EmbedderTestCompositorSoftware() override;
 
+  void SetRenderTargetType(
+      EmbedderTestBackingStoreProducer::RenderTargetType type,
+      FlutterSoftwarePixelFormat software_pixfmt) override;
+
  private:
   bool UpdateOffscrenComposition(const FlutterLayer** layers,
                                  size_t layers_count);

--- a/shell/platform/embedder/tests/embedder_test_compositor_vulkan.cc
+++ b/shell/platform/embedder/tests/embedder_test_compositor_vulkan.cc
@@ -22,6 +22,27 @@ EmbedderTestCompositorVulkan::EmbedderTestCompositorVulkan(
 
 EmbedderTestCompositorVulkan::~EmbedderTestCompositorVulkan() = default;
 
+void EmbedderTestCompositorVulkan::SetRenderTargetType(
+    EmbedderTestBackingStoreProducer::RenderTargetType type,
+    FlutterSoftwarePixelFormat software_pixfmt) {
+  switch (type) {
+    case EmbedderTestBackingStoreProducer::RenderTargetType::kVulkanImage:
+      // no-op.
+      break;
+    case EmbedderTestBackingStoreProducer::RenderTargetType::kMetalTexture:
+    case EmbedderTestBackingStoreProducer::RenderTargetType::kOpenGLFramebuffer:
+    case EmbedderTestBackingStoreProducer::RenderTargetType::kOpenGLSurface:
+    case EmbedderTestBackingStoreProducer::RenderTargetType::kOpenGLTexture:
+    case EmbedderTestBackingStoreProducer::RenderTargetType::kSoftwareBuffer:
+    case EmbedderTestBackingStoreProducer::RenderTargetType::kSoftwareBuffer2:
+      FML_LOG(FATAL) << "Unsupported render target type: "
+                     << static_cast<int>(type);
+      break;
+  }
+  backingstore_producer_ = std::make_unique<EmbedderTestBackingStoreProducer>(
+      context_, type, software_pixfmt);
+}
+
 bool EmbedderTestCompositorVulkan::UpdateOffscrenComposition(
     const FlutterLayer** layers,
     size_t layers_count) {

--- a/shell/platform/embedder/tests/embedder_test_compositor_vulkan.h
+++ b/shell/platform/embedder/tests/embedder_test_compositor_vulkan.h
@@ -19,6 +19,10 @@ class EmbedderTestCompositorVulkan : public EmbedderTestCompositor {
 
   ~EmbedderTestCompositorVulkan() override;
 
+  void SetRenderTargetType(
+      EmbedderTestBackingStoreProducer::RenderTargetType type,
+      FlutterSoftwarePixelFormat software_pixfmt) override;
+
  private:
   bool UpdateOffscrenComposition(const FlutterLayer** layers,
                                  size_t layers_count) override;

--- a/shell/platform/embedder/tests/embedder_test_context.cc
+++ b/shell/platform/embedder/tests/embedder_test_context.cc
@@ -96,32 +96,6 @@ void EmbedderTestContext::SetRootSurfaceTransformation(SkMatrix matrix) {
   root_surface_transformation_ = matrix;
 }
 
-void EmbedderTestContext::SetRenderTargetType(
-    EmbedderTestBackingStoreProducer::RenderTargetType type,
-    FlutterSoftwarePixelFormat software_pixfmt) {
-  // TODO(wrightgeorge): figure out a better way of plumbing through the
-  // GrDirectContext
-  auto& compositor = GetCompositor();
-  auto producer = std::make_unique<EmbedderTestBackingStoreProducer>(
-      compositor.GetGrContext(), type, software_pixfmt);
-#ifdef SHELL_ENABLE_GL
-  switch (type) {
-    case EmbedderTestBackingStoreProducer::RenderTargetType::kOpenGLFramebuffer:
-    case EmbedderTestBackingStoreProducer::RenderTargetType::kOpenGLTexture:
-    case EmbedderTestBackingStoreProducer::RenderTargetType::kOpenGLSurface:
-      producer->SetEGLContext(egl_context_);
-      break;
-    case EmbedderTestBackingStoreProducer::RenderTargetType::kSoftwareBuffer:
-    case EmbedderTestBackingStoreProducer::RenderTargetType::kSoftwareBuffer2:
-    case EmbedderTestBackingStoreProducer::RenderTargetType::kMetalTexture:
-    case EmbedderTestBackingStoreProducer::RenderTargetType::kVulkanImage:
-      // no-op.
-      break;
-  }
-#endif  // SHELL_ENABLE_GL
-  compositor.SetBackingStoreProducer(std::move(producer));
-}
-
 void EmbedderTestContext::AddIsolateCreateCallback(
     const fml::closure& closure) {
   if (closure) {

--- a/shell/platform/embedder/tests/embedder_test_context_gl.cc
+++ b/shell/platform/embedder/tests/embedder_test_context_gl.cc
@@ -140,7 +140,7 @@ void EmbedderTestContextGL::SetupCompositor() {
   FML_CHECK(gl_surface_)
       << "Set up the GL surface before setting up a compositor.";
   compositor_ = std::make_unique<EmbedderTestCompositorGL>(
-      gl_surface_->GetSurfaceSize(), gl_surface_->GetGrContext());
+      egl_context_, gl_surface_->GetSurfaceSize(), gl_surface_->GetGrContext());
   GLClearCurrent();
 }
 


### PR DESCRIPTION
SetRenderTargetType is used to configure the backingstore producer on the compositor, but the backingstore types available to any given compositor are limited to the specific graphics backend in use: Software, GL, Metal, or Vulkan.

This moves SetRenderTargetType to EmbedderTestCompositor and its subclasses and adds RenderTargetType validation. A follow-up patch will refactor EmbedderTestBackingStoreProducer into backend-specific subclasses.

For OpenGL backingstore producers, the egl_context_ from EmbedderTestContext (which is actually set in the EmbedderTestContextGL subclass and should live there, but that's a separate cleanup) is required in SetRenderTargetType, so we now inject it into EmbedderTestCompositor in the constructor so it's available when needed.

Issue: https://github.com/flutter/flutter/issues/158998

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I did not list at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
