### PR TITLE
[Impeller] disable all Adrenos older than 630

### DIFF
--- a/impeller/renderer/backend/vulkan/driver_info_vk.cc
+++ b/impeller/renderer/backend/vulkan/driver_info_vk.cc
@@ -336,22 +336,18 @@ bool DriverInfoVK::IsEmulator() const {
 
 bool DriverInfoVK::IsKnownBadDriver() const {
   if (adreno_gpu_.has_value()) {
-    auto adreno = adreno_gpu_.value();
-    switch (adreno) {
-      // See:
-      // https://github.com/flutter/flutter/issues/154103
-      //
-      // Reports "VK_INCOMPLETE" when compiling certain entity shader with
-      // vkCreateGraphicsPipelines, which is not a valid return status.
-      // See https://github.com/flutter/flutter/issues/155185 .
-      case AdrenoGPU::kAdreno630:
-      // See:
-      // https://github.com/flutter/flutter/issues/155185
-      // Unknown crashes but device is not easily acquirable.
-      case AdrenoGPU::kAdreno506:
-        return true;
-      default:
-        return false;
+    AdrenoGPU adreno = adreno_gpu_.value();
+    // See:
+    // https://github.com/flutter/flutter/issues/154103
+    //
+    // Reports "VK_INCOMPLETE" when compiling certain entity shader with
+    // vkCreateGraphicsPipelines, which is not a valid return status.
+    // See https://github.com/flutter/flutter/issues/155185 .
+    //
+    // https://github.com/flutter/flutter/issues/155185
+    // Unknown crashes but device is not easily acquirable.
+    if (adreno <= AdrenoGPU::kAdreno630) {
+      return true;
     }
   }
   // Disable Maleoon series GPUs, see:

--- a/impeller/renderer/backend/vulkan/driver_info_vk_unittests.cc
+++ b/impeller/renderer/backend/vulkan/driver_info_vk_unittests.cc
@@ -106,6 +106,18 @@ TEST(DriverInfoVKTest, DriverParsingAdreno) {
 
 TEST(DriverInfoVKTest, DisabledDevices) {
   EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 630"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 620"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 610"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 530"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 512"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 509"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 508"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 506"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 505"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 504"));
+
+  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 640"));
+  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 650"));
 }
 
 TEST(DriverInfoVKTest, EnabledDevicesMali) {
@@ -122,14 +134,6 @@ TEST(DriverInfoVKTest, EnabledDevicesAdreno) {
   EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 720"));
   EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 710"));
   EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 702"));
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 530"));
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 512"));
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 509"));
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 508"));
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 505"));
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 504"));
-
-  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 506"));
 }
 
 }  // namespace impeller::testing


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/159834

Disable all older Adreno GPUs