### PR TITLE
Extract backend-specific code in ShellTestPlatformView

### DIFF
--- a/shell/common/shell_test_platform_view.h
+++ b/shell/common/shell_test_platform_view.h
@@ -11,8 +11,7 @@
 #include "flutter/shell/common/shell_test_external_view_embedder.h"
 #include "flutter/shell/common/vsync_waiters_test.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 class ShellTestPlatformView : public PlatformView {
  public:
@@ -53,6 +52,34 @@ class ShellTestPlatformView : public PlatformView {
                         const TaskRunners& task_runners)
       : PlatformView(delegate, task_runners) {}
 
+  static std::unique_ptr<ShellTestPlatformView> CreateGL(
+      PlatformView::Delegate& delegate,
+      const TaskRunners& task_runners,
+      const std::shared_ptr<ShellTestVsyncClock>& vsync_clock,
+      const CreateVsyncWaiter& create_vsync_waiter,
+      const std::shared_ptr<ShellTestExternalViewEmbedder>&
+          shell_test_external_view_embedder,
+      const std::shared_ptr<const fml::SyncSwitch>&
+          is_gpu_disabled_sync_switch);
+  static std::unique_ptr<ShellTestPlatformView> CreateMetal(
+      PlatformView::Delegate& delegate,
+      const TaskRunners& task_runners,
+      const std::shared_ptr<ShellTestVsyncClock>& vsync_clock,
+      const CreateVsyncWaiter& create_vsync_waiter,
+      const std::shared_ptr<ShellTestExternalViewEmbedder>&
+          shell_test_external_view_embedder,
+      const std::shared_ptr<const fml::SyncSwitch>&
+          is_gpu_disabled_sync_switch);
+  static std::unique_ptr<ShellTestPlatformView> CreateVulkan(
+      PlatformView::Delegate& delegate,
+      const TaskRunners& task_runners,
+      const std::shared_ptr<ShellTestVsyncClock>& vsync_clock,
+      const CreateVsyncWaiter& create_vsync_waiter,
+      const std::shared_ptr<ShellTestExternalViewEmbedder>&
+          shell_test_external_view_embedder,
+      const std::shared_ptr<const fml::SyncSwitch>&
+          is_gpu_disabled_sync_switch);
+
   FML_DISALLOW_COPY_AND_ASSIGN(ShellTestPlatformView);
 };
 
@@ -77,7 +104,6 @@ class ShellTestPlatformViewBuilder {
   Config config_;
 };
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_SHELL_COMMON_SHELL_TEST_PLATFORM_VIEW_H_

--- a/shell/common/shell_test_platform_view_gl.cc
+++ b/shell/common/shell_test_platform_view_gl.cc
@@ -22,6 +22,19 @@ static std::vector<std::shared_ptr<fml::Mapping>> ShaderLibraryMappings() {
   };
 }
 
+std::unique_ptr<ShellTestPlatformView> ShellTestPlatformView::CreateGL(
+    PlatformView::Delegate& delegate,
+    const TaskRunners& task_runners,
+    const std::shared_ptr<ShellTestVsyncClock>& vsync_clock,
+    const CreateVsyncWaiter& create_vsync_waiter,
+    const std::shared_ptr<ShellTestExternalViewEmbedder>&
+        shell_test_external_view_embedder,
+    const std::shared_ptr<const fml::SyncSwitch>& is_gpu_disabled_sync_switch) {
+  return std::make_unique<ShellTestPlatformViewGL>(
+      delegate, task_runners, vsync_clock, create_vsync_waiter,
+      shell_test_external_view_embedder);
+}
+
 ShellTestPlatformViewGL::ShellTestPlatformViewGL(
     PlatformView::Delegate& delegate,
     const TaskRunners& task_runners,

--- a/shell/common/shell_test_platform_view_metal.h
+++ b/shell/common/shell_test_platform_view_metal.h
@@ -5,14 +5,16 @@
 #ifndef FLUTTER_SHELL_COMMON_SHELL_TEST_PLATFORM_VIEW_METAL_H_
 #define FLUTTER_SHELL_COMMON_SHELL_TEST_PLATFORM_VIEW_METAL_H_
 
-#include "flutter/fml/macros.h"
 #include "flutter/shell/common/shell_test_platform_view.h"
+
+#import <Metal/Metal.h>
+
+#include "flutter/fml/macros.h"
 #include "flutter/shell/gpu/gpu_surface_metal_delegate.h"
+#include "flutter/shell/platform/darwin/graphics/FlutterDarwinContextMetalImpeller.h"
+#include "flutter/shell/platform/darwin/graphics/FlutterDarwinContextMetalSkia.h"
 
-namespace flutter {
-namespace testing {
-
-struct DarwinContextMetal;
+namespace flutter::testing {
 
 class ShellTestPlatformViewMetal final : public ShellTestPlatformView,
                                          public GPUSurfaceMetalDelegate {
@@ -30,7 +32,9 @@ class ShellTestPlatformViewMetal final : public ShellTestPlatformView,
   virtual ~ShellTestPlatformViewMetal() override;
 
  private:
-  const std::unique_ptr<DarwinContextMetal> metal_context_;
+  FlutterDarwinContextMetalSkia* skia_context_;
+  FlutterDarwinContextMetalImpeller* impeller_context_;
+  id<MTLTexture> offscreen_texture_;
   const CreateVsyncWaiter create_vsync_waiter_;
   const std::shared_ptr<ShellTestVsyncClock> vsync_clock_;
   const std::shared_ptr<ShellTestExternalViewEmbedder>
@@ -70,7 +74,6 @@ class ShellTestPlatformViewMetal final : public ShellTestPlatformView,
   FML_DISALLOW_COPY_AND_ASSIGN(ShellTestPlatformViewMetal);
 };
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_SHELL_COMMON_SHELL_TEST_PLATFORM_VIEW_METAL_H_

--- a/shell/common/shell_test_platform_view_vulkan.cc
+++ b/shell/common/shell_test_platform_view_vulkan.cc
@@ -23,8 +23,20 @@
 #include "flutter/vulkan/swiftshader_path.h"
 #endif
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
+
+std::unique_ptr<ShellTestPlatformView> ShellTestPlatformView::CreateVulkan(
+    PlatformView::Delegate& delegate,
+    const TaskRunners& task_runners,
+    const std::shared_ptr<ShellTestVsyncClock>& vsync_clock,
+    const CreateVsyncWaiter& create_vsync_waiter,
+    const std::shared_ptr<ShellTestExternalViewEmbedder>&
+        shell_test_external_view_embedder,
+    const std::shared_ptr<const fml::SyncSwitch>& is_gpu_disabled_sync_switch) {
+  return std::make_unique<ShellTestPlatformViewVulkan>(
+      delegate, task_runners, vsync_clock, create_vsync_waiter,
+      shell_test_external_view_embedder);
+}
 
 ShellTestPlatformViewVulkan::ShellTestPlatformViewVulkan(
     PlatformView::Delegate& delegate,
@@ -232,5 +244,4 @@ SkMatrix ShellTestPlatformViewVulkan::OffScreenSurface::GetRootTransformation()
   return matrix;
 }
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing

--- a/shell/common/shell_test_platform_view_vulkan.h
+++ b/shell/common/shell_test_platform_view_vulkan.h
@@ -15,8 +15,7 @@
 #include "third_party/skia/include/gpu/vk/VulkanMemoryAllocator.h"
 #include "third_party/skia/include/gpu/vk/VulkanTypes.h"
 
-namespace flutter {
-namespace testing {
+namespace flutter::testing {
 
 class ShellTestPlatformViewVulkan : public ShellTestPlatformView {
  public:
@@ -93,7 +92,6 @@ class ShellTestPlatformViewVulkan : public ShellTestPlatformView {
   FML_DISALLOW_COPY_AND_ASSIGN(ShellTestPlatformViewVulkan);
 };
 
-}  // namespace testing
-}  // namespace flutter
+}  // namespace flutter::testing
 
 #endif  // FLUTTER_SHELL_COMMON_SHELL_TEST_PLATFORM_VIEW_VULKAN_H_


### PR DESCRIPTION
Moves code specific to each graphics backend into the (existing) translation unit associated with that backend.

Previously, we could not include any Objective-C types in `shell_test_platform_view_metal.h`, since that file was included into `shell_test_platform_view.cc`, which is pure C++. To work around this, we had encapsulated Objective-C Metal types in a `DarwinContextMetal` struct hidden in the implementation file with a pointer to it forward-declared in the header.

We now use Metal types directly in the header, without the workarounds.

Issue: https://github.com/flutter/flutter/issues/158998
Issue: https://github.com/flutter/flutter/issues/137801

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
