### PR TITLE
iOS: Eliminate logging of non-zero origin platformviews

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/platform_views_controller.h
+++ b/shell/platform/darwin/ios/framework/Source/platform_views_controller.h
@@ -295,13 +295,6 @@ class PlatformViewsController {
   /// This state is only modified on the raster thread.
   std::unordered_set<int64_t> views_to_recomposite_;
 
-#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
-  /// A set to keep track of embedded views that do not have (0, 0) origin.
-  /// An insertion triggers a warning message about non-zero origin logged on the debug console.
-  /// See https://github.com/flutter/flutter/issues/109700 for details.
-  std::unordered_set<int64_t> non_zero_origin_views_;
-#endif
-
   /// @brief The composition order from the previous thread.
   ///
   /// Only accessed from the platform thread.

--- a/shell/platform/darwin/ios/framework/Source/platform_views_controller.mm
+++ b/shell/platform/darwin/ios/framework/Source/platform_views_controller.mm
@@ -537,26 +537,9 @@ void PlatformViewsController::ApplyMutators(const MutatorsStack& mutators_stack,
 // included in the `views_to_recomposite_`.
 void PlatformViewsController::CompositeWithParams(int64_t view_id,
                                                   const EmbeddedViewParams& params) {
+  /// TODO(https://github.com/flutter/flutter/issues/109700)
   CGRect frame = CGRectMake(0, 0, params.sizePoints().width(), params.sizePoints().height());
   FlutterTouchInterceptingView* touchInterceptor = platform_views_[view_id].touch_interceptor;
-#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
-  FML_DCHECK(CGPointEqualToPoint([touchInterceptor embeddedView].frame.origin, CGPointZero));
-  if (non_zero_origin_views_.find(view_id) == non_zero_origin_views_.end() &&
-      !CGPointEqualToPoint([touchInterceptor embeddedView].frame.origin, CGPointZero)) {
-    non_zero_origin_views_.insert(view_id);
-    NSLog(
-        @"A Embedded PlatformView's origin is not CGPointZero.\n"
-         "  View id: %@\n"
-         "  View info: \n %@ \n"
-         "A non-zero origin might cause undefined behavior.\n"
-         "See https://github.com/flutter/flutter/issues/109700 for more details.\n"
-         "If you are the author of the PlatformView, please update the implementation of the "
-         "PlatformView to have a (0, 0) origin.\n"
-         "If you have a valid case of using a non-zero origin, "
-         "please leave a comment at https://github.com/flutter/flutter/issues/109700 with details.",
-        @(view_id), [touchInterceptor embeddedView]);
-  }
-#endif
   touchInterceptor.layer.transform = CATransform3DIdentity;
   touchInterceptor.frame = frame;
   touchInterceptor.alpha = 1;


### PR DESCRIPTION
In flutter/engine#35501, handling was added to log a debug message to the console in the case where a platform view with a non-zero origin was identified.

Unfortunately:
* In unopt builds, the first thing we do in that block is to call FML_DCHECK asserting that the origin is zero, so we never actually emit the log statement.
* In opt builds, FML_DCHECK is a no-op, so users are unlikely to actually ever notice the crash.

The proper fix is to eliminate this restriction, but in the meantime, this eliminates this block entirely and leaves the TODO. We've had only two comments on that bug in the 2.5 years since it was added.

Issue: https://github.com/flutter/flutter/issues/109700

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
