### PR TITLE
iOS,macOS: Enable ARC in flutter_cflags_objc[c]

### DIFF
--- a/common/config.gni
+++ b/common/config.gni
@@ -77,14 +77,13 @@ if (is_ios || is_mac) {
   flutter_cflags_objc = [
     "-Werror=overriding-method-mismatch",
     "-Werror=undeclared-selector",
+    "-fobjc-arc",
   ]
   if (is_mac) {
     flutter_cflags_objc += [ "-fapplication-extension" ]
   }
 
   flutter_cflags_objcc = flutter_cflags_objc
-  flutter_cflags_objc_arc = flutter_cflags_objc + [ "-fobjc-arc" ]
-  flutter_cflags_objcc_arc = flutter_cflags_objc_arc
 }
 
 # A combo of host os name and cpu is used in several locations to

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -135,8 +135,8 @@ source_set("fml") {
   libs = []
 
   if (is_ios || is_mac) {
-    cflags_objc = flutter_cflags_objc_arc
-    cflags_objcc = flutter_cflags_objcc_arc
+    cflags_objc = flutter_cflags_objc
+    cflags_objcc = flutter_cflags_objcc
 
     sources += [
       "platform/darwin/cf_utils.cc",
@@ -359,8 +359,8 @@ if (enable_unittests) {
     ]
 
     if (is_mac || is_ios) {
-      cflags_objc = flutter_cflags_objc_arc
-      cflags_objcc = flutter_cflags_objcc_arc
+      cflags_objc = flutter_cflags_objc
+      cflags_objcc = flutter_cflags_objcc
 
       sources += [
         "platform/darwin/cf_utils_unittests.mm",

--- a/impeller/tools/component.gni
+++ b/impeller/tools/component.gni
@@ -43,7 +43,7 @@ template("impeller_component") {
       }
 
       if (is_ios || is_mac) {
-        cflags_objc += flutter_cflags_objc_arc
+        cflags_objc += flutter_cflags_objc
       }
 
       if (!defined(invoker.cflags_objcc)) {
@@ -51,7 +51,7 @@ template("impeller_component") {
       }
 
       if (is_ios || is_mac) {
-        cflags_objcc += flutter_cflags_objcc_arc
+        cflags_objcc += flutter_cflags_objcc
       }
     }
   }

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -296,8 +296,8 @@ if (enable_unittests) {
     }
 
     if (test_enable_metal) {
-      cflags_objc = flutter_cflags_objc_arc
-      cflags_objcc = flutter_cflags_objcc_arc
+      cflags_objc = flutter_cflags_objc
+      cflags_objcc = flutter_cflags_objcc
 
       sources += [
         "shell_test_platform_view_metal.h",

--- a/shell/gpu/BUILD.gn
+++ b/shell/gpu/BUILD.gn
@@ -71,8 +71,8 @@ source_set("gpu_surface_vulkan") {
 
 if (shell_enable_metal) {
   source_set("gpu_surface_metal") {
-    cflags_objc = flutter_cflags_objc_arc
-    cflags_objcc = flutter_cflags_objcc_arc
+    cflags_objc = flutter_cflags_objc
+    cflags_objcc = flutter_cflags_objcc
 
     sources = [
       "gpu_surface_metal_delegate.cc",
@@ -99,8 +99,8 @@ if (shell_enable_metal) {
 if (is_mac) {
   impeller_component("gpu_surface_metal_unittests") {
     testonly = true
-    cflags_objc = flutter_cflags_objc_arc
-    cflags_objcc = flutter_cflags_objcc_arc
+    cflags_objc = flutter_cflags_objc
+    cflags_objcc = flutter_cflags_objcc
 
     target_type = "executable"
     sources = [

--- a/shell/platform/darwin/common/BUILD.gn
+++ b/shell/platform/darwin/common/BUILD.gn
@@ -9,8 +9,8 @@ import("//flutter/testing/testing.gni")
 import("framework_common.gni")
 
 source_set("common") {
-  cflags_objc = flutter_cflags_objc_arc
-  cflags_objcc = flutter_cflags_objcc_arc
+  cflags_objc = flutter_cflags_objc
+  cflags_objcc = flutter_cflags_objcc
 
   sources = [
     "buffer_conversions.h",
@@ -75,8 +75,8 @@ config("framework_relative_headers") {
 
 # Framework code shared between iOS and macOS.
 source_set("framework_common") {
-  cflags_objc = flutter_cflags_objc_arc
-  cflags_objcc = flutter_cflags_objcc_arc
+  cflags_objc = flutter_cflags_objc
+  cflags_objcc = flutter_cflags_objcc
 
   sources = [
     "framework/Source/FlutterBinaryMessengerRelay.mm",
@@ -111,8 +111,8 @@ test_fixtures("framework_common_fixtures") {
 # Unit tests for channels.
 executable("framework_common_unittests") {
   testonly = true
-  cflags_objc = flutter_cflags_objc_arc
-  cflags_objcc = flutter_cflags_objcc_arc
+  cflags_objc = flutter_cflags_objc
+  cflags_objcc = flutter_cflags_objcc
   ldflags = [ "-ObjC" ]
 
   sources = [

--- a/shell/platform/darwin/graphics/BUILD.gn
+++ b/shell/platform/darwin/graphics/BUILD.gn
@@ -8,8 +8,8 @@ import("//flutter/common/config.gni")
 import("//flutter/impeller/tools/impeller.gni")
 
 source_set("graphics") {
-  cflags_objc = flutter_cflags_objc_arc
-  cflags_objcc = flutter_cflags_objcc_arc
+  cflags_objc = flutter_cflags_objc
+  cflags_objcc = flutter_cflags_objcc
 
   sources = [
     "FlutterDarwinContextMetalSkia.h",

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -41,8 +41,8 @@ _flutter_framework_headers_copy_dir = "$_flutter_framework_dir/Headers"
 
 source_set("flutter_framework_source") {
   visibility = [ ":*" ]
-  cflags_objc = flutter_cflags_objc_arc
-  cflags_objcc = flutter_cflags_objcc_arc
+  cflags_objc = flutter_cflags_objc
+  cflags_objcc = flutter_cflags_objcc
 
   defines = [ "FLUTTER_FRAMEWORK=1" ]
   if (darwin_extension_safe) {
@@ -203,9 +203,8 @@ shared_library("ios_test_flutter") {
   # This bug results engine build failure since the engine treats warnings as errors.
   # The `-Wno-unguarded-availability-new` can be removed when the Xcode bug is fixed.
   # See details in https://github.com/flutter/flutter/issues/128958.
-  cflags_objc = flutter_cflags_objc_arc
-  cflags_objcc =
-      flutter_cflags_objcc_arc + [ "-Wno-unguarded-availability-new" ]
+  cflags_objc = flutter_cflags_objc
+  cflags_objcc = flutter_cflags_objcc + [ "-Wno-unguarded-availability-new" ]
   cflags = [
     "-fvisibility=default",
     "-F$platform_frameworks_path",

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -52,8 +52,8 @@ _flutter_framework_headers_copy_dir =
 
 source_set("flutter_framework_source") {
   visibility = [ ":*" ]
-  cflags_objc = flutter_cflags_objc_arc
-  cflags_objcc = flutter_cflags_objcc_arc
+  cflags_objc = flutter_cflags_objc
+  cflags_objcc = flutter_cflags_objcc
 
   sources = [
     "framework/Source/AccessibilityBridgeMac.h",
@@ -173,8 +173,8 @@ test_fixtures("flutter_desktop_darwin_fixtures") {
 
 executable("flutter_desktop_darwin_unittests") {
   testonly = true
-  cflags_objc = flutter_cflags_objc_arc
-  cflags_objcc = flutter_cflags_objcc_arc
+  cflags_objc = flutter_cflags_objc
+  cflags_objcc = flutter_cflags_objcc
   ldflags = [ "-ObjC" ]
 
   sources = [

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -144,8 +144,8 @@ template("embedder_source_set") {
     }
 
     if (embedder_enable_metal) {
-      cflags_objc = flutter_cflags_objc_arc
-      cflags_objcc = flutter_cflags_objcc_arc
+      cflags_objc = flutter_cflags_objc
+      cflags_objcc = flutter_cflags_objcc
 
       sources += [
         "embedder_external_texture_metal.h",
@@ -389,8 +389,8 @@ if (enable_unittests) {
     }
 
     if (test_enable_metal) {
-      cflags_objc = flutter_cflags_objc_arc
-      cflags_objcc = flutter_cflags_objcc_arc
+      cflags_objc = flutter_cflags_objc
+      cflags_objcc = flutter_cflags_objcc
 
       sources += [ "tests/embedder_metal_unittests.mm" ]
     }

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -193,8 +193,8 @@ if (is_mac || is_ios) {
     testonly = true
 
     if (shell_enable_metal) {
-      cflags_objc = flutter_cflags_objc_arc
-      cflags_objcc = flutter_cflags_objcc_arc
+      cflags_objc = flutter_cflags_objc
+      cflags_objcc = flutter_cflags_objcc
 
       sources = [
         "test_metal_context.h",
@@ -257,8 +257,8 @@ if (enable_unittests) {
     ]
 
     if (test_enable_metal) {
-      cflags_objc = flutter_cflags_objc_arc
-      cflags_objcc = flutter_cflags_objcc_arc
+      cflags_objc = flutter_cflags_objc
+      cflags_objcc = flutter_cflags_objcc
 
       sources += [ "test_metal_surface_unittests.mm" ]
       deps += [ ":metal" ]

--- a/third_party/accessibility/BUILD.gn
+++ b/third_party/accessibility/BUILD.gn
@@ -76,8 +76,8 @@ if (enable_unittests) {
       ]
 
       if (is_mac) {
-        cflags_objc = flutter_cflags_objc_arc
-        cflags_objcc = flutter_cflags_objcc_arc
+        cflags_objc = flutter_cflags_objc
+        cflags_objcc = flutter_cflags_objcc
         ldflags = [ "-ObjC" ]
 
         sources += [ "ax/platform/ax_platform_node_mac_unittest.mm" ]

--- a/third_party/accessibility/ax/BUILD.gn
+++ b/third_party/accessibility/ax/BUILD.gn
@@ -82,8 +82,8 @@ source_set("ax") {
   ]
 
   if (is_mac) {
-    cflags_objc = flutter_cflags_objc_arc
-    cflags_objcc = flutter_cflags_objcc_arc
+    cflags_objc = flutter_cflags_objc
+    cflags_objcc = flutter_cflags_objcc
 
     sources += [
       "platform/ax_platform_node_mac.h",

--- a/third_party/accessibility/gfx/BUILD.gn
+++ b/third_party/accessibility/gfx/BUILD.gn
@@ -51,8 +51,8 @@ source_set("gfx") {
       "mac/coordinate_conversion.h",
       "mac/coordinate_conversion.mm",
     ]
-    cflags_objc = flutter_cflags_objc_arc
-    cflags_objcc = flutter_cflags_objcc_arc
+    cflags_objc = flutter_cflags_objc
+    cflags_objcc = flutter_cflags_objcc
   }
 
   deps = [


### PR DESCRIPTION
Enables the `-fobjc-arc` compiler flag for Objective-C and Objective-C++ translation units.

Eliminates the flutter_cflags_objc[c]_arc settings, since they're now redundant.

All Obj-C/Obj-C++ code in our codebase has now been migrated to ARC.

Issue: https://github.com/flutter/flutter/issues/137801

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] This wraps up a pretty long ARC of work.
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
