### PR TITLE
[Impeller] switch Pipeline to use raw ptr instead of shared ptr for recorded references.

### DIFF
--- a/impeller/core/BUILD.gn
+++ b/impeller/core/BUILD.gn
@@ -23,6 +23,8 @@ impeller_component("core") {
     "platform.h",
     "range.cc",
     "range.h",
+    "raw_ptr.cc",
+    "raw_ptr.h",
     "resource_binder.cc",
     "resource_binder.h",
     "runtime_types.cc",

--- a/impeller/core/raw_ptr.cc
+++ b/impeller/core/raw_ptr.cc
@@ -1,0 +1,11 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "impeller/core/raw_ptr.h"
+
+namespace impeller {
+
+//
+
+}

--- a/impeller/core/raw_ptr.h
+++ b/impeller/core/raw_ptr.h
@@ -64,7 +64,7 @@ class raw_ptr {
   inline bool operator==(raw_ptr<U> const& other) const {
 #if !NDEBUG
     FML_CHECK(weak_ptr_.lock());
-    FML_CHECK(other_.weak_ptr_.lock());
+    FML_CHECK(other.weak_ptr_.lock());
 #endif
     return ptr_ == other.ptr_;
   }

--- a/impeller/core/raw_ptr.h
+++ b/impeller/core/raw_ptr.h
@@ -1,0 +1,74 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_IMPELLER_CORE_RAW_PTR_H_
+#define FLUTTER_IMPELLER_CORE_RAW_PTR_H_
+
+#include <memory>
+
+namespace impeller {
+
+/// @brief A wrapper around a raw ptr that adds additional unopt mode only
+/// checks.
+template <typename T>
+class raw_ptr {
+ public:
+  explicit raw_ptr(const std::shared_ptr<T>& ptr)
+      : ptr_(ptr.get())
+#if !NDEBUG
+        ,
+        weak_ptr_(ptr)
+#endif
+  {
+  }
+
+  raw_ptr() : ptr_(nullptr) {}
+
+  T* operator->() {
+#if !NDEBUG
+    FML_CHECK(weak_ptr_.lock());
+#endif
+    return ptr_;
+  }
+
+  const T* operator->() const {
+#if !NDEBUG
+    FML_CHECK(weak_ptr_.lock());
+#endif
+    return ptr_;
+  }
+
+  T* get() {
+#if !NDEBUG
+    FML_CHECK(weak_ptr_.lock());
+#endif
+    return ptr_;
+  }
+
+  T& operator*() {
+#if !NDEBUG
+    FML_CHECK(weak_ptr_.lock());
+#endif
+    return *ptr_;
+  }
+
+  const T& operator*() const {
+#if !NDEBUG
+    FML_CHECK(weak_ptr_.lock());
+#endif
+    return *ptr_;
+  }
+
+  explicit operator bool() const { return !!ptr_; }
+
+ private:
+  T* ptr_;
+#if !NDEBUG
+  std::weak_ptr<T> weak_ptr_;
+#endif
+};
+
+}  // namespace impeller
+
+#endif  // FLUTTER_IMPELLER_CORE_RAW_PTR_H_

--- a/impeller/core/raw_ptr.h
+++ b/impeller/core/raw_ptr.h
@@ -60,6 +60,20 @@ class raw_ptr {
     return *ptr_;
   }
 
+  template <class U>
+  inline bool operator==(raw_ptr<U> const& other) const {
+#if !NDEBUG
+    FML_CHECK(weak_ptr_.lock());
+    FML_CHECK(other_.weak_ptr_.lock());
+#endif
+    return ptr_ == other.ptr_;
+  }
+
+  template <class U>
+  inline bool operator!=(raw_ptr<U> const& other) const {
+    return !(*this == other);
+  }
+
   explicit operator bool() const { return !!ptr_; }
 
  private:

--- a/impeller/core/raw_ptr.h
+++ b/impeller/core/raw_ptr.h
@@ -62,10 +62,6 @@ class raw_ptr {
 
   template <class U>
   inline bool operator==(raw_ptr<U> const& other) const {
-#if !NDEBUG
-    FML_CHECK(weak_ptr_.lock());
-    FML_CHECK(other.weak_ptr_.lock());
-#endif
     return ptr_ == other.ptr_;
   }
 

--- a/impeller/entity/contents/color_source_contents.h
+++ b/impeller/entity/contents/color_source_contents.h
@@ -104,8 +104,7 @@ class ColorSourceContents : public Contents {
   using PipelineBuilderMethod = std::shared_ptr<Pipeline<PipelineDescriptor>> (
       impeller::ContentContext::*)(ContentContextOptions) const;
   using PipelineBuilderCallback =
-      std::function<std::shared_ptr<Pipeline<PipelineDescriptor>>(
-          ContentContextOptions)>;
+      std::function<const Pipeline<PipelineDescriptor>*(ContentContextOptions)>;
   using CreateGeometryCallback =
       std::function<GeometryResult(const ContentContext& renderer,
                                    const Entity& entity,

--- a/impeller/entity/contents/color_source_contents.h
+++ b/impeller/entity/contents/color_source_contents.h
@@ -104,7 +104,7 @@ class ColorSourceContents : public Contents {
   using PipelineBuilderMethod = std::shared_ptr<Pipeline<PipelineDescriptor>> (
       impeller::ContentContext::*)(ContentContextOptions) const;
   using PipelineBuilderCallback =
-      std::function<const Pipeline<PipelineDescriptor>*(ContentContextOptions)>;
+      std::function<PipelineRef(ContentContextOptions)>;
   using CreateGeometryCallback =
       std::function<GeometryResult(const ContentContext& renderer,
                                    const Entity& entity,

--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -569,8 +569,7 @@ void ContentContext::SetWireframe(bool wireframe) {
   wireframe_ = wireframe;
 }
 
-const Pipeline<PipelineDescriptor>*
-ContentContext::GetCachedRuntimeEffectPipeline(
+PipelineRef ContentContext::GetCachedRuntimeEffectPipeline(
     const std::string& unique_entrypoint_name,
     const ContentContextOptions& options,
     const std::function<std::shared_ptr<Pipeline<PipelineDescriptor>>()>&
@@ -580,7 +579,7 @@ ContentContext::GetCachedRuntimeEffectPipeline(
   if (it == runtime_effect_pipelines_.end()) {
     it = runtime_effect_pipelines_.insert(it, {key, create_callback()});
   }
-  return it->second.get();
+  return raw_ptr(it->second);
 }
 
 void ContentContext::ClearCachedRuntimeEffectPipeline(

--- a/impeller/entity/contents/content_context.cc
+++ b/impeller/entity/contents/content_context.cc
@@ -569,7 +569,7 @@ void ContentContext::SetWireframe(bool wireframe) {
   wireframe_ = wireframe;
 }
 
-std::shared_ptr<Pipeline<PipelineDescriptor>>
+const Pipeline<PipelineDescriptor>*
 ContentContext::GetCachedRuntimeEffectPipeline(
     const std::string& unique_entrypoint_name,
     const ContentContextOptions& options,
@@ -580,7 +580,7 @@ ContentContext::GetCachedRuntimeEffectPipeline(
   if (it == runtime_effect_pipelines_.end()) {
     it = runtime_effect_pipelines_.insert(it, {key, create_callback()});
   }
-  return it->second;
+  return it->second.get();
 }
 
 void ContentContext::ClearCachedRuntimeEffectPipeline(

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -377,102 +377,93 @@ class ContentContext {
 
   Tessellator& GetTessellator() const;
 
-  const Pipeline<PipelineDescriptor>* GetFastGradientPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetFastGradientPipeline(ContentContextOptions opts) const {
     return GetPipeline(fast_gradient_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetLinearGradientFillPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetLinearGradientFillPipeline(ContentContextOptions opts) const {
     return GetPipeline(linear_gradient_fill_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetLinearGradientUniformFillPipeline(
+  PipelineRef GetLinearGradientUniformFillPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(linear_gradient_uniform_fill_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetRadialGradientUniformFillPipeline(
+  PipelineRef GetRadialGradientUniformFillPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(radial_gradient_uniform_fill_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetConicalGradientUniformFillPipeline(
+  PipelineRef GetConicalGradientUniformFillPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(conical_gradient_uniform_fill_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetSweepGradientUniformFillPipeline(
+  PipelineRef GetSweepGradientUniformFillPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(sweep_gradient_uniform_fill_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetLinearGradientSSBOFillPipeline(
+  PipelineRef GetLinearGradientSSBOFillPipeline(
       ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsSSBO());
     return GetPipeline(linear_gradient_ssbo_fill_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetRadialGradientSSBOFillPipeline(
+  PipelineRef GetRadialGradientSSBOFillPipeline(
       ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsSSBO());
     return GetPipeline(radial_gradient_ssbo_fill_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetConicalGradientSSBOFillPipeline(
+  PipelineRef GetConicalGradientSSBOFillPipeline(
       ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsSSBO());
     return GetPipeline(conical_gradient_ssbo_fill_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetSweepGradientSSBOFillPipeline(
+  PipelineRef GetSweepGradientSSBOFillPipeline(
       ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsSSBO());
     return GetPipeline(sweep_gradient_ssbo_fill_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetRadialGradientFillPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetRadialGradientFillPipeline(ContentContextOptions opts) const {
     return GetPipeline(radial_gradient_fill_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetConicalGradientFillPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetConicalGradientFillPipeline(ContentContextOptions opts) const {
     return GetPipeline(conical_gradient_fill_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetRRectBlurPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetRRectBlurPipeline(ContentContextOptions opts) const {
     return GetPipeline(rrect_blur_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetSweepGradientFillPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetSweepGradientFillPipeline(ContentContextOptions opts) const {
     return GetPipeline(sweep_gradient_fill_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetSolidFillPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetSolidFillPipeline(ContentContextOptions opts) const {
     return GetPipeline(solid_fill_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetTexturePipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetTexturePipeline(ContentContextOptions opts) const {
     return GetPipeline(texture_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetTextureStrictSrcPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetTextureStrictSrcPipeline(ContentContextOptions opts) const {
     return GetPipeline(texture_strict_src_pipelines_, opts);
   }
 
 #ifdef IMPELLER_ENABLE_OPENGLES
-  const Pipeline<PipelineDescriptor>* GetDownsampleTextureGlesPipeline(
+  PipelineRef GetDownsampleTextureGlesPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(texture_downsample_gles_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetTiledTextureExternalPipeline(
+  PipelineRef GetTiledTextureExternalPipeline(
       ContentContextOptions opts) const {
     FML_DCHECK(GetContext()->GetBackendType() ==
                Context::BackendType::kOpenGLES);
@@ -480,236 +471,208 @@ class ContentContext {
   }
 #endif  // IMPELLER_ENABLE_OPENGLES
 
-  const Pipeline<PipelineDescriptor>* GetTiledTexturePipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetTiledTexturePipeline(ContentContextOptions opts) const {
     return GetPipeline(tiled_texture_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetGaussianBlurPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetGaussianBlurPipeline(ContentContextOptions opts) const {
     return GetPipeline(gaussian_blur_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetBorderMaskBlurPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetBorderMaskBlurPipeline(ContentContextOptions opts) const {
     return GetPipeline(border_mask_blur_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetMorphologyFilterPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetMorphologyFilterPipeline(ContentContextOptions opts) const {
     return GetPipeline(morphology_filter_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetColorMatrixColorFilterPipeline(
+  PipelineRef GetColorMatrixColorFilterPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(color_matrix_color_filter_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetLinearToSrgbFilterPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetLinearToSrgbFilterPipeline(ContentContextOptions opts) const {
     return GetPipeline(linear_to_srgb_filter_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetSrgbToLinearFilterPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetSrgbToLinearFilterPipeline(ContentContextOptions opts) const {
     return GetPipeline(srgb_to_linear_filter_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetClipPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetClipPipeline(ContentContextOptions opts) const {
     return GetPipeline(clip_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetGlyphAtlasPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetGlyphAtlasPipeline(ContentContextOptions opts) const {
     return GetPipeline(glyph_atlas_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetYUVToRGBFilterPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetYUVToRGBFilterPipeline(ContentContextOptions opts) const {
     return GetPipeline(yuv_to_rgb_filter_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetPorterDuffBlendPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetPorterDuffBlendPipeline(ContentContextOptions opts) const {
     return GetPipeline(porter_duff_blend_pipelines_, opts);
   }
 
   // Advanced blends.
 
-  const Pipeline<PipelineDescriptor>* GetBlendColorPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetBlendColorPipeline(ContentContextOptions opts) const {
     return GetPipeline(blend_color_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetBlendColorBurnPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetBlendColorBurnPipeline(ContentContextOptions opts) const {
     return GetPipeline(blend_colorburn_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetBlendColorDodgePipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetBlendColorDodgePipeline(ContentContextOptions opts) const {
     return GetPipeline(blend_colordodge_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetBlendDarkenPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetBlendDarkenPipeline(ContentContextOptions opts) const {
     return GetPipeline(blend_darken_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetBlendDifferencePipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetBlendDifferencePipeline(ContentContextOptions opts) const {
     return GetPipeline(blend_difference_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetBlendExclusionPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetBlendExclusionPipeline(ContentContextOptions opts) const {
     return GetPipeline(blend_exclusion_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetBlendHardLightPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetBlendHardLightPipeline(ContentContextOptions opts) const {
     return GetPipeline(blend_hardlight_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetBlendHuePipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetBlendHuePipeline(ContentContextOptions opts) const {
     return GetPipeline(blend_hue_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetBlendLightenPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetBlendLightenPipeline(ContentContextOptions opts) const {
     return GetPipeline(blend_lighten_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetBlendLuminosityPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetBlendLuminosityPipeline(ContentContextOptions opts) const {
     return GetPipeline(blend_luminosity_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetBlendMultiplyPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetBlendMultiplyPipeline(ContentContextOptions opts) const {
     return GetPipeline(blend_multiply_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetBlendOverlayPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetBlendOverlayPipeline(ContentContextOptions opts) const {
     return GetPipeline(blend_overlay_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetBlendSaturationPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetBlendSaturationPipeline(ContentContextOptions opts) const {
     return GetPipeline(blend_saturation_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetBlendScreenPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetBlendScreenPipeline(ContentContextOptions opts) const {
     return GetPipeline(blend_screen_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetBlendSoftLightPipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetBlendSoftLightPipeline(ContentContextOptions opts) const {
     return GetPipeline(blend_softlight_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetDownsamplePipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetDownsamplePipeline(ContentContextOptions opts) const {
     return GetPipeline(texture_downsample_pipelines_, opts);
   }
 
   // Framebuffer Advanced Blends
-  const Pipeline<PipelineDescriptor>* GetFramebufferBlendColorPipeline(
+  PipelineRef GetFramebufferBlendColorPipeline(
       ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_color_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetFramebufferBlendColorBurnPipeline(
+  PipelineRef GetFramebufferBlendColorBurnPipeline(
       ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_colorburn_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetFramebufferBlendColorDodgePipeline(
+  PipelineRef GetFramebufferBlendColorDodgePipeline(
       ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_colordodge_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetFramebufferBlendDarkenPipeline(
+  PipelineRef GetFramebufferBlendDarkenPipeline(
       ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_darken_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetFramebufferBlendDifferencePipeline(
+  PipelineRef GetFramebufferBlendDifferencePipeline(
       ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_difference_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetFramebufferBlendExclusionPipeline(
+  PipelineRef GetFramebufferBlendExclusionPipeline(
       ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_exclusion_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetFramebufferBlendHardLightPipeline(
+  PipelineRef GetFramebufferBlendHardLightPipeline(
       ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_hardlight_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetFramebufferBlendHuePipeline(
-      ContentContextOptions opts) const {
+  PipelineRef GetFramebufferBlendHuePipeline(ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_hue_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetFramebufferBlendLightenPipeline(
+  PipelineRef GetFramebufferBlendLightenPipeline(
       ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_lighten_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetFramebufferBlendLuminosityPipeline(
+  PipelineRef GetFramebufferBlendLuminosityPipeline(
       ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_luminosity_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetFramebufferBlendMultiplyPipeline(
+  PipelineRef GetFramebufferBlendMultiplyPipeline(
       ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_multiply_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetFramebufferBlendOverlayPipeline(
+  PipelineRef GetFramebufferBlendOverlayPipeline(
       ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_overlay_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetFramebufferBlendSaturationPipeline(
+  PipelineRef GetFramebufferBlendSaturationPipeline(
       ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_saturation_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetFramebufferBlendScreenPipeline(
+  PipelineRef GetFramebufferBlendScreenPipeline(
       ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_screen_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetFramebufferBlendSoftLightPipeline(
+  PipelineRef GetFramebufferBlendSoftLightPipeline(
       ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_softlight_pipelines_, opts);
   }
 
-  const Pipeline<PipelineDescriptor>* GetDrawVerticesUberShader(
-      ContentContextOptions opts) const {
+  PipelineRef GetDrawVerticesUberShader(ContentContextOptions opts) const {
     return GetPipeline(vertices_uber_shader_, opts);
   }
 
@@ -761,7 +724,7 @@ class ContentContext {
   ///
   /// The create_callback is synchronously invoked exactly once if a cached
   /// pipeline is not found.
-  const Pipeline<PipelineDescriptor>* GetCachedRuntimeEffectPipeline(
+  PipelineRef GetCachedRuntimeEffectPipeline(
       const std::string& unique_entrypoint_name,
       const ContentContextOptions& options,
       const std::function<std::shared_ptr<Pipeline<PipelineDescriptor>>()>&
@@ -992,14 +955,13 @@ class ContentContext {
   mutable Variants<VerticesUberShader> vertices_uber_shader_;
 
   template <class TypedPipeline>
-  const Pipeline<PipelineDescriptor>* GetPipeline(
-      Variants<TypedPipeline>& container,
-      ContentContextOptions opts) const {
+  PipelineRef GetPipeline(Variants<TypedPipeline>& container,
+                          ContentContextOptions opts) const {
     TypedPipeline* pipeline = CreateIfNeeded(container, opts);
     if (!pipeline) {
-      return nullptr;
+      return raw_ptr<Pipeline<PipelineDescriptor>>();
     }
-    return pipeline->WaitAndGet().get();
+    return raw_ptr(pipeline->WaitAndGet());
   }
 
   template <class RenderPipelineHandleT>

--- a/impeller/entity/contents/content_context.h
+++ b/impeller/entity/contents/content_context.h
@@ -377,102 +377,102 @@ class ContentContext {
 
   Tessellator& GetTessellator() const;
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetFastGradientPipeline(
+  const Pipeline<PipelineDescriptor>* GetFastGradientPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(fast_gradient_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetLinearGradientFillPipeline(
+  const Pipeline<PipelineDescriptor>* GetLinearGradientFillPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(linear_gradient_fill_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>>
-  GetLinearGradientUniformFillPipeline(ContentContextOptions opts) const {
+  const Pipeline<PipelineDescriptor>* GetLinearGradientUniformFillPipeline(
+      ContentContextOptions opts) const {
     return GetPipeline(linear_gradient_uniform_fill_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>>
-  GetRadialGradientUniformFillPipeline(ContentContextOptions opts) const {
+  const Pipeline<PipelineDescriptor>* GetRadialGradientUniformFillPipeline(
+      ContentContextOptions opts) const {
     return GetPipeline(radial_gradient_uniform_fill_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>>
-  GetConicalGradientUniformFillPipeline(ContentContextOptions opts) const {
+  const Pipeline<PipelineDescriptor>* GetConicalGradientUniformFillPipeline(
+      ContentContextOptions opts) const {
     return GetPipeline(conical_gradient_uniform_fill_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>>
-  GetSweepGradientUniformFillPipeline(ContentContextOptions opts) const {
+  const Pipeline<PipelineDescriptor>* GetSweepGradientUniformFillPipeline(
+      ContentContextOptions opts) const {
     return GetPipeline(sweep_gradient_uniform_fill_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>>
-  GetLinearGradientSSBOFillPipeline(ContentContextOptions opts) const {
+  const Pipeline<PipelineDescriptor>* GetLinearGradientSSBOFillPipeline(
+      ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsSSBO());
     return GetPipeline(linear_gradient_ssbo_fill_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>>
-  GetRadialGradientSSBOFillPipeline(ContentContextOptions opts) const {
+  const Pipeline<PipelineDescriptor>* GetRadialGradientSSBOFillPipeline(
+      ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsSSBO());
     return GetPipeline(radial_gradient_ssbo_fill_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>>
-  GetConicalGradientSSBOFillPipeline(ContentContextOptions opts) const {
+  const Pipeline<PipelineDescriptor>* GetConicalGradientSSBOFillPipeline(
+      ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsSSBO());
     return GetPipeline(conical_gradient_ssbo_fill_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>>
-  GetSweepGradientSSBOFillPipeline(ContentContextOptions opts) const {
+  const Pipeline<PipelineDescriptor>* GetSweepGradientSSBOFillPipeline(
+      ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsSSBO());
     return GetPipeline(sweep_gradient_ssbo_fill_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetRadialGradientFillPipeline(
+  const Pipeline<PipelineDescriptor>* GetRadialGradientFillPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(radial_gradient_fill_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetConicalGradientFillPipeline(
+  const Pipeline<PipelineDescriptor>* GetConicalGradientFillPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(conical_gradient_fill_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetRRectBlurPipeline(
+  const Pipeline<PipelineDescriptor>* GetRRectBlurPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(rrect_blur_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetSweepGradientFillPipeline(
+  const Pipeline<PipelineDescriptor>* GetSweepGradientFillPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(sweep_gradient_fill_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetSolidFillPipeline(
+  const Pipeline<PipelineDescriptor>* GetSolidFillPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(solid_fill_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetTexturePipeline(
+  const Pipeline<PipelineDescriptor>* GetTexturePipeline(
       ContentContextOptions opts) const {
     return GetPipeline(texture_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetTextureStrictSrcPipeline(
+  const Pipeline<PipelineDescriptor>* GetTextureStrictSrcPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(texture_strict_src_pipelines_, opts);
   }
 
 #ifdef IMPELLER_ENABLE_OPENGLES
-  std::shared_ptr<Pipeline<PipelineDescriptor>>
-  GetDownsampleTextureGlesPipeline(ContentContextOptions opts) const {
+  const Pipeline<PipelineDescriptor>* GetDownsampleTextureGlesPipeline(
+      ContentContextOptions opts) const {
     return GetPipeline(texture_downsample_gles_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetTiledTextureExternalPipeline(
+  const Pipeline<PipelineDescriptor>* GetTiledTextureExternalPipeline(
       ContentContextOptions opts) const {
     FML_DCHECK(GetContext()->GetBackendType() ==
                Context::BackendType::kOpenGLES);
@@ -480,235 +480,235 @@ class ContentContext {
   }
 #endif  // IMPELLER_ENABLE_OPENGLES
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetTiledTexturePipeline(
+  const Pipeline<PipelineDescriptor>* GetTiledTexturePipeline(
       ContentContextOptions opts) const {
     return GetPipeline(tiled_texture_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetGaussianBlurPipeline(
+  const Pipeline<PipelineDescriptor>* GetGaussianBlurPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(gaussian_blur_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetBorderMaskBlurPipeline(
+  const Pipeline<PipelineDescriptor>* GetBorderMaskBlurPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(border_mask_blur_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetMorphologyFilterPipeline(
+  const Pipeline<PipelineDescriptor>* GetMorphologyFilterPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(morphology_filter_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>>
-  GetColorMatrixColorFilterPipeline(ContentContextOptions opts) const {
+  const Pipeline<PipelineDescriptor>* GetColorMatrixColorFilterPipeline(
+      ContentContextOptions opts) const {
     return GetPipeline(color_matrix_color_filter_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetLinearToSrgbFilterPipeline(
+  const Pipeline<PipelineDescriptor>* GetLinearToSrgbFilterPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(linear_to_srgb_filter_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetSrgbToLinearFilterPipeline(
+  const Pipeline<PipelineDescriptor>* GetSrgbToLinearFilterPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(srgb_to_linear_filter_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetClipPipeline(
+  const Pipeline<PipelineDescriptor>* GetClipPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(clip_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetGlyphAtlasPipeline(
+  const Pipeline<PipelineDescriptor>* GetGlyphAtlasPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(glyph_atlas_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetYUVToRGBFilterPipeline(
+  const Pipeline<PipelineDescriptor>* GetYUVToRGBFilterPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(yuv_to_rgb_filter_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetPorterDuffBlendPipeline(
+  const Pipeline<PipelineDescriptor>* GetPorterDuffBlendPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(porter_duff_blend_pipelines_, opts);
   }
 
   // Advanced blends.
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetBlendColorPipeline(
+  const Pipeline<PipelineDescriptor>* GetBlendColorPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(blend_color_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetBlendColorBurnPipeline(
+  const Pipeline<PipelineDescriptor>* GetBlendColorBurnPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(blend_colorburn_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetBlendColorDodgePipeline(
+  const Pipeline<PipelineDescriptor>* GetBlendColorDodgePipeline(
       ContentContextOptions opts) const {
     return GetPipeline(blend_colordodge_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetBlendDarkenPipeline(
+  const Pipeline<PipelineDescriptor>* GetBlendDarkenPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(blend_darken_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetBlendDifferencePipeline(
+  const Pipeline<PipelineDescriptor>* GetBlendDifferencePipeline(
       ContentContextOptions opts) const {
     return GetPipeline(blend_difference_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetBlendExclusionPipeline(
+  const Pipeline<PipelineDescriptor>* GetBlendExclusionPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(blend_exclusion_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetBlendHardLightPipeline(
+  const Pipeline<PipelineDescriptor>* GetBlendHardLightPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(blend_hardlight_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetBlendHuePipeline(
+  const Pipeline<PipelineDescriptor>* GetBlendHuePipeline(
       ContentContextOptions opts) const {
     return GetPipeline(blend_hue_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetBlendLightenPipeline(
+  const Pipeline<PipelineDescriptor>* GetBlendLightenPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(blend_lighten_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetBlendLuminosityPipeline(
+  const Pipeline<PipelineDescriptor>* GetBlendLuminosityPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(blend_luminosity_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetBlendMultiplyPipeline(
+  const Pipeline<PipelineDescriptor>* GetBlendMultiplyPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(blend_multiply_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetBlendOverlayPipeline(
+  const Pipeline<PipelineDescriptor>* GetBlendOverlayPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(blend_overlay_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetBlendSaturationPipeline(
+  const Pipeline<PipelineDescriptor>* GetBlendSaturationPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(blend_saturation_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetBlendScreenPipeline(
+  const Pipeline<PipelineDescriptor>* GetBlendScreenPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(blend_screen_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetBlendSoftLightPipeline(
+  const Pipeline<PipelineDescriptor>* GetBlendSoftLightPipeline(
       ContentContextOptions opts) const {
     return GetPipeline(blend_softlight_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetDownsamplePipeline(
+  const Pipeline<PipelineDescriptor>* GetDownsamplePipeline(
       ContentContextOptions opts) const {
     return GetPipeline(texture_downsample_pipelines_, opts);
   }
 
   // Framebuffer Advanced Blends
-  std::shared_ptr<Pipeline<PipelineDescriptor>>
-  GetFramebufferBlendColorPipeline(ContentContextOptions opts) const {
+  const Pipeline<PipelineDescriptor>* GetFramebufferBlendColorPipeline(
+      ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_color_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>>
-  GetFramebufferBlendColorBurnPipeline(ContentContextOptions opts) const {
+  const Pipeline<PipelineDescriptor>* GetFramebufferBlendColorBurnPipeline(
+      ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_colorburn_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>>
-  GetFramebufferBlendColorDodgePipeline(ContentContextOptions opts) const {
+  const Pipeline<PipelineDescriptor>* GetFramebufferBlendColorDodgePipeline(
+      ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_colordodge_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>>
-  GetFramebufferBlendDarkenPipeline(ContentContextOptions opts) const {
+  const Pipeline<PipelineDescriptor>* GetFramebufferBlendDarkenPipeline(
+      ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_darken_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>>
-  GetFramebufferBlendDifferencePipeline(ContentContextOptions opts) const {
+  const Pipeline<PipelineDescriptor>* GetFramebufferBlendDifferencePipeline(
+      ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_difference_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>>
-  GetFramebufferBlendExclusionPipeline(ContentContextOptions opts) const {
+  const Pipeline<PipelineDescriptor>* GetFramebufferBlendExclusionPipeline(
+      ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_exclusion_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>>
-  GetFramebufferBlendHardLightPipeline(ContentContextOptions opts) const {
+  const Pipeline<PipelineDescriptor>* GetFramebufferBlendHardLightPipeline(
+      ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_hardlight_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetFramebufferBlendHuePipeline(
+  const Pipeline<PipelineDescriptor>* GetFramebufferBlendHuePipeline(
       ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_hue_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>>
-  GetFramebufferBlendLightenPipeline(ContentContextOptions opts) const {
+  const Pipeline<PipelineDescriptor>* GetFramebufferBlendLightenPipeline(
+      ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_lighten_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>>
-  GetFramebufferBlendLuminosityPipeline(ContentContextOptions opts) const {
+  const Pipeline<PipelineDescriptor>* GetFramebufferBlendLuminosityPipeline(
+      ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_luminosity_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>>
-  GetFramebufferBlendMultiplyPipeline(ContentContextOptions opts) const {
+  const Pipeline<PipelineDescriptor>* GetFramebufferBlendMultiplyPipeline(
+      ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_multiply_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>>
-  GetFramebufferBlendOverlayPipeline(ContentContextOptions opts) const {
+  const Pipeline<PipelineDescriptor>* GetFramebufferBlendOverlayPipeline(
+      ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_overlay_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>>
-  GetFramebufferBlendSaturationPipeline(ContentContextOptions opts) const {
+  const Pipeline<PipelineDescriptor>* GetFramebufferBlendSaturationPipeline(
+      ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_saturation_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>>
-  GetFramebufferBlendScreenPipeline(ContentContextOptions opts) const {
+  const Pipeline<PipelineDescriptor>* GetFramebufferBlendScreenPipeline(
+      ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_screen_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>>
-  GetFramebufferBlendSoftLightPipeline(ContentContextOptions opts) const {
+  const Pipeline<PipelineDescriptor>* GetFramebufferBlendSoftLightPipeline(
+      ContentContextOptions opts) const {
     FML_DCHECK(GetDeviceCapabilities().SupportsFramebufferFetch());
     return GetPipeline(framebuffer_blend_softlight_pipelines_, opts);
   }
 
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetDrawVerticesUberShader(
+  const Pipeline<PipelineDescriptor>* GetDrawVerticesUberShader(
       ContentContextOptions opts) const {
     return GetPipeline(vertices_uber_shader_, opts);
   }
@@ -761,7 +761,7 @@ class ContentContext {
   ///
   /// The create_callback is synchronously invoked exactly once if a cached
   /// pipeline is not found.
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetCachedRuntimeEffectPipeline(
+  const Pipeline<PipelineDescriptor>* GetCachedRuntimeEffectPipeline(
       const std::string& unique_entrypoint_name,
       const ContentContextOptions& options,
       const std::function<std::shared_ptr<Pipeline<PipelineDescriptor>>()>&
@@ -992,14 +992,14 @@ class ContentContext {
   mutable Variants<VerticesUberShader> vertices_uber_shader_;
 
   template <class TypedPipeline>
-  std::shared_ptr<Pipeline<PipelineDescriptor>> GetPipeline(
+  const Pipeline<PipelineDescriptor>* GetPipeline(
       Variants<TypedPipeline>& container,
       ContentContextOptions opts) const {
     TypedPipeline* pipeline = CreateIfNeeded(container, opts);
     if (!pipeline) {
       return nullptr;
     }
-    return pipeline->WaitAndGet();
+    return pipeline->WaitAndGet().get();
   }
 
   template <class RenderPipelineHandleT>
@@ -1023,7 +1023,7 @@ class ContentContext {
     // The default must always be initialized in the constructor.
     FML_CHECK(default_handle != nullptr);
 
-    std::shared_ptr<Pipeline<PipelineDescriptor>> pipeline =
+    const std::shared_ptr<Pipeline<PipelineDescriptor>>& pipeline =
         default_handle->WaitAndGet();
     if (!pipeline) {
       return nullptr;

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -71,8 +71,8 @@ BlendFilterContents::BlendFilterContents() {
 
 BlendFilterContents::~BlendFilterContents() = default;
 
-using PipelineProc = const Pipeline<PipelineDescriptor>* (
-    ContentContext::*)(ContentContextOptions) const;
+using PipelineProc =
+    PipelineRef (ContentContext::*)(ContentContextOptions) const;
 
 template <typename TPipeline>
 static std::optional<Entity> AdvancedBlend(
@@ -170,8 +170,7 @@ static std::optional<Entity> AdvancedBlend(
     auto options = OptionsFromPass(pass);
     options.primitive_type = PrimitiveType::kTriangleStrip;
     options.blend_mode = BlendMode::kSource;
-    const Pipeline<PipelineDescriptor>* pipeline =
-        std::invoke(pipeline_proc, renderer, options);
+    PipelineRef pipeline = std::invoke(pipeline_proc, renderer, options);
 
 #ifdef IMPELLER_DEBUG
     pass.SetCommandLabel(

--- a/impeller/entity/contents/filters/blend_filter_contents.cc
+++ b/impeller/entity/contents/filters/blend_filter_contents.cc
@@ -71,7 +71,7 @@ BlendFilterContents::BlendFilterContents() {
 
 BlendFilterContents::~BlendFilterContents() = default;
 
-using PipelineProc = std::shared_ptr<Pipeline<PipelineDescriptor>> (
+using PipelineProc = const Pipeline<PipelineDescriptor>* (
     ContentContext::*)(ContentContextOptions) const;
 
 template <typename TPipeline>
@@ -170,7 +170,7 @@ static std::optional<Entity> AdvancedBlend(
     auto options = OptionsFromPass(pass);
     options.primitive_type = PrimitiveType::kTriangleStrip;
     options.blend_mode = BlendMode::kSource;
-    std::shared_ptr<Pipeline<PipelineDescriptor>> pipeline =
+    const Pipeline<PipelineDescriptor>* pipeline =
         std::invoke(pipeline_proc, renderer, options);
 
 #ifdef IMPELLER_DEBUG

--- a/impeller/entity/contents/test/recording_render_pass.cc
+++ b/impeller/entity/contents/test/recording_render_pass.cc
@@ -16,7 +16,7 @@ RecordingRenderPass::RecordingRenderPass(
 
 // |RenderPass|
 void RecordingRenderPass::SetPipeline(
-    const std::shared_ptr<Pipeline<PipelineDescriptor>>& pipeline) {
+    const Pipeline<PipelineDescriptor>* pipeline) {
   pending_.pipeline = pipeline;
   if (delegate_) {
     delegate_->SetPipeline(pipeline);

--- a/impeller/entity/contents/test/recording_render_pass.cc
+++ b/impeller/entity/contents/test/recording_render_pass.cc
@@ -15,8 +15,7 @@ RecordingRenderPass::RecordingRenderPass(
     : RenderPass(context, render_target), delegate_(std::move(delegate)) {}
 
 // |RenderPass|
-void RecordingRenderPass::SetPipeline(
-    const Pipeline<PipelineDescriptor>* pipeline) {
+void RecordingRenderPass::SetPipeline(PipelineRef pipeline) {
   pending_.pipeline = pipeline;
   if (delegate_) {
     delegate_->SetPipeline(pipeline);

--- a/impeller/entity/contents/test/recording_render_pass.h
+++ b/impeller/entity/contents/test/recording_render_pass.h
@@ -20,7 +20,7 @@ class RecordingRenderPass : public RenderPass {
   const std::vector<Command>& GetCommands() const override { return commands_; }
 
   // |RenderPass|
-  void SetPipeline(const Pipeline<PipelineDescriptor>* pipeline) override;
+  void SetPipeline(PipelineRef pipeline) override;
 
   void SetCommandLabel(std::string_view label) override;
 

--- a/impeller/entity/contents/test/recording_render_pass.h
+++ b/impeller/entity/contents/test/recording_render_pass.h
@@ -20,8 +20,7 @@ class RecordingRenderPass : public RenderPass {
   const std::vector<Command>& GetCommands() const override { return commands_; }
 
   // |RenderPass|
-  void SetPipeline(
-      const std::shared_ptr<Pipeline<PipelineDescriptor>>& pipeline) override;
+  void SetPipeline(const Pipeline<PipelineDescriptor>* pipeline) override;
 
   void SetCommandLabel(std::string_view label) override;
 

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -1697,7 +1697,7 @@ TEST_P(EntityTest, RuntimeEffect) {
   ASSERT_TRUE(runtime_stage->IsDirty());
 
   bool expect_dirty = true;
-  const raw_ptr<Pipeline<PipelineDescriptor>*> first_pipeline;
+  PipelineRef first_pipeline;
   std::unique_ptr<Geometry> geom = Geometry::MakeCover();
 
   auto callback = [&](ContentContext& context, RenderPass& pass) -> bool {

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -1696,7 +1696,7 @@ TEST_P(EntityTest, RuntimeEffect) {
   ASSERT_TRUE(runtime_stage->IsDirty());
 
   bool expect_dirty = true;
-  Pipeline<PipelineDescriptor>* first_pipeline;
+  const Pipeline<PipelineDescriptor>* first_pipeline;
   std::unique_ptr<Geometry> geom = Geometry::MakeCover();
 
   auto callback = [&](ContentContext& context, RenderPass& pass) -> bool {
@@ -1723,10 +1723,10 @@ TEST_P(EntityTest, RuntimeEffect) {
     bool result = contents->Render(context, entity, pass);
 
     if (expect_dirty) {
-      EXPECT_NE(first_pipeline, pass.GetCommands().back().pipeline.get());
-      first_pipeline = pass.GetCommands().back().pipeline.get();
+      EXPECT_NE(first_pipeline, pass.GetCommands().back().pipeline);
+      first_pipeline = pass.GetCommands().back().pipeline;
     } else {
-      EXPECT_EQ(pass.GetCommands().back().pipeline.get(), first_pipeline);
+      EXPECT_EQ(pass.GetCommands().back().pipeline, first_pipeline);
     }
 
     expect_dirty = false;

--- a/impeller/entity/entity_unittests.cc
+++ b/impeller/entity/entity_unittests.cc
@@ -15,6 +15,7 @@
 #include "impeller/core/device_buffer.h"
 #include "impeller/core/formats.h"
 #include "impeller/core/host_buffer.h"
+#include "impeller/core/raw_ptr.h"
 #include "impeller/core/texture_descriptor.h"
 #include "impeller/entity/contents/clip_contents.h"
 #include "impeller/entity/contents/conical_gradient_contents.h"
@@ -1696,7 +1697,7 @@ TEST_P(EntityTest, RuntimeEffect) {
   ASSERT_TRUE(runtime_stage->IsDirty());
 
   bool expect_dirty = true;
-  const Pipeline<PipelineDescriptor>* first_pipeline;
+  const raw_ptr<Pipeline<PipelineDescriptor>*> first_pipeline;
   std::unique_ptr<Geometry> geom = Geometry::MakeCover();
 
   auto callback = [&](ContentContext& context, RenderPass& pass) -> bool {

--- a/impeller/playground/imgui/imgui_impl_impeller.cc
+++ b/impeller/playground/imgui/imgui_impl_impeller.cc
@@ -30,7 +30,6 @@
 #include "impeller/geometry/point.h"
 #include "impeller/geometry/rect.h"
 #include "impeller/geometry/size.h"
-#include "impeller/renderer/command.h"
 #include "impeller/renderer/context.h"
 #include "impeller/renderer/pipeline_builder.h"
 #include "impeller/renderer/pipeline_descriptor.h"
@@ -256,7 +255,7 @@ void ImGui_ImplImpeller_RenderDrawData(ImDrawData* draw_data,
             "ImGui draw list %d (command %d)", draw_list_i, cmd_i));
         render_pass.SetViewport(viewport);
         render_pass.SetScissor(impeller::IRect::RoundOut(clip_rect));
-        render_pass.SetPipeline(bd->pipeline.get());
+        render_pass.SetPipeline(bd->pipeline);
         VS::BindUniformBuffer(render_pass, vtx_uniforms);
         FS::BindTex(render_pass, bd->font_texture, bd->sampler);
 

--- a/impeller/playground/imgui/imgui_impl_impeller.cc
+++ b/impeller/playground/imgui/imgui_impl_impeller.cc
@@ -256,7 +256,7 @@ void ImGui_ImplImpeller_RenderDrawData(ImDrawData* draw_data,
             "ImGui draw list %d (command %d)", draw_list_i, cmd_i));
         render_pass.SetViewport(viewport);
         render_pass.SetScissor(impeller::IRect::RoundOut(clip_rect));
-        render_pass.SetPipeline(bd->pipeline);
+        render_pass.SetPipeline(bd->pipeline.get());
         VS::BindUniformBuffer(render_pass, vtx_uniforms);
         FS::BindTex(render_pass, bd->font_texture, bd->sampler);
 

--- a/impeller/renderer/backend/metal/render_pass_mtl.h
+++ b/impeller/renderer/backend/metal/render_pass_mtl.h
@@ -58,8 +58,7 @@ class RenderPassMTL final : public RenderPass {
   bool OnEncodeCommands(const Context& context) const override;
 
   // |RenderPass|
-  void SetPipeline(
-      const std::shared_ptr<Pipeline<PipelineDescriptor>>& pipeline) override;
+  void SetPipeline(const Pipeline<PipelineDescriptor>* pipeline) override;
 
   // |RenderPass|
   void SetCommandLabel(std::string_view label) override;

--- a/impeller/renderer/backend/metal/render_pass_mtl.h
+++ b/impeller/renderer/backend/metal/render_pass_mtl.h
@@ -58,7 +58,7 @@ class RenderPassMTL final : public RenderPass {
   bool OnEncodeCommands(const Context& context) const override;
 
   // |RenderPass|
-  void SetPipeline(const Pipeline<PipelineDescriptor>* pipeline) override;
+  void SetPipeline(PipelineRef pipeline) override;
 
   // |RenderPass|
   void SetCommandLabel(std::string_view label) override;

--- a/impeller/renderer/backend/metal/render_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/render_pass_mtl.mm
@@ -233,7 +233,7 @@ static bool Bind(PassBindingsCacheMTL& pass,
 }
 
 // |RenderPass|
-void RenderPassMTL::SetPipeline(const Pipeline<PipelineDescriptor>* pipeline) {
+void RenderPassMTL::SetPipeline(PipelineRef pipeline) {
   const PipelineDescriptor& pipeline_desc = pipeline->GetDescriptor();
   primitive_type_ = pipeline_desc.GetPrimitiveType();
   pass_bindings_.SetRenderPipelineState(

--- a/impeller/renderer/backend/metal/render_pass_mtl.mm
+++ b/impeller/renderer/backend/metal/render_pass_mtl.mm
@@ -233,8 +233,7 @@ static bool Bind(PassBindingsCacheMTL& pass,
 }
 
 // |RenderPass|
-void RenderPassMTL::SetPipeline(
-    const std::shared_ptr<Pipeline<PipelineDescriptor>>& pipeline) {
+void RenderPassMTL::SetPipeline(const Pipeline<PipelineDescriptor>* pipeline) {
   const PipelineDescriptor& pipeline_desc = pipeline->GetDescriptor();
   primitive_type_ = pipeline_desc.GetPrimitiveType();
   pass_bindings_.SetRenderPipelineState(

--- a/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -293,9 +293,8 @@ SharedHandleVK<vk::Framebuffer> RenderPassVK::CreateVKFramebuffer(
 }
 
 // |RenderPass|
-void RenderPassVK::SetPipeline(
-    const std::shared_ptr<Pipeline<PipelineDescriptor>>& pipeline) {
-  pipeline_ = pipeline.get();
+void RenderPassVK::SetPipeline(const Pipeline<PipelineDescriptor>* pipeline) {
+  pipeline_ = pipeline;
   if (!pipeline_) {
     return;
   }

--- a/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -293,7 +293,7 @@ SharedHandleVK<vk::Framebuffer> RenderPassVK::CreateVKFramebuffer(
 }
 
 // |RenderPass|
-void RenderPassVK::SetPipeline(const Pipeline<PipelineDescriptor>* pipeline) {
+void RenderPassVK::SetPipeline(PipelineRef pipeline) {
   pipeline_ = pipeline;
   if (!pipeline_) {
     return;
@@ -304,7 +304,7 @@ void RenderPassVK::SetPipeline(const Pipeline<PipelineDescriptor>* pipeline) {
 
   if (pipeline_uses_input_attachments_) {
     if (bound_image_offset_ >= kMaxBindings) {
-      pipeline_ = nullptr;
+      pipeline_ = PipelineRef(nullptr);
       return;
     }
     vk::DescriptorImageInfo image_info;
@@ -463,7 +463,7 @@ fml::Status RenderPassVK::Draw() {
   /// Jank can be completely eliminated by pre-populating known YUV conversion
   /// pipelines.
   if (immutable_sampler_) {
-    std::shared_ptr<PipelineVK> pipeline_variant =
+    std::shared_ptr<Pipeline<PipelineDescriptor>> pipeline_variant =
         PipelineVK::Cast(*pipeline_)
             .CreateVariantForImmutableSamplers(immutable_sampler_);
     if (!pipeline_variant) {
@@ -471,7 +471,7 @@ fml::Status RenderPassVK::Draw() {
           fml::StatusCode::kAborted,
           "Could not create pipeline variant with immutable sampler.");
     }
-    pipeline_ = pipeline_variant.get();
+    pipeline_ = raw_ptr(pipeline_variant);
   }
 
   const auto& context_vk = ContextVK::Cast(*context_);
@@ -538,7 +538,7 @@ fml::Status RenderPassVK::Draw() {
   instance_count_ = 1u;
   base_vertex_ = 0u;
   element_count_ = 0u;
-  pipeline_ = nullptr;
+  pipeline_ = PipelineRef(nullptr);
   pipeline_uses_input_attachments_ = false;
   immutable_sampler_ = nullptr;
   return fml::Status();

--- a/impeller/renderer/backend/vulkan/render_pass_vk.h
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.h
@@ -49,7 +49,7 @@ class RenderPassVK final : public RenderPass {
   size_t element_count_ = 0u;
   bool has_index_buffer_ = false;
   bool has_label_ = false;
-  const Pipeline<PipelineDescriptor>* pipeline_;
+  PipelineRef pipeline_ = PipelineRef(nullptr);
   bool pipeline_uses_input_attachments_ = false;
   std::shared_ptr<SamplerVK> immutable_sampler_;
 
@@ -58,7 +58,7 @@ class RenderPassVK final : public RenderPass {
                std::shared_ptr<CommandBufferVK> command_buffer);
 
   // |RenderPass|
-  void SetPipeline(const Pipeline<PipelineDescriptor>* pipeline) override;
+  void SetPipeline(PipelineRef pipeline) override;
 
   // |RenderPass|
   void SetCommandLabel(std::string_view label) override;

--- a/impeller/renderer/backend/vulkan/render_pass_vk.h
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.h
@@ -58,8 +58,7 @@ class RenderPassVK final : public RenderPass {
                std::shared_ptr<CommandBufferVK> command_buffer);
 
   // |RenderPass|
-  void SetPipeline(
-      const std::shared_ptr<Pipeline<PipelineDescriptor>>& pipeline) override;
+  void SetPipeline(const Pipeline<PipelineDescriptor>* pipeline) override;
 
   // |RenderPass|
   void SetCommandLabel(std::string_view label) override;

--- a/impeller/renderer/command.h
+++ b/impeller/renderer/command.h
@@ -81,7 +81,7 @@ struct Command {
   //----------------------------------------------------------------------------
   /// The pipeline to use for this command.
   ///
-  const Pipeline<PipelineDescriptor>* pipeline;
+  PipelineRef pipeline;
 
   /// An offset into render pass storage where bound buffers/texture metadata is
   /// stored.

--- a/impeller/renderer/command.h
+++ b/impeller/renderer/command.h
@@ -81,7 +81,7 @@ struct Command {
   //----------------------------------------------------------------------------
   /// The pipeline to use for this command.
   ///
-  std::shared_ptr<Pipeline<PipelineDescriptor>> pipeline;
+  const Pipeline<PipelineDescriptor>* pipeline;
 
   /// An offset into render pass storage where bound buffers/texture metadata is
   /// stored.

--- a/impeller/renderer/pipeline.h
+++ b/impeller/renderer/pipeline.h
@@ -8,6 +8,7 @@
 #include <future>
 
 #include "compute_pipeline_descriptor.h"
+#include "impeller/core/raw_ptr.h"
 #include "impeller/renderer/compute_pipeline_builder.h"
 #include "impeller/renderer/compute_pipeline_descriptor.h"
 #include "impeller/renderer/context.h"
@@ -77,6 +78,8 @@ class Pipeline {
 
   Pipeline& operator=(const Pipeline&) = delete;
 };
+
+using PipelineRef = raw_ptr<Pipeline<PipelineDescriptor>>;
 
 extern template class Pipeline<PipelineDescriptor>;
 extern template class Pipeline<ComputePipelineDescriptor>;

--- a/impeller/renderer/pipeline.h
+++ b/impeller/renderer/pipeline.h
@@ -79,6 +79,10 @@ class Pipeline {
   Pipeline& operator=(const Pipeline&) = delete;
 };
 
+/// @brief A raw ptr to a pipeline object.
+///
+/// These pipeline refs are safe to use as the context will keep the
+/// pipelines alive throughout rendering.
 using PipelineRef = raw_ptr<Pipeline<PipelineDescriptor>>;
 
 extern template class Pipeline<PipelineDescriptor>;

--- a/impeller/renderer/render_pass.cc
+++ b/impeller/renderer/render_pass.cc
@@ -81,8 +81,7 @@ const std::shared_ptr<const Context>& RenderPass::GetContext() const {
   return context_;
 }
 
-void RenderPass::SetPipeline(
-    const std::shared_ptr<Pipeline<PipelineDescriptor>>& pipeline) {
+void RenderPass::SetPipeline(const Pipeline<PipelineDescriptor>* pipeline) {
   pending_.pipeline = pipeline;
 }
 

--- a/impeller/renderer/render_pass.cc
+++ b/impeller/renderer/render_pass.cc
@@ -85,6 +85,11 @@ void RenderPass::SetPipeline(PipelineRef pipeline) {
   pending_.pipeline = pipeline;
 }
 
+void RenderPass::SetPipeline(
+    const std::shared_ptr<Pipeline<PipelineDescriptor>>& pipeline) {
+  SetPipeline(PipelineRef(pipeline));
+}
+
 void RenderPass::SetCommandLabel(std::string_view label) {
 #ifdef IMPELLER_DEBUG
   pending_.label = std::string(label);

--- a/impeller/renderer/render_pass.cc
+++ b/impeller/renderer/render_pass.cc
@@ -81,7 +81,7 @@ const std::shared_ptr<const Context>& RenderPass::GetContext() const {
   return context_;
 }
 
-void RenderPass::SetPipeline(const Pipeline<PipelineDescriptor>* pipeline) {
+void RenderPass::SetPipeline(PipelineRef pipeline) {
   pending_.pipeline = pipeline;
 }
 

--- a/impeller/renderer/render_pass.h
+++ b/impeller/renderer/render_pass.h
@@ -45,8 +45,7 @@ class RenderPass : public ResourceBinder {
 
   //----------------------------------------------------------------------------
   /// The pipeline to use for this command.
-  virtual void SetPipeline(
-      const std::shared_ptr<Pipeline<PipelineDescriptor>>& pipeline);
+  virtual void SetPipeline(const Pipeline<PipelineDescriptor>* pipeline);
 
   //----------------------------------------------------------------------------
   /// The debugging label to use for the command.

--- a/impeller/renderer/render_pass.h
+++ b/impeller/renderer/render_pass.h
@@ -48,6 +48,11 @@ class RenderPass : public ResourceBinder {
   virtual void SetPipeline(PipelineRef pipeline);
 
   //----------------------------------------------------------------------------
+  /// The pipeline to use for this command.
+  void SetPipeline(
+      const std::shared_ptr<Pipeline<PipelineDescriptor>>& pipeline);
+
+  //----------------------------------------------------------------------------
   /// The debugging label to use for the command.
   virtual void SetCommandLabel(std::string_view label);
 

--- a/impeller/renderer/render_pass.h
+++ b/impeller/renderer/render_pass.h
@@ -45,7 +45,7 @@ class RenderPass : public ResourceBinder {
 
   //----------------------------------------------------------------------------
   /// The pipeline to use for this command.
-  virtual void SetPipeline(const Pipeline<PipelineDescriptor>* pipeline);
+  virtual void SetPipeline(PipelineRef pipeline);
 
   //----------------------------------------------------------------------------
   /// The debugging label to use for the command.

--- a/impeller/renderer/renderer_dart_unittests.cc
+++ b/impeller/renderer/renderer_dart_unittests.cc
@@ -235,7 +235,7 @@ class RendererDartTest : public PlaygroundTest,
       TextureVS::BindUniformBuffer(pass, buffer->EmplaceUniform(uniforms));
       TextureFS::BindTextureContents(pass, texture, sampler);
 
-      pass.SetPipeline(pipeline.get());
+      pass.SetPipeline(pipeline);
 
       if (!pass.Draw().ok()) {
         return false;

--- a/impeller/renderer/renderer_dart_unittests.cc
+++ b/impeller/renderer/renderer_dart_unittests.cc
@@ -235,7 +235,7 @@ class RendererDartTest : public PlaygroundTest,
       TextureVS::BindUniformBuffer(pass, buffer->EmplaceUniform(uniforms));
       TextureFS::BindTextureContents(pass, texture, sampler);
 
-      pass.SetPipeline(pipeline);
+      pass.SetPipeline(pipeline.get());
 
       if (!pass.Draw().ok()) {
         return false;

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -93,7 +93,7 @@ TEST_P(RendererTest, CanCreateBoxPrimitive) {
     assert(pipeline && pipeline->IsValid());
 
     pass.SetCommandLabel("Box");
-    pass.SetPipeline(pipeline.get());
+    pass.SetPipeline(pipeline);
     pass.SetVertexBuffer(
         vertex_builder.CreateVertexBuffer(*context->GetResourceAllocator()));
 
@@ -160,7 +160,7 @@ TEST_P(RendererTest, BabysFirstTriangle) {
       *context->GetResourceAllocator());
 
   SinglePassCallback callback = [&](RenderPass& pass) {
-    pass.SetPipeline(pipeline.get());
+    pass.SetPipeline(pipeline);
     pass.SetVertexBuffer(vertex_buffer);
 
     FS::FragInfo frag_info;
@@ -255,7 +255,7 @@ TEST_P(RendererTest, CanRenderPerspectiveCube) {
     ImGui::End();
 
     pass.SetCommandLabel("Perspective Cube");
-    pass.SetPipeline(pipeline.get());
+    pass.SetPipeline(pipeline);
 
     std::array<BufferView, 2> vertex_buffers = {
         BufferView(device_buffer,
@@ -330,7 +330,7 @@ TEST_P(RendererTest, CanRenderMultiplePrimitives) {
     for (size_t i = 0; i < 1; i++) {
       for (size_t j = 0; j < 1; j++) {
         pass.SetCommandLabel("Box");
-        pass.SetPipeline(box_pipeline.get());
+        pass.SetPipeline(box_pipeline);
         pass.SetVertexBuffer(vertex_buffer);
 
         FS::FrameInfo frame_info;
@@ -445,7 +445,7 @@ TEST_P(RendererTest, CanRenderToTexture) {
   }
 
   r2t_pass->SetCommandLabel("Box");
-  r2t_pass->SetPipeline(box_pipeline.get());
+  r2t_pass->SetPipeline(box_pipeline);
   r2t_pass->SetVertexBuffer(vertex_buffer);
 
   FS::FrameInfo frame_info;
@@ -504,7 +504,7 @@ TEST_P(RendererTest, CanRenderInstanced) {
   auto host_buffer = HostBuffer::Create(GetContext()->GetResourceAllocator(),
                                         GetContext()->GetIdleWaiter());
   ASSERT_TRUE(OpenPlaygroundHere([&](RenderPass& pass) -> bool {
-    pass.SetPipeline(pipeline.get());
+    pass.SetPipeline(pipeline);
     pass.SetCommandLabel("InstancedDraw");
 
     VS::FrameInfo frame_info;
@@ -605,7 +605,7 @@ TEST_P(RendererTest, CanBlitTextureToTexture) {
       pass->SetLabel("Playground Render Pass");
       {
         pass->SetCommandLabel("Image");
-        pass->SetPipeline(mipmaps_pipeline.get());
+        pass->SetPipeline(mipmaps_pipeline);
         pass->SetVertexBuffer(vertex_buffer);
 
         VS::FrameInfo frame_info;
@@ -728,7 +728,7 @@ TEST_P(RendererTest, CanBlitTextureToBuffer) {
       pass->SetLabel("Playground Render Pass");
       {
         pass->SetCommandLabel("Image");
-        pass->SetPipeline(mipmaps_pipeline.get());
+        pass->SetPipeline(mipmaps_pipeline);
         pass->SetVertexBuffer(vertex_buffer);
 
         VS::FrameInfo frame_info;
@@ -855,7 +855,7 @@ TEST_P(RendererTest, CanGenerateMipmaps) {
       pass->SetLabel("Playground Render Pass");
       {
         pass->SetCommandLabel("Image LOD");
-        pass->SetPipeline(mipmaps_pipeline.get());
+        pass->SetPipeline(mipmaps_pipeline);
         pass->SetVertexBuffer(vertex_buffer);
 
         VS::FrameInfo frame_info;
@@ -923,7 +923,7 @@ TEST_P(RendererTest, TheImpeller) {
   SinglePassCallback callback = [&](RenderPass& pass) {
     auto size = pass.GetRenderTargetSize();
 
-    pass.SetPipeline(pipeline.get());
+    pass.SetPipeline(pipeline);
     pass.SetCommandLabel("Impeller SDF scene");
     VertexBufferBuilder<VS::PerVertexData> builder;
     builder.AddVertices({{Point()},
@@ -987,7 +987,7 @@ TEST_P(RendererTest, Planet) {
     ImGui::InputFloat("Seed Value", &seed_value);
     ImGui::End();
 
-    pass.SetPipeline(pipeline.get());
+    pass.SetPipeline(pipeline);
     pass.SetCommandLabel("Planet scene");
     VertexBufferBuilder<VS::PerVertexData> builder;
     builder.AddVertices({{Point()},
@@ -1039,7 +1039,7 @@ TEST_P(RendererTest, ArrayUniforms) {
   SinglePassCallback callback = [&](RenderPass& pass) {
     auto size = pass.GetRenderTargetSize();
 
-    pass.SetPipeline(pipeline.get());
+    pass.SetPipeline(pipeline);
     pass.SetCommandLabel("Google Dots");
     VertexBufferBuilder<VS::PerVertexData> builder;
     builder.AddVertices({{Point()},
@@ -1097,7 +1097,7 @@ TEST_P(RendererTest, InactiveUniforms) {
   SinglePassCallback callback = [&](RenderPass& pass) {
     auto size = pass.GetRenderTargetSize();
 
-    pass.SetPipeline(pipeline.get());
+    pass.SetPipeline(pipeline);
     pass.SetCommandLabel("Inactive Uniform");
 
     VertexBufferBuilder<VS::PerVertexData> builder;
@@ -1329,7 +1329,7 @@ TEST_P(RendererTest, StencilMask) {
       assert(pipeline && pipeline->IsValid());
 
       pass->SetCommandLabel("Box");
-      pass->SetPipeline(pipeline.get());
+      pass->SetPipeline(pipeline);
       pass->SetStencilReference(stencil_reference_read);
       pass->SetVertexBuffer(vertex_buffer);
 
@@ -1477,7 +1477,7 @@ TEST_P(RendererTest, CanSepiaToneWithSubpasses) {
 
     // Draw the texture.
     {
-      pass.SetPipeline(texture_pipeline.get());
+      pass.SetPipeline(texture_pipeline);
       pass.SetVertexBuffer(texture_vtx_builder.CreateVertexBuffer(
           *context->GetResourceAllocator()));
       TextureVS::UniformBuffer uniforms;
@@ -1492,7 +1492,7 @@ TEST_P(RendererTest, CanSepiaToneWithSubpasses) {
 
     // Draw the sepia toner.
     {
-      pass.SetPipeline(sepia_pipeline.get());
+      pass.SetPipeline(sepia_pipeline);
       pass.SetVertexBuffer(sepia_vtx_builder.CreateVertexBuffer(
           *context->GetResourceAllocator()));
       SepiaVS::UniformBuffer uniforms;
@@ -1571,7 +1571,7 @@ TEST_P(RendererTest, CanSepiaToneThenSwizzleWithSubpasses) {
 
     // Draw the texture.
     {
-      pass.SetPipeline(texture_pipeline.get());
+      pass.SetPipeline(texture_pipeline);
       pass.SetVertexBuffer(texture_vtx_builder.CreateVertexBuffer(
           *context->GetResourceAllocator()));
       TextureVS::UniformBuffer uniforms;
@@ -1586,7 +1586,7 @@ TEST_P(RendererTest, CanSepiaToneThenSwizzleWithSubpasses) {
 
     // Draw the sepia toner.
     {
-      pass.SetPipeline(sepia_pipeline.get());
+      pass.SetPipeline(sepia_pipeline);
       pass.SetVertexBuffer(sepia_vtx_builder.CreateVertexBuffer(
           *context->GetResourceAllocator()));
       SepiaVS::UniformBuffer uniforms;
@@ -1600,7 +1600,7 @@ TEST_P(RendererTest, CanSepiaToneThenSwizzleWithSubpasses) {
 
     // Draw the swizzle.
     {
-      pass.SetPipeline(swizzle_pipeline.get());
+      pass.SetPipeline(swizzle_pipeline);
       pass.SetVertexBuffer(sepia_vtx_builder.CreateVertexBuffer(
           *context->GetResourceAllocator()));
       SwizzleVS::UniformBuffer uniforms;

--- a/impeller/renderer/renderer_unittests.cc
+++ b/impeller/renderer/renderer_unittests.cc
@@ -93,7 +93,7 @@ TEST_P(RendererTest, CanCreateBoxPrimitive) {
     assert(pipeline && pipeline->IsValid());
 
     pass.SetCommandLabel("Box");
-    pass.SetPipeline(pipeline);
+    pass.SetPipeline(pipeline.get());
     pass.SetVertexBuffer(
         vertex_builder.CreateVertexBuffer(*context->GetResourceAllocator()));
 
@@ -160,7 +160,7 @@ TEST_P(RendererTest, BabysFirstTriangle) {
       *context->GetResourceAllocator());
 
   SinglePassCallback callback = [&](RenderPass& pass) {
-    pass.SetPipeline(pipeline);
+    pass.SetPipeline(pipeline.get());
     pass.SetVertexBuffer(vertex_buffer);
 
     FS::FragInfo frag_info;
@@ -255,7 +255,7 @@ TEST_P(RendererTest, CanRenderPerspectiveCube) {
     ImGui::End();
 
     pass.SetCommandLabel("Perspective Cube");
-    pass.SetPipeline(pipeline);
+    pass.SetPipeline(pipeline.get());
 
     std::array<BufferView, 2> vertex_buffers = {
         BufferView(device_buffer,
@@ -330,7 +330,7 @@ TEST_P(RendererTest, CanRenderMultiplePrimitives) {
     for (size_t i = 0; i < 1; i++) {
       for (size_t j = 0; j < 1; j++) {
         pass.SetCommandLabel("Box");
-        pass.SetPipeline(box_pipeline);
+        pass.SetPipeline(box_pipeline.get());
         pass.SetVertexBuffer(vertex_buffer);
 
         FS::FrameInfo frame_info;
@@ -445,7 +445,7 @@ TEST_P(RendererTest, CanRenderToTexture) {
   }
 
   r2t_pass->SetCommandLabel("Box");
-  r2t_pass->SetPipeline(box_pipeline);
+  r2t_pass->SetPipeline(box_pipeline.get());
   r2t_pass->SetVertexBuffer(vertex_buffer);
 
   FS::FrameInfo frame_info;
@@ -504,7 +504,7 @@ TEST_P(RendererTest, CanRenderInstanced) {
   auto host_buffer = HostBuffer::Create(GetContext()->GetResourceAllocator(),
                                         GetContext()->GetIdleWaiter());
   ASSERT_TRUE(OpenPlaygroundHere([&](RenderPass& pass) -> bool {
-    pass.SetPipeline(pipeline);
+    pass.SetPipeline(pipeline.get());
     pass.SetCommandLabel("InstancedDraw");
 
     VS::FrameInfo frame_info;
@@ -605,7 +605,7 @@ TEST_P(RendererTest, CanBlitTextureToTexture) {
       pass->SetLabel("Playground Render Pass");
       {
         pass->SetCommandLabel("Image");
-        pass->SetPipeline(mipmaps_pipeline);
+        pass->SetPipeline(mipmaps_pipeline.get());
         pass->SetVertexBuffer(vertex_buffer);
 
         VS::FrameInfo frame_info;
@@ -728,7 +728,7 @@ TEST_P(RendererTest, CanBlitTextureToBuffer) {
       pass->SetLabel("Playground Render Pass");
       {
         pass->SetCommandLabel("Image");
-        pass->SetPipeline(mipmaps_pipeline);
+        pass->SetPipeline(mipmaps_pipeline.get());
         pass->SetVertexBuffer(vertex_buffer);
 
         VS::FrameInfo frame_info;
@@ -855,7 +855,7 @@ TEST_P(RendererTest, CanGenerateMipmaps) {
       pass->SetLabel("Playground Render Pass");
       {
         pass->SetCommandLabel("Image LOD");
-        pass->SetPipeline(mipmaps_pipeline);
+        pass->SetPipeline(mipmaps_pipeline.get());
         pass->SetVertexBuffer(vertex_buffer);
 
         VS::FrameInfo frame_info;
@@ -923,7 +923,7 @@ TEST_P(RendererTest, TheImpeller) {
   SinglePassCallback callback = [&](RenderPass& pass) {
     auto size = pass.GetRenderTargetSize();
 
-    pass.SetPipeline(pipeline);
+    pass.SetPipeline(pipeline.get());
     pass.SetCommandLabel("Impeller SDF scene");
     VertexBufferBuilder<VS::PerVertexData> builder;
     builder.AddVertices({{Point()},
@@ -987,7 +987,7 @@ TEST_P(RendererTest, Planet) {
     ImGui::InputFloat("Seed Value", &seed_value);
     ImGui::End();
 
-    pass.SetPipeline(pipeline);
+    pass.SetPipeline(pipeline.get());
     pass.SetCommandLabel("Planet scene");
     VertexBufferBuilder<VS::PerVertexData> builder;
     builder.AddVertices({{Point()},
@@ -1039,7 +1039,7 @@ TEST_P(RendererTest, ArrayUniforms) {
   SinglePassCallback callback = [&](RenderPass& pass) {
     auto size = pass.GetRenderTargetSize();
 
-    pass.SetPipeline(pipeline);
+    pass.SetPipeline(pipeline.get());
     pass.SetCommandLabel("Google Dots");
     VertexBufferBuilder<VS::PerVertexData> builder;
     builder.AddVertices({{Point()},
@@ -1097,7 +1097,7 @@ TEST_P(RendererTest, InactiveUniforms) {
   SinglePassCallback callback = [&](RenderPass& pass) {
     auto size = pass.GetRenderTargetSize();
 
-    pass.SetPipeline(pipeline);
+    pass.SetPipeline(pipeline.get());
     pass.SetCommandLabel("Inactive Uniform");
 
     VertexBufferBuilder<VS::PerVertexData> builder;
@@ -1329,7 +1329,7 @@ TEST_P(RendererTest, StencilMask) {
       assert(pipeline && pipeline->IsValid());
 
       pass->SetCommandLabel("Box");
-      pass->SetPipeline(pipeline);
+      pass->SetPipeline(pipeline.get());
       pass->SetStencilReference(stencil_reference_read);
       pass->SetVertexBuffer(vertex_buffer);
 
@@ -1477,7 +1477,7 @@ TEST_P(RendererTest, CanSepiaToneWithSubpasses) {
 
     // Draw the texture.
     {
-      pass.SetPipeline(texture_pipeline);
+      pass.SetPipeline(texture_pipeline.get());
       pass.SetVertexBuffer(texture_vtx_builder.CreateVertexBuffer(
           *context->GetResourceAllocator()));
       TextureVS::UniformBuffer uniforms;
@@ -1492,7 +1492,7 @@ TEST_P(RendererTest, CanSepiaToneWithSubpasses) {
 
     // Draw the sepia toner.
     {
-      pass.SetPipeline(sepia_pipeline);
+      pass.SetPipeline(sepia_pipeline.get());
       pass.SetVertexBuffer(sepia_vtx_builder.CreateVertexBuffer(
           *context->GetResourceAllocator()));
       SepiaVS::UniformBuffer uniforms;
@@ -1571,7 +1571,7 @@ TEST_P(RendererTest, CanSepiaToneThenSwizzleWithSubpasses) {
 
     // Draw the texture.
     {
-      pass.SetPipeline(texture_pipeline);
+      pass.SetPipeline(texture_pipeline.get());
       pass.SetVertexBuffer(texture_vtx_builder.CreateVertexBuffer(
           *context->GetResourceAllocator()));
       TextureVS::UniformBuffer uniforms;
@@ -1586,7 +1586,7 @@ TEST_P(RendererTest, CanSepiaToneThenSwizzleWithSubpasses) {
 
     // Draw the sepia toner.
     {
-      pass.SetPipeline(sepia_pipeline);
+      pass.SetPipeline(sepia_pipeline.get());
       pass.SetVertexBuffer(sepia_vtx_builder.CreateVertexBuffer(
           *context->GetResourceAllocator()));
       SepiaVS::UniformBuffer uniforms;
@@ -1600,7 +1600,7 @@ TEST_P(RendererTest, CanSepiaToneThenSwizzleWithSubpasses) {
 
     // Draw the swizzle.
     {
-      pass.SetPipeline(swizzle_pipeline);
+      pass.SetPipeline(swizzle_pipeline.get());
       pass.SetVertexBuffer(sepia_vtx_builder.CreateVertexBuffer(
           *context->GetResourceAllocator()));
       SwizzleVS::UniformBuffer uniforms;

--- a/lib/gpu/render_pass.cc
+++ b/lib/gpu/render_pass.cc
@@ -177,7 +177,7 @@ RenderPass::GetOrCreatePipeline() {
 }
 
 bool RenderPass::Draw() {
-  render_pass_->SetPipeline(GetOrCreatePipeline().get());
+  render_pass_->SetPipeline(impeller::PipelineRef(GetOrCreatePipeline()));
 
   for (const auto& [_, buffer] : vertex_uniform_bindings) {
     render_pass_->BindDynamicResource(

--- a/lib/gpu/render_pass.cc
+++ b/lib/gpu/render_pass.cc
@@ -177,7 +177,7 @@ RenderPass::GetOrCreatePipeline() {
 }
 
 bool RenderPass::Draw() {
-  render_pass_->SetPipeline(GetOrCreatePipeline());
+  render_pass_->SetPipeline(GetOrCreatePipeline().get());
 
   for (const auto& [_, buffer] : vertex_uniform_bindings) {
     render_pass_->BindDynamicResource(


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/159566

We don't need recorded commands to keep pipelines alive as the context does that already.
