### PR TITLE
Always check for errors when propagating task values.

### DIFF
--- a/shell/platform/linux/fl_basic_message_channel.cc
+++ b/shell/platform/linux/fl_basic_message_channel.cc
@@ -258,7 +258,10 @@ G_MODULE_EXPORT FlValue* fl_basic_message_channel_send_finish(
   g_return_val_if_fail(g_task_is_valid(result, self), nullptr);
 
   g_autoptr(GTask) task = G_TASK(result);
-  GAsyncResult* r = G_ASYNC_RESULT(g_task_propagate_pointer(task, nullptr));
+  GAsyncResult* r = G_ASYNC_RESULT(g_task_propagate_pointer(task, error));
+  if (r == nullptr) {
+    return nullptr;
+  }
 
   g_autoptr(GBytes) message =
       fl_binary_messenger_send_on_channel_finish(self->messenger, r, error);

--- a/shell/platform/linux/fl_binary_messenger.cc
+++ b/shell/platform/linux/fl_binary_messenger.cc
@@ -291,7 +291,10 @@ static GBytes* send_on_channel_finish(FlBinaryMessenger* messenger,
   g_return_val_if_fail(g_task_is_valid(result, self), FALSE);
 
   g_autoptr(GTask) task = G_TASK(result);
-  GAsyncResult* r = G_ASYNC_RESULT(g_task_propagate_pointer(task, nullptr));
+  GAsyncResult* r = G_ASYNC_RESULT(g_task_propagate_pointer(task, error));
+  if (r == nullptr) {
+    return nullptr;
+  }
 
   g_autoptr(FlEngine) engine = FL_ENGINE(g_weak_ref_get(&self->engine));
   if (engine == nullptr) {

--- a/shell/platform/linux/fl_method_channel.cc
+++ b/shell/platform/linux/fl_method_channel.cc
@@ -197,7 +197,10 @@ G_MODULE_EXPORT FlMethodResponse* fl_method_channel_invoke_method_finish(
   g_return_val_if_fail(g_task_is_valid(result, self), nullptr);
 
   g_autoptr(GTask) task = G_TASK(result);
-  GAsyncResult* r = G_ASYNC_RESULT(g_task_propagate_pointer(task, nullptr));
+  GAsyncResult* r = G_ASYNC_RESULT(g_task_propagate_pointer(task, error));
+  if (r == nullptr) {
+    return nullptr;
+  }
 
   g_autoptr(GBytes) response =
       fl_binary_messenger_send_on_channel_finish(self->messenger, r, error);


### PR DESCRIPTION
This could occur if a request is cancelled, without this it might not chain up to the original caller correctly.
