### PR TITLE
Sped up SubpixelGlyph::Equal

### DIFF
--- a/impeller/typographer/font_glyph_pair.h
+++ b/impeller/typographer/font_glyph_pair.h
@@ -87,17 +87,20 @@ struct SubpixelGlyph {
   struct Equal {
     constexpr bool operator()(const impeller::SubpixelGlyph& lhs,
                               const impeller::SubpixelGlyph& rhs) const {
-      if (!lhs.properties.has_value() && !rhs.properties.has_value()) {
-        return lhs.glyph.index == rhs.glyph.index &&
-               lhs.glyph.type == rhs.glyph.type &&
-               lhs.subpixel_offset == rhs.subpixel_offset;
+      // Check simple non-optionals first.
+      if (lhs.glyph.index != rhs.glyph.index ||
+          lhs.glyph.type != rhs.glyph.type ||
+          lhs.subpixel_offset != rhs.subpixel_offset ||
+          // Mixmatch properties.
+          lhs.properties.has_value() != rhs.properties.has_value()) {
+        return false;
       }
-      return lhs.glyph.index == rhs.glyph.index &&
-             lhs.glyph.type == rhs.glyph.type &&
-             lhs.subpixel_offset == rhs.subpixel_offset &&
-             lhs.properties.has_value() && rhs.properties.has_value() &&
-             GlyphProperties::Equal{}(lhs.properties.value(),
-                                      rhs.properties.value());
+      if (lhs.properties.has_value()) {
+        // Both have properties.
+        return GlyphProperties::Equal{}(lhs.properties.value(),
+                                        rhs.properties.value());
+      }
+      return true;
     }
   };
 };


### PR DESCRIPTION
This allows a quick out when the simple parameters fail to be equal without even looking at optional properties.  In the case where they both have properties there is now one less `has_value()`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
