### PR TITLE
Removes ReactorGLES::Ref

### DIFF
--- a/impeller/renderer/backend/gles/allocator_gles.cc
+++ b/impeller/renderer/backend/gles/allocator_gles.cc
@@ -13,7 +13,7 @@
 
 namespace impeller {
 
-AllocatorGLES::AllocatorGLES(ReactorGLES::Ref reactor)
+AllocatorGLES::AllocatorGLES(std::shared_ptr<ReactorGLES> reactor)
     : reactor_(std::move(reactor)), is_valid_(true) {}
 
 // |Allocator|

--- a/impeller/renderer/backend/gles/allocator_gles.h
+++ b/impeller/renderer/backend/gles/allocator_gles.h
@@ -18,10 +18,10 @@ class AllocatorGLES final : public Allocator {
  private:
   friend class ContextGLES;
 
-  ReactorGLES::Ref reactor_;
+  std::shared_ptr<ReactorGLES> reactor_;
   bool is_valid_ = false;
 
-  explicit AllocatorGLES(ReactorGLES::Ref reactor);
+  explicit AllocatorGLES(std::shared_ptr<ReactorGLES> reactor);
 
   // |Allocator|
   bool IsValid() const;

--- a/impeller/renderer/backend/gles/blit_pass_gles.cc
+++ b/impeller/renderer/backend/gles/blit_pass_gles.cc
@@ -14,7 +14,7 @@
 
 namespace impeller {
 
-BlitPassGLES::BlitPassGLES(ReactorGLES::Ref reactor)
+BlitPassGLES::BlitPassGLES(std::shared_ptr<ReactorGLES> reactor)
     : reactor_(std::move(reactor)),
       is_valid_(reactor_ && reactor_->IsValid()) {}
 

--- a/impeller/renderer/backend/gles/blit_pass_gles.h
+++ b/impeller/renderer/backend/gles/blit_pass_gles.h
@@ -25,11 +25,11 @@ class BlitPassGLES final : public BlitPass,
   friend class CommandBufferGLES;
 
   std::vector<std::unique_ptr<BlitEncodeGLES>> commands_;
-  ReactorGLES::Ref reactor_;
+  std::shared_ptr<ReactorGLES> reactor_;
   std::string label_;
   bool is_valid_ = false;
 
-  explicit BlitPassGLES(ReactorGLES::Ref reactor);
+  explicit BlitPassGLES(std::shared_ptr<ReactorGLES> reactor);
 
   // |BlitPass|
   bool IsValid() const override;

--- a/impeller/renderer/backend/gles/command_buffer_gles.cc
+++ b/impeller/renderer/backend/gles/command_buffer_gles.cc
@@ -11,7 +11,7 @@
 namespace impeller {
 
 CommandBufferGLES::CommandBufferGLES(std::weak_ptr<const Context> context,
-                                     ReactorGLES::Ref reactor)
+                                     std::shared_ptr<ReactorGLES> reactor)
     : CommandBuffer(std::move(context)),
       reactor_(std::move(reactor)),
       is_valid_(reactor_ && reactor_->IsValid()) {}

--- a/impeller/renderer/backend/gles/command_buffer_gles.h
+++ b/impeller/renderer/backend/gles/command_buffer_gles.h
@@ -19,11 +19,11 @@ class CommandBufferGLES final : public CommandBuffer {
  private:
   friend class ContextGLES;
 
-  ReactorGLES::Ref reactor_;
+  std::shared_ptr<ReactorGLES> reactor_;
   bool is_valid_ = false;
 
   CommandBufferGLES(std::weak_ptr<const Context> context,
-                    ReactorGLES::Ref reactor);
+                    std::shared_ptr<ReactorGLES> reactor);
 
   // |CommandBuffer|
   void SetLabel(std::string_view label) const override;

--- a/impeller/renderer/backend/gles/context_gles.cc
+++ b/impeller/renderer/backend/gles/context_gles.cc
@@ -81,7 +81,7 @@ Context::BackendType ContextGLES::GetBackendType() const {
   return Context::BackendType::kOpenGLES;
 }
 
-const ReactorGLES::Ref& ContextGLES::GetReactor() const {
+const std::shared_ptr<ReactorGLES>& ContextGLES::GetReactor() const {
   return reactor_;
 }
 

--- a/impeller/renderer/backend/gles/context_gles.h
+++ b/impeller/renderer/backend/gles/context_gles.h
@@ -34,7 +34,7 @@ class ContextGLES final : public Context,
   // |Context|
   BackendType GetBackendType() const override;
 
-  const ReactorGLES::Ref& GetReactor() const;
+  const std::shared_ptr<ReactorGLES>& GetReactor() const;
 
   std::optional<ReactorGLES::WorkerID> AddReactorWorker(
       const std::shared_ptr<ReactorGLES::Worker>& worker);
@@ -44,7 +44,7 @@ class ContextGLES final : public Context,
   std::shared_ptr<GPUTracerGLES> GetGPUTracer() const { return gpu_tracer_; }
 
  private:
-  ReactorGLES::Ref reactor_;
+  std::shared_ptr<ReactorGLES> reactor_;
   std::shared_ptr<ShaderLibraryGLES> shader_library_;
   std::shared_ptr<PipelineLibraryGLES> pipeline_library_;
   std::shared_ptr<SamplerLibraryGLES> sampler_library_;

--- a/impeller/renderer/backend/gles/device_buffer_gles.cc
+++ b/impeller/renderer/backend/gles/device_buffer_gles.cc
@@ -13,7 +13,7 @@
 namespace impeller {
 
 DeviceBufferGLES::DeviceBufferGLES(DeviceBufferDescriptor desc,
-                                   ReactorGLES::Ref reactor,
+                                   std::shared_ptr<ReactorGLES> reactor,
                                    std::shared_ptr<Allocation> backing_store)
     : DeviceBuffer(desc),
       reactor_(std::move(reactor)),

--- a/impeller/renderer/backend/gles/device_buffer_gles.h
+++ b/impeller/renderer/backend/gles/device_buffer_gles.h
@@ -20,7 +20,7 @@ class DeviceBufferGLES final
       public BackendCast<DeviceBufferGLES, DeviceBuffer> {
  public:
   DeviceBufferGLES(DeviceBufferDescriptor desc,
-                   ReactorGLES::Ref reactor,
+                   std::shared_ptr<ReactorGLES> reactor,
                    std::shared_ptr<Allocation> backing_store);
 
   // |DeviceBuffer|
@@ -41,7 +41,7 @@ class DeviceBufferGLES final
   void Flush(std::optional<Range> range = std::nullopt) const override;
 
  private:
-  ReactorGLES::Ref reactor_;
+  std::shared_ptr<ReactorGLES> reactor_;
   HandleGLES handle_;
   mutable std::shared_ptr<Allocation> backing_store_;
   mutable std::optional<Range> dirty_range_ = std::nullopt;

--- a/impeller/renderer/backend/gles/pipeline_gles.cc
+++ b/impeller/renderer/backend/gles/pipeline_gles.cc
@@ -6,7 +6,7 @@
 
 namespace impeller {
 
-PipelineGLES::PipelineGLES(ReactorGLES::Ref reactor,
+PipelineGLES::PipelineGLES(std::shared_ptr<ReactorGLES> reactor,
                            std::weak_ptr<PipelineLibrary> library,
                            const PipelineDescriptor& desc,
                            std::shared_ptr<UniqueHandleGLES> handle)

--- a/impeller/renderer/backend/gles/pipeline_gles.h
+++ b/impeller/renderer/backend/gles/pipeline_gles.h
@@ -38,7 +38,7 @@ class PipelineGLES final
  private:
   friend PipelineLibraryGLES;
 
-  ReactorGLES::Ref reactor_;
+  std::shared_ptr<ReactorGLES> reactor_;
   std::shared_ptr<UniqueHandleGLES> handle_;
   std::unique_ptr<BufferBindingsGLES> buffer_bindings_;
   bool is_valid_ = false;
@@ -46,7 +46,7 @@ class PipelineGLES final
   // |Pipeline|
   bool IsValid() const override;
 
-  PipelineGLES(ReactorGLES::Ref reactor,
+  PipelineGLES(std::shared_ptr<ReactorGLES> reactor,
                std::weak_ptr<PipelineLibrary> library,
                const PipelineDescriptor& desc,
                std::shared_ptr<UniqueHandleGLES> handle);

--- a/impeller/renderer/backend/gles/pipeline_library_gles.cc
+++ b/impeller/renderer/backend/gles/pipeline_library_gles.cc
@@ -16,7 +16,7 @@
 
 namespace impeller {
 
-PipelineLibraryGLES::PipelineLibraryGLES(ReactorGLES::Ref reactor)
+PipelineLibraryGLES::PipelineLibraryGLES(std::shared_ptr<ReactorGLES> reactor)
     : reactor_(std::move(reactor)) {}
 
 static std::string GetShaderInfoLog(const ProcTableGLES& gl, GLuint shader) {
@@ -324,7 +324,7 @@ void PipelineLibraryGLES::RemovePipelinesWithEntryPoint(
 // |PipelineLibrary|
 PipelineLibraryGLES::~PipelineLibraryGLES() = default;
 
-const ReactorGLES::Ref& PipelineLibraryGLES::GetReactor() const {
+const std::shared_ptr<ReactorGLES>& PipelineLibraryGLES::GetReactor() const {
   return reactor_;
 }
 

--- a/impeller/renderer/backend/gles/pipeline_library_gles.h
+++ b/impeller/renderer/backend/gles/pipeline_library_gles.h
@@ -87,12 +87,12 @@ class PipelineLibraryGLES final
                                         ProgramKey::Hash,
                                         ProgramKey::Equal>;
 
-  ReactorGLES::Ref reactor_;
+  std::shared_ptr<ReactorGLES> reactor_;
   PipelineMap pipelines_;
   Mutex programs_mutex_;
   ProgramMap programs_ IPLR_GUARDED_BY(programs_mutex_);
 
-  explicit PipelineLibraryGLES(ReactorGLES::Ref reactor);
+  explicit PipelineLibraryGLES(std::shared_ptr<ReactorGLES> reactor);
 
   // |PipelineLibrary|
   bool IsValid() const override;
@@ -113,7 +113,7 @@ class PipelineLibraryGLES final
   void RemovePipelinesWithEntryPoint(
       std::shared_ptr<const ShaderFunction> function) override;
 
-  const ReactorGLES::Ref& GetReactor() const;
+  const std::shared_ptr<ReactorGLES>& GetReactor() const;
 
   static std::shared_ptr<PipelineGLES> CreatePipeline(
       const std::weak_ptr<PipelineLibrary>& weak_library,

--- a/impeller/renderer/backend/gles/reactor_gles.h
+++ b/impeller/renderer/backend/gles/reactor_gles.h
@@ -85,8 +85,6 @@ class ReactorGLES {
         const ReactorGLES& reactor) const = 0;
   };
 
-  using Ref = std::shared_ptr<ReactorGLES>;
-
   //----------------------------------------------------------------------------
   /// @brief      Create a new reactor. There are expensive and only one per
   ///             application instance is necessary.

--- a/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -24,7 +24,7 @@ namespace impeller {
 
 RenderPassGLES::RenderPassGLES(std::shared_ptr<const Context> context,
                                const RenderTarget& target,
-                               ReactorGLES::Ref reactor)
+                               std::shared_ptr<ReactorGLES> reactor)
     : RenderPass(std::move(context), target),
       reactor_(std::move(reactor)),
       is_valid_(reactor_ && reactor_->IsValid()) {}

--- a/impeller/renderer/backend/gles/render_pass_gles.h
+++ b/impeller/renderer/backend/gles/render_pass_gles.h
@@ -24,13 +24,13 @@ class RenderPassGLES final
  private:
   friend class CommandBufferGLES;
 
-  ReactorGLES::Ref reactor_;
+  std::shared_ptr<ReactorGLES> reactor_;
   std::string label_;
   bool is_valid_ = false;
 
   RenderPassGLES(std::shared_ptr<const Context> context,
                  const RenderTarget& target,
-                 ReactorGLES::Ref reactor);
+                 std::shared_ptr<ReactorGLES> reactor);
 
   // |RenderPass|
   bool IsValid() const override;

--- a/impeller/renderer/backend/gles/texture_gles.cc
+++ b/impeller/renderer/backend/gles/texture_gles.cc
@@ -140,9 +140,10 @@ HandleType ToHandleType(TextureGLES::Type type) {
   FML_UNREACHABLE();
 }
 
-std::shared_ptr<TextureGLES> TextureGLES::WrapFBO(ReactorGLES::Ref reactor,
-                                                  TextureDescriptor desc,
-                                                  GLuint fbo) {
+std::shared_ptr<TextureGLES> TextureGLES::WrapFBO(
+    std::shared_ptr<ReactorGLES> reactor,
+    TextureDescriptor desc,
+    GLuint fbo) {
   auto texture = std::shared_ptr<TextureGLES>(
       new TextureGLES(std::move(reactor), desc, fbo, std::nullopt));
   if (!texture->IsValid()) {
@@ -152,7 +153,7 @@ std::shared_ptr<TextureGLES> TextureGLES::WrapFBO(ReactorGLES::Ref reactor,
 }
 
 std::shared_ptr<TextureGLES> TextureGLES::WrapTexture(
-    ReactorGLES::Ref reactor,
+    std::shared_ptr<ReactorGLES> reactor,
     TextureDescriptor desc,
     HandleGLES external_handle) {
   if (external_handle.IsDead()) {
@@ -172,12 +173,13 @@ std::shared_ptr<TextureGLES> TextureGLES::WrapTexture(
 }
 
 std::shared_ptr<TextureGLES> TextureGLES::CreatePlaceholder(
-    ReactorGLES::Ref reactor,
+    std::shared_ptr<ReactorGLES> reactor,
     TextureDescriptor desc) {
   return TextureGLES::WrapFBO(std::move(reactor), desc, 0u);
 }
 
-TextureGLES::TextureGLES(ReactorGLES::Ref reactor, TextureDescriptor desc)
+TextureGLES::TextureGLES(std::shared_ptr<ReactorGLES> reactor,
+                         TextureDescriptor desc)
     : TextureGLES(std::move(reactor),  //
                   desc,                //
                   std::nullopt,        //

--- a/impeller/renderer/backend/gles/texture_gles.h
+++ b/impeller/renderer/backend/gles/texture_gles.h
@@ -39,9 +39,10 @@ class TextureGLES final : public Texture,
   /// @return     If a texture representation of the framebuffer could be
   ///             created.
   ///
-  static std::shared_ptr<TextureGLES> WrapFBO(ReactorGLES::Ref reactor,
-                                              TextureDescriptor desc,
-                                              GLuint fbo);
+  static std::shared_ptr<TextureGLES> WrapFBO(
+      std::shared_ptr<ReactorGLES> reactor,
+      TextureDescriptor desc,
+      GLuint fbo);
 
   //----------------------------------------------------------------------------
   /// @brief      Create a texture by wrapping an external OpenGL texture
@@ -55,9 +56,10 @@ class TextureGLES final : public Texture,
   /// @return     If a texture representation of the framebuffer could be
   ///             created.
   ///
-  static std::shared_ptr<TextureGLES> WrapTexture(ReactorGLES::Ref reactor,
-                                                  TextureDescriptor desc,
-                                                  HandleGLES external_handle);
+  static std::shared_ptr<TextureGLES> WrapTexture(
+      std::shared_ptr<ReactorGLES> reactor,
+      TextureDescriptor desc,
+      HandleGLES external_handle);
 
   //----------------------------------------------------------------------------
   /// @brief      Create a "texture" that is never expected to be bound/unbound
@@ -70,10 +72,10 @@ class TextureGLES final : public Texture,
   /// @return     If a texture placeholder could be created.
   ///
   static std::shared_ptr<TextureGLES> CreatePlaceholder(
-      ReactorGLES::Ref reactor,
+      std::shared_ptr<ReactorGLES> reactor,
       TextureDescriptor desc);
 
-  TextureGLES(ReactorGLES::Ref reactor, TextureDescriptor desc);
+  TextureGLES(std::shared_ptr<ReactorGLES> reactor, TextureDescriptor desc);
 
   // |Texture|
   ~TextureGLES() override;
@@ -143,7 +145,7 @@ class TextureGLES final : public Texture,
   std::optional<HandleGLES> GetSyncFence() const;
 
  private:
-  ReactorGLES::Ref reactor_;
+  std::shared_ptr<ReactorGLES> reactor_;
   const Type type_;
   HandleGLES handle_;
   mutable std::optional<HandleGLES> fence_ = std::nullopt;

--- a/impeller/renderer/backend/gles/unique_handle_gles.cc
+++ b/impeller/renderer/backend/gles/unique_handle_gles.cc
@@ -8,7 +8,8 @@
 
 namespace impeller {
 
-UniqueHandleGLES::UniqueHandleGLES(ReactorGLES::Ref reactor, HandleType type)
+UniqueHandleGLES::UniqueHandleGLES(std::shared_ptr<ReactorGLES> reactor,
+                                   HandleType type)
     : reactor_(std::move(reactor)) {
   if (reactor_) {
     handle_ = reactor_->CreateHandle(type);
@@ -16,14 +17,16 @@ UniqueHandleGLES::UniqueHandleGLES(ReactorGLES::Ref reactor, HandleType type)
 }
 
 // static
-UniqueHandleGLES UniqueHandleGLES::MakeUntracked(ReactorGLES::Ref reactor,
-                                                 HandleType type) {
+UniqueHandleGLES UniqueHandleGLES::MakeUntracked(
+    std::shared_ptr<ReactorGLES> reactor,
+    HandleType type) {
   FML_DCHECK(reactor);
   HandleGLES handle = reactor->CreateUntrackedHandle(type);
   return UniqueHandleGLES(std::move(reactor), handle);
 }
 
-UniqueHandleGLES::UniqueHandleGLES(ReactorGLES::Ref reactor, HandleGLES handle)
+UniqueHandleGLES::UniqueHandleGLES(std::shared_ptr<ReactorGLES> reactor,
+                                   HandleGLES handle)
     : reactor_(std::move(reactor)), handle_(handle) {}
 
 UniqueHandleGLES::~UniqueHandleGLES() {

--- a/impeller/renderer/backend/gles/unique_handle_gles.h
+++ b/impeller/renderer/backend/gles/unique_handle_gles.h
@@ -17,12 +17,12 @@ namespace impeller {
 ///
 class UniqueHandleGLES {
  public:
-  UniqueHandleGLES(ReactorGLES::Ref reactor, HandleType type);
+  UniqueHandleGLES(std::shared_ptr<ReactorGLES> reactor, HandleType type);
 
-  static UniqueHandleGLES MakeUntracked(ReactorGLES::Ref reactor,
+  static UniqueHandleGLES MakeUntracked(std::shared_ptr<ReactorGLES> reactor,
                                         HandleType type);
 
-  UniqueHandleGLES(ReactorGLES::Ref reactor, HandleGLES handle);
+  UniqueHandleGLES(std::shared_ptr<ReactorGLES> reactor, HandleGLES handle);
 
   ~UniqueHandleGLES();
 
@@ -37,7 +37,7 @@ class UniqueHandleGLES {
   bool IsValid() const;
 
  private:
-  ReactorGLES::Ref reactor_ = nullptr;
+  std::shared_ptr<ReactorGLES> reactor_ = nullptr;
   HandleGLES handle_ = HandleGLES::DeadHandle();
 };
 


### PR DESCRIPTION
This typedef really wasn't making the codebase any easier to work with.  We don't do this for other std::shared_ptr's

test-exempt: just removes typedef

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/engine/blob/main/docs/testing/Testing-the-engine.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
