### PR TITLE
iOS: Clean up uses of string literal constants

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -4,6 +4,7 @@
 
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h"
 
+#include <CoreMedia/CoreMedia.h>
 #include <IOSurface/IOSurfaceObjC.h>
 #include <Metal/Metal.h>
 #include <UIKit/UIKit.h>
@@ -316,9 +317,9 @@ extern CFTimeInterval display_link_target;
 
   if (self.colorspace != nil) {
     CFStringRef name = CGColorSpaceGetName(self.colorspace);
-    IOSurfaceSetValue(res, CFSTR("IOSurfaceColorSpace"), name);
+    IOSurfaceSetValue(res, kIOSurfaceColorSpace, name);
   } else {
-    IOSurfaceSetValue(res, CFSTR("IOSurfaceColorSpace"), kCGColorSpaceSRGB);
+    IOSurfaceSetValue(res, kIOSurfaceColorSpace, kCGColorSpaceSRGB);
   }
   return (__bridge_transfer IOSurface*)res;
 }

--- a/shell/platform/darwin/ios/framework/Source/IOKit.h
+++ b/shell/platform/darwin/ios/framework/Source/IOKit.h
@@ -25,7 +25,7 @@ extern "C" {
 #define IOKIT
 #include <device/device_types.h>
 
-static const char* kIOServicePlane = "IOService";
+constexpr const char* kIOServicePlane = "IOService";
 
 typedef io_object_t io_registry_entry_t;
 typedef io_object_t io_service_t;

--- a/shell/platform/darwin/macos/framework/Source/FlutterSurface.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurface.mm
@@ -4,6 +4,7 @@
 
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterSurface.h"
 
+#import <CoreMedia/CoreMedia.h>
 #import <Metal/Metal.h>
 
 #import "flutter/fml/platform/darwin/cf_utils.h"
@@ -74,7 +75,7 @@
 }
 
 + (IOSurfaceRef)createIOSurfaceWithSize:(CGSize)size {
-  unsigned pixelFormat = 'BGRA';
+  unsigned pixelFormat = kCVPixelFormatType_32BGRA;
   unsigned bytesPerElement = 4;
 
   size_t bytesPerRow = IOSurfaceAlignProperty(kIOSurfaceBytesPerRow, size.width * bytesPerElement);
@@ -89,7 +90,7 @@
   };
 
   IOSurfaceRef res = IOSurfaceCreate((CFDictionaryRef)options);
-  IOSurfaceSetValue(res, CFSTR("IOSurfaceColorSpace"), kCGColorSpaceSRGB);
+  IOSurfaceSetValue(res, kIOSurfaceColorSpace, kCGColorSpaceSRGB);
   return res;
 }
 


### PR DESCRIPTION
Three changes related to string constants:

1. Uses the kIOSurfaceColorSpace constant, which is a CFStringRef pointing to the string "IOSurfaceColorSpace"

2. Uses the kCVPixelFormatType_32BGRA enum value from the CoreVideo headers (which is equal to 'BGRA') in place of hardcoding the string.

From the headers:
```
kCVPixelFormatType_32BGRA         = 'BGRA',     /* 32 bit BGRA */
```

3. Declares kIOServicePlane as a `constexpr const char*` rather than `static const char*`, this ensures only a single instance is created, rather than one per translation unit into which the header is included. This string is part of IOKit, but see the comment at the top of the header as to why it's apparently needed.

No test changes since there are no semantic changes.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
