### PR TITLE
Add tests for errors encoding message channel request and method calls.

### DIFF
--- a/shell/platform/linux/fl_basic_message_channel.cc
+++ b/shell/platform/linux/fl_basic_message_channel.cc
@@ -239,7 +239,7 @@ G_MODULE_EXPORT void fl_basic_message_channel_send(FlBasicMessageChannel* self,
       fl_message_codec_encode_message(self->codec, message, &error);
   if (data == nullptr) {
     if (task != nullptr) {
-      g_task_return_error(task, error);
+      g_task_return_error(task, g_error_copy(error));
     }
     return;
   }

--- a/shell/platform/linux/fl_basic_message_channel_test.cc
+++ b/shell/platform/linux/fl_basic_message_channel_test.cc
@@ -222,3 +222,35 @@ TEST(FlBasicMessageChannelTest, SendNullMessageWithResponse) {
   // Blocks here until null_message_response_cb is called.
   g_main_loop_run(loop);
 }
+
+// Called when the message response is received in the CustomType test.
+static void custom_type_response_cb(GObject* object,
+                                    GAsyncResult* result,
+                                    gpointer user_data) {
+  g_autoptr(GError) error = nullptr;
+  g_autoptr(FlValue) message = fl_basic_message_channel_send_finish(
+      FL_BASIC_MESSAGE_CHANNEL(object), result, &error);
+  EXPECT_EQ(message, nullptr);
+  EXPECT_NE(error, nullptr);
+  EXPECT_STREQ(error->message, "Custom value not implemented");
+
+  g_main_loop_quit(static_cast<GMainLoop*>(user_data));
+}
+
+// Checks sending a message with a custom type generates an error.
+TEST(FlBasicMessageChannelTest, CustomType) {
+  g_autoptr(GMainLoop) loop = g_main_loop_new(nullptr, 0);
+
+  // Attempt to send an integer with the string codec.
+  g_autoptr(FlEngine) engine = make_mock_engine();
+  g_autoptr(FlBinaryMessenger) messenger = fl_binary_messenger_new(engine);
+  g_autoptr(FlStandardMessageCodec) codec = fl_standard_message_codec_new();
+  g_autoptr(FlBasicMessageChannel) channel = fl_basic_message_channel_new(
+      messenger, "test/echo", FL_MESSAGE_CODEC(codec));
+  g_autoptr(FlValue) message = fl_value_new_custom(42, nullptr, nullptr);
+  fl_basic_message_channel_send(channel, message, nullptr,
+                                custom_type_response_cb, loop);
+
+  // Blocks here until custom_type_response_cb is called.
+  g_main_loop_run(loop);
+}

--- a/shell/platform/linux/fl_method_channel.cc
+++ b/shell/platform/linux/fl_method_channel.cc
@@ -178,7 +178,7 @@ G_MODULE_EXPORT void fl_method_channel_invoke_method(
       fl_method_codec_encode_method_call(self->codec, method, args, &error);
   if (message == nullptr) {
     if (task != nullptr) {
-      g_task_return_error(task, error);
+      g_task_return_error(task, g_error_copy(error));
     }
     return;
   }


### PR DESCRIPTION
Fix error not being copied in this case.

Follow up to https://github.com/flutter/engine/pull/56856