### PR TITLE
iOS: add null check on create impeller context

### DIFF
--- a/shell/platform/darwin/graphics/FlutterDarwinContextMetalImpeller.mm
+++ b/shell/platform/darwin/graphics/FlutterDarwinContextMetalImpeller.mm
@@ -35,15 +35,9 @@ static std::shared_ptr<impeller::ContextMTL> CreateImpellerContext(
   self = [super init];
   if (self != nil) {
     _context = CreateImpellerContext(is_gpu_disabled_sync_switch);
-    if (!_context) {
-      FML_LOG(ERROR) << "Could not create Metal Impeller Context.";
-      return nil;
-    }
+    FML_CHECK(_context) << "Could not create Metal Impeller Context.";
     id<MTLDevice> device = _context->GetMTLDevice();
-    if (!device) {
-      FML_LOG(ERROR) << "Could not acquire Metal device.";
-      return nil;
-    }
+    FML_CHECK(device) << "Could not acquire Metal device.";
 
     CVMetalTextureCacheRef textureCache;
     CVReturn cvReturn = CVMetalTextureCacheCreate(kCFAllocatorDefault,  // allocator
@@ -53,10 +47,7 @@ static std::shared_ptr<impeller::ContextMTL> CreateImpellerContext(
                                                   &textureCache  // [out] cache
     );
 
-    if (cvReturn != kCVReturnSuccess) {
-      FML_DLOG(ERROR) << "Could not create Metal texture cache.";
-      return nil;
-    }
+    FML_CHECK(cvReturn == kCVReturnSuccess) << "Could not acquire Metal device.";
     _textureCache.Reset(textureCache);
   }
   return self;

--- a/shell/platform/darwin/graphics/FlutterDarwinContextMetalImpeller.mm
+++ b/shell/platform/darwin/graphics/FlutterDarwinContextMetalImpeller.mm
@@ -25,14 +25,8 @@ static std::shared_ptr<impeller::ContextMTL> CreateImpellerContext(
       std::make_shared<fml::NonOwnedMapping>(impeller_framebuffer_blend_shaders_data,
                                              impeller_framebuffer_blend_shaders_length),
   };
-  auto context = impeller::ContextMTL::Create(shader_mappings, is_gpu_disabled_sync_switch,
-                                              "Impeller Library");
-  if (!context) {
-    FML_LOG(ERROR) << "Could not create Metal Impeller Context.";
-    return nullptr;
-  }
-
-  return context;
+  return impeller::ContextMTL::Create(shader_mappings, is_gpu_disabled_sync_switch,
+                                      "Impeller Library");
 }
 
 @implementation FlutterDarwinContextMetalImpeller
@@ -41,9 +35,13 @@ static std::shared_ptr<impeller::ContextMTL> CreateImpellerContext(
   self = [super init];
   if (self != nil) {
     _context = CreateImpellerContext(is_gpu_disabled_sync_switch);
+    if (!_context) {
+      FML_LOG(ERROR) << "Could not create Metal Impeller Context.";
+      return nil;
+    }
     id<MTLDevice> device = _context->GetMTLDevice();
     if (!device) {
-      FML_DLOG(ERROR) << "Could not acquire Metal device.";
+      FML_LOG(ERROR) << "Could not acquire Metal device.";
       return nil;
     }
 


### PR DESCRIPTION
In the case where `CreateImpellerContext` encounters an error while creating an `impeller::ContextMTL`, we logged an error, returned nullptr, then immediately dereferenced the null pointer. Now, rather than crash due to a segfault, we now intentionally abort with an appropriate error message.

This adds checks in the `FlutterDarwinContextMetalImpeller` initialiser that aborts with an appropriate error message if impeller context creation fails, Metal device creation fails, or texture cache creation fails.

Rather than bailing out and returning nil from the initialiser to pass the buck to the caller, we terminate since without a graphics context, the app won't be able to render anything to begin with.

Issue: https://github.com/flutter/flutter/issues/157489
Issue: [b/378790930](http://b/378790930)

No test changes since this just changes an accidental crash to an intentional crash.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/engine/blob/main/docs/testing/Testing-the-engine.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
