### PR TITLE
[android] remove fml_check from surface_texture_external_texture

### DIFF
--- a/shell/platform/android/surface_texture_external_texture.cc
+++ b/shell/platform/android/surface_texture_external_texture.cc
@@ -52,7 +52,10 @@ void SurfaceTextureExternalTexture::Paint(PaintContext& context,
   if (should_process_frame) {
     ProcessFrame(context, bounds);
   }
-  FML_CHECK(state_ == AttachmentState::kAttached);
+  // If process frame failed, this may not be in attached state.
+  if (state_ != AttachmentState::kAttached) {
+    return;
+  }
 
   if (!dl_image_) {
     FML_LOG(WARNING)


### PR DESCRIPTION
We may fail to acquire a new image from the external image source. When this happens, don't crash the app.