### PR TITLE
Revert "Remove `android_jit_release_x86`."

### DIFF
--- a/ci/builders/linux_android_debug_engine.json
+++ b/ci/builders/linux_android_debug_engine.json
@@ -11,6 +11,46 @@
         {
             "archives": [
                 {
+                    "name": "ci/android_jit_release_x86",
+                    "type": "gcs",
+                    "base_path": "out/ci/android_jit_release_x86/zip_archives/",
+                    "include_paths": [
+                        "out/ci/android_jit_release_x86/zip_archives/android-x86-jit-release/artifacts.zip",
+                        "out/ci/android_jit_release_x86/zip_archives/download.flutter.io"
+                    ],
+                    "realm": "production"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/android_jit_release_x86",
+                "--android",
+                "--android-cpu=x86",
+                "--runtime-mode=jit_release",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/android_jit_release_x86",
+            "description": "Produces jit-release mode artifacts to target x86 Android from a Linux host.",
+            "ninja": {
+                "config": "ci/android_jit_release_x86",
+                "targets": [
+                    "flutter",
+                    "flutter/shell/platform/android:embedding_jars",
+                    "flutter/shell/platform/android:abi_jars"
+                ]
+            }
+        },
+        {
+            "archives": [
+                {
                     "name": "ci/android_debug",
                     "type": "gcs",
                     "base_path": "out/ci/android_debug/zip_archives/",

--- a/ci/builders/linux_unopt.json
+++ b/ci/builders/linux_unopt.json
@@ -281,6 +281,52 @@
             },
             "gn": [
                 "--target-dir",
+                "ci/android_jit_release_x86_test",
+                "--android",
+                "--android-cpu=x86",
+                "--runtime-mode=jit_release",
+                "--rbe",
+                "--no-goma"
+            ],
+            "name": "ci/android_jit_release_x86_test",
+            "description": "Produces jit-release mode artifacts to target x86 Android from a Linux host.",
+            "ninja": {
+                "config": "ci/android_jit_release_x86_test",
+                "targets": [
+                    "flutter",
+                    "flutter/shell/platform/android:embedding_jars",
+                    "flutter/shell/platform/android:abi_jars",
+                    "flutter/shell/platform/android:robolectric_tests"
+                ]
+            },
+            "tests": [
+                {
+                    "language": "python3",
+                    "name": "Host Tests for android_jit_release_x86_test",
+                    "script": "flutter/testing/run_tests.py",
+                    "parameters": [
+                        "--variant",
+                        "ci/android_jit_release_x86_test",
+                        "--type",
+                        "java",
+                        "--engine-capture-core-dump",
+                        "--android-variant",
+                        "ci/android_jit_release_x86_test"
+                    ]
+                }
+            ]
+        },
+        {
+            "cas_archive": false,
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
                 "ci/android_debug_test",
                 "--android",
                 "--android-cpu=arm",

--- a/docs/JIT-Release-Modes.md
+++ b/docs/JIT-Release-Modes.md
@@ -1,0 +1,15 @@
+Normally Flutter runs in JIT for faster compilation/debugging support in `debug` mode and AOT mode for better performance in `profile` and `release` mode. For platforms that Flutter cannot produce AOT artifacts for, such as Android x86 (32 bit), a JIT release build may be used instead. The advantage of this mode over a regular debug build is that it removes debugging support and disables assertions which makes the final artifact smaller and more performant, though less so than a full AOT build.
+
+
+JIT release mode can be used with a local engine configuration. For example, to setup an Android x86 jit_release and host build you can use the GN command below. Both device and host artifacts need to be built, except in cases where they are the same such as the Desktop shells.
+
+```shell
+./flutter/tools/gn --runtime-mode=jit_release --android --android-cpu=x86
+ninja -C out/android_jit_release_x86
+./flutter/tools/gn --runtime-mode=jit_release
+ninja -C out/host_jit_release
+```
+
+This can be used with the flutter tool [via the `--local-engine`](Debugging-the-engine.md#running-a-flutter-app-with-a-local-engine) flag to produce a bundle containing the jit release artifacts using the `flutter assemble` command. By default, flutter.gradle does not know how to package this artifacts so it requires custom integration into a build pipeline. Nevertheless, the artifact structure should be identical to a debug build, but with asserts disabled and product mode enabled.
+
+jit_release is not supported on iOS devices. Applications built in JIT mode cannot be distributed on the Apple App Store.


### PR DESCRIPTION
Reverts flutter/engine#56548

Failing roll to the framework, the tool is still looking for these artifacts.