### PR TITLE
Add typeface_proxy dependency to the Skia build script for the Android font manager

### DIFF
--- a/skia/BUILD.gn
+++ b/skia/BUILD.gn
@@ -221,6 +221,7 @@ optional("fontmgr_android") {
 
   deps = [
     ":typeface_freetype",
+    ":typeface_proxy",
     "//flutter/third_party/expat",
   ]
   public = skia_ports_fontmgr_android_public


### PR DESCRIPTION
This is required by the refactoring in https://skia.googlesource.com/skia/+/eb9fc76e302f873de982cefa7690443e7a2cede5