### PR TITLE
[DisplayList] Disable group opacity when a RuntimeEffect is in use

### DIFF
--- a/display_list/dl_builder.cc
+++ b/display_list/dl_builder.cc
@@ -244,6 +244,7 @@ void DisplayListBuilder::onSetColorSource(const DlColorSource* source) {
       }
     }
   }
+  UpdateCurrentOpacityCompatibility();
 }
 void DisplayListBuilder::onSetImageFilter(const DlImageFilter* filter) {
   if (filter == nullptr) {
@@ -289,6 +290,7 @@ void DisplayListBuilder::onSetImageFilter(const DlImageFilter* filter) {
       }
     }
   }
+  UpdateCurrentOpacityCompatibility();
 }
 void DisplayListBuilder::onSetColorFilter(const DlColorFilter* filter) {
   if (filter == nullptr) {

--- a/display_list/dl_builder.h
+++ b/display_list/dl_builder.h
@@ -723,6 +723,7 @@ class DisplayListBuilder final : public virtual DlCanvas,
     current_opacity_compatibility_ =             //
         current_.getColorFilter() == nullptr &&  //
         !current_.isInvertColors() &&            //
+        !current_.usesRuntimeEffect() &&         //
         IsOpacityCompatible(current_.getBlendMode());
   }
 

--- a/display_list/dl_paint.h
+++ b/display_list/dl_paint.h
@@ -178,6 +178,11 @@ class DlPaint {
 
   bool isDefault() const { return *this == kDefault; }
 
+  bool usesRuntimeEffect() const {
+    return ((color_source_ && color_source_->asRuntimeEffect()) ||
+            (image_filter_ && image_filter_->asRuntimeEffectFilter()));
+  }
+
   bool operator==(DlPaint const& other) const;
   bool operator!=(DlPaint const& other) const { return !(*this == other); }
 

--- a/display_list/dl_paint_unittests.cc
+++ b/display_list/dl_paint_unittests.cc
@@ -154,5 +154,49 @@ TEST(DisplayListPaint, ChainingConstructor) {
   EXPECT_NE(paint, DlPaint());
 }
 
+TEST(DisplayListPaint, PaintDetectsRuntimeEffects) {
+  const auto runtime_effect = DlRuntimeEffect::MakeSkia(
+      SkRuntimeEffect::MakeForShader(
+          SkString("vec4 main(vec2 p) { return vec4(0); }"))
+          .effect);
+  auto color_source = DlColorSource::MakeRuntimeEffect(
+      runtime_effect, {}, std::make_shared<std::vector<uint8_t>>());
+  auto image_filter = DlImageFilter::MakeRuntimeEffect(
+      runtime_effect, {}, std::make_shared<std::vector<uint8_t>>());
+  DlPaint paint;
+
+  EXPECT_FALSE(paint.usesRuntimeEffect());
+  paint.setColorSource(color_source);
+  EXPECT_TRUE(paint.usesRuntimeEffect());
+  paint.setColorSource(nullptr);
+  EXPECT_FALSE(paint.usesRuntimeEffect());
+
+  EXPECT_FALSE(paint.usesRuntimeEffect());
+  paint.setImageFilter(image_filter);
+  EXPECT_TRUE(paint.usesRuntimeEffect());
+  paint.setImageFilter(nullptr);
+  EXPECT_FALSE(paint.usesRuntimeEffect());
+
+  EXPECT_FALSE(paint.usesRuntimeEffect());
+  paint.setColorSource(color_source);
+  EXPECT_TRUE(paint.usesRuntimeEffect());
+  paint.setImageFilter(image_filter);
+  EXPECT_TRUE(paint.usesRuntimeEffect());
+  paint.setImageFilter(nullptr);
+  EXPECT_TRUE(paint.usesRuntimeEffect());
+  paint.setColorSource(nullptr);
+  EXPECT_FALSE(paint.usesRuntimeEffect());
+
+  EXPECT_FALSE(paint.usesRuntimeEffect());
+  paint.setColorSource(color_source);
+  EXPECT_TRUE(paint.usesRuntimeEffect());
+  paint.setImageFilter(image_filter);
+  EXPECT_TRUE(paint.usesRuntimeEffect());
+  paint.setColorSource(nullptr);
+  EXPECT_TRUE(paint.usesRuntimeEffect());
+  paint.setImageFilter(nullptr);
+  EXPECT_FALSE(paint.usesRuntimeEffect());
+}
+
 }  // namespace testing
 }  // namespace flutter


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/158500

Impeller does not support group opacity for RuntimeEffects so we disable the optimization with a flag when it is detected.