### PR TITLE
Revert "Added assert for opengles thread safety (#56585)"

### DIFF
--- a/impeller/renderer/backend/gles/proc_table_gles.cc
+++ b/impeller/renderer/backend/gles/proc_table_gles.cc
@@ -144,10 +144,6 @@ ProcTableGLES::ProcTableGLES(  // NOLINT(google-readability-function-size)
 
   capabilities_ = std::make_shared<CapabilitiesGLES>(*this);
 
-  // This this will force glUseProgram to only be used on one thread in debug
-  // builds to identify threading violations in the engine.
-  UseProgram.enforce_one_thread = true;
-
   is_valid_ = true;
 }
 


### PR DESCRIPTION
This reverts commit 79fe6b466041648b2241a6fc17af406c3ab10226.

The implementation of the assert assumes that there is a single raster thread ID that will remain constant throughout the lifetime of the process.  That is not true for scenarios like recreating the engine after suspending and resuming an Android app, or instantiating multiple engines within one process.