### PR TITLE
iOS: Eliminate unguarded-availability opt-out

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -199,12 +199,8 @@ shared_library("ios_test_flutter") {
   testonly = true
   visibility = [ "*" ]
 
-  # Xcode 15 beta has a bug where iOS 17 API usage is not guarded.
-  # This bug results engine build failure since the engine treats warnings as errors.
-  # The `-Wno-unguarded-availability-new` can be removed when the Xcode bug is fixed.
-  # See details in https://github.com/flutter/flutter/issues/128958.
   cflags_objc = flutter_cflags_objc
-  cflags_objcc = flutter_cflags_objcc + [ "-Wno-unguarded-availability-new" ]
+  cflags_objcc = flutter_cflags_objcc
   cflags = [
     "-fvisibility=default",
     "-F$platform_frameworks_path",


### PR DESCRIPTION
Eliminates the opt-out of `-Wunguarded-availability-new` in the `ios_test_flutter` target.

Xcode 15 beta XCTest framework headers contained unguarded usage of iOS 17 API. This bug resulted in engine build failures.

This was fixed in a later XCTest framework release.

```
/Applications/Xcode_15-beta.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCTest.framework/Headers/XCUIAccessibilityAuditTypes.h:19:30: error: 'XCUIAccessibilityAuditType' is only available on iOS 17.0 or newer [-Werror,-Wunguarded-availability-new]
   19 | typedef NS_OPTIONS(uint64_t, XCUIAccessibilityAuditType) {
      |                              ^
/Applications/Xcode_15-beta.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCTest.framework/Headers/XCUIAccessibilityAuditTypes.h:19:30: note: 'XCUIAccessibilityAuditType' has been marked as being introduced in iOS 17.0 here, but the deployment target is iOS 13.0.0
/Applications/Xcode_15-beta.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCTest.framework/Headers/XCUIAccessibilityAuditTypes.h:19:9: note: annotate anonymous enum with an availability attribute to silence this warning
   19 | typedef NS_OPTIONS(uint64_t, XCUIAccessibilityAuditType) {
      |         ^
/Applications/Xcode_15-beta.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator17.0.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSObjCRuntime.h:383:34: note: expanded from macro 'NS_OPTIONS'
  383 | #define NS_OPTIONS(_type, _name) CF_OPTIONS(_type, _name)
      |                                  ^
/Applications/Xcode_15-beta.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator17.0.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CFAvailability.h:155:96: note: expanded from macro 'CF_OPTIONS'
  155 | #define CF_OPTIONS(_type, _name) __attribute__((availability(swift,unavailable))) _type _name; enum __CF_OPTIONS_ATTRIBUTES : _name
      |
```

Issue: https://github.com/flutter/flutter/issues/128958

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
