### PR TITLE
[engine] Migrate fuchsia.io Open functions to Open3

### DIFF
--- a/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.cc
+++ b/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.cc
@@ -183,10 +183,8 @@ zx_status_t FdFromPath(const char* path, fml::UniqueFD& fd) {
     path++;
   }
   int raw_fd;
-  if (zx_status_t status = fdio_open_fd_at(
-          dir_fd.get(), path,
-          static_cast<uint32_t>(fuchsia::io::OpenFlags::RIGHT_READABLE),
-          &raw_fd);
+  if (zx_status_t status = fdio_open3_fd_at(
+          dir_fd.get(), path, uint64_t{fuchsia::io::PERM_READABLE}, &raw_fd);
       status != ZX_OK) {
     return status;
   }

--- a/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
@@ -246,10 +246,10 @@ bool DartComponentController::CreateAndBindNamespace() {
         for (auto& dir_str : other_dirs) {
           fuchsia::io::DirectoryHandle dir;
           auto request = dir.NewRequest().TakeChannel();
-          auto status = fdio_open_at(
+          const zx_status_t status = fdio_open3_at(
               dart_outgoing_dir_ptr_.channel().get(), dir_str.c_str(),
-              static_cast<uint32_t>(fuchsia::io::OpenFlags::DIRECTORY |
-                                    fuchsia::io::OpenFlags::RIGHT_READABLE),
+              uint64_t{fuchsia::io::Flags::PROTOCOL_DIRECTORY |
+                       fuchsia::io::PERM_READABLE},
               request.release());
           if (status == ZX_OK) {
             dart_outgoing_dir_->AddEntry(

--- a/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
@@ -283,11 +283,11 @@ bool DartComponentController::CreateAndBindNamespace() {
   dart_outgoing_dir_->AddEntry("svc", std::move(composed_service_dir));
 
   if (start_info_.has_outgoing_dir()) {
+    fidl::ServerEnd<fuchsia_io::Directory> server_end{
+        start_info_.mutable_outgoing_dir()->TakeChannel()};
     dart_outgoing_dir_->Serve(
-        fuchsia::io::OpenFlags::RIGHT_READABLE |
-            fuchsia::io::OpenFlags::RIGHT_WRITABLE |
-            fuchsia::io::OpenFlags::DIRECTORY,
-        start_info_.mutable_outgoing_dir()->TakeChannel());
+        fuchsia_io::wire::kPermReadable | fuchsia_io::wire::kPermWritable,
+        std::move(server_end));
   }
 
   return true;

--- a/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
@@ -215,14 +215,9 @@ bool DartComponentController::CreateAndBindNamespace() {
   // That will prevent FL-175 for public directory
   fdio_service_connect_at(dart_outgoing_dir_ptr_.channel().get(), "svc",
                           dart_public_dir.NewRequest().TakeChannel().release());
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-
+                          
   auto composed_service_dir = std::make_unique<vfs::ComposedServiceDir>();
   composed_service_dir->set_fallback(std::move(dart_public_dir));
-
-#pragma clang diagnostic pop
 
   // Clone and check if client is servicing the directory.
   dart_outgoing_dir_ptr_->Clone(

--- a/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
@@ -210,33 +210,34 @@ bool DartComponentController::CreateAndBindNamespace() {
   dart_outgoing_dir_request_ = dart_outgoing_dir_ptr_.NewRequest();
 
   fuchsia::io::DirectoryHandle dart_public_dir;
-  // TODO(anmittal): when fixing enumeration using new c++ vfs, make sure that
-  // flutter_public_dir is only accessed once we receive OnOpen Event.
-  // That will prevent FL-175 for public directory
-  fdio_service_connect_at(dart_outgoing_dir_ptr_.channel().get(), "svc",
-                          dart_public_dir.NewRequest().TakeChannel().release());
-                          
+  {
+    auto request = dart_public_dir.NewRequest().TakeChannel();
+    const zx_status_t status =
+        fdio_open3_at(dart_outgoing_dir_ptr_.channel().get(), "svc",
+                      uint64_t{fuchsia::io::PERM_READABLE}, request.release());
+    if (status != ZX_OK) {
+      FML_LOG(ERROR) << "Failed to open /svc in outgoing directory: "
+                     << zx_status_get_string(status);
+      return false;
+    }
+  }
+
   auto composed_service_dir = std::make_unique<vfs::ComposedServiceDir>();
   composed_service_dir->set_fallback(std::move(dart_public_dir));
 
-  // Clone and check if client is servicing the directory.
-  dart_outgoing_dir_ptr_->Clone(
-      fuchsia::io::OpenFlags::DESCRIBE |
-          fuchsia::io::OpenFlags::CLONE_SAME_RIGHTS,
-      dart_outgoing_dir_ptr_to_check_on_open_.NewRequest());
+  // Request an event from the directory to ensure it is servicing requests.
+  dart_outgoing_dir_ptr_->Open3(
+      ".",
+      fuchsia::io::Flags::PROTOCOL_NODE |
+          fuchsia::io::Flags::FLAG_SEND_REPRESENTATION,
+      {}, dart_outgoing_dir_ptr_to_check_on_open_.NewRequest().TakeChannel());
 
   // Collect our standard set of directories.
   std::vector<std::string> other_dirs = {"debug", "ctrl"};
 
-  dart_outgoing_dir_ptr_to_check_on_open_.events().OnOpen =
-      [this, other_dirs](zx_status_t status, auto unused) {
+  dart_outgoing_dir_ptr_to_check_on_open_.events().OnRepresentation =
+      [this, other_dirs](auto unused) {
         dart_outgoing_dir_ptr_to_check_on_open_.Unbind();
-        if (status != ZX_OK) {
-          FML_LOG(ERROR) << "could not bind out directory for dart component("
-                         << label_ << "): " << zx_status_get_string(status);
-          return;
-        }
-
         // add other directories as RemoteDirs.
         for (auto& dir_str : other_dirs) {
           fuchsia::io::DirectoryHandle dir;

--- a/shell/platform/fuchsia/flutter/component_v2.cc
+++ b/shell/platform/fuchsia/flutter/component_v2.cc
@@ -235,18 +235,20 @@ ComponentV2::ComponentV2(
 
   // ComponentStartInfo::runtime_dir (optional).
   if (start_info.has_runtime_dir()) {
-    runtime_dir_->Serve(fuchsia::io::OpenFlags::RIGHT_READABLE |
-                            fuchsia::io::OpenFlags::RIGHT_WRITABLE |
-                            fuchsia::io::OpenFlags::DIRECTORY,
-                        start_info.mutable_runtime_dir()->TakeChannel());
+    fidl::ServerEnd<fuchsia_io::Directory> server_end{
+        start_info.mutable_runtime_dir()->TakeChannel()};
+    runtime_dir_->Serve(
+        fuchsia_io::wire::kPermReadable | fuchsia_io::wire::kPermWritable,
+        std::move(server_end));
   }
 
   // ComponentStartInfo::outgoing_dir (optional).
   if (start_info.has_outgoing_dir()) {
-    outgoing_dir_->Serve(fuchsia::io::OpenFlags::RIGHT_READABLE |
-                             fuchsia::io::OpenFlags::RIGHT_WRITABLE |
-                             fuchsia::io::OpenFlags::DIRECTORY,
-                         start_info.mutable_outgoing_dir()->TakeChannel());
+    fidl::ServerEnd<fuchsia_io::Directory> server_end{
+        start_info.mutable_outgoing_dir()->TakeChannel()};
+    outgoing_dir_->Serve(
+        fuchsia_io::wire::kPermReadable | fuchsia_io::wire::kPermWritable,
+        std::move(server_end));
   }
 
   directory_request_ = directory_ptr_.NewRequest();

--- a/shell/platform/fuchsia/flutter/component_v2.cc
+++ b/shell/platform/fuchsia/flutter/component_v2.cc
@@ -261,13 +261,8 @@ ComponentV2::ComponentV2(
   fdio_service_connect_at(directory_ptr_.channel().get(), "svc",
                           request.release());
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-
   auto composed_service_dir = std::make_unique<vfs::ComposedServiceDir>();
   composed_service_dir->set_fallback(std::move(flutter_public_dir));
-
-#pragma clang diagnostic pop
 
   // Clone and check if client is servicing the directory.
   directory_ptr_->Clone(fuchsia::io::OpenFlags::DESCRIBE |

--- a/shell/platform/fuchsia/flutter/component_v2.cc
+++ b/shell/platform/fuchsia/flutter/component_v2.cc
@@ -292,11 +292,11 @@ ComponentV2::ComponentV2(
     for (auto& dir_str : other_dirs) {
       fuchsia::io::DirectoryHandle dir;
       auto request = dir.NewRequest().TakeChannel();
-      auto status = fdio_open_at(
-          directory_ptr_.channel().get(), dir_str.c_str(),
-          static_cast<uint32_t>(fuchsia::io::OpenFlags::DIRECTORY |
-                                fuchsia::io::OpenFlags::RIGHT_READABLE),
-          request.release());
+      const zx_status_t status =
+          fdio_open3_at(directory_ptr_.channel().get(), dir_str.c_str(),
+                        uint64_t{fuchsia::io::Flags::PROTOCOL_DIRECTORY |
+                                 fuchsia::io::PERM_READABLE},
+                        request.release());
       if (status == ZX_OK) {
         outgoing_dir_->AddEntry(
             dir_str.c_str(),

--- a/shell/platform/fuchsia/flutter/file_in_namespace_buffer.cc
+++ b/shell/platform/fuchsia/flutter/file_in_namespace_buffer.cc
@@ -74,16 +74,15 @@ std::unique_ptr<fml::Mapping> LoadFile(int namespace_fd,
 
 std::unique_ptr<fml::FileMapping> MakeFileMapping(const char* path,
                                                   bool executable) {
-  auto flags = fuchsia::io::OpenFlags::RIGHT_READABLE;
+  fuchsia::io::Flags flags = fuchsia::io::PERM_READABLE;
   if (executable) {
-    flags |= fuchsia::io::OpenFlags::RIGHT_EXECUTABLE;
+    flags |= fuchsia::io::PERM_EXECUTABLE;
   }
 
   // The returned file descriptor is compatible with standard posix operations
   // such as close, mmap, etc. We only need to treat open/open_at specially.
   int fd;
-  const zx_status_t status =
-      fdio_open_fd(path, static_cast<uint32_t>(flags), &fd);
+  const zx_status_t status = fdio_open3_fd(path, uint64_t{flags}, &fd);
   if (status != ZX_OK) {
     return nullptr;
   }

--- a/shell/platform/fuchsia/runtime/dart/utils/mapped_resource.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/mapped_resource.cc
@@ -103,13 +103,16 @@ MappedResource::~MappedResource() {
 
 static int OpenFdExec(const std::string& path, int dirfd) {
   int fd = -1;
-  zx_status_t result = fdio_open_fd_at(
-      dirfd, path.c_str(),
-      static_cast<uint32_t>(fuchsia::io::OpenFlags::RIGHT_READABLE |
-                            fuchsia::io::OpenFlags::RIGHT_EXECUTABLE),
-      &fd);
+  // fdio_open3_fd_at only allows relative paths
+  const char* path_ptr = path.c_str();
+  if (path_ptr && path_ptr[0] == '/') {
+    ++path_ptr;
+  }
+  zx_status_t result = fdio_open3_fd_at(
+      dirfd, path_ptr,
+      uint64_t{fuchsia::io::PERM_READABLE | fuchsia::io::PERM_EXECUTABLE}, &fd);
   if (result != ZX_OK) {
-    FML_LOG(ERROR) << "fdio_open_fd_at(" << path << ") "
+    FML_LOG(ERROR) << "fdio_open3_fd_at(" << path << ") "
                    << "failed: " << zx_status_get_string(result);
     return -1;
   }

--- a/shell/platform/fuchsia/runtime/dart/utils/mapped_resource.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/mapped_resource.cc
@@ -103,24 +103,11 @@ MappedResource::~MappedResource() {
 
 static int OpenFdExec(const std::string& path, int dirfd) {
   int fd = -1;
-  zx_status_t result;
-  if (dirfd == AT_FDCWD) {
-    // fdio_open_fd_at does not support AT_FDCWD, by design.  Use fdio_open_fd
-    // and expect an absolute path for that usage pattern.
-    FML_CHECK(path[0] == '/');
-    result = fdio_open_fd(
-        path.c_str(),
-        static_cast<uint32_t>(fuchsia::io::OpenFlags::RIGHT_READABLE |
-                              fuchsia::io::OpenFlags::RIGHT_EXECUTABLE),
-        &fd);
-  } else {
-    FML_CHECK(path[0] != '/');
-    result = fdio_open_fd_at(
-        dirfd, path.c_str(),
-        static_cast<uint32_t>(fuchsia::io::OpenFlags::RIGHT_READABLE |
-                              fuchsia::io::OpenFlags::RIGHT_EXECUTABLE),
-        &fd);
-  }
+  zx_status_t result = fdio_open_fd_at(
+      dirfd, path.c_str(),
+      static_cast<uint32_t>(fuchsia::io::OpenFlags::RIGHT_READABLE |
+                            fuchsia::io::OpenFlags::RIGHT_EXECUTABLE),
+      &fd);
   if (result != ZX_OK) {
     FML_LOG(ERROR) << "fdio_open_fd_at(" << path << ") "
                    << "failed: " << zx_status_get_string(result);

--- a/shell/platform/fuchsia/runtime/dart/utils/vmo.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/vmo.cc
@@ -57,26 +57,7 @@ namespace dart_utils {
 bool VmoFromFilename(const std::string& filename,
                      bool executable,
                      fuchsia::mem::Buffer* buffer) {
-  // Note: the implementation here cannot be shared with VmoFromFilenameAt
-  // because fdio_open_fd_at does not aim to provide POSIX compatibility, and
-  // thus does not handle AT_FDCWD as dirfd.
-  auto flags = fuchsia::io::OpenFlags::RIGHT_READABLE;
-  if (executable) {
-    flags |= fuchsia::io::OpenFlags::RIGHT_EXECUTABLE;
-  }
-
-  int fd;
-  const zx_status_t status =
-      fdio_open_fd(filename.c_str(), static_cast<uint32_t>(flags), &fd);
-  if (status != ZX_OK) {
-    FML_LOG(ERROR) << "fdio_open_fd(\"" << filename << "\", " << std::hex
-                   << static_cast<uint32_t>(flags)
-                   << ") failed: " << zx_status_get_string(status);
-    return false;
-  }
-  bool result = VmoFromFd(fd, executable, buffer);
-  close(fd);
-  return result;
+  return VmoFromFilenameAt(AT_FDCWD, filename, executable, buffer);
 }
 
 bool VmoFromFilenameAt(int dirfd,

--- a/shell/platform/fuchsia/runtime/dart/utils/vmservice_object.h
+++ b/shell/platform/fuchsia/runtime/dart/utils/vmservice_object.h
@@ -9,9 +9,6 @@
 
 namespace dart_utils {
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-
 class VMServiceObject : public vfs::LazyDir {
  public:
   static constexpr const char* kDirName = "DartVM";
@@ -23,8 +20,6 @@ class VMServiceObject : public vfs::LazyDir {
                       uint64_t id,
                       std::string name) const override;
 };
-
-#pragma clang diagnostic pop
 
 }  // namespace dart_utils
 


### PR DESCRIPTION
Migrate the use of fuchsia.io open functions to the new open3 replacements (which also requires transitioning from OpenFlags -> Flags). Likewise, we update all uses of the SDK VFS library to use the new set of flags.

This work is being done as part of the ongoing io2 migration in https://fxbug.dev/378924259

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA]. (I am a Googler)
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
