### PR TITLE
EmbedderTest: templatise GetEmbedderContext

### DIFF
--- a/shell/platform/embedder/tests/embedder_a11y_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_a11y_unittests.cc
@@ -33,8 +33,8 @@ constexpr static char kTooltip[] = "tooltip";
 
 TEST_F(EmbedderTest, CannotProvideMultipleSemanticsCallbacks) {
   {
-    EmbedderConfigBuilder builder(
-        GetEmbedderContext(EmbedderTestContextType::kSoftwareContext));
+    auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
+    EmbedderConfigBuilder builder(context);
     builder.SetSurface(SkISize::Make(1, 1));
     builder.GetProjectArgs().update_semantics_callback =
         [](const FlutterSemanticsUpdate* update, void* user_data) {};
@@ -46,8 +46,8 @@ TEST_F(EmbedderTest, CannotProvideMultipleSemanticsCallbacks) {
   }
 
   {
-    EmbedderConfigBuilder builder(
-        GetEmbedderContext(EmbedderTestContextType::kSoftwareContext));
+    auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
+    EmbedderConfigBuilder builder(context);
     builder.SetSurface(SkISize::Make(1, 1));
     builder.GetProjectArgs().update_semantics_callback2 =
         [](const FlutterSemanticsUpdate2* update, void* user_data) {};
@@ -61,8 +61,8 @@ TEST_F(EmbedderTest, CannotProvideMultipleSemanticsCallbacks) {
   }
 
   {
-    EmbedderConfigBuilder builder(
-        GetEmbedderContext(EmbedderTestContextType::kSoftwareContext));
+    auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
+    EmbedderConfigBuilder builder(context);
     builder.SetSurface(SkISize::Make(1, 1));
     builder.GetProjectArgs().update_semantics_callback =
         [](const FlutterSemanticsUpdate* update, void* user_data) {};
@@ -76,8 +76,8 @@ TEST_F(EmbedderTest, CannotProvideMultipleSemanticsCallbacks) {
   }
 
   {
-    EmbedderConfigBuilder builder(
-        GetEmbedderContext(EmbedderTestContextType::kSoftwareContext));
+    auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
+    EmbedderConfigBuilder builder(context);
     builder.SetSurface(SkISize::Make(1, 1));
     builder.GetProjectArgs().update_semantics_callback2 =
         [](const FlutterSemanticsUpdate2* update, void* user_data) {};
@@ -98,7 +98,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingV3Callbacks) {
   GTEST_SKIP() << "This test crashes on Fuchsia. https://fxbug.dev/87493 ";
 #else
 
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
 
   fml::AutoResetWaitableEvent signal_native_latch;
 
@@ -277,7 +277,7 @@ TEST_F(EmbedderA11yTest, A11yStringAttributes) {
   GTEST_SKIP() << "This test crashes on Fuchsia. https://fxbug.dev/87493 ";
 #else
 
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
 
   fml::AutoResetWaitableEvent signal_native_latch;
 
@@ -397,7 +397,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingV2Callbacks) {
   GTEST_SKIP() << "This test crashes on Fuchsia. https://fxbug.dev/87493 ";
 #else
 
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
 
   fml::AutoResetWaitableEvent signal_native_latch;
 
@@ -570,7 +570,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingV2Callbacks) {
 }
 
 TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingV1Callbacks) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
 
   fml::AutoResetWaitableEvent signal_native_latch;
 

--- a/shell/platform/embedder/tests/embedder_gl_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_gl_unittests.cc
@@ -45,14 +45,9 @@ namespace flutter::testing {
 
 using EmbedderTest = testing::EmbedderTest;
 
-TEST_F(EmbedderTest, CanGetVulkanEmbedderContext) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kVulkanContext);
-  EmbedderConfigBuilder builder(context);
-}
-
 TEST_F(EmbedderTest, CanCreateOpenGLRenderingEngine) {
-  EmbedderConfigBuilder builder(
-      GetEmbedderContext(EmbedderTestContextType::kOpenGLContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
+  EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   auto engine = builder.LaunchEngine();
   ASSERT_TRUE(engine.is_valid());
@@ -65,7 +60,7 @@ TEST_F(EmbedderTest, CanCreateOpenGLRenderingEngine) {
 ///
 TEST_F(EmbedderTest,
        MustPreventEngineLaunchWhenRequiredCompositorArgsAreAbsent) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   builder.SetCompositor();
@@ -83,7 +78,7 @@ TEST_F(EmbedderTest,
 /// render a frame at a later point in time.
 ///
 TEST_F(EmbedderTest, LaunchFailsWhenMultiplePresentCallbacks) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   builder.SetCompositor();
@@ -102,7 +97,7 @@ TEST_F(EmbedderTest, LaunchFailsWhenMultiplePresentCallbacks) {
 /// complete OpenGL textures.
 ///
 TEST_F(EmbedderTest, CompositorMustBeAbleToRenderToOpenGLFramebuffer) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -222,7 +217,7 @@ TEST_F(EmbedderTest, CompositorMustBeAbleToRenderToOpenGLFramebuffer) {
 /// Layers in a hierarchy containing a platform view should not be cached. The
 /// other layers in the hierarchy should be, however.
 TEST_F(EmbedderTest, RasterCacheDisabledWithPlatformViews) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -355,7 +350,7 @@ TEST_F(EmbedderTest, RasterCacheDisabledWithPlatformViews) {
 /// The RasterCache should normally be enabled.
 ///
 TEST_F(EmbedderTest, RasterCacheEnabled) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -441,7 +436,7 @@ TEST_F(EmbedderTest, RasterCacheEnabled) {
 /// the individual layers are OpenGL textures.
 ///
 TEST_F(EmbedderTest, CompositorMustBeAbleToRenderToOpenGLTexture) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -562,7 +557,7 @@ TEST_F(EmbedderTest, CompositorMustBeAbleToRenderToOpenGLTexture) {
 /// individual layers are software buffers.
 ///
 TEST_F(EmbedderTest, CompositorMustBeAbleToRenderToSoftwareBuffer) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -683,7 +678,7 @@ TEST_F(EmbedderTest, CompositorMustBeAbleToRenderToSoftwareBuffer) {
 /// Test the layer structure and pixels rendered when using a custom compositor.
 ///
 TEST_F(EmbedderTest, CompositorMustBeAbleToRenderKnownScene) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -897,7 +892,7 @@ TEST_F(EmbedderTest, CompositorMustBeAbleToRenderKnownScene) {
 /// thread merging mechanism must not interfere with the custom compositor.
 ///
 TEST_F(EmbedderTest, CustomCompositorMustWorkWithCustomTaskRunner) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
 
@@ -1065,7 +1060,7 @@ TEST_F(EmbedderTest, CustomCompositorMustWorkWithCustomTaskRunner) {
 /// and a single layer.
 ///
 TEST_F(EmbedderTest, CompositorMustBeAbleToRenderWithRootLayerOnly) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -1147,7 +1142,7 @@ TEST_F(EmbedderTest, CompositorMustBeAbleToRenderWithRootLayerOnly) {
 /// and ensure that a redundant layer is not added.
 ///
 TEST_F(EmbedderTest, CompositorMustBeAbleToRenderWithPlatformLayerOnBottom) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -1275,7 +1270,7 @@ TEST_F(EmbedderTest, CompositorMustBeAbleToRenderWithPlatformLayerOnBottom) {
 ///
 TEST_F(EmbedderTest,
        CompositorMustBeAbleToRenderKnownSceneWithRootSurfaceTransformation) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(600, 800));
@@ -1492,7 +1487,7 @@ TEST_F(EmbedderTest,
 }
 
 TEST_F(EmbedderTest, CanRenderSceneWithoutCustomCompositor) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
 
@@ -1518,7 +1513,7 @@ TEST_F(EmbedderTest, CanRenderSceneWithoutCustomCompositor) {
 }
 
 TEST_F(EmbedderTest, CanRenderSceneWithoutCustomCompositorWithTransformation) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   const auto root_surface_transformation =
       SkMatrix().preTranslate(0, 800).preRotate(-90, 0, 0);
@@ -1553,7 +1548,6 @@ TEST_F(EmbedderTest, CanRenderSceneWithoutCustomCompositorWithTransformation) {
 TEST_P(EmbedderTestMultiBackend, CanRenderGradientWithoutCompositor) {
   EmbedderTestContextType backend = GetParam();
   auto& context = GetEmbedderContext(backend);
-
   EmbedderConfigBuilder builder(context);
   builder.SetDartEntrypoint("render_gradient");
   builder.SetSurface(SkISize::Make(800, 600));
@@ -1577,7 +1571,7 @@ TEST_P(EmbedderTestMultiBackend, CanRenderGradientWithoutCompositor) {
 }
 
 TEST_F(EmbedderTest, CanRenderGradientWithoutCompositorWithXform) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   const auto root_surface_transformation =
       SkMatrix().preTranslate(0, 800).preRotate(-90, 0, 0);
@@ -1638,7 +1632,7 @@ TEST_P(EmbedderTestMultiBackend, CanRenderGradientWithCompositor) {
 }
 
 TEST_F(EmbedderTest, CanRenderGradientWithCompositorWithXform) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   // This must match the transformation provided in the
   // |CanRenderGradientWithoutCompositorWithXform| test to ensure that
@@ -1808,7 +1802,7 @@ TEST_P(EmbedderTestMultiBackend,
 }
 
 TEST_F(EmbedderTest, CanRenderGradientWithCompositorOnNonRootLayerWithXform) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   // This must match the transformation provided in the
   // |CanRenderGradientWithoutCompositorWithXform| test to ensure that
@@ -1951,7 +1945,7 @@ TEST_F(EmbedderTest, CanRenderGradientWithCompositorOnNonRootLayerWithXform) {
 }
 
 TEST_F(EmbedderTest, VerifyB141980393) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
 
@@ -2072,8 +2066,8 @@ TEST_F(EmbedderTest, CanCreateEmbedderWithCustomRenderTaskRunner) {
           task_latch.Signal();
         }
       });
-  EmbedderConfigBuilder builder(
-      GetEmbedderContext(EmbedderTestContextType::kOpenGLContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
+  EmbedderConfigBuilder builder(context);
   builder.SetDartEntrypoint("can_render_scene_without_custom_compositor");
   builder.SetSurface(SkISize::Make(800, 600));
   builder.SetRenderTaskRunner(
@@ -2132,7 +2126,8 @@ TEST_P(EmbedderTestMultiBackend,
 
   platform_task_runner->PostTask([&]() {
     EmbedderTestContextType backend = GetParam();
-    EmbedderConfigBuilder builder(GetEmbedderContext(backend));
+    auto& context = GetEmbedderContext(backend);
+    EmbedderConfigBuilder builder(context);
     builder.SetDartEntrypoint("can_render_scene_without_custom_compositor");
     builder.SetSurface(SkISize::Make(800, 600));
     builder.SetRenderTaskRunner(
@@ -2305,7 +2300,7 @@ TEST_P(EmbedderTestMultiBackend,
 TEST_F(
     EmbedderTest,
     CompositorMustBeAbleToRenderKnownScenePixelRatioOnSurfaceWithRootSurfaceXformation) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(600, 800));
@@ -2428,7 +2423,7 @@ TEST_F(
 
 TEST_F(EmbedderTest,
        PushingMutlipleFramesSetsUpNewRecordingCanvasWithCustomCompositor) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(600, 1024));
@@ -2472,7 +2467,7 @@ TEST_F(EmbedderTest,
 
 TEST_F(EmbedderTest,
        PushingMutlipleFramesSetsUpNewRecordingCanvasWithoutCustomCompositor) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(600, 1024));
@@ -2621,7 +2616,7 @@ TEST_P(EmbedderTestMultiBackend, PlatformViewMutatorsAreValid) {
 }
 
 TEST_F(EmbedderTest, PlatformViewMutatorsAreValidWithPixelRatio) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -2733,7 +2728,7 @@ TEST_F(EmbedderTest, PlatformViewMutatorsAreValidWithPixelRatio) {
 
 TEST_F(EmbedderTest,
        PlatformViewMutatorsAreValidWithPixelRatioAndRootSurfaceTransformation) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -2850,7 +2845,7 @@ TEST_F(EmbedderTest,
 }
 
 TEST_F(EmbedderTest, EmptySceneIsAcceptable) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -2876,7 +2871,7 @@ TEST_F(EmbedderTest, EmptySceneIsAcceptable) {
 }
 
 TEST_F(EmbedderTest, SceneWithNoRootContainerIsAcceptable) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -2906,7 +2901,7 @@ TEST_F(EmbedderTest, SceneWithNoRootContainerIsAcceptable) {
 // Verifies that https://skia-review.googlesource.com/c/skia/+/259174 is pulled
 // into the engine.
 TEST_F(EmbedderTest, ArcEndCapsAreDrawnCorrectly) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 1024));
@@ -2940,7 +2935,7 @@ TEST_F(EmbedderTest, ArcEndCapsAreDrawnCorrectly) {
 }
 
 TEST_F(EmbedderTest, ClipsAreCorrectlyCalculated) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(400, 300));
@@ -3020,7 +3015,7 @@ TEST_F(EmbedderTest, ClipsAreCorrectlyCalculated) {
 }
 
 TEST_F(EmbedderTest, ComplexClipsAreCorrectlyCalculated) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1024, 600));
@@ -3105,7 +3100,7 @@ TEST_F(EmbedderTest, ComplexClipsAreCorrectlyCalculated) {
 }
 
 TEST_F(EmbedderTest, ObjectsCanBePostedViaPorts) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 1024));
   builder.SetDartEntrypoint("objects_can_be_posted");
@@ -3304,7 +3299,7 @@ TEST_F(EmbedderTest, ObjectsCanBePostedViaPorts) {
 }
 
 TEST_F(EmbedderTest, CompositorCanPostZeroLayersForPresentation) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(300, 200));
@@ -3338,7 +3333,7 @@ TEST_F(EmbedderTest, CompositorCanPostZeroLayersForPresentation) {
 }
 
 TEST_F(EmbedderTest, CompositorCanPostOnlyPlatformViews) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(300, 200));
@@ -3402,7 +3397,7 @@ TEST_F(EmbedderTest, CompositorCanPostOnlyPlatformViews) {
 }
 
 TEST_F(EmbedderTest, CompositorRenderTargetsAreRecycled) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(300, 200));
@@ -3448,7 +3443,7 @@ TEST_F(EmbedderTest, CompositorRenderTargetsAreRecycled) {
 }
 
 TEST_F(EmbedderTest, CompositorRenderTargetsAreInStableOrder) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(300, 200));
@@ -3518,8 +3513,7 @@ TEST_F(EmbedderTest, CompositorRenderTargetsAreInStableOrder) {
 }
 
 TEST_F(EmbedderTest, FrameInfoContainsValidWidthAndHeight) {
-  auto& context = static_cast<EmbedderTestContextGL&>(
-      GetEmbedderContext(EmbedderTestContextType::kOpenGLContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
   const auto root_surface_transformation =
       SkMatrix().preTranslate(0, 1024).preRotate(-90, 0, 0);
   context.SetRootSurfaceTransformation(root_surface_transformation);
@@ -3558,8 +3552,7 @@ TEST_F(EmbedderTest, FrameInfoContainsValidWidthAndHeight) {
 }
 
 TEST_F(EmbedderTest, MustNotRunWithBothFBOCallbacksSet) {
-  auto& context = static_cast<EmbedderTestContextGL&>(
-      GetEmbedderContext(EmbedderTestContextType::kOpenGLContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
   context.SetOpenGLFBOCallBack();
 
   EmbedderConfigBuilder builder(context);
@@ -3570,8 +3563,7 @@ TEST_F(EmbedderTest, MustNotRunWithBothFBOCallbacksSet) {
 }
 
 TEST_F(EmbedderTest, MustNotRunWithBothPresentCallbacksSet) {
-  auto& context = static_cast<EmbedderTestContextGL&>(
-      GetEmbedderContext(EmbedderTestContextType::kOpenGLContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
   context.SetOpenGLPresentCallBack();
 
   EmbedderConfigBuilder builder(context);
@@ -3582,8 +3574,7 @@ TEST_F(EmbedderTest, MustNotRunWithBothPresentCallbacksSet) {
 }
 
 TEST_F(EmbedderTest, MustStillRunWhenPopulateExistingDamageIsNotProvided) {
-  auto& context = static_cast<EmbedderTestContextGL&>(
-      GetEmbedderContext(EmbedderTestContextType::kOpenGLContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
   context.GetRendererConfig().open_gl.populate_existing_damage = nullptr;
 
   EmbedderConfigBuilder builder(context);
@@ -3594,8 +3585,7 @@ TEST_F(EmbedderTest, MustStillRunWhenPopulateExistingDamageIsNotProvided) {
 }
 
 TEST_F(EmbedderTest, MustRunWhenPopulateExistingDamageIsProvided) {
-  auto& context = static_cast<EmbedderTestContextGL&>(
-      GetEmbedderContext(EmbedderTestContextType::kOpenGLContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
   context.GetRendererConfig().open_gl.populate_existing_damage =
       [](void* context, const intptr_t id,
          FlutterDamage* existing_damage) -> void {
@@ -3610,8 +3600,7 @@ TEST_F(EmbedderTest, MustRunWhenPopulateExistingDamageIsProvided) {
 }
 
 TEST_F(EmbedderTest, MustRunWithPopulateExistingDamageAndFBOCallback) {
-  auto& context = static_cast<EmbedderTestContextGL&>(
-      GetEmbedderContext(EmbedderTestContextType::kOpenGLContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
   context.GetRendererConfig().open_gl.fbo_callback =
       [](void* context) -> uint32_t { return 0; };
   context.GetRendererConfig().open_gl.fbo_with_frame_info_callback = nullptr;
@@ -3630,8 +3619,7 @@ TEST_F(EmbedderTest, MustRunWithPopulateExistingDamageAndFBOCallback) {
 
 TEST_F(EmbedderTest,
        MustNotRunWhenPopulateExistingDamageButNoOtherFBOCallback) {
-  auto& context = static_cast<EmbedderTestContextGL&>(
-      GetEmbedderContext(EmbedderTestContextType::kOpenGLContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
   context.GetRendererConfig().open_gl.fbo_callback = nullptr;
   context.GetRendererConfig().open_gl.fbo_with_frame_info_callback = nullptr;
   context.GetRendererConfig().open_gl.populate_existing_damage =
@@ -3648,17 +3636,14 @@ TEST_F(EmbedderTest,
 }
 
 TEST_F(EmbedderTest, PresentInfoContainsValidFBOId) {
-  auto& context = static_cast<EmbedderTestContextGL&>(
-      GetEmbedderContext(EmbedderTestContextType::kOpenGLContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
+  const auto root_surface_transformation =
+      SkMatrix().preTranslate(0, 1024).preRotate(-90, 0, 0);
+  context.SetRootSurfaceTransformation(root_surface_transformation);
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(600, 1024));
   builder.SetDartEntrypoint("push_frames_over_and_over");
-
-  const auto root_surface_transformation =
-      SkMatrix().preTranslate(0, 1024).preRotate(-90, 0, 0);
-
-  context.SetRootSurfaceTransformation(root_surface_transformation);
 
   auto engine = builder.LaunchEngine();
 
@@ -3692,8 +3677,7 @@ TEST_F(EmbedderTest, PresentInfoContainsValidFBOId) {
 
 TEST_F(EmbedderTest,
        PresentInfoReceivesFullDamageWhenExistingDamageIsWholeScreen) {
-  auto& context = static_cast<EmbedderTestContextGL&>(
-      GetEmbedderContext(EmbedderTestContextType::kOpenGLContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
   context.GetRendererConfig().open_gl.populate_existing_damage =
       [](void* context, const intptr_t id,
          FlutterDamage* existing_damage) -> void {
@@ -3773,8 +3757,7 @@ TEST_F(EmbedderTest,
 }
 
 TEST_F(EmbedderTest, PresentInfoReceivesEmptyDamage) {
-  auto& context = static_cast<EmbedderTestContextGL&>(
-      GetEmbedderContext(EmbedderTestContextType::kOpenGLContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
   context.GetRendererConfig().open_gl.populate_existing_damage =
       [](void* context, const intptr_t id,
          FlutterDamage* existing_damage) -> void {
@@ -3853,8 +3836,7 @@ TEST_F(EmbedderTest, PresentInfoReceivesEmptyDamage) {
 }
 
 TEST_F(EmbedderTest, PresentInfoReceivesPartialDamage) {
-  auto& context = static_cast<EmbedderTestContextGL&>(
-      GetEmbedderContext(EmbedderTestContextType::kOpenGLContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
   context.GetRendererConfig().open_gl.populate_existing_damage =
       [](void* context, const intptr_t id,
          FlutterDamage* existing_damage) -> void {
@@ -3934,8 +3916,7 @@ TEST_F(EmbedderTest, PresentInfoReceivesPartialDamage) {
 }
 
 TEST_F(EmbedderTest, PopulateExistingDamageReceivesValidID) {
-  auto& context = static_cast<EmbedderTestContextGL&>(
-      GetEmbedderContext(EmbedderTestContextType::kOpenGLContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
   context.GetRendererConfig().open_gl.populate_existing_damage =
       [](void* context, const intptr_t id,
          FlutterDamage* existing_damage) -> void {
@@ -3969,8 +3950,7 @@ TEST_F(EmbedderTest, PopulateExistingDamageReceivesValidID) {
 }
 
 TEST_F(EmbedderTest, PopulateExistingDamageReceivesInvalidID) {
-  auto& context = static_cast<EmbedderTestContextGL&>(
-      GetEmbedderContext(EmbedderTestContextType::kOpenGLContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
   context.GetRendererConfig().open_gl.populate_existing_damage =
       [](void* context, const intptr_t id,
          FlutterDamage* existing_damage) -> void {
@@ -4014,7 +3994,7 @@ TEST_F(EmbedderTest, PopulateExistingDamageReceivesInvalidID) {
 }
 
 TEST_F(EmbedderTest, SetSingleDisplayConfigurationWithDisplayId) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -4056,7 +4036,7 @@ TEST_F(EmbedderTest, SetSingleDisplayConfigurationWithDisplayId) {
 }
 
 TEST_F(EmbedderTest, SetSingleDisplayConfigurationWithoutDisplayId) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -4098,7 +4078,7 @@ TEST_F(EmbedderTest, SetSingleDisplayConfigurationWithoutDisplayId) {
 }
 
 TEST_F(EmbedderTest, SetValidMultiDisplayConfiguration) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -4147,7 +4127,7 @@ TEST_F(EmbedderTest, SetValidMultiDisplayConfiguration) {
 }
 
 TEST_F(EmbedderTest, MultipleDisplaysWithSingleDisplayTrueIsInvalid) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -4193,7 +4173,7 @@ TEST_F(EmbedderTest, MultipleDisplaysWithSingleDisplayTrueIsInvalid) {
 }
 
 TEST_F(EmbedderTest, MultipleDisplaysWithSameDisplayIdIsInvalid) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -4239,7 +4219,7 @@ TEST_F(EmbedderTest, MultipleDisplaysWithSameDisplayIdIsInvalid) {
 }
 
 TEST_F(EmbedderTest, CompositorRenderTargetsNotRecycledWhenAvoidsCacheSet) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(300, 200));
@@ -4287,7 +4267,7 @@ TEST_F(EmbedderTest, CompositorRenderTargetsNotRecycledWhenAvoidsCacheSet) {
 }
 
 TEST_F(EmbedderTest, SnapshotRenderTargetScalesDownToDriverMax) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -4330,7 +4310,7 @@ TEST_F(EmbedderTest, SnapshotRenderTargetScalesDownToDriverMax) {
 }
 
 TEST_F(EmbedderTest, ObjectsPostedViaPortsServicedOnSecondaryTaskHeap) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 1024));
   builder.SetDartEntrypoint("objects_can_be_posted");
@@ -4380,7 +4360,7 @@ TEST_F(EmbedderTest, ObjectsPostedViaPortsServicedOnSecondaryTaskHeap) {
 }
 
 TEST_F(EmbedderTest, CreateInvalidBackingstoreOpenGLTexture) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
   builder.SetCompositor();
@@ -4443,7 +4423,7 @@ TEST_F(EmbedderTest, CreateInvalidBackingstoreOpenGLTexture) {
 }
 
 TEST_F(EmbedderTest, CreateInvalidBackingstoreOpenGLFramebuffer) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
   builder.SetCompositor();
@@ -4506,7 +4486,7 @@ TEST_F(EmbedderTest, CreateInvalidBackingstoreOpenGLFramebuffer) {
 }
 
 TEST_F(EmbedderTest, CreateInvalidBackingstoreOpenGLSurface) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
   builder.SetCompositor();
@@ -4628,8 +4608,7 @@ TEST_F(EmbedderTest, ExternalTextureGLRefreshedTooOften) {
 TEST_F(
     EmbedderTest,
     PresentInfoReceivesFullScreenDamageWhenPopulateExistingDamageIsNotProvided) {
-  auto& context = static_cast<EmbedderTestContextGL&>(
-      GetEmbedderContext(EmbedderTestContextType::kOpenGLContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
   context.GetRendererConfig().open_gl.populate_existing_damage = nullptr;
 
   EmbedderConfigBuilder builder(context);
@@ -4695,8 +4674,7 @@ TEST_F(
 
 TEST_F(EmbedderTest,
        PresentInfoReceivesJoinedDamageWhenExistingDamageContainsMultipleRects) {
-  auto& context = static_cast<EmbedderTestContextGL&>(
-      GetEmbedderContext(EmbedderTestContextType::kOpenGLContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
   context.GetRendererConfig().open_gl.populate_existing_damage =
       [](void* context, const intptr_t id,
          FlutterDamage* existing_damage) -> void {
@@ -4778,8 +4756,7 @@ TEST_F(EmbedderTest,
 }
 
 TEST_F(EmbedderTest, CanRenderWithImpellerOpenGL) {
-  EmbedderTestContextGL& context = static_cast<EmbedderTestContextGL&>(
-      GetEmbedderContext(EmbedderTestContextType::kOpenGLContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
   EmbedderConfigBuilder builder(context);
 
   bool present_called = false;
@@ -4838,7 +4815,7 @@ TEST_F(EmbedderTest, CanRenderWithImpellerOpenGL) {
 }
 
 TEST_F(EmbedderTest, CompositorMustBeAbleToRenderToOpenGLSurface) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -4954,7 +4931,7 @@ TEST_F(EmbedderTest, CompositorMustBeAbleToRenderToOpenGLSurface) {
 }
 
 TEST_F(EmbedderTest, CompositorMustBeAbleToRenderKnownSceneToOpenGLSurfaces) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kOpenGLContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextGL>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));

--- a/shell/platform/embedder/tests/embedder_metal_unittests.mm
+++ b/shell/platform/embedder/tests/embedder_metal_unittests.mm
@@ -36,7 +36,7 @@ namespace testing {
 using EmbedderTest = testing::EmbedderTest;
 
 TEST_F(EmbedderTest, CanRenderGradientWithMetal) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kMetalContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextMetal>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetDartEntrypoint("render_gradient");
@@ -74,8 +74,7 @@ static sk_sp<SkSurface> GetSurfaceFromTexture(const sk_sp<GrDirectContext>& skia
 }
 
 TEST_F(EmbedderTest, ExternalTextureMetal) {
-  EmbedderTestContextMetal& context = reinterpret_cast<EmbedderTestContextMetal&>(
-      GetEmbedderContext(EmbedderTestContextType::kMetalContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextMetal>();
 
   const auto texture_size = SkISize::Make(800, 600);
   const int64_t texture_id = 1;
@@ -128,7 +127,7 @@ TEST_F(EmbedderTest, ExternalTextureMetal) {
 }
 
 TEST_F(EmbedderTest, MetalCompositorMustBeAbleToRenderPlatformViews) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kMetalContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextMetal>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -239,7 +238,7 @@ TEST_F(EmbedderTest, MetalCompositorMustBeAbleToRenderPlatformViews) {
 }
 
 TEST_F(EmbedderTest, CanRenderSceneWithoutCustomCompositorMetal) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kMetalContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextMetal>();
 
   EmbedderConfigBuilder builder(context);
 
@@ -263,8 +262,8 @@ TEST_F(EmbedderTest, CanRenderSceneWithoutCustomCompositorMetal) {
 }
 
 TEST_F(EmbedderTest, TextureDestructionCallbackCalledWithoutCustomCompositorMetal) {
-  EmbedderTestContextMetal& context = reinterpret_cast<EmbedderTestContextMetal&>(
-      GetEmbedderContext(EmbedderTestContextType::kMetalContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextMetal>();
+
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
   builder.SetDartEntrypoint("texture_destruction_callback_called_without_custom_compositor");
@@ -313,7 +312,7 @@ TEST_F(EmbedderTest, TextureDestructionCallbackCalledWithoutCustomCompositorMeta
 }
 
 TEST_F(EmbedderTest, CompositorMustBeAbleToRenderKnownSceneMetal) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kMetalContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextMetal>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -510,7 +509,7 @@ TEST_F(EmbedderTest, CompositorMustBeAbleToRenderKnownSceneMetal) {
 }
 
 TEST_F(EmbedderTest, CreateInvalidBackingstoreMetalTexture) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kMetalContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextMetal>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
   builder.SetCompositor();
@@ -565,8 +564,7 @@ TEST_F(EmbedderTest, CreateInvalidBackingstoreMetalTexture) {
 }
 
 TEST_F(EmbedderTest, ExternalTextureMetalRefreshedTooOften) {
-  EmbedderTestContextMetal& context = reinterpret_cast<EmbedderTestContextMetal&>(
-      GetEmbedderContext(EmbedderTestContextType::kMetalContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextMetal>();
 
   TestMetalContext* metal_context = context.GetTestMetalContext();
   auto metal_texture = metal_context->CreateMetalTexture(SkISize::Make(100, 100));
@@ -614,7 +612,7 @@ TEST_F(EmbedderTest, ExternalTextureMetalRefreshedTooOften) {
 }
 
 TEST_F(EmbedderTest, CanRenderWithImpellerMetal) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kMetalContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextMetal>();
 
   EmbedderConfigBuilder builder(context);
 
@@ -639,7 +637,7 @@ TEST_F(EmbedderTest, CanRenderWithImpellerMetal) {
 }
 
 TEST_F(EmbedderTest, CanRenderTextWithImpellerMetal) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kMetalContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextMetal>();
 
   EmbedderConfigBuilder builder(context);
 
@@ -664,7 +662,7 @@ TEST_F(EmbedderTest, CanRenderTextWithImpellerMetal) {
 }
 
 TEST_F(EmbedderTest, CanRenderTextWithImpellerAndCompositorMetal) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kMetalContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextMetal>();
 
   EmbedderConfigBuilder builder(context);
 

--- a/shell/platform/embedder/tests/embedder_test.h
+++ b/shell/platform/embedder/tests/embedder_test.h
@@ -54,6 +54,12 @@ class EmbedderTest : public ThreadTest {
   }
 
  protected:
+  // We return the base class here and reinterpret_cast in the template
+  // specializations because we're using forward declarations rather than
+  // including the headers directly, and thus the relationship between the base
+  // class and subclasses is unknown to the compiler here. We avoid including
+  // the headers directly because the Metal headers include Objective-C types,
+  // and thus cannot be included in pure C++ translation units.
   EmbedderTestContext& GetGLContext();
   EmbedderTestContext& GetMetalContext();
   EmbedderTestContext& GetSoftwareContext();

--- a/shell/platform/embedder/tests/embedder_test_gl.cc
+++ b/shell/platform/embedder/tests/embedder_test_gl.cc
@@ -8,8 +8,12 @@
 
 namespace flutter::testing {
 
-std::unique_ptr<EmbedderTestContext> EmbedderTest::CreateGLContext() {
-  return std::make_unique<EmbedderTestContextGL>(GetFixturesDirectory());
+EmbedderTestContext& EmbedderTest::GetGLContext() {
+  if (!gl_context_) {
+    gl_context_ =
+        std::make_unique<EmbedderTestContextGL>(GetFixturesDirectory());
+  }
+  return *gl_context_.get();
 }
 
 }  // namespace flutter::testing

--- a/shell/platform/embedder/tests/embedder_test_metal.mm
+++ b/shell/platform/embedder/tests/embedder_test_metal.mm
@@ -8,8 +8,11 @@
 
 namespace flutter::testing {
 
-std::unique_ptr<EmbedderTestContext> EmbedderTest::CreateMetalContext() {
-  return std::make_unique<EmbedderTestContextMetal>(GetFixturesDirectory());
+EmbedderTestContext& EmbedderTest::GetMetalContext() {
+  if (!metal_context_) {
+    metal_context_ = std::make_unique<EmbedderTestContextMetal>(GetFixturesDirectory());
+  }
+  return *metal_context_.get();
 }
 
 }  // namespace flutter::testing

--- a/shell/platform/embedder/tests/embedder_test_vulkan.cc
+++ b/shell/platform/embedder/tests/embedder_test_vulkan.cc
@@ -8,8 +8,12 @@
 
 namespace flutter::testing {
 
-std::unique_ptr<EmbedderTestContext> EmbedderTest::CreateVulkanContext() {
-  return std::make_unique<EmbedderTestContextVulkan>(GetFixturesDirectory());
+EmbedderTestContext& EmbedderTest::GetVulkanContext() {
+  if (!vulkan_context_) {
+    vulkan_context_ =
+        std::make_unique<EmbedderTestContextVulkan>(GetFixturesDirectory());
+  }
+  return *vulkan_context_.get();
 }
 
 }  // namespace flutter::testing

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -65,7 +65,7 @@ TEST(EmbedderTestNoFixture, MustNotRunWithInvalidArgs) {
 }
 
 TEST_F(EmbedderTest, CanLaunchAndShutdownWithValidProjectArgs) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   fml::AutoResetWaitableEvent latch;
   context.AddIsolateCreateCallback([&latch]() { latch.Signal(); });
   EmbedderConfigBuilder builder(context);
@@ -79,8 +79,8 @@ TEST_F(EmbedderTest, CanLaunchAndShutdownWithValidProjectArgs) {
 
 // TODO(41999): Disabled because flaky.
 TEST_F(EmbedderTest, DISABLED_CanLaunchAndShutdownMultipleTimes) {
-  EmbedderConfigBuilder builder(
-      GetEmbedderContext(EmbedderTestContextType::kSoftwareContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
+  EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   for (size_t i = 0; i < 3; ++i) {
     auto engine = builder.LaunchEngine();
@@ -90,7 +90,7 @@ TEST_F(EmbedderTest, DISABLED_CanLaunchAndShutdownMultipleTimes) {
 }
 
 TEST_F(EmbedderTest, CanInvokeCustomEntrypoint) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   static fml::AutoResetWaitableEvent latch;
   Dart_NativeFunction entrypoint = [](Dart_NativeArguments args) {
     latch.Signal();
@@ -105,7 +105,7 @@ TEST_F(EmbedderTest, CanInvokeCustomEntrypoint) {
 }
 
 TEST_F(EmbedderTest, CanInvokeCustomEntrypointMacro) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
 
   fml::AutoResetWaitableEvent latch1;
   fml::AutoResetWaitableEvent latch2;
@@ -146,7 +146,7 @@ TEST_F(EmbedderTest, CanInvokeCustomEntrypointMacro) {
 }
 
 TEST_F(EmbedderTest, CanTerminateCleanly) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   builder.SetDartEntrypoint("terminateExitCodeHandler");
@@ -155,7 +155,7 @@ TEST_F(EmbedderTest, CanTerminateCleanly) {
 }
 
 TEST_F(EmbedderTest, ExecutableNameNotNull) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
 
   // Supply a callback to Dart for the test fixture to pass Platform.executable
   // back to us.
@@ -180,7 +180,7 @@ TEST_F(EmbedderTest, ImplicitViewNotNull) {
   // TODO(loicsharma): Update this test when embedders can opt-out
   // of the implicit view.
   // See: https://github.com/flutter/flutter/issues/120306
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
 
   bool implicitViewNotNull = false;
   fml::AutoResetWaitableEvent latch;
@@ -203,7 +203,7 @@ TEST_F(EmbedderTest, ImplicitViewNotNull) {
 std::atomic_size_t EmbedderTestTaskRunner::sEmbedderTaskRunnerIdentifiers = {};
 
 TEST_F(EmbedderTest, CanSpecifyCustomPlatformTaskRunner) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   fml::AutoResetWaitableEvent latch;
 
   // Run the test on its own thread with a message loop so that it can safely
@@ -281,7 +281,7 @@ TEST(EmbedderTestNoFixture, CanGetCurrentTimeInNanoseconds) {
 }
 
 TEST_F(EmbedderTest, CanReloadSystemFonts) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   auto engine = builder.LaunchEngine();
@@ -292,7 +292,7 @@ TEST_F(EmbedderTest, CanReloadSystemFonts) {
 }
 
 TEST_F(EmbedderTest, IsolateServiceIdSent) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   fml::AutoResetWaitableEvent latch;
 
   fml::Thread thread;
@@ -335,7 +335,7 @@ TEST_F(EmbedderTest, IsolateServiceIdSent) {
 /// immediately collects the same.
 ///
 TEST_F(EmbedderTest, CanCreateAndCollectCallbacks) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   builder.SetDartEntrypoint("platform_messages_response");
@@ -373,8 +373,7 @@ TEST_F(EmbedderTest, PlatformMessagesCanReceiveResponse) {
 
   CreateNewThread()->PostTask([&]() {
     captures.thread_id = std::this_thread::get_id();
-    auto& context =
-        GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+    auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
     EmbedderConfigBuilder builder(context);
     builder.SetSurface(SkISize::Make(1, 1));
     builder.SetDartEntrypoint("platform_messages_response");
@@ -430,7 +429,7 @@ TEST_F(EmbedderTest, PlatformMessagesCanReceiveResponse) {
 /// callback with the response is invoked to assert integrity.
 ///
 TEST_F(EmbedderTest, PlatformMessagesCanBeSentWithoutResponseHandles) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   builder.SetDartEntrypoint("platform_messages_no_response");
@@ -475,7 +474,7 @@ TEST_F(EmbedderTest, PlatformMessagesCanBeSentWithoutResponseHandles) {
 /// Tests that a null platform message can be sent.
 ///
 TEST_F(EmbedderTest, NullPlatformMessagesCanBeSent) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   builder.SetDartEntrypoint("null_platform_messages");
@@ -517,7 +516,7 @@ TEST_F(EmbedderTest, NullPlatformMessagesCanBeSent) {
 /// isn't equals to 0.
 ///
 TEST_F(EmbedderTest, InvalidPlatformMessages) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   auto engine = builder.LaunchEngine();
@@ -541,7 +540,7 @@ TEST_F(EmbedderTest, InvalidPlatformMessages) {
 /// using tag "flutter".
 TEST_F(EmbedderTest, CanSetCustomLogMessageCallback) {
   fml::AutoResetWaitableEvent callback_latch;
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetDartEntrypoint("custom_logger");
   builder.SetSurface(SkISize::Make(1, 1));
@@ -560,7 +559,7 @@ TEST_F(EmbedderTest, CanSetCustomLogMessageCallback) {
 /// Tests that setting a custom log tag works.
 TEST_F(EmbedderTest, CanSetCustomLogTag) {
   fml::AutoResetWaitableEvent callback_latch;
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetDartEntrypoint("custom_logger");
   builder.SetSurface(SkISize::Make(1, 1));
@@ -581,7 +580,7 @@ TEST_F(EmbedderTest, CanSetCustomLogTag) {
 /// set to true by default in these unit-tests).
 ///
 TEST_F(EmbedderTest, VMShutsDownWhenNoEnginesInProcess) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   const auto launch_count = DartVM::GetVMLaunchCount();
@@ -600,7 +599,7 @@ TEST_F(EmbedderTest, VMShutsDownWhenNoEnginesInProcess) {
 //------------------------------------------------------------------------------
 ///
 TEST_F(EmbedderTest, DartEntrypointArgs) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   builder.AddDartEntrypointArgument("foo");
@@ -634,7 +633,7 @@ TEST_F(EmbedderTest, VMAndIsolateSnapshotSizesAreRedundantInAOTMode) {
     GTEST_SKIP();
     return;
   }
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
 
@@ -649,7 +648,7 @@ TEST_F(EmbedderTest, VMAndIsolateSnapshotSizesAreRedundantInAOTMode) {
 }
 
 TEST_F(EmbedderTest, CanRenderImplicitView) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -681,7 +680,7 @@ TEST_F(EmbedderTest, CanRenderImplicitView) {
 }
 
 TEST_F(EmbedderTest, CanRenderImplicitViewUsingPresentLayersCallback) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -726,7 +725,7 @@ TEST_F(EmbedderTest,
        CompositorMustBeAbleToRenderKnownSceneWithSoftwareCompositor) {
 #endif  // FML_OS_MACOSX && FML_ARCH_CPU_ARM64
 
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -945,7 +944,7 @@ TEST_F(EmbedderTest,
 /// compositor, with a transparent overlay
 ///
 TEST_F(EmbedderTest, NoLayerCreatedForTransparentOverlayOnTopOfPlatformLayer) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -1082,7 +1081,7 @@ TEST_F(EmbedderTest, NoLayerCreatedForTransparentOverlayOnTopOfPlatformLayer) {
 /// compositor, with a no overlay
 ///
 TEST_F(EmbedderTest, NoLayerCreatedForNoOverlayOnTopOfPlatformLayer) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(800, 600));
@@ -1218,8 +1217,8 @@ TEST_F(EmbedderTest, NoLayerCreatedForNoOverlayOnTopOfPlatformLayer) {
 /// Test that an engine can be initialized but not run.
 ///
 TEST_F(EmbedderTest, CanCreateInitializedEngine) {
-  EmbedderConfigBuilder builder(
-      GetEmbedderContext(EmbedderTestContextType::kSoftwareContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
+  EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   auto engine = builder.InitializeEngine();
   ASSERT_TRUE(engine.is_valid());
@@ -1230,8 +1229,8 @@ TEST_F(EmbedderTest, CanCreateInitializedEngine) {
 /// Test that an initialized engine can be run exactly once.
 ///
 TEST_F(EmbedderTest, CanRunInitializedEngine) {
-  EmbedderConfigBuilder builder(
-      GetEmbedderContext(EmbedderTestContextType::kSoftwareContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
+  EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   auto engine = builder.InitializeEngine();
   ASSERT_TRUE(engine.is_valid());
@@ -1245,8 +1244,8 @@ TEST_F(EmbedderTest, CanRunInitializedEngine) {
 /// Test that an engine can be deinitialized.
 ///
 TEST_F(EmbedderTest, CanDeinitializeAnEngine) {
-  EmbedderConfigBuilder builder(
-      GetEmbedderContext(EmbedderTestContextType::kSoftwareContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
+  EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   auto engine = builder.InitializeEngine();
   ASSERT_TRUE(engine.is_valid());
@@ -1276,7 +1275,7 @@ TEST_F(EmbedderTest, CanDeinitializeAnEngine) {
 /// Test that a view can be added to a running engine.
 ///
 TEST_F(EmbedderTest, CanAddView) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   builder.SetDartEntrypoint("window_metrics_event_all_view_ids");
@@ -1324,7 +1323,7 @@ TEST_F(EmbedderTest, CanAddView) {
 /// Test that adding a view schedules a frame.
 ///
 TEST_F(EmbedderTest, AddViewSchedulesFrame) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   builder.SetDartEntrypoint("add_view_schedules_frame");
@@ -1369,7 +1368,7 @@ TEST_F(EmbedderTest, AddViewSchedulesFrame) {
 /// Test that a view that was added can be removed.
 ///
 TEST_F(EmbedderTest, CanRemoveView) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   builder.SetDartEntrypoint("window_metrics_event_all_view_ids");
@@ -1430,7 +1429,7 @@ TEST_F(EmbedderTest, CanRemoveView) {
 /// can *always* be rendered to. Test that this view cannot be removed.
 ///
 TEST_F(EmbedderTest, CannotRemoveImplicitView) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
 
@@ -1450,7 +1449,7 @@ TEST_F(EmbedderTest, CannotRemoveImplicitView) {
 /// Test that a view cannot be added if its ID already exists.
 ///
 TEST_F(EmbedderTest, CannotAddDuplicateViews) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   builder.SetDartEntrypoint("window_metrics_event_all_view_ids");
@@ -1522,7 +1521,7 @@ TEST_F(EmbedderTest, CannotAddDuplicateViews) {
 /// Test that a removed view's ID can be reused to add a new view.
 ///
 TEST_F(EmbedderTest, CanReuseViewIds) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   builder.SetDartEntrypoint("window_metrics_event_all_view_ids");
@@ -1587,7 +1586,7 @@ TEST_F(EmbedderTest, CanReuseViewIds) {
 /// Test that attempting to remove a view that does not exist fails as expected.
 ///
 TEST_F(EmbedderTest, CannotRemoveUnknownView) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
 
@@ -1613,7 +1612,7 @@ TEST_F(EmbedderTest, CannotRemoveUnknownView) {
 /// embedder's and engine's states remain synchronized.
 ///
 TEST_F(EmbedderTest, ViewOperationsOrdered) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   builder.SetDartEntrypoint("window_metrics_event_all_view_ids");
@@ -1760,7 +1759,7 @@ TEST_F(EmbedderTest, ViewOperationsOrdered) {
 /// Test the engine can present to multiple views.
 ///
 TEST_F(EmbedderTest, CanRenderMultipleViews) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   builder.SetCompositor();
@@ -1839,7 +1838,7 @@ TEST_F(EmbedderTest, CanRenderMultipleViews) {
 TEST_F(EmbedderTest, BackingStoresCorrespondToTheirViews) {
   constexpr FlutterViewId kSecondViewId = 123;
   constexpr FlutterViewId kThirdViewId = 456;
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetDartEntrypoint("render_all_views");
@@ -1993,7 +1992,7 @@ TEST_F(EmbedderTest, BackingStoresCorrespondToTheirViews) {
 }
 
 TEST_F(EmbedderTest, CanUpdateLocales) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   builder.SetDartEntrypoint("can_receive_locale_updates");
@@ -2052,7 +2051,7 @@ TEST_F(EmbedderTest, CanUpdateLocales) {
 }
 
 TEST_F(EmbedderTest, LocalizationCallbacksCalled) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   fml::AutoResetWaitableEvent latch;
   context.AddIsolateCreateCallback([&latch]() { latch.Signal(); });
   EmbedderConfigBuilder builder(context);
@@ -2084,7 +2083,7 @@ TEST_F(EmbedderTest, CanQueryDartAOTMode) {
 }
 
 TEST_F(EmbedderTest, VerifyB143464703WithSoftwareBackend) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1024, 600));
@@ -2208,7 +2207,7 @@ TEST_F(EmbedderTest, VerifyB143464703WithSoftwareBackend) {
 }
 
 TEST_F(EmbedderTest, CanSendLowMemoryNotification) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
 
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
@@ -2237,9 +2236,7 @@ TEST_F(EmbedderTest, CanPostTaskToAllNativeThreads) {
   auto platform_task_runner = CreateNewThread("platform_thread");
 
   platform_task_runner->PostTask([&]() {
-    auto& context =
-        GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
-
+    auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
     EmbedderConfigBuilder builder(context);
     builder.SetSurface(SkISize::Make(1, 1));
 
@@ -2379,7 +2376,7 @@ TEST_F(EmbedderTest, MustNotRunWithMultipleAOTSources) {
     GTEST_SKIP();
     return;
   }
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
 
   EmbedderConfigBuilder builder(
       context,
@@ -2421,7 +2418,7 @@ TEST_F(EmbedderTest, CanLaunchAndShutdownWithAValidElfSource) {
     GTEST_SKIP();
     return;
   }
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
 
   fml::AutoResetWaitableEvent latch;
   context.AddIsolateCreateCallback([&latch]() { latch.Signal(); });
@@ -2464,7 +2461,7 @@ TEST_F(EmbedderTest, CanSuccessfullyPopulateSpecificJITSnapshotCallbacks) {
     return;
   }
 
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
 
@@ -2520,7 +2517,7 @@ TEST_F(EmbedderTest, JITSnapshotCallbacksFailWithInvalidLocation) {
     return;
   }
 
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
 
@@ -2557,7 +2554,7 @@ TEST_F(EmbedderTest, CanLaunchEngineWithSpecifiedJITSnapshots) {
     return;
   }
 
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
 
@@ -2597,7 +2594,7 @@ TEST_F(EmbedderTest, CanLaunchEngineWithSomeSpecifiedJITSnapshots) {
     return;
   }
 
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
 
@@ -2630,7 +2627,7 @@ TEST_F(EmbedderTest, CanLaunchEngineWithInvalidJITSnapshots) {
     return;
   }
 
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
 
@@ -2656,7 +2653,7 @@ TEST_F(EmbedderTest, CanLaunchEngineWithUnspecifiedJITSnapshots) {
     return;
   }
 
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
 
@@ -2670,7 +2667,7 @@ TEST_F(EmbedderTest, CanLaunchEngineWithUnspecifiedJITSnapshots) {
 }
 
 TEST_F(EmbedderTest, InvalidFlutterWindowMetricsEvent) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   auto engine = builder.LaunchEngine();
@@ -2717,8 +2714,7 @@ static void expectSoftwareRenderingOutputMatches(
     std::string entrypoint,
     FlutterSoftwarePixelFormat pixfmt,
     const std::vector<uint8_t>& bytes) {
-  auto& context =
-      test.GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = test.GetEmbedderContext<EmbedderTestContextSoftware>();
 
   EmbedderConfigBuilder builder(context);
   fml::AutoResetWaitableEvent latch;
@@ -2940,8 +2936,7 @@ TEST_F(EmbedderTest, KeyDataIsCorrectlySerialized) {
   UniqueEngine engine;
   fml::AutoResetWaitableEvent ready;
   platform_task_runner->PostTask([&]() {
-    auto& context =
-        GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+    auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
     EmbedderConfigBuilder builder(context);
     builder.SetSurface(SkISize::Make(1, 1));
     builder.SetDartEntrypoint("key_data_echo");
@@ -3062,8 +3057,7 @@ TEST_F(EmbedderTest, KeyDataAreBuffered) {
   UniqueEngine engine;
   fml::AutoResetWaitableEvent ready;
   platform_task_runner->PostTask([&]() {
-    auto& context =
-        GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+    auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
     EmbedderConfigBuilder builder(context);
     builder.SetSurface(SkISize::Make(1, 1));
     builder.SetDartEntrypoint("key_data_late_echo");
@@ -3163,8 +3157,7 @@ TEST_F(EmbedderTest, KeyDataResponseIsCorrectlyInvoked) {
   auto platform_task_runner = CreateNewThread("platform_thread");
 
   platform_task_runner->PostTask([&]() {
-    auto& context =
-        GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+    auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
     EmbedderConfigBuilder builder(context);
     builder.SetSurface(SkISize::Make(1, 1));
     builder.SetDartEntrypoint("key_data_echo");
@@ -3237,9 +3230,7 @@ TEST_F(EmbedderTest, BackToBackKeyEventResponsesCorrectlyInvoked) {
   auto platform_task_runner = CreateNewThread("platform_thread");
 
   platform_task_runner->PostTask([&]() {
-    auto& context =
-        GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
-
+    auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
     EmbedderConfigBuilder builder(context);
     builder.SetSurface(SkISize::Make(1, 1));
     builder.SetDartEntrypoint("key_data_echo");
@@ -3324,9 +3315,7 @@ TEST_F(EmbedderTest, VsyncCallbackPostedIntoFuture) {
   auto platform_task_runner = CreateNewThread("platform_thread");
 
   platform_task_runner->PostTask([&]() {
-    auto& context =
-        GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
-
+    auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
     context.SetVsyncCallback([&](intptr_t baton) {
       platform_task_runner->PostTask([baton = baton, &engine, &vsync_latch]() {
         FlutterEngineOnVsync(engine.get(), baton, NanosFromEpoch(16),
@@ -3369,7 +3358,7 @@ TEST_F(EmbedderTest, VsyncCallbackPostedIntoFuture) {
 }
 
 TEST_F(EmbedderTest, CanScheduleFrame) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   builder.SetDartEntrypoint("can_schedule_frame");
@@ -3397,7 +3386,7 @@ TEST_F(EmbedderTest, CanScheduleFrame) {
 }
 
 TEST_F(EmbedderTest, CanSetNextFrameCallback) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   builder.SetDartEntrypoint("draw_solid_red");
@@ -3484,7 +3473,7 @@ TEST_F(EmbedderTest, EmbedderThreadHostUseCustomThreadConfig) {
 /// Send a pointer event to Dart and wait until the Dart code signals
 /// it received the event.
 TEST_F(EmbedderTest, CanSendPointer) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   builder.SetDartEntrypoint("pointer_data_packet");
@@ -3535,7 +3524,7 @@ TEST_F(EmbedderTest, CanSendPointer) {
 /// Send a pointer event to Dart and wait until the Dart code echos with the
 /// view ID.
 TEST_F(EmbedderTest, CanSendPointerEventWithViewId) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   builder.SetDartEntrypoint("pointer_data_packet_view_id");
@@ -3597,7 +3586,7 @@ TEST_F(EmbedderTest, CanSendPointerEventWithViewId) {
 }
 
 TEST_F(EmbedderTest, WindowMetricsEventDefaultsToImplicitView) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   builder.SetDartEntrypoint("window_metrics_event_view_id");
@@ -3638,7 +3627,7 @@ TEST_F(EmbedderTest, WindowMetricsEventDefaultsToImplicitView) {
 }
 
 TEST_F(EmbedderTest, IgnoresWindowMetricsEventForUnknownView) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   EmbedderConfigBuilder builder(context);
   builder.SetSurface(SkISize::Make(1, 1));
   builder.SetDartEntrypoint("window_metrics_event_view_id");
@@ -3694,7 +3683,7 @@ TEST_F(EmbedderTest, IgnoresWindowMetricsEventForUnknownView) {
 }
 
 TEST_F(EmbedderTest, RegisterChannelListener) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
 
   fml::AutoResetWaitableEvent latch;
   fml::AutoResetWaitableEvent latch2;
@@ -3725,7 +3714,7 @@ TEST_F(EmbedderTest, RegisterChannelListener) {
 }
 
 TEST_F(EmbedderTest, PlatformThreadIsolatesWithCustomPlatformTaskRunner) {
-  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  auto& context = GetEmbedderContext<EmbedderTestContextSoftware>();
   static fml::AutoResetWaitableEvent latch;
 
   static std::thread::id ffi_call_thread_id;

--- a/shell/platform/embedder/tests/embedder_vk_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_vk_unittests.cc
@@ -95,11 +95,15 @@ static_assert(
     CheckSameSignature<decltype(QueueSubmit), decltype(vkQueueSubmit)>::value);
 }  // namespace
 
+TEST_F(EmbedderTest, CanGetVulkanEmbedderContext) {
+  auto& context = GetEmbedderContext<EmbedderTestContextVulkan>();
+  EmbedderConfigBuilder builder(context);
+}
+
 TEST_F(EmbedderTest, CanSwapOutVulkanCalls) {
   fml::AutoResetWaitableEvent latch;
 
-  auto& context = static_cast<EmbedderTestContextVulkan&>(
-      GetEmbedderContext(EmbedderTestContextType::kVulkanContext));
+  auto& context = GetEmbedderContext<EmbedderTestContextVulkan>();
   context.AddIsolateCreateCallback([&latch]() { latch.Signal(); });
   context.SetVulkanInstanceProcAddressCallback(
       [](void* user_data, FlutterVulkanInstanceHandle instance,


### PR DESCRIPTION
In many embedder tests, we want to get at the appropriate backend-specific `EmbedderTestContext` subclass (`EmbedderTestContextGL`, etc.) in order to make backend-specific setup calls such as `SetGLFBOCallback()` or others. Formerly, this required casting the returned `EmbedderTestContext&` to the appropriate subclass in each test.

This templatises the `GetEmbedderContext()` method to return the appropriate backend-specific subclass directly.

Issue: https://github.com/flutter/flutter/issues/158998

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
