### PR TITLE
Clean up key embedder responder tests

### DIFF
--- a/shell/platform/linux/fl_key_embedder_responder_test.cc
+++ b/shell/platform/linux/fl_key_embedder_responder_test.cc
@@ -129,7 +129,7 @@ static void record_calls(const FlutterKeyEvent* event,
 TEST(FlKeyEmbedderResponderTest, SendKeyEvent) {
   g_autoptr(GPtrArray) call_records =
       g_ptr_array_new_with_free_func(g_object_unref);
-  FlKeyEmbedderResponder* responder =
+  g_autoptr(FlKeyEmbedderResponder) responder =
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
@@ -215,16 +215,13 @@ TEST(FlKeyEmbedderResponderTest, SendKeyEvent) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, FALSE, &user_data);
-  clear_records(call_records);
-
-  g_object_unref(responder);
 }
 
 // Basic key presses, but uses the specified logical key if it is not 0.
 TEST(FlKeyEmbedderResponderTest, UsesSpecifiedLogicalKey) {
   g_autoptr(GPtrArray) call_records =
       g_ptr_array_new_with_free_func(g_object_unref);
-  FlKeyEmbedderResponder* responder =
+  g_autoptr(FlKeyEmbedderResponder) responder =
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
@@ -249,15 +246,13 @@ TEST(FlKeyEmbedderResponderTest, UsesSpecifiedLogicalKey) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-
-  g_object_unref(responder);
 }
 
 // Press Shift, key A, then release Shift, key A.
 TEST(FlKeyEmbedderResponderTest, PressShiftDuringLetterKeyTap) {
   g_autoptr(GPtrArray) call_records =
       g_ptr_array_new_with_free_func(g_object_unref);
-  FlKeyEmbedderResponder* responder =
+  g_autoptr(FlKeyEmbedderResponder) responder =
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
@@ -331,9 +326,6 @@ TEST(FlKeyEmbedderResponderTest, PressShiftDuringLetterKeyTap) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  clear_records(call_records);
-
-  g_object_unref(responder);
 }
 
 // Press or release Numpad 1 between presses/releases of NumLock.
@@ -347,7 +339,7 @@ TEST(FlKeyEmbedderResponderTest, PressShiftDuringLetterKeyTap) {
 TEST(FlKeyEmbedderResponderTest, TapNumPadKeysBetweenNumLockEvents) {
   g_autoptr(GPtrArray) call_records =
       g_ptr_array_new_with_free_func(g_object_unref);
-  FlKeyEmbedderResponder* responder =
+  g_autoptr(FlKeyEmbedderResponder) responder =
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
@@ -489,9 +481,6 @@ TEST(FlKeyEmbedderResponderTest, TapNumPadKeysBetweenNumLockEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  clear_records(call_records);
-
-  g_object_unref(responder);
 }
 
 // Press or release digit 1 between presses/releases of Shift.
@@ -501,7 +490,7 @@ TEST(FlKeyEmbedderResponderTest, TapNumPadKeysBetweenNumLockEvents) {
 TEST(FlKeyEmbedderResponderTest, ReleaseShiftKeyBetweenDigitKeyEvents) {
   g_autoptr(GPtrArray) call_records =
       g_ptr_array_new_with_free_func(g_object_unref);
-  FlKeyEmbedderResponder* responder =
+  g_autoptr(FlKeyEmbedderResponder) responder =
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
@@ -579,9 +568,6 @@ TEST(FlKeyEmbedderResponderTest, ReleaseShiftKeyBetweenDigitKeyEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  clear_records(call_records);
-
-  g_object_unref(responder);
 }
 
 // Press or release letter key between presses/releases of CapsLock.
@@ -591,7 +577,7 @@ TEST(FlKeyEmbedderResponderTest, ReleaseShiftKeyBetweenDigitKeyEvents) {
 TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEvents) {
   g_autoptr(GPtrArray) call_records =
       g_ptr_array_new_with_free_func(g_object_unref);
-  FlKeyEmbedderResponder* responder =
+  g_autoptr(FlKeyEmbedderResponder) responder =
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
@@ -733,9 +719,6 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  clear_records(call_records);
-
-  g_object_unref(responder);
 }
 
 // Press or release letter key between presses/releases of CapsLock, on
@@ -745,7 +728,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEvents) {
 TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEventsReversed) {
   g_autoptr(GPtrArray) call_records =
       g_ptr_array_new_with_free_func(g_object_unref);
-  FlKeyEmbedderResponder* responder =
+  g_autoptr(FlKeyEmbedderResponder) responder =
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
@@ -887,14 +870,12 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEventsReversed) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-
-  g_object_unref(responder);
 }
 
 TEST(FlKeyEmbedderResponderTest, TurnDuplicateDownEventsToRepeats) {
   g_autoptr(GPtrArray) call_records =
       g_ptr_array_new_with_free_func(g_object_unref);
-  FlKeyEmbedderResponder* responder =
+  g_autoptr(FlKeyEmbedderResponder) responder =
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
@@ -942,8 +923,6 @@ TEST(FlKeyEmbedderResponderTest, TurnDuplicateDownEventsToRepeats) {
   EXPECT_EQ(call_records->len, 1u);
   record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-
-  g_object_unref(responder);
 }
 
 TEST(FlKeyEmbedderResponderTest, IgnoreAbruptUpEvent) {
@@ -951,7 +930,7 @@ TEST(FlKeyEmbedderResponderTest, IgnoreAbruptUpEvent) {
 
   g_autoptr(GPtrArray) call_records =
       g_ptr_array_new_with_free_func(g_object_unref);
-  FlKeyEmbedderResponder* responder =
+  g_autoptr(FlKeyEmbedderResponder) responder =
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
@@ -971,8 +950,6 @@ TEST(FlKeyEmbedderResponderTest, IgnoreAbruptUpEvent) {
   EXPECT_STREQ(record->event->character, nullptr);
   EXPECT_EQ(record->event->synthesized, false);
   EXPECT_EQ(record->callback, nullptr);
-
-  g_object_unref(responder);
 }
 
 // Test if missed modifier keys can be detected and synthesized with state
@@ -980,7 +957,7 @@ TEST(FlKeyEmbedderResponderTest, IgnoreAbruptUpEvent) {
 TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncPressingStateOnSelfEvents) {
   g_autoptr(GPtrArray) call_records =
       g_ptr_array_new_with_free_func(g_object_unref);
-  FlKeyEmbedderResponder* responder =
+  g_autoptr(FlKeyEmbedderResponder) responder =
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
@@ -1093,8 +1070,6 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncPressingStateOnSelfEvents) {
   EXPECT_EQ(record->event->logical, kLogicalControlLeft);
   EXPECT_STREQ(record->event->character, nullptr);
   EXPECT_EQ(record->event->synthesized, true);
-
-  g_object_unref(responder);
 }
 
 // Test if missed modifier keys can be detected and synthesized with state
@@ -1103,7 +1078,7 @@ TEST(FlKeyEmbedderResponderTest,
      SynthesizeForDesyncPressingStateOnNonSelfEvents) {
   g_autoptr(GPtrArray) call_records =
       g_ptr_array_new_with_free_func(g_object_unref);
-  FlKeyEmbedderResponder* responder =
+  g_autoptr(FlKeyEmbedderResponder) responder =
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
@@ -1218,8 +1193,6 @@ TEST(FlKeyEmbedderResponderTest,
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-
-  g_object_unref(responder);
 }
 
 // Test if missed modifier keys can be detected and synthesized with state
@@ -1228,7 +1201,7 @@ TEST(FlKeyEmbedderResponderTest,
      SynthesizeForDesyncPressingStateOnRemappedEvents) {
   g_autoptr(GPtrArray) call_records =
       g_ptr_array_new_with_free_func(g_object_unref);
-  FlKeyEmbedderResponder* responder =
+  g_autoptr(FlKeyEmbedderResponder) responder =
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
@@ -1283,8 +1256,6 @@ TEST(FlKeyEmbedderResponderTest,
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-
-  g_object_unref(responder);
 }
 
 // Test if missed lock keys can be detected and synthesized with state
@@ -1292,7 +1263,7 @@ TEST(FlKeyEmbedderResponderTest,
 TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncLockModeOnNonSelfEvents) {
   g_autoptr(GPtrArray) call_records =
       g_ptr_array_new_with_free_func(g_object_unref);
-  FlKeyEmbedderResponder* responder =
+  g_autoptr(FlKeyEmbedderResponder) responder =
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
@@ -1387,8 +1358,6 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncLockModeOnNonSelfEvents) {
   EXPECT_STREQ(record->event->character, nullptr);
   EXPECT_EQ(record->event->synthesized, false);
   EXPECT_EQ(record->callback, nullptr);
-
-  g_object_unref(responder);
 }
 
 // Test if missed lock keys can be detected and synthesized with state
@@ -1396,7 +1365,7 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncLockModeOnNonSelfEvents) {
 TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncLockModeOnSelfEvents) {
   g_autoptr(GPtrArray) call_records =
       g_ptr_array_new_with_free_func(g_object_unref);
-  FlKeyEmbedderResponder* responder =
+  g_autoptr(FlKeyEmbedderResponder) responder =
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
@@ -1482,8 +1451,6 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncLockModeOnSelfEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-
-  g_object_unref(responder);
 }
 
 // Ensures that even if the primary event is ignored (due to duplicate
@@ -1491,7 +1458,7 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncLockModeOnSelfEvents) {
 TEST(FlKeyEmbedderResponderTest, SynthesizationOccursOnIgnoredEvents) {
   g_autoptr(GPtrArray) call_records =
       g_ptr_array_new_with_free_func(g_object_unref);
-  FlKeyEmbedderResponder* responder =
+  g_autoptr(FlKeyEmbedderResponder) responder =
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
@@ -1524,8 +1491,6 @@ TEST(FlKeyEmbedderResponderTest, SynthesizationOccursOnIgnoredEvents) {
   EXPECT_EQ(record->event->logical, kLogicalControlLeft);
   EXPECT_STREQ(record->event->character, nullptr);
   EXPECT_EQ(record->event->synthesized, true);
-
-  g_object_unref(responder);
 }
 
 // This test case occurs when the following two cases collide:
@@ -1541,7 +1506,7 @@ TEST(FlKeyEmbedderResponderTest, SynthesizationOccursOnIgnoredEvents) {
 TEST(FlKeyEmbedderResponderTest, HandlesShiftAltVersusGroupNext) {
   g_autoptr(GPtrArray) call_records =
       g_ptr_array_new_with_free_func(g_object_unref);
-  FlKeyEmbedderResponder* responder =
+  g_autoptr(FlKeyEmbedderResponder) responder =
       fl_key_embedder_responder_new(record_calls, call_records);
 
   g_expected_handled = true;
@@ -1635,8 +1600,6 @@ TEST(FlKeyEmbedderResponderTest, HandlesShiftAltVersusGroupNext) {
   EXPECT_EQ(record->event->physical, kPhysicalShiftLeft);
   EXPECT_EQ(record->event->logical, kLogicalGroupNext);
   EXPECT_EQ(record->event->synthesized, false);
-
-  g_object_unref(responder);
 }
 
 // Shift + AltLeft results in GDK event whose keyval is MetaLeft but whose
@@ -1648,7 +1611,7 @@ TEST(FlKeyEmbedderResponderTest, HandlesShiftAltVersusGroupNext) {
 TEST(FlKeyEmbedderResponderTest, HandlesShiftAltLeftIsMetaLeft) {
   g_autoptr(GPtrArray) call_records =
       g_ptr_array_new_with_free_func(g_object_unref);
-  FlKeyEmbedderResponder* responder =
+  g_autoptr(FlKeyEmbedderResponder) responder =
       fl_key_embedder_responder_new(record_calls, call_records);
 
   g_expected_handled = true;
@@ -1713,6 +1676,4 @@ TEST(FlKeyEmbedderResponderTest, HandlesShiftAltLeftIsMetaLeft) {
   EXPECT_EQ(record->event->physical, kPhysicalMetaLeft);
   EXPECT_EQ(record->event->logical, kLogicalMetaLeft);
   EXPECT_EQ(record->event->synthesized, false);
-
-  g_object_unref(responder);
 }

--- a/shell/platform/linux/fl_key_embedder_responder_test.cc
+++ b/shell/platform/linux/fl_key_embedder_responder_test.cc
@@ -31,7 +31,7 @@ constexpr guint16 kKeyCodeControlRight = 0x69u;
 using namespace ::flutter::testing::keycodes;
 }  // namespace
 
-static void g_ptr_array_clear(GPtrArray* array) {
+static void clear_records(GPtrArray* array) {
   g_ptr_array_remove_range(array, 0, array->len);
 }
 
@@ -154,7 +154,7 @@ TEST(FlKeyEmbedderResponderTest, SendKeyEvent) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Key up
   g_autoptr(FlKeyEvent) event2 =
@@ -174,7 +174,7 @@ TEST(FlKeyEmbedderResponderTest, SendKeyEvent) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, FALSE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // On an AZERTY keyboard, press key Q (physically key A), and release.
   // Key down
@@ -195,7 +195,7 @@ TEST(FlKeyEmbedderResponderTest, SendKeyEvent) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Key up
   g_autoptr(FlKeyEvent) event4 =
@@ -215,7 +215,7 @@ TEST(FlKeyEmbedderResponderTest, SendKeyEvent) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, FALSE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   g_object_unref(responder);
 }
@@ -279,7 +279,7 @@ TEST(FlKeyEmbedderResponderTest, PressShiftDuringLetterKeyTap) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Press key A
   g_autoptr(FlKeyEvent) event2 =
@@ -296,7 +296,7 @@ TEST(FlKeyEmbedderResponderTest, PressShiftDuringLetterKeyTap) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Release shift right
   g_autoptr(FlKeyEvent) event3 = fl_key_event_new(
@@ -313,7 +313,7 @@ TEST(FlKeyEmbedderResponderTest, PressShiftDuringLetterKeyTap) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Release key A
   g_autoptr(FlKeyEvent) event4 =
@@ -331,7 +331,7 @@ TEST(FlKeyEmbedderResponderTest, PressShiftDuringLetterKeyTap) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   g_object_unref(responder);
 }
@@ -369,7 +369,7 @@ TEST(FlKeyEmbedderResponderTest, TapNumPadKeysBetweenNumLockEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Press NumLock (stage 0 -> 1)
   g_autoptr(FlKeyEvent) event2 =
@@ -387,7 +387,7 @@ TEST(FlKeyEmbedderResponderTest, TapNumPadKeysBetweenNumLockEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Release numpad 1 (stage 1)
   g_autoptr(FlKeyEvent) event3 = fl_key_event_new(
@@ -404,7 +404,7 @@ TEST(FlKeyEmbedderResponderTest, TapNumPadKeysBetweenNumLockEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Release NumLock (stage 1 -> 2)
   g_autoptr(FlKeyEvent) event4 = fl_key_event_new(
@@ -421,7 +421,7 @@ TEST(FlKeyEmbedderResponderTest, TapNumPadKeysBetweenNumLockEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Press Numpad 1 (stage 2)
   g_autoptr(FlKeyEvent) event5 = fl_key_event_new(
@@ -438,7 +438,7 @@ TEST(FlKeyEmbedderResponderTest, TapNumPadKeysBetweenNumLockEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Press NumLock (stage 2 -> 3)
   g_autoptr(FlKeyEvent) event6 = fl_key_event_new(
@@ -455,7 +455,7 @@ TEST(FlKeyEmbedderResponderTest, TapNumPadKeysBetweenNumLockEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Release numpad 1 (stage 3)
   g_autoptr(FlKeyEvent) event7 = fl_key_event_new(
@@ -472,7 +472,7 @@ TEST(FlKeyEmbedderResponderTest, TapNumPadKeysBetweenNumLockEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Release NumLock (stage 3 -> 0)
   g_autoptr(FlKeyEvent) event8 = fl_key_event_new(
@@ -489,7 +489,7 @@ TEST(FlKeyEmbedderResponderTest, TapNumPadKeysBetweenNumLockEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   g_object_unref(responder);
 }
@@ -524,7 +524,7 @@ TEST(FlKeyEmbedderResponderTest, ReleaseShiftKeyBetweenDigitKeyEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   state = GDK_SHIFT_MASK;
 
@@ -543,7 +543,7 @@ TEST(FlKeyEmbedderResponderTest, ReleaseShiftKeyBetweenDigitKeyEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Release shift
   g_autoptr(FlKeyEvent) event3 = fl_key_event_new(
@@ -560,7 +560,7 @@ TEST(FlKeyEmbedderResponderTest, ReleaseShiftKeyBetweenDigitKeyEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   state = static_cast<GdkModifierType>(0);
 
@@ -579,7 +579,7 @@ TEST(FlKeyEmbedderResponderTest, ReleaseShiftKeyBetweenDigitKeyEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   g_object_unref(responder);
 }
@@ -613,7 +613,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Press key A (stage 1)
   g_autoptr(FlKeyEvent) event2 =
@@ -630,7 +630,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Release CapsLock (stage 1 -> 2)
   g_autoptr(FlKeyEvent) event3 = fl_key_event_new(
@@ -647,7 +647,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Release key A (stage 2)
   g_autoptr(FlKeyEvent) event4 = fl_key_event_new(104, kRelease, kKeyCodeKeyA,
@@ -664,7 +664,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Press CapsLock (stage 2 -> 3)
   g_autoptr(FlKeyEvent) event5 = fl_key_event_new(
@@ -681,7 +681,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Press key A (stage 3)
   g_autoptr(FlKeyEvent) event6 =
@@ -698,7 +698,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Release CapsLock (stage 3 -> 0)
   g_autoptr(FlKeyEvent) event7 = fl_key_event_new(
@@ -715,7 +715,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Release key A (stage 0)
   g_autoptr(FlKeyEvent) event8 =
@@ -733,7 +733,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   g_object_unref(responder);
 }
@@ -766,7 +766,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEventsReversed) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Press CapsLock (stage 0 -> 1)
   g_autoptr(FlKeyEvent) event2 = fl_key_event_new(
@@ -783,7 +783,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEventsReversed) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Release CapsLock (stage 1 -> 2)
   g_autoptr(FlKeyEvent) event3 = fl_key_event_new(
@@ -800,7 +800,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEventsReversed) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Release key A (stage 2)
   g_autoptr(FlKeyEvent) event4 = fl_key_event_new(104, kRelease, kKeyCodeKeyA,
@@ -817,7 +817,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEventsReversed) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Press key A (stage 2)
   g_autoptr(FlKeyEvent) event5 =
@@ -834,7 +834,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEventsReversed) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Press CapsLock (stage 2 -> 3)
   g_autoptr(FlKeyEvent) event6 =
@@ -852,7 +852,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEventsReversed) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Release CapsLock (stage 3 -> 0)
   g_autoptr(FlKeyEvent) event7 = fl_key_event_new(
@@ -869,7 +869,7 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEventsReversed) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Release key A (stage 0)
   g_autoptr(FlKeyEvent) event8 =
@@ -910,7 +910,7 @@ TEST(FlKeyEmbedderResponderTest, TurnDuplicateDownEventsToRepeats) {
 
   record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Another KeyA down events, which usually means a repeated event.
   g_expected_handled = false;
@@ -930,7 +930,7 @@ TEST(FlKeyEmbedderResponderTest, TurnDuplicateDownEventsToRepeats) {
   EXPECT_NE(record->callback, nullptr);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Release KeyA
   g_autoptr(FlKeyEvent) event3 =
@@ -1015,7 +1015,7 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncPressingStateOnSelfEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Test 2: synthesize key up.
 
@@ -1028,7 +1028,7 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncPressingStateOnSelfEvents) {
   EXPECT_EQ(call_records->len, 1u);
   record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // A key up of control left is missed.
   state = static_cast<GdkModifierType>(0);
@@ -1057,7 +1057,7 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncPressingStateOnSelfEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Send a ControlLeft up to clear up state.
   state = GDK_CONTROL_MASK;
@@ -1068,7 +1068,7 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncPressingStateOnSelfEvents) {
   EXPECT_EQ(call_records->len, 1u);
   record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Test 3: synthesize by right modifier.
 
@@ -1136,7 +1136,7 @@ TEST(FlKeyEmbedderResponderTest,
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // A key up of control left is missed.
   state = static_cast<GdkModifierType>(0);
@@ -1165,7 +1165,7 @@ TEST(FlKeyEmbedderResponderTest,
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Test non-default key mapping.
 
@@ -1187,7 +1187,7 @@ TEST(FlKeyEmbedderResponderTest,
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // The key up of the control left press is missed.
   state = static_cast<GdkModifierType>(0);
@@ -1252,7 +1252,7 @@ TEST(FlKeyEmbedderResponderTest,
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // The key up of the control left press is missed.
   state = static_cast<GdkModifierType>(0);
@@ -1325,7 +1325,7 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncLockModeOnNonSelfEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // The NumLock is desynchronized by being disabled.
   state = static_cast<GdkModifierType>(0);
@@ -1370,7 +1370,7 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncLockModeOnNonSelfEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // Release NumLock. Since the previous event should have synthesized NumLock
   // to be released, this should result in only an empty event.
@@ -1437,7 +1437,7 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncLockModeOnSelfEvents) {
   EXPECT_EQ(record->event->synthesized, false);
 
   invoke_record_callback_and_verify(record, TRUE, &user_data);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // The NumLock is desynchronized by being enabled in a press event.
   state = GDK_MOD2_MASK;
@@ -1692,7 +1692,7 @@ TEST(FlKeyEmbedderResponderTest, HandlesShiftAltLeftIsMetaLeft) {
                                               GDK_MODIFIER_RESERVED_25_MASK));
   send_key_event(kRelease, GDK_KEY_Shift_L, kKeyCodeShiftLeft,
                  GDK_MODIFIER_RESERVED_25_MASK);
-  g_ptr_array_clear(call_records);
+  clear_records(call_records);
 
   // ShiftRight + AltLeft
   send_key_event(kPress, GDK_KEY_Shift_R, kKeyCodeShiftRight,

--- a/shell/platform/linux/fl_key_embedder_responder_test.cc
+++ b/shell/platform/linux/fl_key_embedder_responder_test.cc
@@ -133,8 +133,6 @@ TEST(FlKeyEmbedderResponderTest, SendKeyEvent) {
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
-  FlKeyEmbedderCallRecord* record;
-
   // On a QWERTY keyboard, press key Q (physically key A), and release.
   // Key down
   g_autoptr(FlKeyEvent) event1 =
@@ -144,7 +142,8 @@ TEST(FlKeyEmbedderResponderTest, SendKeyEvent) {
                                          verify_response_handled, &user_data);
 
   EXPECT_EQ(call_records->len, 1u);
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
+  FlKeyEmbedderCallRecord* record =
+      FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
   EXPECT_EQ(record->event->struct_size, sizeof(FlutterKeyEvent));
   EXPECT_EQ(record->event->timestamp, 12345000);
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
@@ -225,8 +224,6 @@ TEST(FlKeyEmbedderResponderTest, UsesSpecifiedLogicalKey) {
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
-  FlKeyEmbedderCallRecord* record;
-
   // On an AZERTY keyboard, press physical key 1, and release.
   // Key down
   g_autoptr(FlKeyEvent) event =
@@ -236,7 +233,8 @@ TEST(FlKeyEmbedderResponderTest, UsesSpecifiedLogicalKey) {
                                          verify_response_handled, &user_data);
 
   EXPECT_EQ(call_records->len, 1u);
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
+  FlKeyEmbedderCallRecord* record =
+      FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
   EXPECT_EQ(record->event->struct_size, sizeof(FlutterKeyEvent));
   EXPECT_EQ(record->event->timestamp, 12345000);
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
@@ -256,8 +254,6 @@ TEST(FlKeyEmbedderResponderTest, PressShiftDuringLetterKeyTap) {
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
-  FlKeyEmbedderCallRecord* record;
-
   // Press shift right
   g_autoptr(FlKeyEvent) event1 =
       fl_key_event_new(101, kPress, kKeyCodeShiftRight, GDK_KEY_Shift_R,
@@ -266,7 +262,8 @@ TEST(FlKeyEmbedderResponderTest, PressShiftDuringLetterKeyTap) {
                                          verify_response_handled, &user_data);
 
   EXPECT_EQ(call_records->len, 1u);
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
+  FlKeyEmbedderCallRecord* record =
+      FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(record->event->physical, kPhysicalShiftRight);
   EXPECT_EQ(record->event->logical, kLogicalShiftRight);
@@ -343,8 +340,6 @@ TEST(FlKeyEmbedderResponderTest, TapNumPadKeysBetweenNumLockEvents) {
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
-  FlKeyEmbedderCallRecord* record;
-
   // Press Numpad 1 (stage 0)
   g_autoptr(FlKeyEvent) event1 =
       fl_key_event_new(101, kPress, kKeyCodeNumpad1, GDK_KEY_KP_End,
@@ -353,7 +348,8 @@ TEST(FlKeyEmbedderResponderTest, TapNumPadKeysBetweenNumLockEvents) {
                                          verify_response_handled, &user_data);
 
   EXPECT_EQ(call_records->len, 1u);
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
+  FlKeyEmbedderCallRecord* record =
+      FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(record->event->physical, kPhysicalNumpad1);
   EXPECT_EQ(record->event->logical, kLogicalNumpad1);
@@ -494,8 +490,6 @@ TEST(FlKeyEmbedderResponderTest, ReleaseShiftKeyBetweenDigitKeyEvents) {
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
-  FlKeyEmbedderCallRecord* record;
-
   GdkModifierType state = static_cast<GdkModifierType>(0);
 
   // Press shift left
@@ -505,7 +499,8 @@ TEST(FlKeyEmbedderResponderTest, ReleaseShiftKeyBetweenDigitKeyEvents) {
                                          verify_response_handled, &user_data);
 
   EXPECT_EQ(call_records->len, 1u);
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
+  FlKeyEmbedderCallRecord* record =
+      FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(record->event->physical, kPhysicalShiftLeft);
   EXPECT_EQ(record->event->logical, kLogicalShiftLeft);
@@ -581,8 +576,6 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEvents) {
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
-  FlKeyEmbedderCallRecord* record;
-
   // Press CapsLock (stage 0 -> 1)
   g_autoptr(FlKeyEvent) event1 =
       fl_key_event_new(101, kPress, kKeyCodeCapsLock, GDK_KEY_Caps_Lock,
@@ -591,7 +584,8 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEvents) {
                                          verify_response_handled, &user_data);
 
   EXPECT_EQ(call_records->len, 1u);
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
+  FlKeyEmbedderCallRecord* record =
+      FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(record->event->physical, kPhysicalCapsLock);
   EXPECT_EQ(record->event->logical, kLogicalCapsLock);
@@ -732,8 +726,6 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEventsReversed) {
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
-  FlKeyEmbedderCallRecord* record;
-
   // Press key A (stage 0)
   g_autoptr(FlKeyEvent) event1 = fl_key_event_new(
       101, kPress, kKeyCodeKeyA, GDK_KEY_a, static_cast<GdkModifierType>(0), 0);
@@ -741,7 +733,8 @@ TEST(FlKeyEmbedderResponderTest, TapLetterKeysBetweenCapsLockEventsReversed) {
                                          verify_response_handled, &user_data);
 
   EXPECT_EQ(call_records->len, 1u);
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
+  FlKeyEmbedderCallRecord* record =
+      FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(record->event->physical, kPhysicalKeyA);
   EXPECT_EQ(record->event->logical, kLogicalKeyA);
@@ -879,8 +872,6 @@ TEST(FlKeyEmbedderResponderTest, TurnDuplicateDownEventsToRepeats) {
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
-  FlKeyEmbedderCallRecord* record;
-
   // Press KeyA
   g_autoptr(FlKeyEvent) event1 = fl_key_event_new(
       101, kPress, kKeyCodeKeyA, GDK_KEY_a, static_cast<GdkModifierType>(0), 0);
@@ -889,7 +880,8 @@ TEST(FlKeyEmbedderResponderTest, TurnDuplicateDownEventsToRepeats) {
 
   EXPECT_EQ(call_records->len, 1u);
 
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
+  FlKeyEmbedderCallRecord* record =
+      FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
   invoke_record_callback_and_verify(record, TRUE, &user_data);
   clear_records(call_records);
 
@@ -926,8 +918,6 @@ TEST(FlKeyEmbedderResponderTest, TurnDuplicateDownEventsToRepeats) {
 }
 
 TEST(FlKeyEmbedderResponderTest, IgnoreAbruptUpEvent) {
-  FlKeyEmbedderCallRecord* record;
-
   g_autoptr(GPtrArray) call_records =
       g_ptr_array_new_with_free_func(g_object_unref);
   g_autoptr(FlKeyEmbedderResponder) responder =
@@ -944,7 +934,8 @@ TEST(FlKeyEmbedderResponderTest, IgnoreAbruptUpEvent) {
 
   EXPECT_EQ(call_records->len, 1u);
 
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
+  FlKeyEmbedderCallRecord* record =
+      FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
   EXPECT_EQ(record->event->physical, 0ull);
   EXPECT_EQ(record->event->logical, 0ull);
   EXPECT_STREQ(record->event->character, nullptr);
@@ -961,8 +952,6 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncPressingStateOnSelfEvents) {
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
-  FlKeyEmbedderCallRecord* record;
-
   // Test 1: synthesize key down.
 
   // A key down of control left is missed.
@@ -975,7 +964,8 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncPressingStateOnSelfEvents) {
                                          verify_response_handled, &user_data);
 
   EXPECT_EQ(call_records->len, 2u);
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
+  FlKeyEmbedderCallRecord* record =
+      FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
   EXPECT_EQ(record->event->timestamp, 101000);
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(record->event->physical, kPhysicalControlLeft);
@@ -1082,8 +1072,6 @@ TEST(FlKeyEmbedderResponderTest,
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
-  FlKeyEmbedderCallRecord* record;
-
   // A key down of control left is missed.
   GdkModifierType state = GDK_CONTROL_MASK;
 
@@ -1094,7 +1082,8 @@ TEST(FlKeyEmbedderResponderTest,
                                          verify_response_handled, &user_data);
 
   EXPECT_EQ(call_records->len, 2u);
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
+  FlKeyEmbedderCallRecord* record =
+      FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
   EXPECT_EQ(record->event->timestamp, 101000);
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(record->event->physical, kPhysicalControlLeft);
@@ -1205,8 +1194,6 @@ TEST(FlKeyEmbedderResponderTest,
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
-  FlKeyEmbedderCallRecord* record;
-
   // Press a key with physical CapsLock and logical ControlLeft.
   GdkModifierType state = static_cast<GdkModifierType>(0);
 
@@ -1216,7 +1203,8 @@ TEST(FlKeyEmbedderResponderTest,
                                          verify_response_handled, &user_data);
 
   EXPECT_EQ(call_records->len, 1u);
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
+  FlKeyEmbedderCallRecord* record =
+      FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
   EXPECT_EQ(record->event->timestamp, 101000);
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(record->event->physical, kPhysicalCapsLock);
@@ -1267,8 +1255,6 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncLockModeOnNonSelfEvents) {
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
-  FlKeyEmbedderCallRecord* record;
-
   // The NumLock is desynchronized by being enabled.
   GdkModifierType state = GDK_MOD2_MASK;
 
@@ -1279,7 +1265,8 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncLockModeOnNonSelfEvents) {
                                          verify_response_handled, &user_data);
 
   EXPECT_EQ(call_records->len, 2u);
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
+  FlKeyEmbedderCallRecord* record =
+      FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
   EXPECT_EQ(record->event->timestamp, 101000);
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(record->event->physical, kPhysicalNumLock);
@@ -1369,8 +1356,6 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncLockModeOnSelfEvents) {
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
-  FlKeyEmbedderCallRecord* record;
-
   // The NumLock is desynchronized by being enabled.
   GdkModifierType state = GDK_MOD2_MASK;
 
@@ -1381,7 +1366,8 @@ TEST(FlKeyEmbedderResponderTest, SynthesizeForDesyncLockModeOnSelfEvents) {
                                          verify_response_handled, &user_data);
 
   EXPECT_EQ(call_records->len, 3u);
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
+  FlKeyEmbedderCallRecord* record =
+      FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
   EXPECT_EQ(record->event->timestamp, 101000);
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(record->event->physical, kPhysicalNumLock);
@@ -1462,8 +1448,6 @@ TEST(FlKeyEmbedderResponderTest, SynthesizationOccursOnIgnoredEvents) {
       fl_key_embedder_responder_new(record_calls, call_records);
   int user_data = 123;  // Arbitrary user data
 
-  FlKeyEmbedderCallRecord* record;
-
   // The NumLock is desynchronized by being enabled, and Control is pressed.
   GdkModifierType state =
       static_cast<GdkModifierType>(GDK_MOD2_MASK | GDK_CONTROL_MASK);
@@ -1476,7 +1460,8 @@ TEST(FlKeyEmbedderResponderTest, SynthesizationOccursOnIgnoredEvents) {
                                          verify_response_handled, &user_data);
 
   EXPECT_EQ(call_records->len, 2u);
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
+  FlKeyEmbedderCallRecord* record =
+      FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
   EXPECT_EQ(record->event->timestamp, 101000);
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(record->event->physical, kPhysicalNumLock);
@@ -1523,12 +1508,11 @@ TEST(FlKeyEmbedderResponderTest, HandlesShiftAltVersusGroupNext) {
                                            verify_response_handled, &user_data);
   };
 
-  FlKeyEmbedderCallRecord* record;
-
   send_key_event(kPress, GDK_KEY_Shift_L, kKeyCodeShiftLeft,
                  GDK_MODIFIER_RESERVED_25_MASK);
   EXPECT_EQ(call_records->len, 1u);
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
+  FlKeyEmbedderCallRecord* record =
+      FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(record->event->physical, kPhysicalShiftLeft);
   EXPECT_EQ(record->event->logical, kLogicalShiftLeft);
@@ -1628,13 +1612,12 @@ TEST(FlKeyEmbedderResponderTest, HandlesShiftAltLeftIsMetaLeft) {
                                            verify_response_handled, &user_data);
   };
 
-  FlKeyEmbedderCallRecord* record;
-
   // ShiftLeft + AltLeft
   send_key_event(kPress, GDK_KEY_Shift_L, kKeyCodeShiftLeft,
                  GDK_MODIFIER_RESERVED_25_MASK);
   EXPECT_EQ(call_records->len, 1u);
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
+  FlKeyEmbedderCallRecord* record =
+      FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(call_records, 0));
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(record->event->physical, kPhysicalShiftLeft);
   EXPECT_EQ(record->event->logical, kLogicalShiftLeft);


### PR DESCRIPTION
Remove global variable.
Rename function so doesn't look like provided by GLib.
Use g_autoptr to remove explicit unref.
Move type definition inline.
