### PR TITLE
Split keyevent channel into own class

### DIFF
--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -116,6 +116,7 @@ source_set("flutter_linux_sources") {
     "fl_key_channel_responder.cc",
     "fl_key_embedder_responder.cc",
     "fl_key_event.cc",
+    "fl_key_event_channel.cc",
     "fl_keyboard_channel.cc",
     "fl_keyboard_handler.cc",
     "fl_keyboard_layout.cc",

--- a/shell/platform/linux/fl_key_channel_responder.cc
+++ b/shell/platform/linux/fl_key_channel_responder.cc
@@ -7,23 +7,7 @@
 #include <gtk/gtk.h>
 #include <cinttypes>
 
-#include "flutter/shell/platform/linux/public/flutter_linux/fl_basic_message_channel.h"
-#include "flutter/shell/platform/linux/public/flutter_linux/fl_json_message_codec.h"
-
-static constexpr char kChannelName[] = "flutter/keyevent";
-static constexpr char kTypeKey[] = "type";
-static constexpr char kTypeValueUp[] = "keyup";
-static constexpr char kTypeValueDown[] = "keydown";
-static constexpr char kKeymapKey[] = "keymap";
-static constexpr char kKeyCodeKey[] = "keyCode";
-static constexpr char kScanCodeKey[] = "scanCode";
-static constexpr char kModifiersKey[] = "modifiers";
-static constexpr char kToolkitKey[] = "toolkit";
-static constexpr char kSpecifiedLogicalKey[] = "specifiedLogicalKey";
-static constexpr char kUnicodeScalarValuesKey[] = "unicodeScalarValues";
-
-static constexpr char kGtkToolkit[] = "gtk";
-static constexpr char kLinuxKeymap[] = "linux";
+#include "flutter/shell/platform/linux/fl_key_event_channel.h"
 
 /* Declare and define FlKeyChannelUserData */
 
@@ -93,7 +77,7 @@ static FlKeyChannelUserData* fl_key_channel_user_data_new(
 struct _FlKeyChannelResponder {
   GObject parent_instance;
 
-  FlBasicMessageChannel* channel;
+  FlKeyEventChannel* channel;
 };
 
 G_DEFINE_TYPE(FlKeyChannelResponder, fl_key_channel_responder, G_TYPE_OBJECT)
@@ -111,19 +95,11 @@ static void handle_response(GObject* object,
     return;
   }
 
+  gboolean handled = FALSE;
   g_autoptr(GError) error = nullptr;
-  FlBasicMessageChannel* messageChannel = FL_BASIC_MESSAGE_CHANNEL(object);
-  FlValue* message =
-      fl_basic_message_channel_send_finish(messageChannel, result, &error);
-  bool handled = false;
-  if (error != nullptr) {
+  if (!fl_key_event_channel_send_finish(object, result, &handled, &error)) {
     g_warning("Unable to retrieve framework response: %s", error->message);
-  } else {
-    g_autoptr(FlValue) handled_value =
-        fl_value_lookup_string(message, "handled");
-    handled = fl_value_get_bool(handled_value);
   }
-
   data->callback(handled, data->user_data);
 }
 
@@ -155,9 +131,7 @@ FlKeyChannelResponder* fl_key_channel_responder_new(
   FlKeyChannelResponder* self = FL_KEY_CHANNEL_RESPONDER(
       g_object_new(fl_key_channel_responder_get_type(), nullptr));
 
-  g_autoptr(FlJsonMessageCodec) codec = fl_json_message_codec_new();
-  self->channel = fl_basic_message_channel_new(messenger, kChannelName,
-                                               FL_MESSAGE_CODEC(codec));
+  self->channel = fl_key_event_channel_new(messenger);
 
   return self;
 }
@@ -171,8 +145,9 @@ void fl_key_channel_responder_handle_event(
   g_return_if_fail(event != nullptr);
   g_return_if_fail(callback != nullptr);
 
-  const gchar* type =
-      fl_key_event_get_is_press(event) ? kTypeValueDown : kTypeValueUp;
+  FlKeyEventType type = fl_key_event_get_is_press(event)
+                            ? FL_KEY_EVENT_TYPE_KEYDOWN
+                            : FL_KEY_EVENT_TYPE_KEYUP;
   int64_t scan_code = fl_key_event_get_keycode(event);
   int64_t unicode_scarlar_values =
       gdk_keyval_to_unicode(fl_key_event_get_keyval(event));
@@ -223,29 +198,10 @@ void fl_key_channel_responder_handle_event(
   state |= (shift_lock_pressed || caps_lock_pressed) ? GDK_LOCK_MASK : 0x0;
   state |= num_lock_pressed ? GDK_MOD2_MASK : 0x0;
 
-  g_autoptr(FlValue) message = fl_value_new_map();
-  fl_value_set_string_take(message, kTypeKey, fl_value_new_string(type));
-  fl_value_set_string_take(message, kKeymapKey,
-                           fl_value_new_string(kLinuxKeymap));
-  fl_value_set_string_take(message, kScanCodeKey, fl_value_new_int(scan_code));
-  fl_value_set_string_take(message, kToolkitKey,
-                           fl_value_new_string(kGtkToolkit));
-  fl_value_set_string_take(message, kKeyCodeKey,
-                           fl_value_new_int(fl_key_event_get_keyval(event)));
-  fl_value_set_string_take(message, kModifiersKey, fl_value_new_int(state));
-  if (unicode_scarlar_values != 0) {
-    fl_value_set_string_take(message, kUnicodeScalarValuesKey,
-                             fl_value_new_int(unicode_scarlar_values));
-  }
-
-  if (specified_logical_key != 0) {
-    fl_value_set_string_take(message, kSpecifiedLogicalKey,
-                             fl_value_new_int(specified_logical_key));
-  }
-
   FlKeyChannelUserData* data =
       fl_key_channel_user_data_new(self, callback, user_data);
-  // Send the message off to the framework for handling (or not).
-  fl_basic_message_channel_send(self->channel, message, nullptr,
-                                handle_response, data);
+  fl_key_event_channel_send(self->channel, type, scan_code,
+                            fl_key_event_get_keyval(event), state,
+                            unicode_scarlar_values, specified_logical_key,
+                            nullptr, handle_response, data);
 }

--- a/shell/platform/linux/fl_key_channel_responder.h
+++ b/shell/platform/linux/fl_key_channel_responder.h
@@ -7,9 +7,6 @@
 
 #include "flutter/shell/platform/linux/fl_key_event.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_binary_messenger.h"
-#include "flutter/shell/platform/linux/public/flutter_linux/fl_value.h"
-
-typedef FlValue* (*FlValueConverter)(FlValue*);
 
 G_BEGIN_DECLS
 

--- a/shell/platform/linux/fl_key_event_channel.cc
+++ b/shell/platform/linux/fl_key_event_channel.cc
@@ -1,0 +1,119 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/linux/fl_key_event_channel.h"
+
+#include "flutter/shell/platform/linux/public/flutter_linux/fl_basic_message_channel.h"
+#include "flutter/shell/platform/linux/public/flutter_linux/fl_json_message_codec.h"
+
+static constexpr char kChannelName[] = "flutter/keyevent";
+static constexpr char kTypeKey[] = "type";
+static constexpr char kTypeValueUp[] = "keyup";
+static constexpr char kTypeValueDown[] = "keydown";
+static constexpr char kKeymapKey[] = "keymap";
+static constexpr char kKeyCodeKey[] = "keyCode";
+static constexpr char kScanCodeKey[] = "scanCode";
+static constexpr char kModifiersKey[] = "modifiers";
+static constexpr char kToolkitKey[] = "toolkit";
+static constexpr char kSpecifiedLogicalKey[] = "specifiedLogicalKey";
+static constexpr char kUnicodeScalarValuesKey[] = "unicodeScalarValues";
+
+static constexpr char kGtkToolkit[] = "gtk";
+static constexpr char kLinuxKeymap[] = "linux";
+
+struct _FlKeyEventChannel {
+  GObject parent_instance;
+
+  FlBasicMessageChannel* channel;
+};
+
+G_DEFINE_TYPE(FlKeyEventChannel, fl_key_event_channel, G_TYPE_OBJECT)
+
+static void fl_key_event_channel_dispose(GObject* object) {
+  FlKeyEventChannel* self = FL_KEY_EVENT_CHANNEL(object);
+
+  g_clear_object(&self->channel);
+
+  G_OBJECT_CLASS(fl_key_event_channel_parent_class)->dispose(object);
+}
+
+static void fl_key_event_channel_class_init(FlKeyEventChannelClass* klass) {
+  G_OBJECT_CLASS(klass)->dispose = fl_key_event_channel_dispose;
+}
+
+static void fl_key_event_channel_init(FlKeyEventChannel* self) {}
+
+FlKeyEventChannel* fl_key_event_channel_new(FlBinaryMessenger* messenger) {
+  g_return_val_if_fail(FL_IS_BINARY_MESSENGER(messenger), nullptr);
+
+  FlKeyEventChannel* self = FL_KEY_EVENT_CHANNEL(
+      g_object_new(fl_key_event_channel_get_type(), nullptr));
+
+  g_autoptr(FlJsonMessageCodec) codec = fl_json_message_codec_new();
+  self->channel = fl_basic_message_channel_new(messenger, kChannelName,
+                                               FL_MESSAGE_CODEC(codec));
+
+  return self;
+}
+
+void fl_key_event_channel_send(FlKeyEventChannel* self,
+                               FlKeyEventType type,
+                               int64_t scan_code,
+                               int64_t key_code,
+                               int64_t modifiers,
+                               int64_t unicode_scarlar_values,
+                               int64_t specified_logical_key,
+                               GCancellable* cancellable,
+                               GAsyncReadyCallback callback,
+                               gpointer user_data) {
+  g_return_if_fail(FL_IS_KEY_EVENT_CHANNEL(self));
+
+  const gchar* type_string;
+  switch (type) {
+    case FL_KEY_EVENT_TYPE_KEYUP:
+      type_string = kTypeValueUp;
+      break;
+    case FL_KEY_EVENT_TYPE_KEYDOWN:
+      type_string = kTypeValueDown;
+      break;
+    default:
+      g_assert_not_reached();
+  }
+
+  g_autoptr(FlValue) message = fl_value_new_map();
+  fl_value_set_string_take(message, kTypeKey, fl_value_new_string(type_string));
+  fl_value_set_string_take(message, kKeymapKey,
+                           fl_value_new_string(kLinuxKeymap));
+  fl_value_set_string_take(message, kScanCodeKey, fl_value_new_int(scan_code));
+  fl_value_set_string_take(message, kToolkitKey,
+                           fl_value_new_string(kGtkToolkit));
+  fl_value_set_string_take(message, kKeyCodeKey, fl_value_new_int(key_code));
+  fl_value_set_string_take(message, kModifiersKey, fl_value_new_int(modifiers));
+  if (unicode_scarlar_values != 0) {
+    fl_value_set_string_take(message, kUnicodeScalarValuesKey,
+                             fl_value_new_int(unicode_scarlar_values));
+  }
+  if (specified_logical_key != 0) {
+    fl_value_set_string_take(message, kSpecifiedLogicalKey,
+                             fl_value_new_int(specified_logical_key));
+  }
+  fl_basic_message_channel_send(self->channel, message, cancellable, callback,
+                                user_data);
+}
+
+gboolean fl_key_event_channel_send_finish(GObject* object,
+                                          GAsyncResult* result,
+                                          gboolean* handled,
+                                          GError** error) {
+  FlValue* message = fl_basic_message_channel_send_finish(
+      FL_BASIC_MESSAGE_CHANNEL(object), result, error);
+  if (message == nullptr) {
+    return FALSE;
+  }
+
+  g_autoptr(FlValue) handled_value = fl_value_lookup_string(message, "handled");
+  *handled = fl_value_get_bool(handled_value);
+
+  return TRUE;
+}

--- a/shell/platform/linux/fl_key_event_channel.h
+++ b/shell/platform/linux/fl_key_event_channel.h
@@ -1,0 +1,86 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_LINUX_FL_KEY_EVENT_CHANNEL_H_
+#define FLUTTER_SHELL_PLATFORM_LINUX_FL_KEY_EVENT_CHANNEL_H_
+
+#include "flutter/shell/platform/linux/public/flutter_linux/fl_binary_messenger.h"
+
+G_BEGIN_DECLS
+
+G_DECLARE_FINAL_TYPE(FlKeyEventChannel,
+                     fl_key_event_channel,
+                     FL,
+                     KEY_EVENT_CHANNEL,
+                     GObject);
+
+/**
+ * FlKeyEventChannel:
+ *
+ * #FlKeyEventChannel is a channel that implements the shell side
+ * of SystemChannels.keyEvent from the Flutter services library.
+ */
+
+typedef enum {
+  FL_KEY_EVENT_TYPE_KEYUP,
+  FL_KEY_EVENT_TYPE_KEYDOWN,
+} FlKeyEventType;
+
+/**
+ * fl_key_event_channel_new:
+ * @messenger: an #FlBinaryMessenger
+ *
+ * Creates a new channel that implements SystemChannels.keyEvent from the
+ * Flutter services library.
+ *
+ * Returns: a new #FlKeyEventChannel.
+ */
+FlKeyEventChannel* fl_key_event_channel_new(FlBinaryMessenger* messenger);
+
+/**
+ * fl_key_event_channel_send:
+ * @channel: an #FlKeyEventChannel
+ * @type: event type.
+ * @scan_code: scan code.
+ * @key_code: key code.
+ * @modifiers: modifiers.
+ * @unicode_scarlar_values:
+ * @specified_logical_key:
+ * @cancellable: (allow-none): a #GCancellable or %NULL.
+ * @callback: (scope async): a #GAsyncReadyCallback to call when the method
+ * returns.
+ * @user_data: (closure): user data to pass to @callback.
+ *
+ * Send a key event to the platform.
+ */
+void fl_key_event_channel_send(FlKeyEventChannel* channel,
+                               FlKeyEventType type,
+                               int64_t scan_code,
+                               int64_t key_code,
+                               int64_t modifiers,
+                               int64_t unicode_scarlar_values,
+                               int64_t specified_logical_key,
+                               GCancellable* cancellable,
+                               GAsyncReadyCallback callback,
+                               gpointer user_data);
+
+/**
+ * fl_key_event_channel_send_finish:
+ * @object:
+ * @result: a #GAsyncResult.
+ * @error: (allow-none): #GError location to store the error occurring, or %NULL
+ * to ignore.
+ *
+ * Completes request started with fl_key_event_channel_send().
+ *
+ * Returns: %TRUE on success.
+ */
+gboolean fl_key_event_channel_send_finish(GObject* object,
+                                          GAsyncResult* result,
+                                          gboolean* handled,
+                                          GError** error);
+
+G_END_DECLS
+
+#endif  // FLUTTER_SHELL_PLATFORM_LINUX_FL_KEY_EVENT_CHANNEL_H_


### PR DESCRIPTION
Split the channel messaging out of the system channels to make them simpler to understand and refactor.

The new channel classes could be automatically generated in a second phase, e.g. using Pigeon to reduce code usage.
    
The new classes don't have tests as they will already be covered by the existing code.
