### PR TITLE
iOS: Eliminate FlutterEngine dealloc notification

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -84,7 +84,6 @@ NSString* const FlutterDefaultInitialRoute = nil;
 
 #pragma mark - Internal constants
 
-NSString* const kFlutterEngineWillDealloc = @"FlutterEngineWillDealloc";
 NSString* const kFlutterKeyDataChannel = @"flutter/keydata";
 static constexpr int kNumProfilerSamplesPerSec = 5;
 
@@ -281,10 +280,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
       [object detachFromEngineForRegistrar:registrar];
     }
   }];
-
-  [[NSNotificationCenter defaultCenter] postNotificationName:kFlutterEngineWillDealloc
-                                                      object:self
-                                                    userInfo:nil];
 
   // nil out weak references.
   // TODO(cbracken): https://github.com/flutter/flutter/issues/156222

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineGroupTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineGroupTest.mm
@@ -37,11 +37,16 @@ FLUTTER_ASSERT_ARC
 }
 
 - (void)testDeleteLastEngine {
+  __weak FlutterEngine* weakSpawner;
   FlutterEngineGroup* group = [[FlutterEngineGroup alloc] initWithName:@"foo" project:nil];
   @autoreleasepool {
     FlutterEngine* spawner = [group makeEngineWithEntrypoint:nil libraryURI:nil];
+    weakSpawner = spawner;
     XCTAssertNotNil(spawner);
+    XCTAssertNotNil(weakSpawner);
   }
+  XCTAssertNil(weakSpawner);
+
   FlutterEngine* spawnee = [group makeEngineWithEntrypoint:nil libraryURI:nil];
   XCTAssertNotNil(spawnee);
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -262,23 +262,6 @@ FLUTTER_ASSERT_ARC
   XCTAssertNotNil(spawn);
 }
 
-- (void)testDeallocNotification {
-  XCTestExpectation* deallocNotification = [self expectationWithDescription:@"deallocNotification"];
-  NSNotificationCenter* center = [NSNotificationCenter defaultCenter];
-  id<NSObject> observer;
-  @autoreleasepool {
-    FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar"];
-    observer = [center addObserverForName:kFlutterEngineWillDealloc
-                                   object:engine
-                                    queue:[NSOperationQueue mainQueue]
-                               usingBlock:^(NSNotification* note) {
-                                 [deallocNotification fulfill];
-                               }];
-  }
-  [self waitForExpectations:@[ deallocNotification ]];
-  [center removeObserver:observer];
-}
-
 - (void)testSetHandlerAfterRun {
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar"];
   XCTestExpectation* gotMessage = [self expectationWithDescription:@"gotMessage"];

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -29,8 +29,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern NSString* const kFlutterEngineWillDealloc;
-
 @interface FlutterEngine () <FlutterViewEngineDelegate>
 
 - (flutter::Shell&)shell;

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine_Test.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine_Test.h
@@ -11,8 +11,6 @@
 #import "flutter/shell/platform/darwin/ios/rendering_api_selection.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 
-extern NSString* const kFlutterEngineWillDealloc;
-
 @class FlutterBinaryMessengerRelay;
 
 namespace flutter {


### PR DESCRIPTION
FlutterEngineGroup keeps an array of all live FlutterEngine instances it has created such that after the first engine, it can spawn further engines using the first.

Previously we manually managed this array by adding engines to it upon creation, then having [FlutterEngine dealloc] emit a notification such that FlutterEngineGroup can listen for it, and remove instances from the array upon reception of the notification.

Instead, we now use an NSPointerArray of of weak pointers such that pointers are automatically nilled out by ARC after the last strong reference is collected. This eliminates the need for the manual notification during dealloc.

Unfortunately, NSPointerArray is "clever" and assumes that if the array has not been mutated to store a nil pointer since its last compact call, it must not contain a nil pointer and can thus skip compaction. Under ARC, weak pointers are automatically nilled out when the last strong reference is released, so the above heuristic is no longer valid. We work around the issue by storing a nil pointer before calling compact.

See http://www.openradar.me/15396578 for the radar tracking this bug.

I'm not thrilled with the fact that we're replacing one sort of TODO with another, but the code is much simpler and avoids relying on a trip through the notification center, which seems objectively better.

Issue: https://github.com/flutter/flutter/issues/155943
Issue: https://github.com/flutter/flutter/issues/137801

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
