### PR TITLE
Make Felt unzip Chrome into a temporary directory next to the final location of the files

### DIFF
--- a/lib/web_ui/dev/chrome_installer.dart
+++ b/lib/web_ui/dev/chrome_installer.dart
@@ -218,7 +218,7 @@ class ChromeInstaller {
       // version directory. However, the zip file contains a top-level directory
       // named e.g. 'chrome-linux'. We need to copy the files out of that
       // directory and into the version directory.
-      final io.Directory tmpDir = await io.Directory.systemTemp.createTemp();
+      final io.Directory tmpDir = await chromeInstallationDir.createTemp();
       final io.Directory unzipDir = tmpDir;
       final io.ProcessResult unzipResult =
           await io.Process.run('unzip', <String>[


### PR DESCRIPTION
The Web Felt script downloads a Chrome zip archive, extracts it to a temporary directory, and then moves the files to a location expected by the script.

Previously Felt used a temporary directory based on io.Directory.systemTemp.  This may not work because the FileSystemEntity.rename operation used to move the files can fail if the system temp directory is located in a different filesystem from the destination directory.