### PR TITLE
[Impeller] support GLES 3.0 MSAA without extension.

### DIFF
--- a/impeller/display_list/canvas.cc
+++ b/impeller/display_list/canvas.cc
@@ -1667,10 +1667,15 @@ bool Canvas::BlitToOnscreen() {
   auto offscreen_target = render_passes_.back()
                               .inline_pass_context->GetPassTarget()
                               .GetRenderTarget();
-
+  // Unlike other backends the blit to restore the onscreen fails for GLES
+  // if the src is a multisample framebuffer, even if we specifically target
+  // the non-multisampled resolve of the dst.
+  bool is_gles_and_must_skip_blit = renderer_.GetContext()->GetBackendType() ==
+                                    Context::BackendType::kOpenGLES;
   if (renderer_.GetContext()
           ->GetCapabilities()
-          ->SupportsTextureToTextureBlits()) {
+          ->SupportsTextureToTextureBlits() &&
+      !is_gles_and_must_skip_blit) {
     auto blit_pass = command_buffer->CreateBlitPass();
     blit_pass->AddCopy(offscreen_target.GetRenderTargetTexture(),
                        render_target_.GetRenderTargetTexture());

--- a/impeller/renderer/backend/gles/capabilities_gles.cc
+++ b/impeller/renderer/backend/gles/capabilities_gles.cc
@@ -128,6 +128,11 @@ CapabilitiesGLES::CapabilitiesGLES(const ProcTableGLES& gl) {
     gl.GetIntegerv(GL_MAX_SAMPLES_EXT, &value);
     supports_offscreen_msaa_ = value >= 4;
   }
+  if (desc->GetGlVersion().IsAtLeast(Version{3, 0, 0})) {
+    GLint value = 0;
+    gl.GetIntegerv(GL_MAX_SAMPLES_EXT, &value);
+    supports_offscreen_msaa_ = value >= 4;
+  }
   is_es_ = desc->IsES();
   is_angle_ = desc->IsANGLE();
 }

--- a/impeller/renderer/backend/gles/capabilities_gles.cc
+++ b/impeller/renderer/backend/gles/capabilities_gles.cc
@@ -127,8 +127,7 @@ CapabilitiesGLES::CapabilitiesGLES(const ProcTableGLES& gl) {
     GLint value = 0;
     gl.GetIntegerv(GL_MAX_SAMPLES_EXT, &value);
     supports_offscreen_msaa_ = value >= 4;
-  }
-  if (desc->GetGlVersion().IsAtLeast(Version{3, 0, 0})) {
+  } else if (desc->GetGlVersion().major_version >= 3 && desc->IsES()) {
     GLint value = 0;
     gl.GetIntegerv(GL_MAX_SAMPLES_EXT, &value);
     supports_offscreen_msaa_ = value >= 4;

--- a/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/impeller/renderer/backend/gles/proc_table_gles.h
@@ -262,6 +262,7 @@ void(glDepthRange)(GLdouble n, GLdouble f);
   PROC(FenceSync);                         \
   PROC(DeleteSync);                        \
   PROC(WaitSync);                          \
+  PROC(RenderbufferStorageMultisample)     \
   PROC(BlitFramebuffer);
 
 #define FOR_EACH_IMPELLER_EXT_PROC(PROC)    \

--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -603,6 +603,7 @@ bool RenderPassGLES::OnEncodeCommands(const Context& context) const {
   // discard the attachment when we are done.
   if (color0.resolve_texture) {
     pass_data->discard_color_attachment =
+        pass_data->discard_color_attachment &&
         !context.GetCapabilities()->SupportsImplicitResolvingMSAA();
   }
 

--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -6,8 +6,6 @@
 
 #include <cstdint>
 
-#include "GLES3/gl3.h"
-#include "flutter/fml/trace_event.h"
 #include "fml/closure.h"
 #include "fml/logging.h"
 #include "impeller/base/validation.h"
@@ -127,6 +125,7 @@ struct RenderPassData {
   Scalar clear_depth = 1.0;
 
   std::shared_ptr<Texture> color_attachment;
+  std::shared_ptr<Texture> resolve_attachment;
   std::shared_ptr<Texture> depth_attachment;
   std::shared_ptr<Texture> stencil_attachment;
 
@@ -191,8 +190,6 @@ void RenderPassGLES::ResetGLState(const ProcTableGLES& gl) {
     const ReactorGLES& reactor,
     const std::vector<Command>& commands,
     const std::shared_ptr<GPUTracerGLES>& tracer) {
-  TRACE_EVENT0("impeller", "RenderPassGLES::EncodeCommandsInReactor");
-
   const auto& gl = reactor.GetProcTable();
 #ifdef IMPELLER_DEBUG
   tracer->MarkFrameStart(gl);
@@ -517,6 +514,52 @@ void RenderPassGLES::ResetGLState(const ProcTableGLES& gl) {
     );
   }
 
+  if (pass_data.resolve_attachment &&
+      pass_data.resolve_attachment != pass_data.color_attachment &&
+      !is_default_fbo) {
+    // Perform multisample resolve via blit.
+    // Create and bind a resolve FBO.
+    GLuint resolve_fbo;
+    gl.GenFramebuffers(1u, &resolve_fbo);
+    gl.BindFramebuffer(GL_FRAMEBUFFER, resolve_fbo);
+
+    if (!TextureGLES::Cast(*pass_data.resolve_attachment)
+             .SetAsFramebufferAttachment(
+                 GL_FRAMEBUFFER, TextureGLES::AttachmentType::kColor0)) {
+      return false;
+    }
+
+    auto status = gl.CheckFramebufferStatus(GL_FRAMEBUFFER);
+    if (gl.CheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+      VALIDATION_LOG << "Could not create a complete frambuffer: "
+                     << DebugToFramebufferError(status);
+      return false;
+    }
+
+    // Bind MSAA renderbuffer to read framebuffer.
+    gl.BindFramebuffer(GL_READ_FRAMEBUFFER, fbo);
+    gl.BindFramebuffer(GL_DRAW_FRAMEBUFFER, resolve_fbo);
+
+    RenderPassGLES::ResetGLState(gl);
+    auto size = pass_data.color_attachment->GetSize();
+
+    gl.BlitFramebuffer(0,                    // srcX0
+                       0,                    // srcY0
+                       size.width,           // srcX1
+                       size.height,          // srcY1
+                       0,                    // dstX0
+                       0,                    // dstY0
+                       size.width,           // dstX1
+                       size.height,          // dstY1
+                       GL_COLOR_BUFFER_BIT,  // mask
+                       GL_NEAREST            // filter
+    );
+
+    gl.BindFramebuffer(GL_DRAW_FRAMEBUFFER, GL_NONE);
+    gl.BindFramebuffer(GL_READ_FRAMEBUFFER, GL_NONE);
+    gl.DeleteFramebuffers(1u, &resolve_fbo);
+  }
+
 #ifdef IMPELLER_DEBUG
   if (is_default_fbo) {
     tracer->MarkFrameEnd(gl);
@@ -547,6 +590,7 @@ bool RenderPassGLES::OnEncodeCommands(const Context& context) const {
   /// Setup color data.
   ///
   pass_data->color_attachment = color0.texture;
+  pass_data->resolve_attachment = color0.resolve_texture;
   pass_data->clear_color = color0.clear_color;
   pass_data->clear_color_attachment = CanClearAttachment(color0.load_action);
   pass_data->discard_color_attachment =
@@ -556,8 +600,8 @@ bool RenderPassGLES::OnEncodeCommands(const Context& context) const {
   // resolved when we bind the texture to the framebuffer. We don't need to
   // discard the attachment when we are done.
   if (color0.resolve_texture) {
-    FML_DCHECK(context.GetCapabilities()->SupportsImplicitResolvingMSAA());
-    pass_data->discard_color_attachment = false;
+    pass_data->discard_color_attachment =
+        context.GetCapabilities()->SupportsImplicitResolvingMSAA();
   }
 
   //----------------------------------------------------------------------------

--- a/impeller/renderer/backend/gles/texture_gles.cc
+++ b/impeller/renderer/backend/gles/texture_gles.cc
@@ -53,7 +53,7 @@ static TextureGLES::Type GetTextureTypeFromDescriptor(
     return is_msaa ? TextureGLES::Type::kRenderBufferMultisampled
                    : TextureGLES::Type::kRenderBuffer;
   }
-  return is_msaa ? TextureGLES::Type::kTextureMultisampled
+  return is_msaa ? TextureGLES::Type::kRenderBufferMultisampled
                  : TextureGLES::Type::kTexture;
 }
 
@@ -362,7 +362,7 @@ static std::optional<GLenum> ToRenderBufferFormat(PixelFormat format) {
   switch (format) {
     case PixelFormat::kB8G8R8A8UNormInt:
     case PixelFormat::kR8G8B8A8UNormInt:
-      return GL_RGBA4;
+      return GL_RGBA8;
     case PixelFormat::kR32G32B32A32Float:
       return GL_RGBA32F;
     case PixelFormat::kR16G16B16A16Float:
@@ -445,7 +445,8 @@ void TextureGLES::InitializeContentsIfNecessary() const {
       {
         TRACE_EVENT0("impeller", "RenderBufferStorageInitialization");
         if (type_ == Type::kRenderBufferMultisampled) {
-          gl.RenderbufferStorageMultisampleEXT(
+          FML_DCHECK(gl.RenderbufferStorageMultisample.IsAvailable());
+          gl.RenderbufferStorageMultisample(
               GL_RENDERBUFFER,               // target
               4,                             // samples
               render_buffer_format.value(),  // internal format


### PR DESCRIPTION
Adds multisampling support for GLES devices without GL_EXT_multisampled_render_to_texture provided they are at least GLES 3.0 to support mutlisampled render buffers.

Fixes https://github.com/flutter/flutter/issues/158360
Fixes https://github.com/flutter/flutter/issues/157951


TBD: should we prefer renderbuffer 3.0 approach over multisample_render_to_texture?