### PR TITLE
EmbedderTest: Extract backend-specific user_data

### DIFF
--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.h
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.h
@@ -21,29 +21,6 @@ namespace flutter::testing {
 
 class EmbedderTestBackingStoreProducer {
  public:
-  struct UserData {
-    UserData() : surface(nullptr), image(nullptr){};
-
-    explicit UserData(sk_sp<SkSurface> surface)
-        : surface(std::move(surface)), image(nullptr){};
-
-    UserData(sk_sp<SkSurface> surface, FlutterVulkanImage* vk_image)
-        : surface(std::move(surface)), image(vk_image){};
-
-    sk_sp<SkSurface> surface;
-    FlutterVulkanImage* image;
-#ifdef SHELL_ENABLE_GL
-    UserData(sk_sp<SkSurface> surface,
-             FlutterVulkanImage* vk_image,
-             std::unique_ptr<TestGLOnscreenOnlySurface> gl_surface)
-        : surface(std::move(surface)),
-          image(vk_image),
-          gl_surface(std::move(gl_surface)){};
-
-    std::unique_ptr<TestGLOnscreenOnlySurface> gl_surface;
-#endif
-  };
-
   enum class RenderTargetType {
     kSoftwareBuffer,
     kSoftwareBuffer2,
@@ -60,6 +37,12 @@ class EmbedderTestBackingStoreProducer {
 
   virtual bool Create(const FlutterBackingStoreConfig* config,
                       FlutterBackingStore* backing_store_out) = 0;
+
+  virtual sk_sp<SkSurface> GetSurface(
+      const FlutterBackingStore* backing_store) const = 0;
+
+  virtual sk_sp<SkImage> MakeImageSnapshot(
+      const FlutterBackingStore* backing_store) const = 0;
 
  protected:
   sk_sp<GrDirectContext> context_;

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer_gl.h
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer_gl.h
@@ -23,8 +23,14 @@ class EmbedderTestBackingStoreProducerGL
 
   virtual ~EmbedderTestBackingStoreProducerGL();
 
-  virtual bool Create(const FlutterBackingStoreConfig* config,
-                      FlutterBackingStore* backing_store_out);
+  bool Create(const FlutterBackingStoreConfig* config,
+              FlutterBackingStore* backing_store_out) override;
+
+  sk_sp<SkSurface> GetSurface(
+      const FlutterBackingStore* backing_store) const override;
+
+  sk_sp<SkImage> MakeImageSnapshot(
+      const FlutterBackingStore* backing_store) const override;
 
  private:
   bool CreateFramebuffer(const FlutterBackingStoreConfig* config,

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer_metal.h
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer_metal.h
@@ -18,8 +18,14 @@ class EmbedderTestBackingStoreProducerMetal
 
   virtual ~EmbedderTestBackingStoreProducerMetal();
 
-  virtual bool Create(const FlutterBackingStoreConfig* config,
-                      FlutterBackingStore* backing_store_out);
+  bool Create(const FlutterBackingStoreConfig* config,
+              FlutterBackingStore* backing_store_out) override;
+
+  sk_sp<SkSurface> GetSurface(
+      const FlutterBackingStore* backing_store) const override;
+
+  sk_sp<SkImage> MakeImageSnapshot(
+      const FlutterBackingStore* backing_store) const override;
 
  private:
   std::unique_ptr<TestMetalContext> test_metal_context_;

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer_metal.mm
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer_metal.mm
@@ -4,6 +4,8 @@
 
 #include "flutter/shell/platform/embedder/tests/embedder_test_backingstore_producer_metal.h"
 
+#include <exception>
+
 #include "flutter/fml/logging.h"
 #include "third_party/skia/include/core/SkColorSpace.h"
 #include "third_party/skia/include/gpu/ganesh/GrBackendSurface.h"
@@ -54,6 +56,18 @@ bool EmbedderTestBackingStoreProducerMetal::Create(const FlutterBackingStoreConf
   };
 
   return true;
+}
+
+sk_sp<SkSurface> EmbedderTestBackingStoreProducerMetal::GetSurface(
+    const FlutterBackingStore* backing_store) const {
+  FML_LOG(FATAL) << "Unimplemented.";
+  std::terminate();
+}
+
+sk_sp<SkImage> EmbedderTestBackingStoreProducerMetal::MakeImageSnapshot(
+    const FlutterBackingStore* backing_store) const {
+  FML_LOG(FATAL) << "Unimplemented.";
+  std::terminate();
 }
 
 }  // namespace flutter::testing

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer_software.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer_software.cc
@@ -12,6 +12,12 @@
 
 namespace flutter::testing {
 
+namespace {
+struct UserData {
+  sk_sp<SkSurface> surface;
+};
+}  // namespace
+
 EmbedderTestBackingStoreProducerSoftware::
     EmbedderTestBackingStoreProducerSoftware(
         sk_sp<GrDirectContext> context,
@@ -46,6 +52,18 @@ bool EmbedderTestBackingStoreProducerSoftware::Create(
   }
 }
 
+sk_sp<SkSurface> EmbedderTestBackingStoreProducerSoftware::GetSurface(
+    const FlutterBackingStore* backing_store) const {
+  UserData* user_data = reinterpret_cast<UserData*>(backing_store->user_data);
+  return user_data->surface;
+}
+
+sk_sp<SkImage> EmbedderTestBackingStoreProducerSoftware::MakeImageSnapshot(
+    const FlutterBackingStore* backing_store) const {
+  auto user_data = reinterpret_cast<UserData*>(backing_store->user_data);
+  return user_data->surface->makeImageSnapshot();
+}
+
 bool EmbedderTestBackingStoreProducerSoftware::CreateSoftware(
     const FlutterBackingStoreConfig* config,
     FlutterBackingStore* backing_store_out) {
@@ -64,8 +82,7 @@ bool EmbedderTestBackingStoreProducerSoftware::CreateSoftware(
     return false;
   }
 
-  auto user_data = new UserData(surface);
-
+  auto user_data = new UserData{.surface = surface};
   backing_store_out->type = kFlutterBackingStoreTypeSoftware;
   backing_store_out->user_data = user_data;
   backing_store_out->software.allocation = pixmap.addr();
@@ -101,8 +118,7 @@ bool EmbedderTestBackingStoreProducerSoftware::CreateSoftware2(
     return false;
   }
 
-  auto user_data = new UserData(surface);
-
+  auto user_data = new UserData{.surface = surface};
   backing_store_out->type = kFlutterBackingStoreTypeSoftware2;
   backing_store_out->user_data = user_data;
   backing_store_out->software2.struct_size =

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer_software.h
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer_software.h
@@ -20,8 +20,14 @@ class EmbedderTestBackingStoreProducerSoftware
 
   virtual ~EmbedderTestBackingStoreProducerSoftware();
 
-  virtual bool Create(const FlutterBackingStoreConfig* config,
-                      FlutterBackingStore* backing_store_out);
+  bool Create(const FlutterBackingStoreConfig* config,
+              FlutterBackingStore* backing_store_out) override;
+
+  sk_sp<SkSurface> GetSurface(
+      const FlutterBackingStore* backing_store) const override;
+
+  sk_sp<SkImage> MakeImageSnapshot(
+      const FlutterBackingStore* backing_store) const override;
 
  private:
   bool CreateSoftware(const FlutterBackingStoreConfig* config,

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer_vulkan.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer_vulkan.cc
@@ -13,6 +13,13 @@
 
 namespace flutter::testing {
 
+namespace {
+struct UserData {
+  sk_sp<SkSurface> surface;
+  FlutterVulkanImage* image;
+};
+}  // namespace
+
 EmbedderTestBackingStoreProducerVulkan::EmbedderTestBackingStoreProducerVulkan(
     sk_sp<GrDirectContext> context,
     RenderTargetType type)
@@ -83,7 +90,7 @@ bool EmbedderTestBackingStoreProducerVulkan::Create(
 
   // Collect all allocated resources in the destruction_callback.
   {
-    auto user_data = new UserData(surface, image);
+    auto user_data = new UserData{.surface = surface, .image = image};
     backing_store_out->user_data = user_data;
     backing_store_out->vulkan.user_data = user_data;
     backing_store_out->vulkan.destruction_callback = [](void* user_data) {
@@ -94,6 +101,18 @@ bool EmbedderTestBackingStoreProducerVulkan::Create(
   }
 
   return true;
+}
+
+sk_sp<SkSurface> EmbedderTestBackingStoreProducerVulkan::GetSurface(
+    const FlutterBackingStore* backing_store) const {
+  UserData* user_data = reinterpret_cast<UserData*>(backing_store->user_data);
+  return user_data->surface;
+}
+
+sk_sp<SkImage> EmbedderTestBackingStoreProducerVulkan::MakeImageSnapshot(
+    const FlutterBackingStore* backing_store) const {
+  UserData* user_data = reinterpret_cast<UserData*>(backing_store->user_data);
+  return user_data->surface->makeImageSnapshot();
 }
 
 }  // namespace flutter::testing

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer_vulkan.h
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer_vulkan.h
@@ -19,8 +19,14 @@ class EmbedderTestBackingStoreProducerVulkan
 
   virtual ~EmbedderTestBackingStoreProducerVulkan();
 
-  virtual bool Create(const FlutterBackingStoreConfig* config,
-                      FlutterBackingStore* backing_store_out);
+  bool Create(const FlutterBackingStoreConfig* config,
+              FlutterBackingStore* backing_store_out) override;
+
+  sk_sp<SkSurface> GetSurface(
+      const FlutterBackingStore* backing_store) const override;
+
+  sk_sp<SkImage> MakeImageSnapshot(
+      const FlutterBackingStore* backing_store) const override;
 
  private:
   fml::RefPtr<TestVulkanContext> test_vulkan_context_;

--- a/shell/platform/embedder/tests/embedder_test_compositor.cc
+++ b/shell/platform/embedder/tests/embedder_test_compositor.cc
@@ -51,6 +51,11 @@ bool EmbedderTestCompositor::CollectBackingStore(
   return true;
 }
 
+sk_sp<SkSurface> EmbedderTestCompositor::GetSurface(
+    const FlutterBackingStore* backing_store) const {
+  return backingstore_producer_->GetSurface(backing_store);
+}
+
 sk_sp<SkImage> EmbedderTestCompositor::GetLastComposition() {
   return last_composition_;
 }

--- a/shell/platform/embedder/tests/embedder_test_compositor.h
+++ b/shell/platform/embedder/tests/embedder_test_compositor.h
@@ -45,6 +45,8 @@ class EmbedderTestCompositor {
   void SetPlatformViewRendererCallback(
       const PlatformViewRendererCallback& callback);
 
+  sk_sp<SkSurface> GetSurface(const FlutterBackingStore* backing_store) const;
+
   //----------------------------------------------------------------------------
   /// @brief      Allows tests to install a callback to notify them when the
   ///             entire render tree has been finalized so they can run their

--- a/shell/platform/embedder/tests/embedder_test_compositor_gl.cc
+++ b/shell/platform/embedder/tests/embedder_test_compositor_gl.cc
@@ -89,24 +89,8 @@ bool EmbedderTestCompositorGL::UpdateOffscrenComposition(
 
     switch (layer->type) {
       case kFlutterLayerContentTypeBackingStore: {
-        auto gl_user_data =
-            reinterpret_cast<EmbedderTestBackingStoreProducer::UserData*>(
-                layer->backing_store->user_data);
-
-        if (gl_user_data->gl_surface != nullptr) {
-          // This backing store is a OpenGL Surface.
-          // We need to make it current so we can snapshot it.
-
-          gl_user_data->gl_surface->MakeCurrent();
-
-          // GetRasterSurfaceSnapshot() does two
-          // gl_surface->makeImageSnapshot()'s. Doing a single
-          // ->makeImageSnapshot() will not work.
-          layer_image = gl_user_data->gl_surface->GetRasterSurfaceSnapshot();
-        } else {
-          layer_image = gl_user_data->surface->makeImageSnapshot();
-        }
-
+        layer_image =
+            backingstore_producer_->MakeImageSnapshot(layer->backing_store);
         // We don't clear the current surface here because we need the
         // EGL context to be current for surface->makeImageSnapshot() below.
         break;

--- a/shell/platform/embedder/tests/embedder_test_compositor_software.cc
+++ b/shell/platform/embedder/tests/embedder_test_compositor_software.cc
@@ -68,13 +68,11 @@ bool EmbedderTestCompositorSoftware::UpdateOffscrenComposition(
     SkIPoint canvas_offset = SkIPoint::Make(0, 0);
 
     switch (layer->type) {
-      case kFlutterLayerContentTypeBackingStore:
+      case kFlutterLayerContentTypeBackingStore: {
         layer_image =
-            reinterpret_cast<EmbedderTestBackingStoreProducer::UserData*>(
-                layer->backing_store->user_data)
-                ->surface->makeImageSnapshot();
-
+            backingstore_producer_->MakeImageSnapshot(layer->backing_store);
         break;
+      }
       case kFlutterLayerContentTypePlatformView:
         layer_image = platform_view_renderer_callback_
                           ? platform_view_renderer_callback_(*layer, nullptr)

--- a/shell/platform/embedder/tests/embedder_test_compositor_vulkan.cc
+++ b/shell/platform/embedder/tests/embedder_test_compositor_vulkan.cc
@@ -82,9 +82,7 @@ bool EmbedderTestCompositorVulkan::UpdateOffscrenComposition(
     switch (layer->type) {
       case kFlutterLayerContentTypeBackingStore:
         layer_image =
-            reinterpret_cast<EmbedderTestBackingStoreProducer::UserData*>(
-                layer->backing_store->user_data)
-                ->surface->makeImageSnapshot();
+            backingstore_producer_->MakeImageSnapshot(layer->backing_store);
         break;
       case kFlutterLayerContentTypePlatformView:
         layer_image =

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -2735,17 +2735,15 @@ static void expectSoftwareRenderingOutputMatches(
   ASSERT_TRUE(engine.is_valid());
 
   context.GetCompositor().SetNextPresentCallback(
-      [&matches, &bytes, &latch](FlutterViewId view_id,
-                                 const FlutterLayer** layers,
-                                 size_t layers_count) {
+      [&context, &matches, &bytes, &latch](FlutterViewId view_id,
+                                           const FlutterLayer** layers,
+                                           size_t layers_count) {
         ASSERT_EQ(layers[0]->type, kFlutterLayerContentTypeBackingStore);
         ASSERT_EQ(layers[0]->backing_store->type,
                   kFlutterBackingStoreTypeSoftware2);
-        matches = SurfacePixelDataMatchesBytes(
-            reinterpret_cast<EmbedderTestBackingStoreProducer::UserData*>(
-                layers[0]->backing_store->software2.user_data)
-                ->surface.get(),
-            bytes);
+        sk_sp<SkSurface> surface =
+            context.GetCompositor().GetSurface(layers[0]->backing_store);
+        matches = SurfacePixelDataMatchesBytes(surface.get(), bytes);
         latch.Signal();
       });
 


### PR DESCRIPTION
Replace the top-level public EmbedderBackingStoreProducer::UserData struct with backend-specific UserData classes, and make them internal to those backends. UserData internals shouldn't be visible to/manipulated by unit tests and compositors, but instead constrained to the backing store producer itself.

Issue: https://github.com/flutter/flutter/issues/158998

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
