### PR TITLE
[Impeller] Ensure that SnapshotControllerImpeller has a rendering context before creating the snapshot

### DIFF
--- a/shell/common/snapshot_controller_impeller.cc
+++ b/shell/common/snapshot_controller_impeller.cc
@@ -18,6 +18,7 @@
 namespace flutter {
 
 namespace {
+
 sk_sp<DlImage> DoMakeRasterSnapshot(
     const sk_sp<DisplayList>& display_list,
     SkISize size,
@@ -51,6 +52,27 @@ sk_sp<DlImage> DoMakeRasterSnapshot(
                                      /*reset_host_buffer=*/false,
                                      /*generate_mips=*/true),
       DlImage::OwningContext::kRaster);
+}
+
+sk_sp<DlImage> DoMakeRasterSnapshot(
+    const sk_sp<DisplayList>& display_list,
+    SkISize size,
+    const SnapshotController::Delegate& delegate) {
+  // Ensure that the current thread has a rendering context.  This must be done
+  // before calling GetAiksContext because constructing the AiksContext may
+  // invoke graphics APIs.
+  std::unique_ptr<Surface> pbuffer_surface;
+  if (delegate.GetSurface()) {
+    delegate.GetSurface()->MakeRenderContextCurrent();
+  } else if (delegate.GetSnapshotSurfaceProducer()) {
+    pbuffer_surface =
+        delegate.GetSnapshotSurfaceProducer()->CreateSnapshotSurface();
+    if (pbuffer_surface) {
+      pbuffer_surface->MakeRenderContextCurrent();
+    }
+  }
+
+  return DoMakeRasterSnapshot(display_list, size, delegate.GetAiksContext());
 }
 
 sk_sp<DlImage> DoMakeRasterSnapshot(
@@ -112,16 +134,14 @@ void SnapshotControllerImpeller::MakeRasterSnapshot(
             }
 #endif
             callback(DoMakeRasterSnapshot(display_list, picture_size,
-                                          GetDelegate().GetAiksContext()));
+                                          GetDelegate()));
           }));
 }
 
 sk_sp<DlImage> SnapshotControllerImpeller::MakeRasterSnapshotSync(
     sk_sp<DisplayList> display_list,
     SkISize picture_size) {
-  return DoMakeRasterSnapshot(display_list, picture_size,
-                              GetDelegate().GetIsGpuDisabledSyncSwitch(),
-                              GetDelegate().GetAiksContext());
+  return DoMakeRasterSnapshot(display_list, picture_size, GetDelegate());
 }
 
 void SnapshotControllerImpeller::CacheRuntimeStage(

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -1598,18 +1598,17 @@ void render_impeller_text_test() {
 
 @pragma('vm:entry-point')
 // ignore: non_constant_identifier_names
-void render_impeller_image_snapshot_test() async {
+Future<void> render_impeller_image_snapshot_test() async {
   final PictureRecorder recorder = PictureRecorder();
   final Canvas canvas = Canvas(recorder);
-  const int alpha = 255;
-  const int blue = 123;
-  canvas.drawPaint(Paint()..color = Color.fromARGB(alpha, 0, 0, blue));
+  const Color color = Color.fromARGB(255, 0, 0, 123);
+  canvas.drawPaint(Paint()..color = color);
   final Picture picture = recorder.endRecording();
 
   final Image image = await picture.toImage(100, 100);
   final ByteData? imageData = await image.toByteData();
   final int pixel = imageData!.getInt32(0);
 
-  final bool result = (pixel & 0xFF) == alpha && ((pixel >> 8) & 0xFF) == blue;
+  final bool result = (pixel & 0xFF) == color.alpha && ((pixel >> 8) & 0xFF) == color.blue;
   notifyBoolValue(result);
 }

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -1595,3 +1595,21 @@ void render_impeller_text_test() {
   };
   PlatformDispatcher.instance.scheduleFrame();
 }
+
+@pragma('vm:entry-point')
+// ignore: non_constant_identifier_names
+void render_impeller_image_snapshot_test() async {
+  final PictureRecorder recorder = PictureRecorder();
+  final Canvas canvas = Canvas(recorder);
+  const int alpha = 255;
+  const int blue = 123;
+  canvas.drawPaint(Paint()..color = Color.fromARGB(alpha, 0, 0, blue));
+  final Picture picture = recorder.endRecording();
+
+  final Image image = await picture.toImage(100, 100);
+  final ByteData? imageData = await image.toByteData();
+  final int pixel = imageData!.getInt32(0);
+
+  final bool result = (pixel & 0xFF) == alpha && ((pixel >> 8) & 0xFF) == blue;
+  notifyBoolValue(result);
+}


### PR DESCRIPTION
The Skia snapshot controller will activate the delegate's surface render context on the current thread.  If the delegate has no surface, then it will use the snapshot surface producer to create a temporary surface.

The Impeller snapshot controller needs to do the same in order to support OpenGL/GLES scenarios where the thread does not currently have an EGL context.