### PR TITLE
[Impeller] avoid expensive texture labeling w/ no validation layers.

### DIFF
--- a/impeller/renderer/backend/vulkan/texture_vk.cc
+++ b/impeller/renderer/backend/vulkan/texture_vk.cc
@@ -15,12 +15,19 @@ TextureVK::TextureVK(std::weak_ptr<Context> context,
                      std::shared_ptr<TextureSourceVK> source)
     : Texture(source->GetTextureDescriptor()),
       context_(std::move(context)),
-      source_(std::move(source)) {}
+      source_(std::move(source)) {
+#ifdef IMPELLER_DEBUG
+  has_validation_layers_ = HasValidationLayers();
+#endif  // IMPELLER_DEBUG
+}
 
 TextureVK::~TextureVK() = default;
 
 void TextureVK::SetLabel(std::string_view label) {
 #ifdef IMPELLER_DEBUG
+  if (!has_validation_layers_) {
+    return;
+  }
   auto context = context_.lock();
   if (!context) {
     // The context may have died.

--- a/impeller/renderer/backend/vulkan/texture_vk.h
+++ b/impeller/renderer/backend/vulkan/texture_vk.h
@@ -77,6 +77,7 @@ class TextureVK final : public Texture, public BackendCast<TextureVK, Texture> {
  private:
   std::weak_ptr<Context> context_;
   std::shared_ptr<TextureSourceVK> source_;
+  bool has_validation_layers_ = false;
 
   // |Texture|
   void SetLabel(std::string_view label) override;


### PR DESCRIPTION
Labelling textures shows up in all of our profiles because of the cost to lock the context weak ptr and then call into both the image and image view. remove this if no layers are present that would read the label.
