### PR TITLE
Format _empty.dart

### DIFF
--- a/sky/packages/sky_engine/lib/_empty.dart
+++ b/sky/packages/sky_engine/lib/_empty.dart
@@ -1,0 +1,3 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.


### PR DESCRIPTION
When `dartfmt` formatted `_empty.dart` it formatted it with a trailing newline, which then makes the license script angry. Rather then treating `_empty.dart` special, this just makes it a regular source file with header and everything.