### PR TITLE
[Impeller] make sampler use string_view instead of std::string.

### DIFF
--- a/impeller/core/sampler_descriptor.cc
+++ b/impeller/core/sampler_descriptor.cc
@@ -4,19 +4,17 @@
 
 #include "impeller/core/sampler_descriptor.h"
 
-#include "fml/logging.h"
-
 namespace impeller {
 
 SamplerDescriptor::SamplerDescriptor() = default;
 
-SamplerDescriptor::SamplerDescriptor(std::string label,
+SamplerDescriptor::SamplerDescriptor(std::string_view label,
                                      MinMagFilter min_filter,
                                      MinMagFilter mag_filter,
                                      MipFilter mip_filter)
     : min_filter(min_filter),
       mag_filter(mag_filter),
       mip_filter(mip_filter),
-      label(std::move(label)) {}
+      label(label) {}
 
 }  // namespace impeller

--- a/impeller/core/sampler_descriptor.h
+++ b/impeller/core/sampler_descriptor.h
@@ -21,11 +21,11 @@ struct SamplerDescriptor final : public Comparable<SamplerDescriptor> {
   SamplerAddressMode height_address_mode = SamplerAddressMode::kClampToEdge;
   SamplerAddressMode depth_address_mode = SamplerAddressMode::kClampToEdge;
 
-  std::string label = "NN Clamp Sampler";
+  std::string_view label = "NN Clamp Sampler";
 
   SamplerDescriptor();
 
-  SamplerDescriptor(std::string label,
+  SamplerDescriptor(std::string_view label,
                     MinMagFilter min_filter,
                     MinMagFilter mag_filter,
                     MipFilter mip_filter);

--- a/impeller/display_list/canvas.cc
+++ b/impeller/display_list/canvas.cc
@@ -786,6 +786,7 @@ void Canvas::DrawVertices(const std::shared_ptr<VerticesGeometry>& vertices,
     contents->SetEffectTransform(effect_transform);
     contents->SetTexture(texture);
     contents->SetTileMode(x_tile_mode, y_tile_mode);
+    contents->SetSamplerDescriptor(sampler_descriptor);
 
     entity.SetContents(paint.WithFilters(std::move(contents)));
     AddRenderEntityToCurrentPass(entity);

--- a/impeller/renderer/backend/metal/sampler_library_mtl.mm
+++ b/impeller/renderer/backend/metal/sampler_library_mtl.mm
@@ -34,9 +34,11 @@ const std::unique_ptr<const Sampler>& SamplerLibraryMTL::GetSampler(
   if (@available(iOS 14.0, macos 10.12, *)) {
     desc.borderColor = MTLSamplerBorderColorTransparentBlack;
   }
+#ifdef IMPELLER_DEBUG
   if (!descriptor.label.empty()) {
-    desc.label = @(descriptor.label.c_str());
+    desc.label = @(descriptor.label.data());
   }
+#endif  // IMPELLER_DEBUG
 
   auto mtl_sampler = [device_ newSamplerStateWithDescriptor:desc];
   if (!mtl_sampler) {

--- a/impeller/renderer/backend/vulkan/sampler_vk.cc
+++ b/impeller/renderer/backend/vulkan/sampler_vk.cc
@@ -92,7 +92,7 @@ static vk::UniqueSampler CreateSampler(
   }
 
   if (!desc.label.empty()) {
-    ContextVK::SetDebugName(device, sampler.value.get(), desc.label.c_str());
+    ContextVK::SetDebugName(device, sampler.value.get(), desc.label.data());
   }
 
   return std::move(sampler.value);


### PR DESCRIPTION
I believe these are always const strings anyway, so remove the copy associated with using std::string.
