### PR TITLE
[Impeller] avoid re-binding winding order and cull mode.

### DIFF
--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -309,6 +309,10 @@ void RenderPassGLES::ResetGLState(const ProcTableGLES& gl) {
     }
   }
 
+  CullMode current_cull_mode = CullMode::kNone;
+  WindingOrder current_winding_order = WindingOrder::kClockwise;
+  gl.FrontFace(GL_CW);
+
   for (const auto& command : commands) {
     if (command.instance_count != 1u) {
       VALIDATION_LOG << "GLES backend does not support instanced rendering.";
@@ -401,29 +405,39 @@ void RenderPassGLES::ResetGLState(const ProcTableGLES& gl) {
     //--------------------------------------------------------------------------
     /// Setup culling.
     ///
-    switch (pipeline.GetDescriptor().GetCullMode()) {
-      case CullMode::kNone:
-        gl.Disable(GL_CULL_FACE);
-        break;
-      case CullMode::kFrontFace:
-        gl.Enable(GL_CULL_FACE);
-        gl.CullFace(GL_FRONT);
-        break;
-      case CullMode::kBackFace:
-        gl.Enable(GL_CULL_FACE);
-        gl.CullFace(GL_BACK);
-        break;
+    CullMode pipeline_cull_mode = pipeline.GetDescriptor().GetCullMode();
+    if (current_cull_mode != pipeline_cull_mode) {
+      switch (pipeline_cull_mode) {
+        case CullMode::kNone:
+          gl.Disable(GL_CULL_FACE);
+          break;
+        case CullMode::kFrontFace:
+          gl.Enable(GL_CULL_FACE);
+          gl.CullFace(GL_FRONT);
+          break;
+        case CullMode::kBackFace:
+          gl.Enable(GL_CULL_FACE);
+          gl.CullFace(GL_BACK);
+          break;
+      }
+      current_cull_mode = pipeline_cull_mode;
     }
+
     //--------------------------------------------------------------------------
     /// Setup winding order.
     ///
-    switch (pipeline.GetDescriptor().GetWindingOrder()) {
-      case WindingOrder::kClockwise:
-        gl.FrontFace(GL_CW);
-        break;
-      case WindingOrder::kCounterClockwise:
-        gl.FrontFace(GL_CCW);
-        break;
+    WindingOrder pipeline_winding_order =
+        pipeline.GetDescriptor().GetWindingOrder();
+    if (current_winding_order != pipeline_winding_order) {
+      switch (pipeline.GetDescriptor().GetWindingOrder()) {
+        case WindingOrder::kClockwise:
+          gl.FrontFace(GL_CW);
+          break;
+        case WindingOrder::kCounterClockwise:
+          gl.FrontFace(GL_CCW);
+          break;
+      }
+      current_winding_order = pipeline_winding_order;
     }
 
     auto vertex_desc_gles = pipeline.GetBufferBindings();


### PR DESCRIPTION
Winding order and cull mode almost never change, so avoid re-binding them over and over again. Minor performance improvement.