### PR TITLE
[Impeller] set UniformBlockBinding once.

### DIFF
--- a/impeller/renderer/backend/gles/buffer_bindings_gles.cc
+++ b/impeller/renderer/backend/gles/buffer_bindings_gles.cc
@@ -126,6 +126,8 @@ bool BufferBindingsGLES::ReadUniformsBindingsV3(const ProcTableGLES& gl,
     gl.GetActiveUniformBlockName(program, i, name_length, &length, name.data());
 
     GLuint block_index = gl.GetUniformBlockIndex(program, name.data());
+    gl.UniformBlockBinding(program_handle_, block_index, i);
+
     ubo_locations_[std::string{name.data(), static_cast<size_t>(length)}] =
         std::make_pair(block_index, i);
   }
@@ -336,8 +338,6 @@ bool BufferBindingsGLES::BindUniformBufferV3(
     return BindUniformBufferV2(gl, buffer, metadata, device_buffer_gles);
   }
   const auto& [block_index, binding_point] = it->second;
-  gl.UniformBlockBinding(program_handle_, block_index, binding_point);
-
   if (!device_buffer_gles.BindAndUploadDataIfNecessary(
           DeviceBufferGLES::BindingType::kUniformBuffer)) {
     return false;


### PR DESCRIPTION
gl.UniformBlockBinding only needs to be set once when the pipeline is linked, and not on every draw.
