### PR TITLE
[Impeller] Allow per call debug error checking and logging.

### DIFF
--- a/impeller/renderer/backend/gles/proc_table_gles.cc
+++ b/impeller/renderer/backend/gles/proc_table_gles.cc
@@ -436,7 +436,7 @@ void ProcTableGLES::RegisterProc(GLProcBase* proc) {
 }
 
 void ProcTableGLES::IterateDebugProcs(
-    std::function<bool(GLProcBase*)> iterator) const {
+    const std::function<bool(GLProcBase*)>& iterator) const {
   if (!iterator) {
     return;
   }

--- a/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/impeller/renderer/backend/gles/proc_table_gles.h
@@ -405,7 +405,8 @@ class ProcTableGLES {
 
   ProcTableGLES& operator=(const ProcTableGLES&) = delete;
 
-  void IterateDebugProcs(std::function<bool(GLProcBase*)> iterator) const;
+  void IterateDebugProcs(
+      const std::function<bool(GLProcBase*)>& iterator) const;
 
   void RegisterProc(GLProcBase* proc);
 };

--- a/impeller/renderer/backend/gles/test/proc_table_gles_unittests.cc
+++ b/impeller/renderer/backend/gles/test/proc_table_gles_unittests.cc
@@ -33,5 +33,39 @@ TEST(ProcTableGLES, ResolvesCorrectClearDepthProcOnDesktopGL) {
   FOR_EACH_IMPELLER_ES_ONLY_PROC(EXPECT_UNAVAILABLE);
 }
 
+TEST(ProcTableGLES, DebuggingOptionsAreRespected) {
+#ifndef IMPELLER_DEBUG
+  if ((true)) {
+    GTEST_SKIP() << "Debugging is only available in IMPELLER_DEBUG";
+  }
+#endif  // IMPELLER_DEBUG
+  auto mock_gles = MockGLES::Init(std::nullopt, "OpenGL ES 3.0");
+  auto& gl = mock_gles->GetProcTable();
+  // Check call logging.
+  {
+    gl.SetDebugGLCallLogging(false);
+    ASSERT_FALSE(gl.Clear.log_calls);
+    gl.SetDebugGLCallLogging(true);
+    ASSERT_TRUE(gl.Clear.log_calls);
+    gl.SetDebugGLCallLogging(false);
+    ASSERT_FALSE(gl.Clear.log_calls);
+    gl.SetDebugGLCallLogging(true, "glClear");
+    ASSERT_TRUE(gl.Clear.log_calls);
+    gl.SetDebugGLCallLogging(false, "glClear");
+    ASSERT_FALSE(gl.Clear.log_calls);
+  }
+  // Check error checking.
+  {
+    gl.SetDebugGLErrorChecking(true);
+    ASSERT_NE(gl.Clear.error_fn, nullptr);
+    gl.SetDebugGLErrorChecking(false);
+    ASSERT_EQ(gl.Clear.error_fn, nullptr);
+    gl.SetDebugGLErrorChecking(true, "glClear");
+    ASSERT_NE(gl.Clear.error_fn, nullptr);
+    gl.SetDebugGLErrorChecking(false, "glClear");
+    ASSERT_EQ(gl.Clear.error_fn, nullptr);
+  }
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/impeller/toolkit/glvk/proc_table.h
+++ b/impeller/toolkit/glvk/proc_table.h
@@ -87,7 +87,8 @@ class ProcTable {
   ///
   bool IsValid() const;
 
-#define GLVK_PROC(name) GLProc<decltype(gl##name)> name = {"gl" #name, nullptr};
+#define GLVK_PROC(name) \
+  GLProc<decltype(gl##name)> name = GLProc<decltype(gl##name)>("gl" #name);
 
   FOR_EACH_GLVK_PROC(GLVK_PROC);
 

--- a/impeller/toolkit/interop/context.cc
+++ b/impeller/toolkit/interop/context.cc
@@ -108,4 +108,44 @@ AiksContext& Context::GetAiksContext() {
   return context_;
 }
 
+void Context::SetDebugGLCallLogging(const char* function_name_or_null,
+                                    bool enable) {
+#if IMPELLER_ENABLE_OPENGLES
+  if (context_.GetContext()->GetBackendType() !=
+      impeller::Context::BackendType::kOpenGLES) {
+    VALIDATION_LOG << "Not an OpenGL context.";
+    return;
+  }
+  auto& gl =
+      ContextGLES::Cast(*context_.GetContext()).GetReactor()->GetProcTable();
+  if (function_name_or_null == nullptr) {
+    gl.SetDebugGLCallLogging(enable);
+  } else {
+    gl.SetDebugGLCallLogging(enable, function_name_or_null);
+  }
+#else   // IMPELLER_ENABLE_OPENGLES
+  VALIDATION_LOG << "OpenGL unavailable."
+#endif  // IMPELLER_ENABLE_OPENGLES
+}
+
+void Context::SetDebugGLErrorChecking(const char* function_name_or_null,
+                                      bool enable) {
+#if IMPELLER_ENABLE_OPENGLES
+  if (context_.GetContext()->GetBackendType() !=
+      impeller::Context::BackendType::kOpenGLES) {
+    VALIDATION_LOG << "Not an OpenGL context.";
+    return;
+  }
+  auto& gl =
+      ContextGLES::Cast(*context_.GetContext()).GetReactor()->GetProcTable();
+  if (function_name_or_null == nullptr) {
+    gl.SetDebugGLErrorChecking(enable);
+  } else {
+    gl.SetDebugGLErrorChecking(enable, function_name_or_null);
+  }
+#else   // IMPELLER_ENABLE_OPENGLES
+  VALIDATION_LOG << "OpenGL unavailable."
+#endif  // IMPELLER_ENABLE_OPENGLES
+}
+
 }  // namespace impeller::interop

--- a/impeller/toolkit/interop/context.h
+++ b/impeller/toolkit/interop/context.h
@@ -37,6 +37,10 @@ class Context final
 
   AiksContext& GetAiksContext();
 
+  void SetDebugGLCallLogging(const char* function_name_or_null, bool enable);
+
+  void SetDebugGLErrorChecking(const char* function_name_or_null, bool enable);
+
  private:
   impeller::AiksContext context_;
   std::shared_ptr<BackendData> backend_data_;

--- a/impeller/toolkit/interop/impeller.cc
+++ b/impeller/toolkit/interop/impeller.cc
@@ -1152,4 +1152,18 @@ bool ImpellerTypographyContextRegisterFont(ImpellerTypographyContext context,
                                         family_name_alias);
 }
 
+IMPELLER_EXTERN_C
+void ImpellerContextSetDebugGLCallLogging(ImpellerContext context,
+                                          const char* opengl_function_name,
+                                          bool enable) {
+  GetPeer(context)->SetDebugGLCallLogging(opengl_function_name, enable);
+}
+
+IMPELLER_EXTERN_C
+void ImpellerContextSetDebugGLErrorChecking(ImpellerContext context,
+                                            const char* opengl_function_name,
+                                            bool enable) {
+  GetPeer(context)->SetDebugGLErrorChecking(opengl_function_name, enable);
+}
+
 }  // namespace impeller::interop

--- a/impeller/toolkit/interop/impeller.h
+++ b/impeller/toolkit/interop/impeller.h
@@ -626,6 +626,71 @@ ImpellerContextCreateOpenGLESNew(
     void* IMPELLER_NULLABLE gl_proc_address_callback_user_data);
 
 //------------------------------------------------------------------------------
+/// @brief      Only available in instrumented builds with IMPELLER_DEBUG
+///             enabled, setting GL call logging will log all OpenGL calls along
+///             with their arguments.
+///
+///             This becomes spammy and is only meant to be used as a debugging
+///             aid in environments where traditional graphics debuggers like
+///             RenderDoc are not available.
+///
+///             If the function name is NULL, the option applies to all OpenGL
+///             calls made by Impeller.
+///
+///             Only calls made by Impeller will be logged. Impeller doesn't
+///             know about OpenGL calls made by the embedder.
+///
+///             Expect logging in the form of:
+///
+///             ```
+///             glDepthMask(1)
+///             glViewport(0, 0, 2048, 1536)
+///             glDepthRangef(0, 1)
+///             glDisable(2884)
+///             glFrontFace(2304)
+///             ```
+///
+///             This function does nothing if the context is not an OpenGL
+///             context.
+///
+/// @param[in]  context               The context
+/// @param[in]  opengl_function_name  The opengl function name or NULL if the
+///                                   option must be set for all OpenGL methods.
+/// @param[in]  enable                If logging must be enabled.
+///
+IMPELLER_EXPORT void ImpellerContextSetDebugGLCallLogging(
+    ImpellerContext IMPELLER_NONNULL context,
+    const char* IMPELLER_NULLABLE opengl_function_name,
+    bool enable);
+
+//------------------------------------------------------------------------------
+/// @brief      Only available in instrumented builds with IMPELLER_DEBUG
+///             enabled, setting GL error checking will trap on all OpenGL error
+///             after OpenGL calls made by Impeller.
+///
+///             There is appreciable overhead to this form of debugging and it
+///             must only be used in environments where traditional graphics
+///             debuggers like RenderDoc are not available.
+///
+///             If the function name is NULL, the option applies to all OpenGL
+///             calls made by Impeller.
+///
+///             Only calls made by Impeller will be logged. Impeller doesn't
+///             know about OpenGL calls made by the embedder.
+///
+///             This function does nothing if the context is not an OpenGL
+///             context.
+///
+/// @param[in]  context               The context
+/// @param[in]  opengl_function_name  The opengl function name
+/// @param[in]  enable                The enable
+///
+IMPELLER_EXPORT void ImpellerContextSetDebugGLErrorChecking(
+    ImpellerContext IMPELLER_NONNULL context,
+    const char* IMPELLER_NULLABLE opengl_function_name,
+    bool enable);
+
+//------------------------------------------------------------------------------
 /// @brief      Retain a strong reference to the object. The object can be NULL
 ///             in which case this method is a no-op.
 ///


### PR DESCRIPTION
In the OpenGL backend, the following behavior now applies:

If `IMPELLER_DEBUG` is unset (`release` runtime mode only):
* Zero overhead during GL function dispatch. All flag checks and validations are compiled away.

If `IMPELLER_DEBUG` is set (`debug` and `profile` runtime modes only):
* Debugging options are checked for error checking, call logging, and thread checking. Except thread checking for `UseProgram`, **all options are false out of the box**. The only overhead is the checking of the flags that are expected to be false.
* Options for individual procs or the entire table can be toggled at runtime.

If `IMPELLER_DEBUG` is set and `UNOPT` modes are enabled:
* Debug error checking is enabled out of the box. This is @gaaclarke s preference and matches previous behavior.

The difference between this and what is on ToT is that debugging is now available in OPT modes but the flags that enable checking are off by default (in OPT modes).

Wires up debugging options for the libImpeller.

This effectively backs out https://github.com/flutter/engine/pull/54016
