### PR TITLE
[web] Start with a smaller memory allocation for CanvasKit

### DIFF
--- a/skia/modules/canvaskit/BUILD.gn
+++ b/skia/modules/canvaskit/BUILD.gn
@@ -170,7 +170,10 @@ canvaskit_wasm_lib("canvaskit") {
     "-sFILESYSTEM=0",
     "-sMODULARIZE",
     "-sNO_EXIT_RUNTIME=1",
-    "-sINITIAL_MEMORY=64MB",
+    "-sINITIAL_MEMORY=32MB",
+
+    # Grow memory by +100% i.e. double the size each time we run out of memory.
+    "-sMEMORY_GROWTH_GEOMETRIC_STEP=1.0",
     "-sWASM",
     "-sSTRICT=1",
   ]

--- a/skia/modules/canvaskit/BUILD.gn
+++ b/skia/modules/canvaskit/BUILD.gn
@@ -170,7 +170,7 @@ canvaskit_wasm_lib("canvaskit") {
     "-sFILESYSTEM=0",
     "-sMODULARIZE",
     "-sNO_EXIT_RUNTIME=1",
-    "-sINITIAL_MEMORY=128MB",
+    "-sINITIAL_MEMORY=64MB",
     "-sWASM",
     "-sSTRICT=1",
   ]


### PR DESCRIPTION
Confirmed that a sample Flutter app starts with a 32MB memory allocation for CanvasKit instead of 128MB.

| Before | After|
|-|-|
| ![image](https://github.com/user-attachments/assets/5f6f2d4d-9155-499e-b20e-a15e3d8b53ab) | ![image](https://github.com/user-attachments/assets/bf1956c4-2d2a-44a8-b781-b110be93bc6a) |

Fixes https://github.com/flutter/flutter/issues/159499

<hr>

Relevant emscripten settings:
- [`INITIAL_MEMORY`](https://emscripten.org/docs/tools_reference/settings_reference.html#initial-memory)
- [`ALLOW_MEMORY_GROWTH`](https://emscripten.org/docs/tools_reference/settings_reference.html#allow-memory-growth)
- [`MEMORY_GROWTH_GEOMETRIC_STEP`](https://emscripten.org/docs/tools_reference/settings_reference.html#memory-growth-geometric-step)
- [`MEMORY_GROWTH_GEOMETRIC_CAP`](https://emscripten.org/docs/tools_reference/settings_reference.html#memory-growth-geometric-cap)
- [`ABORTING_MALLOC`](https://emscripten.org/docs/tools_reference/settings_reference.html#aborting-malloc)

Relevant emscripten code:
- https://github.com/emscripten-core/emscripten/blob/58889f9f20f74d0dbaed7d49025c49b864359ae1/src/library.js#L290
- Emscripten tries to grow memory by the provided growth factor. If it fails, it tries to grow by 50% of that amount. If it fails, it tries 25%. Then it gives up and fails gracefully.