### PR TITLE
Do not handle Dart isolate messages if the isolate is being shut down

### DIFF
--- a/third_party/tonic/dart_message_handler.cc
+++ b/third_party/tonic/dart_message_handler.cc
@@ -39,7 +39,9 @@ void DartMessageHandler::OnMessage(DartState* dart_state) {
   auto weak_dart_state = dart_state->GetWeakPtr();
   task_dispatcher_([weak_dart_state]() {
     if (auto dart_state = weak_dart_state.lock()) {
-      dart_state->message_handler().OnHandleMessage(dart_state.get());
+      if (!dart_state->IsShuttingDown()) {
+        dart_state->message_handler().OnHandleMessage(dart_state.get());
+      }
     }
   });
 }


### PR DESCRIPTION
This fixes a race that can happen if Dart invokes an isolate's message handling callback during isolate shutdown.  The callback installed by Tonic will invoke a dispatcher set by the engine's DartIsolate::SetMessageHandlingTaskRunner, which will queue a message handling task to the designated task runner.

If the queued task runs after DartIsolate::Shutdown has been called, then Tonic's DartMessageHandler::OnHandleMessage will fail when it tries to enter the isolate.

DartIsolate will set a shutdown flag on the DartState when Dart invokes the isolate's shutdown callback.  Tonic can avoid this race by checking that flag before proceeding with message handling.

Fixes https://github.com/flutter/flutter/issues/160003