### PR TITLE
Reland: Replaces bespoke call captures from mock gles with gmock

### DIFF
--- a/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles_unittests.cc
@@ -12,12 +12,18 @@
 namespace impeller {
 namespace testing {
 
+using ::testing::_;
+
 TEST(BufferBindingsGLESTest, BindUniformData) {
   BufferBindingsGLES bindings;
   absl::flat_hash_map<std::string, GLint> uniform_bindings;
   uniform_bindings["SHADERMETADATA.FOOBAR"] = 1;
   bindings.SetUniformBindings(std::move(uniform_bindings));
-  std::shared_ptr<MockGLES> mock_gl = MockGLES::Init();
+  auto mock_gles_impl = std::make_unique<MockGLESImpl>();
+
+  EXPECT_CALL(*mock_gles_impl, Uniform1fv(_, _, _)).Times(1);
+
+  std::shared_ptr<MockGLES> mock_gl = MockGLES::Init(std::move(mock_gles_impl));
   std::vector<BufferResource> bound_buffers;
   std::vector<TextureAndSampler> bound_textures;
 
@@ -39,9 +45,6 @@ TEST(BufferBindingsGLESTest, BindUniformData) {
   EXPECT_TRUE(bindings.BindUniformData(mock_gl->GetProcTable(), bound_textures,
                                        bound_buffers, Range{0, 0},
                                        Range{0, 1}));
-  std::vector<std::string> captured_calls = mock_gl->GetCapturedCalls();
-  EXPECT_TRUE(std::find(captured_calls.begin(), captured_calls.end(),
-                        "glUniform1fv") != captured_calls.end());
 }
 
 }  // namespace testing

--- a/impeller/renderer/backend/gles/test/capabilities_unittests.cc
+++ b/impeller/renderer/backend/gles/test/capabilities_unittests.cc
@@ -33,9 +33,9 @@ TEST(CapabilitiesGLES, CanInitializeWithDefaults) {
 }
 
 TEST(CapabilitiesGLES, SupportsDecalSamplerAddressMode) {
-  auto const extensions = std::vector<const unsigned char*>{
-      reinterpret_cast<const unsigned char*>("GL_KHR_debug"),                 //
-      reinterpret_cast<const unsigned char*>("GL_EXT_texture_border_clamp"),  //
+  auto const extensions = std::vector<const char*>{
+      "GL_KHR_debug",                 //
+      "GL_EXT_texture_border_clamp",  //
   };
   auto mock_gles = MockGLES::Init(extensions);
   auto capabilities = mock_gles->GetProcTable().GetCapabilities();
@@ -43,9 +43,9 @@ TEST(CapabilitiesGLES, SupportsDecalSamplerAddressMode) {
 }
 
 TEST(CapabilitiesGLES, SupportsDecalSamplerAddressModeNotOES) {
-  auto const extensions = std::vector<const unsigned char*>{
-      reinterpret_cast<const unsigned char*>("GL_KHR_debug"),                 //
-      reinterpret_cast<const unsigned char*>("GL_OES_texture_border_clamp"),  //
+  auto const extensions = std::vector<const char*>{
+      "GL_KHR_debug",                 //
+      "GL_OES_texture_border_clamp",  //
   };
   auto mock_gles = MockGLES::Init(extensions);
   auto capabilities = mock_gles->GetProcTable().GetCapabilities();
@@ -53,10 +53,9 @@ TEST(CapabilitiesGLES, SupportsDecalSamplerAddressModeNotOES) {
 }
 
 TEST(CapabilitiesGLES, SupportsFramebufferFetch) {
-  auto const extensions = std::vector<const unsigned char*>{
-      reinterpret_cast<const unsigned char*>("GL_KHR_debug"),  //
-      reinterpret_cast<const unsigned char*>(
-          "GL_EXT_shader_framebuffer_fetch"),  //
+  auto const extensions = std::vector<const char*>{
+      "GL_KHR_debug",                     //
+      "GL_EXT_shader_framebuffer_fetch",  //
   };
   auto mock_gles = MockGLES::Init(extensions);
   auto capabilities = mock_gles->GetProcTable().GetCapabilities();

--- a/impeller/renderer/backend/gles/test/capabilities_unittests.cc
+++ b/impeller/renderer/backend/gles/test/capabilities_unittests.cc
@@ -63,9 +63,8 @@ TEST(CapabilitiesGLES, SupportsFramebufferFetch) {
 }
 
 TEST(CapabilitiesGLES, SupportsMSAA) {
-  auto const extensions = std::vector<const unsigned char*>{
-      reinterpret_cast<const unsigned char*>(
-          "GL_EXT_multisampled_render_to_texture"),
+  auto const extensions = std::vector<const char*>{
+      "GL_EXT_multisampled_render_to_texture",
   };
   auto mock_gles = MockGLES::Init(extensions);
   auto capabilities = mock_gles->GetProcTable().GetCapabilities();

--- a/impeller/renderer/backend/gles/test/gpu_tracer_gles_unittests.cc
+++ b/impeller/renderer/backend/gles/test/gpu_tracer_gles_unittests.cc
@@ -10,38 +10,48 @@
 namespace impeller {
 namespace testing {
 
+using ::testing::_;
+
 #ifdef IMPELLER_DEBUG
 TEST(GPUTracerGLES, CanFormatFramebufferErrorMessage) {
-  auto const extensions = std::vector<const unsigned char*>{
-      reinterpret_cast<const unsigned char*>("GL_KHR_debug"),                 //
-      reinterpret_cast<const unsigned char*>("GL_EXT_disjoint_timer_query"),  //
+  auto const extensions = std::vector<const char*>{
+      "GL_KHR_debug",                 //
+      "GL_EXT_disjoint_timer_query",  //
   };
-  auto mock_gles = MockGLES::Init(extensions);
+  auto mock_gles_impl = std::make_unique<MockGLESImpl>();
+
+  {
+    ::testing::InSequence seq;
+    auto gen_queries = [](GLsizei n, GLuint* ids) {
+      for (int i = 0; i < n; ++i) {
+        ids[i] = i + 1;
+      }
+    };
+    EXPECT_CALL(*mock_gles_impl, GenQueriesEXT(_, _)).WillOnce(gen_queries);
+    EXPECT_CALL(*mock_gles_impl, BeginQueryEXT(GL_TIME_ELAPSED_EXT, _));
+    EXPECT_CALL(*mock_gles_impl, EndQueryEXT(GL_TIME_ELAPSED_EXT));
+    EXPECT_CALL(*mock_gles_impl,
+                GetQueryObjectuivEXT(_, GL_QUERY_RESULT_AVAILABLE_EXT, _))
+        .WillOnce([](GLuint id, GLenum target, GLuint* result) {
+          *result = GL_TRUE;
+        });
+    EXPECT_CALL(*mock_gles_impl,
+                GetQueryObjectui64vEXT(_, GL_QUERY_RESULT_EXT, _))
+        .WillOnce([](GLuint id, GLenum target, GLuint64* result) {
+          *result = 1000u;
+        });
+    EXPECT_CALL(*mock_gles_impl, DeleteQueriesEXT(_, _));
+    EXPECT_CALL(*mock_gles_impl, GenQueriesEXT(_, _)).WillOnce(gen_queries);
+    EXPECT_CALL(*mock_gles_impl, BeginQueryEXT(GL_TIME_ELAPSED_EXT, _));
+  }
+  std::shared_ptr<MockGLES> mock_gles =
+      MockGLES::Init(std::move(mock_gles_impl), extensions);
   auto tracer =
       std::make_shared<GPUTracerGLES>(mock_gles->GetProcTable(), true);
   tracer->RecordRasterThread();
   tracer->MarkFrameStart(mock_gles->GetProcTable());
   tracer->MarkFrameEnd(mock_gles->GetProcTable());
-
-  auto calls = mock_gles->GetCapturedCalls();
-
-  std::vector<std::string> expected = {"glGenQueriesEXT", "glBeginQueryEXT",
-                                       "glEndQueryEXT"};
-  for (auto i = 0; i < 3; i++) {
-    EXPECT_EQ(calls[i], expected[i]);
-  }
-
-  // Begin second frame, which prompts the tracer to query the result
-  // from the previous frame.
   tracer->MarkFrameStart(mock_gles->GetProcTable());
-
-  calls = mock_gles->GetCapturedCalls();
-  std::vector<std::string> expected_b = {"glGetQueryObjectuivEXT",
-                                         "glGetQueryObjectui64vEXT",
-                                         "glDeleteQueriesEXT"};
-  for (auto i = 0; i < 3; i++) {
-    EXPECT_EQ(calls[i], expected_b[i]);
-  }
 }
 
 #endif  // IMPELLER_DEBUG

--- a/impeller/renderer/backend/gles/test/mock_gles_unittests.cc
+++ b/impeller/renderer/backend/gles/test/mock_gles_unittests.cc
@@ -21,19 +21,6 @@ TEST(MockGLES, CanInitialize) {
   EXPECT_EQ(vendor, "MockGLES");
 }
 
-// Tests we can call two functions and capture the calls.
-TEST(MockGLES, CapturesPushAndPopDebugGroup) {
-  auto mock_gles = MockGLES::Init();
-
-  auto& gl = mock_gles->GetProcTable();
-  gl.PushDebugGroupKHR(GL_DEBUG_SOURCE_APPLICATION_KHR, 0, -1, "test");
-  gl.PopDebugGroupKHR();
-
-  auto calls = mock_gles->GetCapturedCalls();
-  EXPECT_EQ(calls, std::vector<std::string>(
-                       {"PushDebugGroupKHR", "PopDebugGroupKHR"}));
-}
-
 // Tests that if we call a function we have not mocked, it's OK.
 TEST(MockGLES, CanCallUnmockedFunction) {
   auto mock_gles = MockGLES::Init();


### PR DESCRIPTION
relands https://github.com/flutter/engine/pull/56995

It previously landed with stale presubmits, this should be up to date now.  I have the fix in a separate commit.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/engine/blob/main/docs/testing/Testing-the-engine.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
