### PR TITLE
[Impeller] Fix a race in the ReactorGLES.PerThreadOperationQueues test

### DIFF
--- a/impeller/renderer/backend/gles/test/reactor_unittests.cc
+++ b/impeller/renderer/backend/gles/test/reactor_unittests.cc
@@ -131,8 +131,8 @@ TEST(ReactorGLES, PerThreadOperationQueues) {
   fml::AutoResetWaitableEvent event;
   bool op2_called = false;
   std::thread thread([&] {
-    EXPECT_TRUE(
-        reactor->AddOperation([&](const ReactorGLES&) { op2_called = true; }));
+    EXPECT_TRUE(reactor->AddOperation(
+        [&](const ReactorGLES&) { op2_called = true; }, true));
     event.Wait();
     EXPECT_TRUE(reactor->React());
   });


### PR DESCRIPTION
Pass a flag to AddOperation to ensure that ReactorGLES does not immediately execute the operation on the second thread.