### PR TITLE
Added enum isLight and isDark getter to Brightness enum

### DIFF
--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -998,17 +998,31 @@ class AccessibilityFeatures {
 
 /// Describes the contrast of a theme or color palette.
 enum Brightness {
+  /// {@template dart.ui.window.brightness.dark}
   /// The color is dark and will require a light text color to achieve readable
   /// contrast.
   ///
   /// For example, the color might be dark grey, requiring white text.
+  /// {@endtemplate}
   dark,
 
+  /// {@template dart.ui.window.brightness.light}
   /// The color is light and will require a dark text color to achieve readable
   /// contrast.
   ///
   /// For example, the color might be bright white, requiring black text.
-  light,
+  /// {@endtemplate}
+  light;
+
+  /// Checks if the brightness is [Brightness.dark].
+  ///
+  /// {@macro dart.ui.window.brightness.dark}
+  bool get isDark => this == Brightness.dark;
+
+  /// Checks if the brightness is [Brightness.light].
+  ///
+  /// {@macro dart.ui.window.brightness.light}
+  bool get isLight => this == Brightness.light;
 }
 
 /// Deprecated. Will be removed in a future version of Flutter.

--- a/lib/web_ui/lib/window.dart
+++ b/lib/web_ui/lib/window.dart
@@ -121,9 +121,33 @@ abstract class AccessibilityFeatures {
   bool get onOffSwitchLabels;
 }
 
+/// Describes the contrast of a theme or color palette.
 enum Brightness {
+  /// {@template dart.ui.window.brightness.dark}
+  /// The color is dark and will require a light text color to achieve readable
+  /// contrast.
+  ///
+  /// For example, the color might be dark grey, requiring white text.
+  /// {@endtemplate}
   dark,
-  light,
+
+  /// {@template dart.ui.window.brightness.light}
+  /// The color is light and will require a dark text color to achieve readable
+  /// contrast.
+  ///
+  /// For example, the color might be bright white, requiring black text.
+  /// {@endtemplate}
+  light;
+
+  /// Checks if the brightness is [Brightness.dark].
+  ///
+  /// {@macro dart.ui.window.brightness.dark}
+  bool get isDark => this == Brightness.dark;
+
+  /// Checks if the brightness is [Brightness.light].
+  ///
+  /// {@macro dart.ui.window.brightness.light}
+  bool get isLight => this == Brightness.light;
 }
 
 // Unimplemented classes.


### PR DESCRIPTION
Added the following enums to the Brightness enum:

`isLight` => quick way to check if enum is Brightness.light.
`isDark` => quick way to check if enum is Brightness.dark.

*List which issues are fixed by this PR. You must list at least one issue.*
https://github.com/flutter/flutter/issues/159569

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
