### PR TITLE
iOS: Eliminate unnecessary use of NSClassFromString

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
@@ -42,7 +42,7 @@ FLUTTER_ASSERT_ARC
                           pixelFormat:(MTLPixelFormat)pixelFormat {
   self = [self init];
 
-  if ([self.layer isKindOfClass:NSClassFromString(@"CAMetalLayer")]) {
+  if ([self.layer isKindOfClass:[CAMetalLayer class]]) {
     self.layer.allowsGroupOpacity = NO;
     self.layer.contentsScale = contentsScale;
     self.layer.rasterizationScale = contentsScale;

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -2458,7 +2458,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
   // Find ForwardGestureRecognizer
   UIGestureRecognizer* forwardGectureRecognizer = nil;
   for (UIGestureRecognizer* gestureRecognizer in touchInteceptorView.gestureRecognizers) {
-    if ([gestureRecognizer isKindOfClass:NSClassFromString(@"ForwardingGestureRecognizer")]) {
+    if ([gestureRecognizer isKindOfClass:[ForwardingGestureRecognizer class]]) {
       forwardGectureRecognizer = gestureRecognizer;
       break;
     }
@@ -2525,7 +2525,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
   // Find ForwardGestureRecognizer
   UIGestureRecognizer* forwardGectureRecognizer = nil;
   for (UIGestureRecognizer* gestureRecognizer in touchInteceptorView.gestureRecognizers) {
-    if ([gestureRecognizer isKindOfClass:NSClassFromString(@"ForwardingGestureRecognizer")]) {
+    if ([gestureRecognizer isKindOfClass:[ForwardingGestureRecognizer class]]) {
       forwardGectureRecognizer = gestureRecognizer;
       break;
     }
@@ -2649,7 +2649,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
   // Find ForwardGestureRecognizer
   UIGestureRecognizer* forwardGectureRecognizer = nil;
   for (UIGestureRecognizer* gestureRecognizer in touchInteceptorView.gestureRecognizers) {
-    if ([gestureRecognizer isKindOfClass:NSClassFromString(@"ForwardingGestureRecognizer")]) {
+    if ([gestureRecognizer isKindOfClass:[ForwardingGestureRecognizer class]]) {
       forwardGectureRecognizer = gestureRecognizer;
       break;
     }
@@ -2763,7 +2763,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
   // Find ForwardGestureRecognizer
   UIGestureRecognizer* forwardGectureRecognizer = nil;
   for (UIGestureRecognizer* gestureRecognizer in touchInteceptorView.gestureRecognizers) {
-    if ([gestureRecognizer isKindOfClass:NSClassFromString(@"ForwardingGestureRecognizer")]) {
+    if ([gestureRecognizer isKindOfClass:[ForwardingGestureRecognizer class]]) {
       forwardGectureRecognizer = gestureRecognizer;
       break;
     }
@@ -2828,7 +2828,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
   // Find ForwardGestureRecognizer
   __block UIGestureRecognizer* forwardGestureRecognizer = nil;
   for (UIGestureRecognizer* gestureRecognizer in touchInteceptorView.gestureRecognizers) {
-    if ([gestureRecognizer isKindOfClass:NSClassFromString(@"ForwardingGestureRecognizer")]) {
+    if ([gestureRecognizer isKindOfClass:[ForwardingGestureRecognizer class]]) {
       forwardGestureRecognizer = gestureRecognizer;
       break;
     }
@@ -2851,7 +2851,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
   dispatch_async(dispatch_get_main_queue(), ^{
     // Re-query forward gesture recognizer since it's recreated.
     for (UIGestureRecognizer* gestureRecognizer in touchInteceptorView.gestureRecognizers) {
-      if ([gestureRecognizer isKindOfClass:NSClassFromString(@"ForwardingGestureRecognizer")]) {
+      if ([gestureRecognizer isKindOfClass:[ForwardingGestureRecognizer class]]) {
         forwardGestureRecognizer = gestureRecognizer;
         break;
       }
@@ -2873,7 +2873,7 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
   dispatch_async(dispatch_get_main_queue(), ^{
     // Re-query forward gesture recognizer since it's recreated.
     for (UIGestureRecognizer* gestureRecognizer in touchInteceptorView.gestureRecognizers) {
-      if ([gestureRecognizer isKindOfClass:NSClassFromString(@"ForwardingGestureRecognizer")]) {
+      if ([gestureRecognizer isKindOfClass:[ForwardingGestureRecognizer class]]) {
         forwardGestureRecognizer = gestureRecognizer;
         break;
       }

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -21,8 +21,6 @@
 #import "flutter/shell/platform/darwin/ios/framework/Source/platform_views_controller.h"
 #import "flutter/shell/platform/darwin/ios/ios_context.h"
 
-@class FlutterTouchInterceptingView;
-
 // A UIView that acts as a clipping mask for the |ChildClippingView|.
 //
 // On the [UIView drawRect:] method, this view performs a series of clipping operations and sets the
@@ -157,6 +155,46 @@
 @interface UIView (FirstResponder)
 // Returns YES if a view or any of its descendant view is the first responder. Returns NO otherwise.
 @property(nonatomic, readonly) BOOL flt_hasFirstResponderInViewHierarchySubtree;
+@end
+
+// This recognizer delays touch events from being dispatched to the responder chain until it failed
+// recognizing a gesture.
+//
+// We only fail this recognizer when asked to do so by the Flutter framework (which does so by
+// invoking an acceptGesture method on the platform_views channel). And this is how we allow the
+// Flutter framework to delay or prevent the embedded view from getting a touch sequence.
+@interface FlutterDelayingGestureRecognizer : UIGestureRecognizer <UIGestureRecognizerDelegate>
+
+// Indicates that if the `FlutterDelayingGestureRecognizer`'s state should be set to
+// `UIGestureRecognizerStateEnded` during next `touchesEnded` call.
+@property(nonatomic) BOOL shouldEndInNextTouchesEnded;
+
+// Indicates that the `FlutterDelayingGestureRecognizer`'s `touchesEnded` has been invoked without
+// setting the state to `UIGestureRecognizerStateEnded`.
+@property(nonatomic) BOOL touchedEndedWithoutBlocking;
+
+@property(nonatomic) UIGestureRecognizer* forwardingRecognizer;
+
+- (instancetype)initWithTarget:(id)target
+                        action:(SEL)action
+          forwardingRecognizer:(UIGestureRecognizer*)forwardingRecognizer;
+@end
+
+// While the FlutterDelayingGestureRecognizer is preventing touches from hitting the responder chain
+// the touch events are not arriving to the FlutterView (and thus not arriving to the Flutter
+// framework). We use this gesture recognizer to dispatch the events directly to the FlutterView
+// while during this phase.
+//
+// If the Flutter framework decides to dispatch events to the embedded view, we fail the
+// FlutterDelayingGestureRecognizer which sends the events up the responder chain. But since the
+// events are handled by the embedded view they are not delivered to the Flutter framework in this
+// phase as well. So during this phase as well the ForwardingGestureRecognizer dispatched the events
+// directly to the FlutterView.
+@interface ForwardingGestureRecognizer : UIGestureRecognizer <UIGestureRecognizerDelegate>
+- (instancetype)initWithTarget:(id)target
+       platformViewsController:
+           (fml::WeakPtr<flutter::PlatformViewsController>)platformViewsController;
+- (ForwardingGestureRecognizer*)recreateRecognizerWithTarget:(id)target;
 @end
 
 #endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERPLATFORMVIEWS_INTERNAL_H_

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -510,46 +510,6 @@ static BOOL _preparedOnce = NO;
 }
 @end
 
-// This recognizer delays touch events from being dispatched to the responder chain until it failed
-// recognizing a gesture.
-//
-// We only fail this recognizer when asked to do so by the Flutter framework (which does so by
-// invoking an acceptGesture method on the platform_views channel). And this is how we allow the
-// Flutter framework to delay or prevent the embedded view from getting a touch sequence.
-@interface FlutterDelayingGestureRecognizer : UIGestureRecognizer <UIGestureRecognizerDelegate>
-
-// Indicates that if the `FlutterDelayingGestureRecognizer`'s state should be set to
-// `UIGestureRecognizerStateEnded` during next `touchesEnded` call.
-@property(nonatomic) BOOL shouldEndInNextTouchesEnded;
-
-// Indicates that the `FlutterDelayingGestureRecognizer`'s `touchesEnded` has been invoked without
-// setting the state to `UIGestureRecognizerStateEnded`.
-@property(nonatomic) BOOL touchedEndedWithoutBlocking;
-
-@property(nonatomic) UIGestureRecognizer* forwardingRecognizer;
-
-- (instancetype)initWithTarget:(id)target
-                        action:(SEL)action
-          forwardingRecognizer:(UIGestureRecognizer*)forwardingRecognizer;
-@end
-
-// While the FlutterDelayingGestureRecognizer is preventing touches from hitting the responder chain
-// the touch events are not arriving to the FlutterView (and thus not arriving to the Flutter
-// framework). We use this gesture recognizer to dispatch the events directly to the FlutterView
-// while during this phase.
-//
-// If the Flutter framework decides to dispatch events to the embedded view, we fail the
-// FlutterDelayingGestureRecognizer which sends the events up the responder chain. But since the
-// events are handled by the embedded view they are not delivered to the Flutter framework in this
-// phase as well. So during this phase as well the ForwardingGestureRecognizer dispatched the events
-// directly to the FlutterView.
-@interface ForwardingGestureRecognizer : UIGestureRecognizer <UIGestureRecognizerDelegate>
-- (instancetype)initWithTarget:(id)target
-       platformViewsController:
-           (fml::WeakPtr<flutter::PlatformViewsController>)platformViewsController;
-- (ForwardingGestureRecognizer*)recreateRecognizerWithTarget:(id)target;
-@end
-
 @interface FlutterTouchInterceptingView ()
 @property(nonatomic, weak, readonly) UIView* embeddedView;
 @property(nonatomic, readonly) FlutterDelayingGestureRecognizer* delayingRecognizer;

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -40,7 +40,7 @@ FLUTTER_ASSERT_ARC
 }
 
 - (MTLPixelFormat)pixelFormat {
-  if ([self.layer isKindOfClass:NSClassFromString(@"CAMetalLayer")]) {
+  if ([self.layer isKindOfClass:[CAMetalLayer class]]) {
 // It is a known Apple bug that CAMetalLayer incorrectly reports its supported
 // SDKs. It is, in fact, available since iOS 8.
 #pragma clang diagnostic push
@@ -93,7 +93,7 @@ static void PrintWideGamutWarningOnce() {
 }
 
 - (void)layoutSubviews {
-  if ([self.layer isKindOfClass:NSClassFromString(@"CAMetalLayer")]) {
+  if ([self.layer isKindOfClass:[CAMetalLayer class]]) {
 // It is a known Apple bug that CAMetalLayer incorrectly reports its supported
 // SDKs. It is, in fact, available since iOS 8.
 #pragma clang diagnostic push

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewTest.mm
@@ -62,7 +62,7 @@ FLUTTER_ASSERT_ARC
   delegate.isUsingImpeller = NO;
   FlutterView* view = [[FlutterView alloc] initWithDelegate:delegate opaque:NO enableWideGamut:YES];
   [view layoutSubviews];
-  XCTAssertTrue([view.layer isKindOfClass:NSClassFromString(@"CAMetalLayer")]);
+  XCTAssertTrue([view.layer isKindOfClass:[CAMetalLayer class]]);
   CAMetalLayer* layer = (CAMetalLayer*)view.layer;
   XCTAssertEqual(layer.pixelFormat, MTLPixelFormatBGRA8Unorm);
 }


### PR DESCRIPTION
When performing `isKindOfClass` checks, we were occasionally looking up the class in question using `NSClassFromString()`, instead we now check against the class directly, which has the added benefit of being type-safe, and not succeptible to string typos.

Moves the declaration of ForwardingGestureRecognizer and FlutterDelayingGestureRecognizer to the FlutterPlatfomViews_Internal.h header, which is non-public.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
