### PR TITLE
iOS: Make FlutterViewController.engine a strong ref

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
@@ -233,7 +233,7 @@ FLUTTER_DARWIN_EXPORT
  * `FlutterViewController` is initialized with or a new `FlutterEngine` implicitly created if
  * no engine was supplied during initialization.
  */
-@property(weak, nonatomic, readonly) FlutterEngine* engine;
+@property(nonatomic, readonly) FlutterEngine* engine;
 
 /**
  * The `FlutterBinaryMessenger` associated with this FlutterViewController (used for communicating

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -153,7 +153,6 @@ typedef struct MouseState {
 @end
 
 @implementation FlutterViewController {
-  FlutterEngine* _engine;
   flutter::ViewportMetrics _viewportMetrics;
   MouseState _mouseState;
 }
@@ -300,10 +299,6 @@ typedef struct MouseState {
   // TODO(cbracken): https://github.com/flutter/flutter/issues/157140
   // Eliminate method calls in initializers and dealloc.
   [self setUpNotificationCenterObservers];
-}
-
-- (FlutterEngine*)engine {
-  return _engine;
 }
 
 - (void)setUpNotificationCenterObservers {


### PR DESCRIPTION
Previously, FlutterViewController.engine was declared as a weak readonly property, but we explicitly declared the `FlutterEngine* _engine` ivar as a strong reference in the implementation. This changes the property declaration to be strong and eliminates the now unnecessary ivar.

There is also no semantic change to FlutterViewController itself, since the `_engine` ivar had been manually declared as a strong reference.

There is no semantic change for users of FlutterViewController.engine since whether a user acquires a strong or weak reference to the engine is determined by whether they declare the pointer to which they assign it as strong or weak.

This also eliminates the need for the `engine` getter, which was only present to prevent a warning that the strong ivar didn't match the weak property declaration.

No changes to tests since this introduces no semantic changes.

Issue: https://github.com/flutter/flutter/issues/137801

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
