### PR TITLE
[iOS] option to enable suggestions with autocorrect off

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -78,6 +78,7 @@ static NSString* const kAutofillEditingValue = @"editingValue";
 static NSString* const kAutofillHints = @"hints";
 
 static NSString* const kAutocorrectionType = @"autocorrect";
+static NSString* const kEnableSuggestions = @"enableSuggestions";
 
 #pragma mark - Static Functions
 
@@ -934,8 +935,10 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
   bool autocorrectIsDisabled = autocorrect && ![autocorrect boolValue];
   self.autocorrectionType =
       autocorrectIsDisabled ? UITextAutocorrectionTypeNo : UITextAutocorrectionTypeDefault;
+  NSString* enableSuggestions = configuration[kEnableSuggestions];
+  bool disableSuggestions = enableSuggestions && ![enableSuggestions boolValue];
   self.spellCheckingType =
-      autocorrectIsDisabled ? UITextSpellCheckingTypeNo : UITextSpellCheckingTypeDefault;
+      disableSuggestions ? UITextSpellCheckingTypeNo : UITextSpellCheckingTypeDefault;
   self.autofillId = AutofillIdFromDictionary(configuration);
   if (autofill == nil) {
     self.textContentType = @"";

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -810,23 +810,6 @@ FLUTTER_ASSERT_ARC
   OCMVerify([mockBinaryMessenger sendOnChannel:@"flutter/textinput" message:encodedMethodCall]);
 }
 
-- (void)testDisablingAutocorrectDisablesSpellChecking {
-  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
-
-  // Disable the interactive selection.
-  NSDictionary* config = self.mutableTemplateCopy;
-  [inputView configureWithDictionary:config];
-
-  XCTAssertEqual(inputView.autocorrectionType, UITextAutocorrectionTypeDefault);
-  XCTAssertEqual(inputView.spellCheckingType, UITextSpellCheckingTypeDefault);
-
-  [config setValue:@(NO) forKey:@"autocorrect"];
-  [inputView configureWithDictionary:config];
-
-  XCTAssertEqual(inputView.autocorrectionType, UITextAutocorrectionTypeNo);
-  XCTAssertEqual(inputView.spellCheckingType, UITextSpellCheckingTypeNo);
-}
-
 - (void)testReplaceTestLocalAdjustSelectionAndMarkedTextRange {
   FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithOwner:textInputPlugin];
   [inputView setMarkedText:@"test text" selectedRange:NSMakeRange(0, 5)];


### PR DESCRIPTION
There is no possibility on iOS to leave the auto-suggest bar visible and have the autocorrection turned off when showing `TextField`. Tapping outside `TextField` with autocorrection on fills the `TextField` with suggestion and it's not always an intended behaviour.

![Autocorrection on](https://github.com/user-attachments/assets/a435831b-e303-42c3-8da3-ad182987c6aa)

![Autocorrection off, enableSuggestion on](https://github.com/user-attachments/assets/8aa60b66-a351-4476-a935-9eee2d9a1027)

Fixes https://github.com/flutter/flutter/issues/159584

Removed 1 Test.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
