### PR TITLE
Replaces Resource's shared_ptr with unique_ptr

### DIFF
--- a/impeller/renderer/command.h
+++ b/impeller/renderer/command.h
@@ -29,7 +29,8 @@ namespace impeller {
 #endif  // IMPELLER_DEBUG
 
 template <class T>
-struct Resource {
+class Resource {
+ public:
   using ResourceType = T;
   ResourceType resource;
 
@@ -40,7 +41,7 @@ struct Resource {
 
   Resource(const ShaderMetadata& metadata, ResourceType p_resource)
       : resource(p_resource),
-        dynamic_metadata_(std::make_shared<ShaderMetadata>(metadata)) {}
+        dynamic_metadata_(std::make_unique<ShaderMetadata>(metadata)) {}
 
   const ShaderMetadata* GetMetadata() const {
     return dynamic_metadata_ ? dynamic_metadata_.get() : metadata_;
@@ -51,7 +52,7 @@ struct Resource {
   const ShaderMetadata* metadata_ = nullptr;
 
   // Dynamically generated shader metadata.
-  std::shared_ptr<const ShaderMetadata> dynamic_metadata_ = nullptr;
+  std::unique_ptr<const ShaderMetadata> dynamic_metadata_ = nullptr;
 };
 
 using BufferResource = Resource<BufferView>;


### PR DESCRIPTION
A non-inconsequential amount of time is spent in ~shared_ptr for no reason in ~Resource

<img width="1057" alt="Screenshot 2024-11-23 at 3 22 11 PM" src="https://github.com/user-attachments/assets/fba73908-2e43-4908-8008-ddd78fd77831">

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
