### PR TITLE
[Impeller] Add keep alive for 4 frames in render target cache.

### DIFF
--- a/impeller/entity/render_target_cache.h
+++ b/impeller/entity/render_target_cache.h
@@ -16,7 +16,8 @@ namespace impeller {
 ///        Any textures unused after a frame are immediately discarded.
 class RenderTargetCache : public RenderTargetAllocator {
  public:
-  explicit RenderTargetCache(std::shared_ptr<Allocator> allocator);
+  explicit RenderTargetCache(std::shared_ptr<Allocator> allocator,
+                             uint32_t keep_alive_frame_count = 4);
 
   ~RenderTargetCache() = default;
 
@@ -59,11 +60,13 @@ class RenderTargetCache : public RenderTargetAllocator {
  private:
   struct RenderTargetData {
     bool used_this_frame;
+    uint32_t keep_alive_frame_count;
     RenderTargetConfig config;
     RenderTarget render_target;
   };
 
   std::vector<RenderTargetData> render_target_data_;
+  uint32_t keep_alive_frame_count_;
 
   RenderTargetCache(const RenderTargetCache&) = delete;
 


### PR DESCRIPTION
Improve cache usage by keeping textures alive for 4 frames after the last usage. This improves cache usage in scenarios such as repeatidly dragging the android overscroll functionality.

THis isn't expected to have a negative impact on memory, because a texture cannot be _immediately_ deleted anyway.