### PR TITLE
Add support for dart formatter

### DIFF
--- a/ci/bin/format.dart
+++ b/ci/bin/format.dart
@@ -911,7 +911,9 @@ class DartFormatChecker extends FormatChecker {
         for (final WorkerJob job in incorrect) {
           stdout.write(job.result.stdout
               .replaceFirst('b/-', 'b/${job.command[job.command.length - 2]}')
-              .replaceFirst('b/-', 'b/${job.command[job.command.length - 2]}'));
+              .replaceFirst('b/-', 'b/${job.command[job.command.length - 2]}')
+              .replaceFirst(RegExp('\\+Formatted \\d+ files? \\(\\d+ changed\\) in \\d+.\\d+ seconds.\n'), '')
+          );
         }
         stdout.writeln('DONE');
         stdout.writeln();

--- a/ci/bin/format.dart
+++ b/ci/bin/format.dart
@@ -846,6 +846,7 @@ class DartFormatChecker extends FormatChecker {
       _dartBin,
       'format',
       '--set-exit-if-changed',
+      '--show=none',
       if (!fixing) '--output=show',
       if (fixing) '--output=write',
     ];

--- a/ci/bin/format.dart
+++ b/ci/bin/format.dart
@@ -819,7 +819,7 @@ class DartFormatChecker extends FormatChecker {
       'sdks',
       'dart-sdk',
       'bin',
-      'dart',
+      Platform.isWindows ? 'dart.exe' : 'dart',
     );
   }
 

--- a/ci/test/format_test.dart
+++ b/ci/test/format_test.dart
@@ -24,7 +24,7 @@ final FileContentPair ccContentPair = FileContentPair(
 final FileContentPair hContentPair =
     FileContentPair('int\nmain\n()\n;\n', 'int main();\n');
 final FileContentPair dartContentPair = FileContentPair(
-    'enum \n\nfoo {\n  entry1,\n  entry2\n}', 'enum foo { entry1, entry2 }\n');
+    'enum \n\nfoo {\n  entry1,\n  entry2,\n}', 'enum foo { entry1, entry2 }\n');
 final FileContentPair gnContentPair = FileContentPair(
     'test\n(){testvar=true}\n', 'test() {\n  testvar = true\n}\n');
 final FileContentPair javaContentPair = FileContentPair(

--- a/ci/test/format_test.dart
+++ b/ci/test/format_test.dart
@@ -23,6 +23,8 @@ final FileContentPair ccContentPair = FileContentPair(
     'int main(){return 0;}\n', 'int main() {\n  return 0;\n}\n');
 final FileContentPair hContentPair =
     FileContentPair('int\nmain\n()\n;\n', 'int main();\n');
+final FileContentPair dartContentPair = FileContentPair(
+    'enum \n\nfoo {\n  entry1,\n  entry2\n}', 'enum foo { entry1, entry2 }\n');
 final FileContentPair gnContentPair = FileContentPair(
     'test\n(){testvar=true}\n', 'test() {\n  testvar = true\n}\n');
 final FileContentPair javaContentPair = FileContentPair(
@@ -60,6 +62,10 @@ class TestFileFixture {
         final io.File hFile = io.File('${repoDir.path}/format_test.h');
         hFile.writeAsStringSync(hContentPair.original);
         files.add(hFile);
+      case target.FormatCheck.dart:
+        final io.File dartFile = io.File('${repoDir.path}/format_test.dart');
+        dartFile.writeAsStringSync(dartContentPair.original);
+        files.add(dartFile);
       case target.FormatCheck.gn:
         final io.File gnFile = io.File('${repoDir.path}/format_test.gn');
         gnFile.writeAsStringSync(gnContentPair.original);
@@ -116,6 +122,11 @@ class TestFileFixture {
                 ? ccContentPair.formatted
                 : hContentPair.formatted,
           );
+        case target.FormatCheck.dart:
+          return FileContentPair(
+            content,
+            dartContentPair.formatted,
+          );
         case target.FormatCheck.gn:
           return FileContentPair(
             content,
@@ -155,6 +166,22 @@ void main() {
     try {
       fixture.gitAdd();
       io.Process.runSync(formatterPath, <String>['--check', 'clang', '--fix'],
+          workingDirectory: repoDir.path);
+
+      final Iterable<FileContentPair> files = fixture.getFileContents();
+      for (final FileContentPair pair in files) {
+        expect(pair.original, equals(pair.formatted));
+      }
+    } finally {
+      fixture.gitRemove();
+    }
+  });
+
+  test('Can fix Dart formatting errors', () {
+    final TestFileFixture fixture = TestFileFixture(target.FormatCheck.dart);
+    try {
+      fixture.gitAdd();
+      io.Process.runSync(formatterPath, <String>['--check', 'dart', '--fix'],
           workingDirectory: repoDir.path);
 
       final Iterable<FileContentPair> files = fixture.getFileContents();


### PR DESCRIPTION
Currently it is off by default since we haven't migrated any files over to the new format. To try it out, run `dart ci/bin/format.dart -c dart -f`.

Once we turn it on by default `et` will automatically format dart files as it calls into `format.dart`.