### PR TITLE
Moved font glyph atlas to flat_hash_map

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -593,7 +593,7 @@ deps = {
   Var('chromium_git') + '/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator' + '@' + '7de5cc00de50e71a3aab22dea52fbb7ff4efceb6',
 
   'src/flutter/third_party/abseil-cpp':
-  Var('flutter_git') + '/third_party/abseil-cpp.git' + '@' + 'ff6504dc527b25fef0f3c531e7dba0ed6b69c162',
+  'https://github.com/gaaclarke/flutter-abseil-cpp.git' + '@' + '59efcc9ce43c60f9897f3073463eb58ed299c7d4',
 
    # Dart packages
   'src/flutter/third_party/pkg/archive':

--- a/DEPS
+++ b/DEPS
@@ -593,7 +593,7 @@ deps = {
   Var('chromium_git') + '/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator' + '@' + '7de5cc00de50e71a3aab22dea52fbb7ff4efceb6',
 
   'src/flutter/third_party/abseil-cpp':
-  Var('flutter_git') + '/third_party/abseil-cpp.git' + '@' + 'ff6504dc527b25fef0f3c531e7dba0ed6b69c162',
+  Var('flutter_git') + '/third_party/abseil-cpp.git' + '@' + '599954e7ca3c86dcfd1ed6c809b323e59d86ceaf',
 
    # Dart packages
   'src/flutter/third_party/pkg/archive':

--- a/DEPS
+++ b/DEPS
@@ -593,7 +593,7 @@ deps = {
   Var('chromium_git') + '/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator' + '@' + '7de5cc00de50e71a3aab22dea52fbb7ff4efceb6',
 
   'src/flutter/third_party/abseil-cpp':
-  'https://github.com/gaaclarke/flutter-abseil-cpp.git' + '@' + '59efcc9ce43c60f9897f3073463eb58ed299c7d4',
+  Var('flutter_git') + '/third_party/abseil-cpp.git' + '@' + 'ff6504dc527b25fef0f3c531e7dba0ed6b69c162',
 
    # Dart packages
   'src/flutter/third_party/pkg/archive':

--- a/DEPS
+++ b/DEPS
@@ -593,7 +593,7 @@ deps = {
   Var('chromium_git') + '/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator' + '@' + '7de5cc00de50e71a3aab22dea52fbb7ff4efceb6',
 
   'src/flutter/third_party/abseil-cpp':
-  Var('flutter_git') + '/third_party/abseil-cpp.git' + '@' + '599954e7ca3c86dcfd1ed6c809b323e59d86ceaf',
+  Var('flutter_git') + '/third_party/abseil-cpp.git' + '@' + 'ff6504dc527b25fef0f3c531e7dba0ed6b69c162',
 
    # Dart packages
   'src/flutter/third_party/pkg/archive':

--- a/impeller/typographer/BUILD.gn
+++ b/impeller/typographer/BUILD.gn
@@ -32,8 +32,13 @@ impeller_component("typographer") {
     "../base",
     "../geometry",
     "../renderer",
-    "//flutter/third_party/abseil-cpp/absl/container:flat_hash_map",
   ]
+
+  if (!is_fuchsia) {
+    public_deps += [
+      "//flutter/third_party/abseil-cpp/absl/container:flat_hash_map",
+    ]
+  }
 
   deps = [ "//flutter/fml" ]
 }

--- a/impeller/typographer/BUILD.gn
+++ b/impeller/typographer/BUILD.gn
@@ -35,9 +35,8 @@ impeller_component("typographer") {
   ]
 
   if (!is_fuchsia) {
-    public_deps += [
-      "//flutter/third_party/abseil-cpp/absl/container:flat_hash_map",
-    ]
+    public_deps +=
+        [ "//flutter/third_party/abseil-cpp/absl/container:flat_hash_map" ]
   }
 
   deps = [ "//flutter/fml" ]

--- a/impeller/typographer/BUILD.gn
+++ b/impeller/typographer/BUILD.gn
@@ -33,7 +33,6 @@ impeller_component("typographer") {
     "../geometry",
     "../renderer",
     "//flutter/third_party/abseil-cpp/absl/container:flat_hash_map",
-    "//flutter/third_party/abseil-cpp/absl/hash:hash",
   ]
 
   deps = [ "//flutter/fml" ]

--- a/impeller/typographer/BUILD.gn
+++ b/impeller/typographer/BUILD.gn
@@ -32,6 +32,7 @@ impeller_component("typographer") {
     "../base",
     "../geometry",
     "../renderer",
+    "//flutter/third_party/abseil-cpp/absl/container:flat_hash_map",
   ]
 
   deps = [ "//flutter/fml" ]

--- a/impeller/typographer/BUILD.gn
+++ b/impeller/typographer/BUILD.gn
@@ -33,6 +33,7 @@ impeller_component("typographer") {
     "../geometry",
     "../renderer",
     "//flutter/third_party/abseil-cpp/absl/container:flat_hash_map",
+    "//flutter/third_party/abseil-cpp/absl/hash:hash",
   ]
 
   deps = [ "//flutter/fml" ]

--- a/impeller/typographer/font_glyph_pair.h
+++ b/impeller/typographer/font_glyph_pair.h
@@ -41,11 +41,10 @@ struct ScaledFont {
   Font font;
   Scalar scale;
 
-  struct Hash {
-    constexpr std::size_t operator()(const impeller::ScaledFont& sf) const {
-      return fml::HashCombine(sf.font.GetHash(), sf.scale);
-    }
-  };
+  template <typename H>
+  friend H AbslHashValue(H h, const ScaledFont& sf) {
+    return H::combine(std::move(h), sf.font.GetHash(), sf.scale);
+  }
 
   struct Equal {
     constexpr bool operator()(const impeller::ScaledFont& lhs,
@@ -70,19 +69,18 @@ struct SubpixelGlyph {
         subpixel_offset(p_subpixel_offset),
         properties(p_properties) {}
 
-  struct Hash {
-    constexpr std::size_t operator()(const impeller::SubpixelGlyph& sg) const {
-      if (!sg.properties.has_value()) {
-        return fml::HashCombine(sg.glyph.index, sg.subpixel_offset.x,
-                                sg.subpixel_offset.y);
-      }
-      return fml::HashCombine(
-          sg.glyph.index, sg.subpixel_offset.x, sg.subpixel_offset.y,
-          sg.properties->color.ToARGB(), sg.properties->stroke,
-          sg.properties->stroke_cap, sg.properties->stroke_join,
-          sg.properties->stroke_miter, sg.properties->stroke_width);
+  template <typename H>
+  friend H AbslHashValue(H h, const SubpixelGlyph& sg) {
+    if (!sg.properties.has_value()) {
+      return H::combine(std::move(h), sg.glyph.index, sg.subpixel_offset.x,
+                        sg.subpixel_offset.y);
     }
-  };
+    return H::combine(std::move(h), sg.glyph.index, sg.subpixel_offset.x,
+                      sg.subpixel_offset.y, sg.properties->color.ToARGB(),
+                      sg.properties->stroke, sg.properties->stroke_cap,
+                      sg.properties->stroke_join, sg.properties->stroke_miter,
+                      sg.properties->stroke_width);
+  }
 
   struct Equal {
     constexpr bool operator()(const impeller::SubpixelGlyph& lhs,

--- a/impeller/typographer/glyph_atlas.cc
+++ b/impeller/typographer/glyph_atlas.cc
@@ -78,7 +78,9 @@ void GlyphAtlas::SetAtlasGeneration(size_t generation) {
 void GlyphAtlas::AddTypefaceGlyphPositionAndBounds(const FontGlyphPair& pair,
                                                    Rect position,
                                                    Rect bounds) {
-  font_atlas_map_[pair.scaled_font].positions_[pair.glyph] =
+  FontAtlasMap::iterator it = font_atlas_map_.find(pair.scaled_font);
+  FML_DCHECK(it != font_atlas_map_.end());
+  it->second.positions_[pair.glyph] =
       FrameBounds{position, bounds, /*is_placeholder=*/false};
 }
 
@@ -93,12 +95,9 @@ std::optional<FrameBounds> GlyphAtlas::FindFontGlyphBounds(
 
 FontGlyphAtlas* GlyphAtlas::GetOrCreateFontGlyphAtlas(
     const ScaledFont& scaled_font) {
-  const auto& found = font_atlas_map_.find(scaled_font);
-  if (found != font_atlas_map_.end()) {
-    return &found->second;
-  }
-  font_atlas_map_[scaled_font] = FontGlyphAtlas();
-  return &font_atlas_map_[scaled_font];
+  auto [iter, inserted] =
+      font_atlas_map_.try_emplace(scaled_font, FontGlyphAtlas());
+  return &iter->second;
 }
 
 size_t GlyphAtlas::GetGlyphCount() const {

--- a/impeller/typographer/glyph_atlas.h
+++ b/impeller/typographer/glyph_atlas.h
@@ -10,7 +10,6 @@
 #include <optional>
 
 #include "flutter/third_party/abseil-cpp/absl/container/flat_hash_map.h"
-#include "flutter/third_party/abseil-cpp/absl/hash/hash.h"
 #include "impeller/core/texture.h"
 #include "impeller/geometry/rect.h"
 #include "impeller/typographer/font_glyph_pair.h"

--- a/impeller/typographer/glyph_atlas.h
+++ b/impeller/typographer/glyph_atlas.h
@@ -9,7 +9,9 @@
 #include <memory>
 #include <optional>
 
+#if !defined(OS_FUCHSIA)
 #include "flutter/third_party/abseil-cpp/absl/container/flat_hash_map.h"
+#endif
 #include "impeller/core/texture.h"
 #include "impeller/geometry/rect.h"
 #include "impeller/typographer/font_glyph_pair.h"
@@ -250,12 +252,21 @@ class FontGlyphAtlas {
  private:
   friend class GlyphAtlas;
 
-  absl::flat_hash_map<SubpixelGlyph,
-                      FrameBounds,
-                      absl::Hash<SubpixelGlyph>,
-                      SubpixelGlyph::Equal>
-      positions_;
+#if defined(OS_FUCHSIA)
+  // TODO(gaaclarke): Migrate to use absl. I couldn't get it working since absl
+  // has special logic in its GN files for Fuchsia that I couldn't sort out.
+  using PositionsMap = absl::flat_hash_map<SubpixelGlyph,
+                                           FrameBounds,
+                                           absl::Hash<SubpixelGlyph>,
+                                           SubpixelGlyph::Equal>;
+#else
+  using PositionsMap = absl::flat_hash_map<SubpixelGlyph,
+                                           FrameBounds,
+                                           absl::Hash<SubpixelGlyph>,
+                                           SubpixelGlyph::Equal>;
+#endif
 
+  PositionsMap positions_;
   FontGlyphAtlas(const FontGlyphAtlas&) = delete;
 };
 

--- a/impeller/typographer/glyph_atlas.h
+++ b/impeller/typographer/glyph_atlas.h
@@ -9,6 +9,8 @@
 #include <memory>
 #include <optional>
 
+#include "flutter/fml/build_config.h"
+
 #if defined(OS_FUCHSIA)
 // TODO(gaaclarke): Migrate to use absl. I couldn't get it working since absl
 // has special logic in its GN files for Fuchsia that I couldn't sort out.

--- a/impeller/typographer/glyph_atlas.h
+++ b/impeller/typographer/glyph_atlas.h
@@ -8,8 +8,8 @@
 #include <functional>
 #include <memory>
 #include <optional>
-#include <unordered_map>
 
+#include "flutter/third_party/abseil-cpp/absl/container/flat_hash_map.h"
 #include "impeller/core/texture.h"
 #include "impeller/geometry/rect.h"
 #include "impeller/typographer/font_glyph_pair.h"
@@ -160,11 +160,11 @@ class GlyphAtlas {
   std::shared_ptr<Texture> texture_;
   size_t generation_ = 0;
 
-  std::unordered_map<ScaledFont,
-                     FontGlyphAtlas,
-                     ScaledFont::Hash,
-                     ScaledFont::Equal>
-      font_atlas_map_;
+  using FontAtlasMap = absl::flat_hash_map<ScaledFont,
+                                           FontGlyphAtlas,
+                                           ScaledFont::Hash,
+                                           ScaledFont::Equal>;
+  FontAtlasMap font_atlas_map_;
 
   GlyphAtlas(const GlyphAtlas&) = delete;
 
@@ -228,6 +228,7 @@ class GlyphAtlasContext {
 class FontGlyphAtlas {
  public:
   FontGlyphAtlas() = default;
+  FontGlyphAtlas(FontGlyphAtlas&&) = default;
 
   //----------------------------------------------------------------------------
   /// @brief      Find the location of a glyph in the atlas.
@@ -249,10 +250,10 @@ class FontGlyphAtlas {
  private:
   friend class GlyphAtlas;
 
-  std::unordered_map<SubpixelGlyph,
-                     FrameBounds,
-                     SubpixelGlyph::Hash,
-                     SubpixelGlyph::Equal>
+  absl::flat_hash_map<SubpixelGlyph,
+                      FrameBounds,
+                      SubpixelGlyph::Hash,
+                      SubpixelGlyph::Equal>
       positions_;
 
   FontGlyphAtlas(const FontGlyphAtlas&) = delete;

--- a/impeller/typographer/glyph_atlas.h
+++ b/impeller/typographer/glyph_atlas.h
@@ -10,6 +10,7 @@
 #include <optional>
 
 #include "flutter/third_party/abseil-cpp/absl/container/flat_hash_map.h"
+#include "flutter/third_party/abseil-cpp/absl/hash/hash.h"
 #include "impeller/core/texture.h"
 #include "impeller/geometry/rect.h"
 #include "impeller/typographer/font_glyph_pair.h"
@@ -162,7 +163,7 @@ class GlyphAtlas {
 
   using FontAtlasMap = absl::flat_hash_map<ScaledFont,
                                            FontGlyphAtlas,
-                                           ScaledFont::Hash,
+                                           absl::Hash<ScaledFont>,
                                            ScaledFont::Equal>;
   FontAtlasMap font_atlas_map_;
 
@@ -252,7 +253,7 @@ class FontGlyphAtlas {
 
   absl::flat_hash_map<SubpixelGlyph,
                       FrameBounds,
-                      SubpixelGlyph::Hash,
+                      absl::Hash<SubpixelGlyph>,
                       SubpixelGlyph::Equal>
       positions_;
 


### PR DESCRIPTION
In https://github.com/flutter/engine/pull/56844 we saw a 15% increase in performance by switching to absl::flat_hash_map.  I suspect we say see even better results ([source](https://martin.ankerl.com/2022/08/27/hashmap-bench-01)).  The absl guidance is to default to using this.

test exempt: no intentional functional change, just performance

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
