### PR TITLE
Eliminate ShellTestPlatformView::BackendType::kDefaultBackendType

### DIFF
--- a/shell/common/animator_unittests.cc
+++ b/shell/common/animator_unittests.cc
@@ -88,8 +88,8 @@ TEST_F(ShellTest, VSyncTargetTime) {
         flutter::PlatformData(), task_runners, settings,
         [vsync_clock, &create_vsync_waiter](Shell& shell) {
           return ShellTestPlatformView::Create(
-              shell, shell.GetTaskRunners(), vsync_clock, create_vsync_waiter,
-              ShellTestPlatformView::BackendType::kDefaultBackend, nullptr,
+              ShellTestPlatformView::DefaultBackendType(), shell,
+              shell.GetTaskRunners(), vsync_clock, create_vsync_waiter, nullptr,
               shell.GetIsGpuDisabledSyncSwitch());
         },
         [](Shell& shell) { return std::make_unique<Rasterizer>(shell); });

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -500,13 +500,13 @@ TEST_F(ShellTest,
         // vsync mechanism. We should have better DI in the tests.
         const auto vsync_clock = std::make_shared<ShellTestVsyncClock>();
         return ShellTestPlatformView::Create(
-            shell, shell.GetTaskRunners(), vsync_clock,
+            ShellTestPlatformView::DefaultBackendType(), shell,
+            shell.GetTaskRunners(), vsync_clock,
             [task_runners = shell.GetTaskRunners()]() {
               return static_cast<std::unique_ptr<VsyncWaiter>>(
                   std::make_unique<VsyncWaiterFallback>(task_runners));
             },
-            ShellTestPlatformView::BackendType::kDefaultBackend, nullptr,
-            shell.GetIsGpuDisabledSyncSwitch());
+            nullptr, shell.GetIsGpuDisabledSyncSwitch());
       },
       [](Shell& shell) { return std::make_unique<Rasterizer>(shell); });
   ASSERT_TRUE(ValidateShell(shell.get()));


### PR DESCRIPTION
`kDefaultBackendType` is intended to make life easier for authors of tests, but in any switch statement where it's used (currently just a single location), we rely on ordering it first and `#ifdef`ing out all backends that aren't available.

Instead, we define a static function that returns the default that callers can invoke instead. This avoids reliance on case ordering and fallthrough.

In https://github.com/flutter/engine/pull/56722 we split backends out into separate translation units, and should remove the `#ifdef`s, which means we can't rely on this trick anymore.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
