### PR TITLE
[Impeller] cache and reuse openGL framebuffer attachments.

### DIFF
--- a/impeller/renderer/backend/gles/texture_gles.cc
+++ b/impeller/renderer/backend/gles/texture_gles.cc
@@ -648,9 +648,12 @@ std::optional<HandleGLES> TextureGLES::GetSyncFence() const {
   return fence_;
 }
 
-void TextureGLES::SetCachedFBO(GLuint fbo) { cached_fbo_ = fbo; }
+void TextureGLES::SetCachedFBO(GLuint fbo) {
+  cached_fbo_ = fbo;
+}
 
-GLuint TextureGLES::GetCachedFBO() const { return cached_fbo_; }
-
+GLuint TextureGLES::GetCachedFBO() const {
+  return cached_fbo_;
+}
 
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/texture_gles.cc
+++ b/impeller/renderer/backend/gles/texture_gles.cc
@@ -217,6 +217,9 @@ TextureGLES::TextureGLES(std::shared_ptr<ReactorGLES> reactor,
 // |Texture|
 TextureGLES::~TextureGLES() {
   reactor_->CollectHandle(handle_);
+  if (cached_fbo_ != GL_NONE) {
+    reactor_->GetProcTable().DeleteFramebuffers(1, &cached_fbo_);
+  }
 }
 
 // |Texture|

--- a/impeller/renderer/backend/gles/texture_gles.cc
+++ b/impeller/renderer/backend/gles/texture_gles.cc
@@ -648,4 +648,9 @@ std::optional<HandleGLES> TextureGLES::GetSyncFence() const {
   return fence_;
 }
 
+void TextureGLES::SetCachedFBO(GLuint fbo) { cached_fbo_ = fbo; }
+
+GLuint TextureGLES::GetCachedFBO() const { return cached_fbo_; }
+
+
 }  // namespace impeller

--- a/impeller/renderer/backend/gles/texture_gles.h
+++ b/impeller/renderer/backend/gles/texture_gles.h
@@ -130,9 +130,14 @@ class TextureGLES final : public Texture,
   ///
   void SetFence(HandleGLES fence);
 
-  void SetCachedFBO(GLuint fbo) { cached_fbo_ = fbo; }
+  /// Store the FBO object for recycling in the 2D renderer.
+  ///
+  /// The color0 texture used by the 2D renderer will use this texture
+  /// object to store the associated FBO the first time it is used.
+  void SetCachedFBO(GLuint fbo);
 
-  GLuint GetCachedFBO() const { return cached_fbo_; }
+  /// Retrieve the cached FBO object, or GL_NONE if there is no object.
+  GLuint GetCachedFBO() const;
 
   // Visible for testing.
   std::optional<HandleGLES> GetSyncFence() const;

--- a/impeller/renderer/backend/gles/texture_gles.h
+++ b/impeller/renderer/backend/gles/texture_gles.h
@@ -130,6 +130,10 @@ class TextureGLES final : public Texture,
   ///
   void SetFence(HandleGLES fence);
 
+  void SetCachedFBO(GLuint fbo) { cached_fbo_ = fbo; }
+
+  GLuint GetCachedFBO() const { return cached_fbo_; }
+
   // Visible for testing.
   std::optional<HandleGLES> GetSyncFence() const;
 
@@ -141,6 +145,7 @@ class TextureGLES final : public Texture,
   mutable std::bitset<6> slices_initialized_ = 0;
   const bool is_wrapped_;
   const std::optional<GLuint> wrapped_fbo_;
+  GLuint cached_fbo_ = GL_NONE;
   bool is_valid_ = false;
 
   TextureGLES(std::shared_ptr<ReactorGLES> reactor,


### PR DESCRIPTION
Creating and attaching textures/render buffers to a FBO is an expensive operation. Similar to how we cache vulkan framebuffers/render passes, we can cache the FBO object on the color0 texture to avoid extra state invalidation.

Part of https://github.com/flutter/flutter/issues/159177