### PR TITLE
[Impeller] flush all GLES cmd buffers together.

### DIFF
--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -160,6 +160,11 @@ void ContextGLES::ResetThreadLocalState() const {
 }
 
 // |Context|
+[[nodiscard]] bool ContextGLES::FlushCommandBuffers() {
+  return reactor_->React();
+}
+
+// |Context|
 bool ContextGLES::AddTrackingFence(
     const std::shared_ptr<Texture>& texture) const {
   if (!reactor_->GetProcTable().FenceSync.IsAvailable()) {

--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -159,6 +159,11 @@ void ContextGLES::ResetThreadLocalState() const {
       });
 }
 
+bool ContextGLES::EnqueueCommandBuffer(
+    std::shared_ptr<CommandBuffer> command_buffer) {
+  return true;
+}
+
 // |Context|
 [[nodiscard]] bool ContextGLES::FlushCommandBuffers() {
   return reactor_->React();

--- a/impeller/renderer/backend/gles/context_gles.h
+++ b/impeller/renderer/backend/gles/context_gles.h
@@ -99,6 +99,15 @@ class ContextGLES final : public Context,
   // |Context|
   void ResetThreadLocalState() const override;
 
+  // |Context|
+  [[nodiscard]] bool EnqueueCommandBuffer(
+      std::shared_ptr<CommandBuffer> command_buffer) override {
+    return true;
+  }
+
+  // |Context|
+  [[nodiscard]] bool FlushCommandBuffers() override;
+
   ContextGLES(const ContextGLES&) = delete;
 
   ContextGLES& operator=(const ContextGLES&) = delete;

--- a/impeller/renderer/backend/gles/context_gles.h
+++ b/impeller/renderer/backend/gles/context_gles.h
@@ -101,9 +101,7 @@ class ContextGLES final : public Context,
 
   // |Context|
   [[nodiscard]] bool EnqueueCommandBuffer(
-      std::shared_ptr<CommandBuffer> command_buffer) override {
-    return true;
-  }
+      std::shared_ptr<CommandBuffer> command_buffer) override;
 
   // |Context|
   [[nodiscard]] bool FlushCommandBuffers() override;

--- a/impeller/renderer/backend/gles/reactor_gles.cc
+++ b/impeller/renderer/backend/gles/reactor_gles.cc
@@ -166,7 +166,7 @@ std::optional<GLsync> ReactorGLES::GetGLFence(const HandleGLES& handle) const {
   return std::nullopt;
 }
 
-bool ReactorGLES::AddOperation(Operation operation) {
+bool ReactorGLES::AddOperation(Operation operation, bool defer) {
   if (!operation) {
     return false;
   }
@@ -176,7 +176,9 @@ bool ReactorGLES::AddOperation(Operation operation) {
     ops_[thread_id].emplace_back(std::move(operation));
   }
   // Attempt a reaction if able but it is not an error if this isn't possible.
-  [[maybe_unused]] auto result = React();
+  if (!defer) {
+    [[maybe_unused]] auto result = React();
+  }
   return true;
 }
 

--- a/impeller/renderer/backend/gles/reactor_gles.h
+++ b/impeller/renderer/backend/gles/reactor_gles.h
@@ -214,6 +214,8 @@ class ReactorGLES {
   ///             torn down.
   ///
   /// @param[in]  operation  The operation
+  /// @param[in]  defer      If false, the reactor attempts to React after
+  ///                        adding this operation.
   ///
   /// @return     If the operation was successfully queued for completion.
   ///

--- a/impeller/renderer/backend/gles/reactor_gles.h
+++ b/impeller/renderer/backend/gles/reactor_gles.h
@@ -217,7 +217,7 @@ class ReactorGLES {
   ///
   /// @return     If the operation was successfully queued for completion.
   ///
-  [[nodiscard]] bool AddOperation(Operation operation);
+  [[nodiscard]] bool AddOperation(Operation operation, bool defer = false);
 
   //----------------------------------------------------------------------------
   /// @brief      Register a cleanup callback that will be invokved with the

--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -585,14 +585,15 @@ bool RenderPassGLES::OnEncodeCommands(const Context& context) const {
 
   std::shared_ptr<const RenderPassGLES> shared_this = shared_from_this();
   auto tracer = ContextGLES::Cast(context).GetGPUTracer();
-  return reactor_->AddOperation([pass_data,
-                                 allocator = context.GetResourceAllocator(),
-                                 render_pass = std::move(shared_this),
-                                 tracer](const auto& reactor) {
-    auto result = EncodeCommandsInReactor(*pass_data, allocator, reactor,
-                                          render_pass->commands_, tracer);
-    FML_CHECK(result) << "Must be able to encode GL commands without error.";
-  });
+  return reactor_->AddOperation(
+      [pass_data, allocator = context.GetResourceAllocator(),
+       render_pass = std::move(shared_this), tracer](const auto& reactor) {
+        auto result = EncodeCommandsInReactor(*pass_data, allocator, reactor,
+                                              render_pass->commands_, tracer);
+        FML_CHECK(result)
+            << "Must be able to encode GL commands without error.";
+      },
+      /*defer=*/true);
 }
 
 }  // namespace impeller


### PR DESCRIPTION
Locally this gives much better performance, about doubling frame time on the Pixel 4. This avoids multiple glbuffersubdata calls that seems to perform particularly bad on mobile devices.

Thinking about it more, I'm not sure that having a separate EncodeCommands API is useful for RenderPass/BlitPass. instead they should probably just use submit. but that is a refactor for another day.


https://github.com/flutter/flutter/issues/159177