### PR TITLE
display_list: Extract backend-specific surface providers

### DIFF
--- a/display_list/testing/BUILD.gn
+++ b/display_list/testing/BUILD.gn
@@ -86,6 +86,7 @@ source_set("display_list_surface_provider") {
 
   if (surface_provider_include_software) {
     sources += [
+      "dl_test_surface_provider_software.cc",
       "dl_test_surface_software.cc",
       "dl_test_surface_software.h",
     ]
@@ -95,6 +96,7 @@ source_set("display_list_surface_provider") {
     sources += [
       "dl_test_surface_gl.cc",
       "dl_test_surface_gl.h",
+      "dl_test_surface_provider_gl.cc",
     ]
     deps += [ "//flutter/testing:opengl" ]
   }
@@ -103,6 +105,7 @@ source_set("display_list_surface_provider") {
     sources += [
       "dl_test_surface_metal.h",
       "dl_test_surface_metal.mm",
+      "dl_test_surface_provider_metal.mm",
     ]
     deps += [
       "//flutter/impeller/display_list",

--- a/display_list/testing/dl_test_surface_provider.cc
+++ b/display_list/testing/dl_test_surface_provider.cc
@@ -10,50 +10,29 @@
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/encode/SkPngEncoder.h"
 
-#ifdef ENABLE_SOFTWARE_BENCHMARKS
-#include "flutter/display_list/testing/dl_test_surface_software.h"
-#endif
-#ifdef ENABLE_OPENGL_BENCHMARKS
-#include "flutter/display_list/testing/dl_test_surface_gl.h"
-#endif
-#ifdef ENABLE_METAL_BENCHMARKS
-#include "flutter/display_list/testing/dl_test_surface_metal.h"
-#endif
-
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 std::string DlSurfaceProvider::BackendName(BackendType type) {
   switch (type) {
-    case kMetalBackend:
-      return "Metal";
-    case kOpenGlBackend:
-      return "OpenGL";
     case kSoftwareBackend:
       return "Software";
+    case kOpenGlBackend:
+      return "OpenGL";
+    case kMetalBackend:
+      return "Metal";
   }
 }
 
 std::unique_ptr<DlSurfaceProvider> DlSurfaceProvider::Create(
     BackendType backend_type) {
   switch (backend_type) {
-#ifdef ENABLE_SOFTWARE_BENCHMARKS
     case kSoftwareBackend:
-      return std::make_unique<DlSoftwareSurfaceProvider>();
-#endif
-#ifdef ENABLE_OPENGL_BENCHMARKS
-    case kOpenGLBackend:
-      return std::make_unique<DlOpenGLSurfaceProvider>();
-#endif
-#ifdef ENABLE_METAL_BENCHMARKS
+      return CreateSoftware();
+    case kOpenGlBackend:
+      return CreateOpenGL();
     case kMetalBackend:
-      return std::make_unique<DlMetalSurfaceProvider>();
-#endif
-    default:
-      return nullptr;
+      return CreateMetal();
   }
-
-  return nullptr;
 }
 
 bool DlSurfaceProvider::Snapshot(std::string& filename) const {
@@ -78,5 +57,20 @@ bool DlSurfaceProvider::Snapshot(std::string& filename) const {
 #endif
 }
 
-}  // namespace testing
-}  // namespace flutter
+#ifndef ENABLE_SOFTWARE_BENCHMARKS
+std::unique_ptr<DlSurfaceProvider> DlSurfaceProvider::CreateSoftware() {
+  return nullptr;
+}
+#endif
+#ifndef ENABLE_OPENGL_BENCHMARKS
+std::unique_ptr<DlSurfaceProvider> DlSurfaceProvider::CreateOpenGL() {
+  return nullptr;
+}
+#endif
+#ifndef ENABLE_METAL_BENCHMARKS
+std::unique_ptr<DlSurfaceProvider> DlSurfaceProvider::CreateMetal() {
+  return nullptr;
+}
+#endif
+
+}  // namespace flutter::testing

--- a/display_list/testing/dl_test_surface_provider.h
+++ b/display_list/testing/dl_test_surface_provider.h
@@ -97,6 +97,11 @@ class DlSurfaceProvider {
 
  protected:
   DlSurfaceProvider() = default;
+
+ private:
+  static std::unique_ptr<DlSurfaceProvider> CreateSoftware();
+  static std::unique_ptr<DlSurfaceProvider> CreateMetal();
+  static std::unique_ptr<DlSurfaceProvider> CreateOpenGL();
 };
 
 }  // namespace testing

--- a/display_list/testing/dl_test_surface_provider_gl.cc
+++ b/display_list/testing/dl_test_surface_provider_gl.cc
@@ -1,0 +1,15 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/display_list/testing/dl_test_surface_provider.h"
+
+#include "flutter/display_list/testing/dl_test_surface_gl.h"
+
+namespace flutter::testing {
+
+std::unique_ptr<DlSurfaceProvider> DlSurfaceProvider::CreateOpenGL() {
+  return std::make_unique<DlOpenGLSurfaceProvider>();
+}
+
+}  // namespace flutter::testing

--- a/display_list/testing/dl_test_surface_provider_metal.mm
+++ b/display_list/testing/dl_test_surface_provider_metal.mm
@@ -1,0 +1,15 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/display_list/testing/dl_test_surface_provider.h"
+
+#include "flutter/display_list/testing/dl_test_surface_metal.h"
+
+namespace flutter::testing {
+
+std::unique_ptr<DlSurfaceProvider> DlSurfaceProvider::CreateMetal() {
+  return std::make_unique<DlMetalSurfaceProvider>();
+}
+
+}  // namespace flutter::testing

--- a/display_list/testing/dl_test_surface_provider_software.cc
+++ b/display_list/testing/dl_test_surface_provider_software.cc
@@ -1,0 +1,15 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/display_list/testing/dl_test_surface_provider.h"
+
+#include "flutter/display_list/testing/dl_test_surface_software.h"
+
+namespace flutter::testing {
+
+std::unique_ptr<DlSurfaceProvider> DlSurfaceProvider::CreateSoftware() {
+  return std::make_unique<DlSoftwareSurfaceProvider>();
+}
+
+}  // namespace flutter::testing


### PR DESCRIPTION
Extracts backend-specific code in DlSurfaceProvider to separate translation units. In particular, this allows for less conditional header includes, and more specifically, allows code relating to the Metal backend to include headers that include ARC-managed Objective-C types. Today we cast these all to void* (and manage refcounting manually) since these headers are included in dl_surface_provider.cc, which is a pure C++ translation unit.

No test changes since this patch includes no semantic changes.

Issue: https://github.com/flutter/flutter/issues/137801

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
