### PR TITLE
iOS: Clean up @synthesize directives / ivars

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.h
@@ -9,16 +9,20 @@
 
 /// Drop-in replacement (as far as Flutter is concerned) for CAMetalLayer
 /// that can present with transaction from a background thread.
+///
+/// Properties and method declarations must exactly match those in the
+/// CAMetalLayer interface declaration.
 @interface FlutterMetalLayer : CALayer
 
 @property(nullable, retain) id<MTLDevice> device;
-@property(nullable, readonly) id<MTLDevice> preferredDevice;
+@property(nullable, readonly)
+    id<MTLDevice> preferredDevice API_AVAILABLE(macos(10.15), ios(13.0), tvos(13.0))
+        API_UNAVAILABLE(watchos);
 @property MTLPixelFormat pixelFormat;
 @property BOOL framebufferOnly;
 @property CGSize drawableSize;
 @property BOOL presentsWithTransaction;
 @property(nullable) CGColorSpaceRef colorspace;
-@property BOOL wantsExtendedDynamicRangeContent;
 
 - (nullable id<CAMetalDrawable>)nextDrawable;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -56,11 +56,7 @@ extern CFTimeInterval display_link_target;
 
 @end
 
-@interface FlutterTexture : NSObject {
-  id<MTLTexture> _texture;
-  IOSurface* _surface;
-  CFTimeInterval _presentedTime;
-}
+@interface FlutterTexture : NSObject
 
 @property(readonly, nonatomic) id<MTLTexture> texture;
 @property(readonly, nonatomic) IOSurface* surface;
@@ -70,11 +66,6 @@ extern CFTimeInterval display_link_target;
 @end
 
 @implementation FlutterTexture
-
-@synthesize texture = _texture;
-@synthesize surface = _surface;
-@synthesize presentedTime = _presentedTime;
-@synthesize waitingForCompletion;
 
 - (instancetype)initWithTexture:(id<MTLTexture>)texture surface:(IOSurface*)surface {
   if (self = [super init]) {
@@ -185,13 +176,6 @@ extern CFTimeInterval display_link_target;
 @end
 
 @implementation FlutterMetalLayer
-
-@synthesize preferredDevice = _preferredDevice;
-@synthesize device = _device;
-@synthesize pixelFormat = _pixelFormat;
-@synthesize framebufferOnly = _framebufferOnly;
-@synthesize colorspace = _colorspace;
-@synthesize wantsExtendedDynamicRangeContent = _wantsExtendedDynamicRangeContent;
 
 - (instancetype)init {
   if (self = [super init]) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -662,6 +662,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 
 @implementation FlutterTextSelectionRect
 
+// Synthesize properties declared readonly in UITextSelectionRect.
 @synthesize rect = _rect;
 @synthesize writingDirection = _writingDirection;
 @synthesize containsStart = _containsStart;

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -79,6 +79,9 @@ typedef struct MouseState {
 @property(nonatomic, assign) BOOL isHomeIndicatorHidden;
 @property(nonatomic, assign) BOOL isPresentingViewControllerAnimating;
 
+// Internal state backing override of UIView.prefersStatusBarHidden.
+@property(nonatomic, assign) BOOL flutterPrefersStatusBarHidden;
+
 @property(nonatomic, strong) NSMutableSet<NSNumber*>* ongoingTouches;
 // This scroll view is a workaround to accommodate iOS 13 and higher.  There isn't a way to get
 // touches on the status bar to trigger scrolling to the top of a scroll view.  We place a
@@ -158,9 +161,13 @@ typedef struct MouseState {
   MouseState _mouseState;
 }
 
+// Synthesize properties with an overridden getter/setter.
 @synthesize viewOpaque = _viewOpaque;
 @synthesize displayingFlutterUI = _displayingFlutterUI;
-@synthesize prefersStatusBarHidden = _flutterPrefersStatusBarHidden;
+
+// TODO(dkwingsmt): https://github.com/flutter/flutter/issues/138168
+// No backing ivar is currently required; when multiple views are supported, we'll need to
+// synthesize the ivar and store the view identifier.
 @dynamic viewIdentifier;
 
 #pragma mark - Manage and override all designated initializers
@@ -2307,14 +2314,14 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 }
 
 - (void)setPrefersStatusBarHidden:(BOOL)hidden {
-  if (hidden != _flutterPrefersStatusBarHidden) {
-    _flutterPrefersStatusBarHidden = hidden;
+  if (hidden != self.flutterPrefersStatusBarHidden) {
+    self.flutterPrefersStatusBarHidden = hidden;
     [self setNeedsStatusBarAppearanceUpdate];
   }
 }
 
 - (BOOL)prefersStatusBarHidden {
-  return _flutterPrefersStatusBarHidden;
+  return self.flutterPrefersStatusBarHidden;
 }
 
 #pragma mark - Platform views

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -38,21 +38,26 @@ using namespace flutter::testing;
 /// Sometimes we have to use a custom mock to avoid retain cycles in OCMock.
 /// Used for testing low memory notification.
 @interface FlutterEnginePartialMock : FlutterEngine
+
 @property(nonatomic, strong) FlutterBasicMessageChannel* lifecycleChannel;
 @property(nonatomic, strong) FlutterBasicMessageChannel* keyEventChannel;
 @property(nonatomic, weak) FlutterViewController* viewController;
 @property(nonatomic, strong) FlutterTextInputPlugin* textInputPlugin;
 @property(nonatomic, assign) BOOL didCallNotifyLowMemory;
+
 - (FlutterTextInputPlugin*)textInputPlugin;
+
 - (void)sendKeyEvent:(const FlutterKeyEvent&)event
             callback:(nullable FlutterKeyEventCallback)callback
             userData:(nullable void*)userData;
 @end
 
 @implementation FlutterEnginePartialMock
-@synthesize viewController;
+
+// Synthesize properties declared readonly in FlutterEngine.
 @synthesize lifecycleChannel;
 @synthesize keyEventChannel;
+@synthesize viewController;
 @synthesize textInputPlugin;
 
 - (void)notifyLowMemory {

--- a/shell/platform/darwin/ios/framework/Source/TextInputSemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/TextInputSemanticsObject.mm
@@ -22,6 +22,7 @@ static const UIAccessibilityTraits kUIAccessibilityTraitUndocumentedEmptyLine = 
 
 @implementation FlutterInactiveTextInput
 
+// Synthesize properties declared in UITextInput protocol.
 @synthesize beginningOfDocument = _beginningOfDocument;
 @synthesize endOfDocument = _endOfDocument;
 @synthesize inputDelegate = _inputDelegate;

--- a/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponder.mm
@@ -29,6 +29,7 @@
 
 @implementation FlutterChannelKeyResponder
 
+// Synthesize properties declared in FlutterKeyPrimaryResponder protocol.
 @synthesize layoutMap;
 
 - (nonnull instancetype)initWithChannel:(nonnull FlutterBasicMessageChannel*)channel {

--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.mm
@@ -473,6 +473,7 @@ struct FlutterKeyPendingResponse {
 
 @implementation FlutterEmbedderKeyResponder
 
+// Synthesize properties declared in FlutterKeyPrimaryResponder protocol.
 @synthesize layoutMap;
 
 - (nonnull instancetype)initWithSendEvent:(FlutterSendEmbedderKeyEvent)sendEvent {

--- a/shell/platform/darwin/macos/framework/Source/FlutterMenuPluginTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMenuPluginTest.mm
@@ -25,6 +25,8 @@
 @end
 
 @implementation FakePluginRegistrar
+
+// Synthesize properties declared in FlutterPluginRegistrar protocol.
 @synthesize messenger;
 @synthesize textures;
 @synthesize view;

--- a/shell/platform/darwin/macos/framework/Source/FlutterThreadSynchronizerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterThreadSynchronizerTest.mm
@@ -28,8 +28,6 @@
   FlutterThreadSynchronizer* _synchronizer;
 }
 
-@synthesize synchronizer = _synchronizer;
-
 - (nullable instancetype)init {
   self = [super init];
   if (self != nil) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterVSyncWaiterTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterVSyncWaiterTest.mm
@@ -7,8 +7,7 @@
 
 #import "flutter/testing/testing.h"
 
-@interface TestDisplayLink : FlutterDisplayLink {
-}
+@interface TestDisplayLink : FlutterDisplayLink
 
 @property(nonatomic) CFTimeInterval nominalOutputRefreshPeriod;
 
@@ -16,20 +15,19 @@
 
 @implementation TestDisplayLink
 
+// Synthesize properties declared readonly in FlutterDisplayLink.
 @synthesize nominalOutputRefreshPeriod = _nominalOutputRefreshPeriod;
-@synthesize delegate = _delegate;
-@synthesize paused = _paused;
 
 - (instancetype)init {
   if (self = [super init]) {
-    _paused = YES;
+    self.paused = YES;
   }
   return self;
 }
 
 - (void)tickWithTimestamp:(CFTimeInterval)timestamp
           targetTimestamp:(CFTimeInterval)targetTimestamp {
-  [_delegate onDisplayLink:timestamp targetTimestamp:targetTimestamp];
+  [self.delegate onDisplayLink:timestamp targetTimestamp:targetTimestamp];
 }
 
 - (void)invalidate {

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -341,7 +341,9 @@ static void OnKeyboardLayoutChanged(CFNotificationCenterRef center,
   FlutterThreadSynchronizer* _threadSynchronizer;
 }
 
+// Synthesize properties declared readonly.
 @synthesize viewIdentifier = _viewIdentifier;
+
 @dynamic accessibilityBridge;
 
 /**


### PR DESCRIPTION
In modern Objective-C, `@property` directives automatically generate a backing ivar (property name prefixed with an underscore), the getter, and (for readwrite properties) the setter. `@synthesize` directives are generally only required if the backing ivar has a different name from the property.

Also updates the FlutterMetalLayer API to match CAMetalLayer:
* Adds API_AVAILABLE declaration to match that on CAMetalLayer.
* Eliminates wantsExtendedDynamicRangeContent property as it's also part of CALayer's interface and unused in our implementation.

Also eliminates unnecessary ivars where they're being synthesized by `@property` declarations.

Previously, we were overriding the behaviour of
UIViewController.prefersStatusBarHidden by synthesizing _flutterPrefersStatusBarHidden as a backing ivar. Since we're explicitly overriding the behaviour of a superclass, it's more idiomatic to synthesize a private property or explicitly declare an ivar then explicitly override the getter instead.

Further, this adds documentation to cases where `@synthesize` directives are required, such as:
* Creating a backing ivar for a readonly property.
* Creating a backing ivar for a property with a custom getter/setter.
* Synthesising the ivar, getter, and setter for a property declared in a protocol being implemented.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
