### PR TITLE
Roll Skia to 14f8f6d984ff

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -14,7 +14,7 @@ vars = {
   'flutter_git': 'https://flutter.googlesource.com',
   'skia_git': 'https://skia.googlesource.com',
   'llvm_git': 'https://llvm.googlesource.com',
-  'skia_revision': 'e78dd02650024d7f0e4d8cb73e3b6657b19b0317',
+  'skia_revision': '14f8f6d984ff23bed1f9ae7acf98be683eccaeac',
 
   # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
   # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.

--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -2805,6 +2805,7 @@
 ../../../flutter/third_party/skia/modules/canvaskit/wasm_tools/SIMD/.gitignore
 ../../../flutter/third_party/skia/modules/jetski/BUILD.bazel
 ../../../flutter/third_party/skia/modules/jetski/README
+../../../flutter/third_party/skia/modules/jsonreader/BUILD.bazel
 ../../../flutter/third_party/skia/modules/pathkit/.gitignore
 ../../../flutter/third_party/skia/modules/pathkit/BUILD.bazel
 ../../../flutter/third_party/skia/modules/pathkit/CHANGELOG.md

--- a/ci/licenses_golden/licenses_skia
+++ b/ci/licenses_golden/licenses_skia
@@ -1,4 +1,4 @@
-Signature: a4491fcc5578e3c1714db99d545cc295
+Signature: 46741797d10275489df2fe44716fd9a1
 
 ====================================================================================================
 LIBRARY: etc1
@@ -9528,6 +9528,7 @@ ORIGIN: ../../../flutter/third_party/skia/include/gpu/graphite/precompile/Precom
 ORIGIN: ../../../flutter/third_party/skia/include/gpu/graphite/precompile/PrecompileMaskFilter.h + ../../../flutter/third_party/skia/LICENSE
 ORIGIN: ../../../flutter/third_party/skia/include/gpu/graphite/precompile/PrecompileRuntimeEffect.h + ../../../flutter/third_party/skia/LICENSE
 ORIGIN: ../../../flutter/third_party/skia/include/gpu/graphite/precompile/PrecompileShader.h + ../../../flutter/third_party/skia/LICENSE
+ORIGIN: ../../../flutter/third_party/skia/modules/jsonreader/SkJSONReader.h + ../../../flutter/third_party/skia/LICENSE
 ORIGIN: ../../../flutter/third_party/skia/modules/skshaper/include/SkShaper_coretext.h + ../../../flutter/third_party/skia/LICENSE
 ORIGIN: ../../../flutter/third_party/skia/modules/skshaper/include/SkShaper_factory.h + ../../../flutter/third_party/skia/LICENSE
 ORIGIN: ../../../flutter/third_party/skia/modules/skshaper/include/SkShaper_harfbuzz.h + ../../../flutter/third_party/skia/LICENSE
@@ -9655,6 +9656,7 @@ FILE: ../../../flutter/third_party/skia/include/gpu/graphite/precompile/Precompi
 FILE: ../../../flutter/third_party/skia/include/gpu/graphite/precompile/PrecompileMaskFilter.h
 FILE: ../../../flutter/third_party/skia/include/gpu/graphite/precompile/PrecompileRuntimeEffect.h
 FILE: ../../../flutter/third_party/skia/include/gpu/graphite/precompile/PrecompileShader.h
+FILE: ../../../flutter/third_party/skia/modules/jsonreader/SkJSONReader.h
 FILE: ../../../flutter/third_party/skia/modules/skshaper/include/SkShaper_coretext.h
 FILE: ../../../flutter/third_party/skia/modules/skshaper/include/SkShaper_factory.h
 FILE: ../../../flutter/third_party/skia/modules/skshaper/include/SkShaper_harfbuzz.h

--- a/skia/BUILD.gn
+++ b/skia/BUILD.gn
@@ -514,6 +514,7 @@ optional("jpeg_decode") {
 
 optional("jpeg_encode") {
   enabled = skia_use_libjpeg_turbo_encode && !skia_use_ndk_images
+  public_defines = [ "SK_CODEC_ENCODES_JPEG" ]
 
   deps = [ "//flutter/third_party/libjpeg-turbo:libjpeg" ]
   public = skia_encode_jpeg_public
@@ -538,22 +539,27 @@ optional("xps") {
   sources = skia_xps_sources
 }
 
-optional("png_decode") {
+optional("png_decode_libpng") {
   enabled = skia_use_libpng_decode
   public_defines = [
     "SK_CODEC_DECODES_PNG",
     "SK_CODEC_DECODES_ICO",
+    "SK_CODEC_DECODES_PNG_WITH_LIBPNG",
   ]
 
   deps = [ "//flutter/third_party/libpng" ]
-  sources = [ "$_skia_root/src/codec/SkIcoCodec.cpp" ]
-  sources += skia_codec_png
+  sources = [ "$_skia_root/src/codec/SkIcoCodec.cpp" ] + skia_codec_png_base +
+            skia_codec_libpng_srcs
 }
 
 optional("png_encode") {
   enabled = skia_use_libpng_encode && !skia_use_ndk_images
-  public = skia_encode_png_public
+  public_defines = [
+    "SK_CODEC_ENCODES_PNG",
+    "SK_CODEC_ENCODES_PNG_WITH_LIBPNG",
+  ]
 
+  public = skia_encode_png_public
   deps = [ "//flutter/third_party/libpng" ]
   sources = skia_encode_png_srcs
 }
@@ -576,6 +582,7 @@ optional("webp_decode") {
 
 optional("webp_encode") {
   enabled = skia_use_libwebp_encode && !skia_use_ndk_images
+  public_defines = [ "SK_CODEC_ENCODES_WEBP" ]
   public = skia_encode_webp_public
 
   deps = [ "//flutter/third_party/libwebp" ]
@@ -634,7 +641,7 @@ skia_component("skia") {
     ":hsw",
     ":jpeg_decode",
     ":ndk_images",
-    ":png_decode",
+    ":png_decode_libpng",
     ":webp_decode",
     ":wuffs",
     ":xml",

--- a/tools/gn
+++ b/tools/gn
@@ -434,6 +434,10 @@ def to_gn_args(args):
     gn_args['enable_unittests'] = False
 
   # Skia GN args.
+  gn_args['skia_use_libpng_decode'] = True
+  gn_args['skia_use_libpng_encode'] = True
+  gn_args['skia_use_rust_png_decode'] = False
+  gn_args['skia_use_rust_png_encode'] = False
   gn_args['skia_use_dng_sdk'] = False  # RAW image handling.
   gn_args['skia_enable_pdf'] = False  # PDF handling.
   gn_args['skia_use_x11'] = False  # Never add the X11 dependency (only takes effect on Linux).


### PR DESCRIPTION
Resolves https://github.com/flutter/engine/pull/57068.

Set args `skia_use_libpng_decode=true` and `skia_use_rust_png_decode=false`.

https://skia.googlesource.com/skia.git/+log/e78dd0265002..14f8f6d984ff

2024-12-09 kjlubick@google.com Update GN build to allow for rust PNG decoding only
2024-12-09 lukasza@chromium.org [rust png] Update Skia => `png` dependency to version 0.17.15.
2024-12-09 kjlubick@google.com Add placeholder files for jsonreader