### PR TITLE
Smaller reactor handle locks

### DIFF
--- a/impeller/renderer/backend/gles/reactor_gles.cc
+++ b/impeller/renderer/backend/gles/reactor_gles.cc
@@ -203,7 +203,6 @@ HandleGLES ReactorGLES::CreateHandle(HandleType type, GLuint external_handle) {
   if (new_handle.IsDead()) {
     return HandleGLES::DeadHandle();
   }
-  WriterLock handles_lock(handles_mutex_);
 
   std::optional<ReactorGLES::GLStorage> gl_handle;
   if (external_handle != GL_NONE) {
@@ -211,6 +210,8 @@ HandleGLES ReactorGLES::CreateHandle(HandleType type, GLuint external_handle) {
   } else if (CanReactOnCurrentThread()) {
     gl_handle = CreateGLHandle(GetProcTable(), type);
   }
+
+  WriterLock handles_lock(handles_mutex_);
   handles_[new_handle] = LiveHandle{gl_handle};
   return new_handle;
 }


### PR DESCRIPTION
This reduces the amount of work that is happening inside the read/write mutex for tracking handles in the Reactor.
1) Now gl cleanup calls happen outside of the write lock
1) Now setting gl debug texts are out of the write lock
1) Now creating objects with CreateHandle are out of the write lock

Jonah was seeing considerable time in the rwmutex, this should alleviate some of that.

![setlabel](https://github.com/user-attachments/assets/6ebe247b-76f4-457f-b28b-70ddcd5615a8)

issue: https://github.com/flutter/flutter/issues/159177

tests: no functional change, just performance

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
