### PR TITLE
iOS: Extract constant for CADisableMinimumFrameDurationOnPhone

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -2093,7 +2093,7 @@ extern NSNotificationName const FlutterViewControllerWillDealloc;
 
 - (void)testSetupKeyboardAnimationVsyncClientWillCreateNewVsyncClientForFlutterViewController {
   id bundleMock = OCMPartialMock([NSBundle mainBundle]);
-  OCMStub([bundleMock objectForInfoDictionaryKey:@"CADisableMinimumFrameDurationOnPhone"])
+  OCMStub([bundleMock objectForInfoDictionaryKey:kCADisableMinimumFrameDurationOnPhoneKey])
       .andReturn(@YES);
   id mockDisplayLinkManager = [OCMockObject mockForClass:[DisplayLinkManager class]];
   double maxFrameRate = 120;

--- a/shell/platform/darwin/ios/framework/Source/VsyncWaiterIosTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/VsyncWaiterIosTest.mm
@@ -53,7 +53,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(const std::string& name) {
   auto thread_task_runner = CreateNewThread("VsyncWaiterIosTest");
   auto callback = [](std::unique_ptr<flutter::FrameTimingsRecorder> recorder) {};
   id bundleMock = OCMPartialMock([NSBundle mainBundle]);
-  OCMStub([bundleMock objectForInfoDictionaryKey:@"CADisableMinimumFrameDurationOnPhone"])
+  OCMStub([bundleMock objectForInfoDictionaryKey:kCADisableMinimumFrameDurationOnPhoneKey])
       .andReturn(@YES);
   id mockDisplayLinkManager = [OCMockObject mockForClass:[DisplayLinkManager class]];
   double maxFrameRate = 120;
@@ -75,7 +75,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(const std::string& name) {
   auto thread_task_runner = CreateNewThread("VsyncWaiterIosTest");
   auto callback = [](std::unique_ptr<flutter::FrameTimingsRecorder> recorder) {};
   id bundleMock = OCMPartialMock([NSBundle mainBundle]);
-  OCMStub([bundleMock objectForInfoDictionaryKey:@"CADisableMinimumFrameDurationOnPhone"])
+  OCMStub([bundleMock objectForInfoDictionaryKey:kCADisableMinimumFrameDurationOnPhoneKey])
       .andReturn(@NO);
   id mockDisplayLinkManager = [OCMockObject mockForClass:[DisplayLinkManager class]];
   double maxFrameRate = 120;

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
@@ -11,6 +11,8 @@
 #include "flutter/shell/common/variable_refresh_rate_reporter.h"
 #include "flutter/shell/common/vsync_waiter.h"
 
+extern NSString* const kCADisableMinimumFrameDurationOnPhoneKey;
+
 @interface DisplayLinkManager : NSObject
 
 // Whether the max refresh rate on iPhone Pro-motion devices are enabled.

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
@@ -11,15 +11,24 @@
 #include "flutter/shell/common/variable_refresh_rate_reporter.h"
 #include "flutter/shell/common/vsync_waiter.h"
 
+//------------------------------------------------------------------------------
+/// @brief      Info.plist key enabling the full range of ProMotion refresh rates for CADisplayLink
+///             callbacks and CAAnimation animations in the app.
+///
+/// @see
+/// https://developer.apple.com/documentation/quartzcore/optimizing_promotion_refresh_rates_for_iphone_13_pro_and_ipad_pro#3885321
+///
 extern NSString* const kCADisableMinimumFrameDurationOnPhoneKey;
 
 @interface DisplayLinkManager : NSObject
 
-// Whether the max refresh rate on iPhone Pro-motion devices are enabled.
-// This reflects the value of `CADisableMinimumFrameDurationOnPhone` in the
-// info.plist file.
-//
-// Note on iPads that support Pro-motion, the max refresh rate is always enabled.
+//------------------------------------------------------------------------------
+/// @brief      Whether the max refresh rate on iPhone ProMotion devices are enabled. This reflects
+///             the value of `CADisableMinimumFrameDurationOnPhone` in the info.plist file. On iPads
+///             that support ProMotion, the max refresh rate is always enabled.
+///
+/// @return     YES if the max refresh rate on ProMotion devices is enabled.
+///
 @property(class, nonatomic, readonly) BOOL maxRefreshRateEnabledOnIPhone;
 
 //------------------------------------------------------------------------------

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -18,6 +18,8 @@
 
 FLUTTER_ASSERT_ARC
 
+NSString* const kCADisableMinimumFrameDurationOnPhoneKey = @"CADisableMinimumFrameDurationOnPhone";
+
 @interface VSyncClient ()
 @property(nonatomic, assign, readonly) double refreshRate;
 @end
@@ -170,7 +172,7 @@ double VsyncWaiterIOS::GetRefreshRate() const {
 }
 
 + (BOOL)maxRefreshRateEnabledOnIPhone {
-  return [[NSBundle.mainBundle objectForInfoDictionaryKey:@"CADisableMinimumFrameDurationOnPhone"]
+  return [[NSBundle.mainBundle objectForInfoDictionaryKey:kCADisableMinimumFrameDurationOnPhoneKey]
       boolValue];
 }
 


### PR DESCRIPTION
In our vsync waiter and related tests, we hardcode the "CADisableMinimumFrameDurationOnPhone" key in several places. This pulls those into a constant kCADisableMinimumFrameDurationOnPhoneKey declared in the vsync waiter header, which is non-public, and uses that instead.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
