### PR TITLE
Update the Skia build scripts for a refactoring of the Fontconfig font manager

### DIFF
--- a/skia/BUILD.gn
+++ b/skia/BUILD.gn
@@ -270,6 +270,11 @@ optional("fontmgr_custom_empty") {
   sources = skia_ports_fontmgr_empty_sources
 }
 
+skia_source_set("typeface_proxy") {
+  configs = [ ":skia_public" ]
+  sources = skia_ports_typeface_proxy_sources
+}
+
 optional("fontmgr_fontconfig") {
   enabled = skia_enable_fontmgr_fontconfig
   public_defines = [ "SK_FONTMGR_FONTCONFIG_AVAILABLE" ]
@@ -277,7 +282,10 @@ optional("fontmgr_fontconfig") {
   # The public header includes fontconfig.h and uses FcConfig*
   public_deps = [ "//third_party:fontconfig" ]
   public = skia_ports_fontmgr_fontconfig_public
-  deps = [ ":typeface_freetype" ]
+  deps = [
+    ":typeface_freetype",
+    ":typeface_proxy",
+  ]
   sources = skia_ports_fontmgr_fontconfig_sources
 }
 


### PR DESCRIPTION
Skia is reorganizing some font managers, and the Flutter engine's build scripts need to match the changes made to Skia.

See https://skia-review.googlesource.com/c/skia/+/915316