### PR TITLE
[ios]fix unused variable clang tidy warning

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -237,7 +237,7 @@ FLUTTER_ASSERT_ARC
   @autoreleasepool {
     FlutterEngine* flutterEngine = OCMClassMock([FlutterEngine class]);
     weakFlutterEngine = flutterEngine;
-    NSAssert(weakFlutterEngine, @"flutter engine must not be nil");
+    XCTAssertNotNil(weakFlutterEngine, @"flutter engine must not be nil");
     FlutterTextInputPlugin* flutterTextInputPlugin = [[FlutterTextInputPlugin alloc]
         initWithDelegate:(id<FlutterTextInputDelegate>)flutterEngine];
     weakFlutterTextInputPlugin = flutterTextInputPlugin;
@@ -254,8 +254,8 @@ FLUTTER_ASSERT_ARC
     currentView = flutterTextInputPlugin.activeView;
   }
 
-  NSAssert(!weakFlutterEngine, @"flutter engine must be nil");
-  NSAssert(currentView, @"current view must not be nil");
+  XCTAssertNil(weakFlutterEngine, @"flutter engine must be nil");
+  XCTAssertNotNil(currentView, @"current view must not be nil");
 
   XCTAssertNil(weakFlutterTextInputPlugin);
   // Verify that the view can no longer access the deallocated engine/text input plugin


### PR DESCRIPTION
Spot another clang-tidy linter failure from: https://github.com/flutter/engine/pull/56631

In release mode, if we remove NSAssert, then weakFlutterEngine is not used at all. This should have been an XCTAssert rather than NSAssert in the first place. 

```
❌ Failures for clang-tidy on /Volumes/Work/s/w/ir/cache/builder/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm:
/Volumes/Work/s/w/ir/cache/builder/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm:239:5: error: Value stored to 'weakFlutterEngine' is never read [clang-analyzer-deadcode.DeadStores,-warnings-as-errors]
  239 |     weakFlutterEngine = flutterEngine;
      |     ^                   ~~~~~~~~~~~~~
/Volumes/Work/s/w/ir/cache/builder/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm:239:5: note: Value stored to 'weakFlutterEngine' is never read
  239 |     weakFlutterEngine = flutterEngine;
      |     ^                   ~~~~~~~~~~~~~
Suppressed 9240 warnings (9111 in non-user code, 129 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
```


*List which issues are fixed by this PR. You must list at least one issue.*
https://github.com/flutter/flutter/issues/157837

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
