### PR TITLE
iOS: Delete FlutterPlatformViewsController.layerPoolSize

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.h
@@ -125,9 +125,6 @@
 
 - (size_t)embeddedViewCount;
 
-// TODO(cbracken): Delete. This is unused.
-- (size_t)layerPoolSize;
-
 // Returns the `FlutterPlatformView`'s `view` object associated with the view_id.
 //
 // If the `PlatformViewsController` does not contain any `FlutterPlatformView` object or

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -538,10 +538,6 @@ BOOL canApplyBlurBackdrop = YES;
   return self.compositionOrder.size();
 }
 
-- (size_t)layerPoolSize {
-  return self.layerPool->size();
-}
-
 - (UIView*)platformViewForId:(int64_t)viewId {
   return [self flutterTouchInterceptingViewForId:viewId].embeddedView;
 }


### PR DESCRIPTION
This field is unused in the codebase/tests.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
