### PR TITLE
iOS: Reduce engine/view controller coupling

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -10,6 +10,7 @@
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Test.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate_internal.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h"
 
 FLUTTER_ASSERT_ARC
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
@@ -11,6 +11,7 @@
 #include "flutter/fml/message_loop.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Test.h"
 #import "flutter/shell/platform/darwin/ios/platform_view_ios.h"
 
 FLUTTER_ASSERT_ARC
@@ -101,7 +102,7 @@ flutter::FakeDelegate fake_delegate;
   XCTAssertNotNil(engine);
   id mockEngine = OCMPartialMock(engine);
   OCMStub([mockEngine notifyLowMemory]);
-  OCMStub([mockEngine iosPlatformView]).andReturn(platform_view.get());
+  OCMStub([mockEngine platformView]).andReturn(platform_view.get());
 
   [engine setViewController:nil];
   OCMVerify([mockEngine notifyLowMemory]);

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -75,8 +75,6 @@ FLUTTER_ASSERT_ARC
   XCTAssertNotNil(engine);
 
   // Ensure getters don't deref _shell when it's null, and instead return nullptr.
-  XCTAssertEqual(engine.platformView.get(), nullptr);
-  XCTAssertEqual(engine.iosPlatformView, nullptr);
   XCTAssertEqual(engine.platformTaskRunner.get(), nullptr);
   XCTAssertEqual(engine.uiTaskRunner.get(), nullptr);
   XCTAssertEqual(engine.rasterTaskRunner.get(), nullptr);
@@ -435,10 +433,10 @@ FLUTTER_ASSERT_ARC
                                         initialRoute:nil
                                       entrypointArgs:nil];
   XCTAssertNotNil(spawn);
-  XCTAssertTrue([engine iosPlatformView] != nullptr);
-  XCTAssertTrue([spawn iosPlatformView] != nullptr);
-  std::shared_ptr<flutter::IOSContext> engine_context = [engine iosPlatformView]->GetIosContext();
-  std::shared_ptr<flutter::IOSContext> spawn_context = [spawn iosPlatformView]->GetIosContext();
+  XCTAssertTrue(engine.platformView != nullptr);
+  XCTAssertTrue(spawn.platformView != nullptr);
+  std::shared_ptr<flutter::IOSContext> engine_context = engine.platformView->GetIosContext();
+  std::shared_ptr<flutter::IOSContext> spawn_context = spawn.platformView->GetIosContext();
   XCTAssertEqual(engine_context, spawn_context);
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -25,13 +25,11 @@
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterRestorationPlugin.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h"
-#import "flutter/shell/platform/darwin/ios/platform_view_ios.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterView.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface FlutterEngine () <FlutterViewEngineDelegate>
-
-- (flutter::Shell&)shell;
 
 - (void)updateViewportMetrics:(flutter::ViewportMetrics)viewportMetrics;
 - (void)dispatchPointerDataPacket:(std::unique_ptr<flutter::PointerDataPacket>)packet;
@@ -40,7 +38,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (fml::RefPtr<fml::TaskRunner>)uiTaskRunner;
 - (fml::RefPtr<fml::TaskRunner>)rasterTaskRunner;
 
-- (fml::WeakPtr<flutter::PlatformView>)platformView;
+- (void)installFirstFrameCallback:(void (^)(void))block;
+- (void)enableSemantics:(BOOL)enabled withFlags:(int64_t)flags;
+- (void)notifyViewCreated;
+- (void)notifyViewDestroyed;
 
 - (flutter::Rasterizer::Screenshot)screenshot:(flutter::Rasterizer::ScreenshotType)type
                                  base64Encode:(bool)base64Encode;
@@ -56,8 +57,13 @@ NS_ASSUME_NONNULL_BEGIN
        initialRoute:(nullable NSString*)initialRoute;
 - (void)attachView;
 - (void)notifyLowMemory;
-- (flutter::PlatformViewIOS*)iosPlatformView;
 
+/// Blocks until the first frame is presented or the timeout is exceeded, then invokes callback.
+- (void)waitForFirstFrameSync:(NSTimeInterval)timeout
+                     callback:(NS_NOESCAPE void (^)(BOOL didTimeout))callback;
+
+/// Asynchronously waits until the first frame is presented or the timeout is exceeded, then invokes
+/// callback.
 - (void)waitForFirstFrame:(NSTimeInterval)timeout callback:(void (^)(BOOL didTimeout))callback;
 
 /**

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine_Test.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine_Test.h
@@ -8,6 +8,7 @@
 #import "flutter/shell/common/shell.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h"
+#include "flutter/shell/platform/darwin/ios/platform_view_ios.h"
 #import "flutter/shell/platform/darwin/ios/rendering_api_selection.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 
@@ -24,6 +25,8 @@ class ThreadHost;
 @property(readonly, nonatomic) BOOL enableEmbedderAPI;
 
 - (flutter::Shell&)shell;
+- (flutter::PlatformViewIOS*)platformView;
+
 - (void)setBinaryMessenger:(FlutterBinaryMessengerRelay*)binaryMessenger;
 - (flutter::IOSRenderingAPI)platformViewsRenderingAPI;
 - (void)waitForFirstFrame:(NSTimeInterval)timeout callback:(void (^)(BOOL didTimeout))callback;

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -16,7 +16,7 @@
 #include "flutter/fml/thread.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
-#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Test.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterTouchInterceptingView_Test.h"
@@ -4319,8 +4319,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
   // Create an IOSContext and GrDirectContext.
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar"];
   [engine run];
-  XCTAssertTrue([engine iosPlatformView] != nullptr);
-  auto ios_context = [engine iosPlatformView]->GetIosContext();
+  XCTAssertTrue(engine.platformView != nullptr);
+  auto ios_context = engine.platformView->GetIosContext();
   auto gr_context = ios_context->GetMainContext();
 
   auto pool = flutter::OverlayLayerPool{};

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -642,23 +642,10 @@ static void SendFakeTouchEvent(UIScreen* screen,
   if (!self.engine) {
     return;
   }
-
-  fml::WeakPtr<flutter::PlatformViewIOS> weakPlatformView = self.engine.platformView;
-  if (!weakPlatformView) {
-    return;
-  }
-
-  // Start on the platform thread.
   __weak FlutterViewController* weakSelf = self;
-  weakPlatformView->SetNextFrameCallback([weakSelf,
-                                          platformTaskRunner = self.engine.platformTaskRunner,
-                                          rasterTaskRunner = self.engine.rasterTaskRunner]() {
-    FML_DCHECK(platformTaskRunner);
-    FML_DCHECK(rasterTaskRunner);
-    FML_DCHECK(rasterTaskRunner->RunsTasksOnCurrentThread());
-    // Get callback on raster thread and jump back to platform thread.
-    platformTaskRunner->PostTask([weakSelf]() { [weakSelf onFirstFrameRendered]; });
-  });
+  [self.engine installFirstFrameCallback:^{
+    [weakSelf onFirstFrameRendered];
+  }];
 }
 
 #pragma mark - Properties
@@ -749,10 +736,10 @@ static void SendFakeTouchEvent(UIScreen* screen,
     [self installFirstFrameCallback];
     self.platformViewsController.flutterView = self.flutterView;
     self.platformViewsController.flutterViewController = self;
-    [self.engine iosPlatformView]->NotifyCreated();
+    [self.engine notifyViewCreated];
   } else {
     self.displayingFlutterUI = NO;
-    [self.engine iosPlatformView]->NotifyDestroyed();
+    [self.engine notifyViewDestroyed];
     self.platformViewsController.flutterView = nil;
     self.platformViewsController.flutterViewController = nil;
   }
@@ -1333,13 +1320,11 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
     return;
   }
 
-  flutter::Shell& shell = self.engine.shell;
   auto callback = [](std::unique_ptr<flutter::FrameTimingsRecorder> recorder) {
     // Do nothing in this block. Just trigger system to callback touch events with correct rate.
   };
   _touchRateCorrectionVSyncClient =
-      [[VSyncClient alloc] initWithTaskRunner:shell.GetTaskRunners().GetPlatformTaskRunner()
-                                     callback:callback];
+      [[VSyncClient alloc] initWithTaskRunner:self.engine.platformTaskRunner callback:callback];
   _touchRateCorrectionVSyncClient.allowPauseAfterVsync = NO;
 }
 
@@ -1416,19 +1401,21 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   // the viewport metrics update tasks.
   if (firstViewBoundsUpdate && applicationOrSceneIsActive && self.engine) {
     [self surfaceUpdated:YES];
-
-    flutter::Shell& shell = self.engine.shell;
-    fml::TimeDelta waitTime =
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
-        fml::TimeDelta::FromMilliseconds(200);
+    NSTimeInterval timeout = 0.2;
 #else
-        fml::TimeDelta::FromMilliseconds(100);
+    NSTimeInterval timeout = 0.1;
 #endif
-    if (shell.WaitForFirstFrame(waitTime).code() == fml::StatusCode::kDeadlineExceeded) {
-      FML_LOG(INFO) << "Timeout waiting for the first frame to render.  This may happen in "
-                    << "unoptimized builds.  If this is a release build, you should load a less "
-                    << "complex frame to avoid the timeout.";
-    }
+    [self.engine
+        waitForFirstFrameSync:timeout
+                     callback:^(BOOL didTimeout) {
+                       if (didTimeout) {
+                         FML_LOG(INFO)
+                             << "Timeout waiting for the first frame to render. This may happen in "
+                                "unoptimized builds. If this is a release build, you should load a "
+                                "less complex frame to avoid the timeout.";
+                       }
+                     }];
   }
 }
 
@@ -2106,26 +2093,22 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   if (!self.engine) {
     return;
   }
-  fml::WeakPtr<flutter::PlatformView> platformView = self.engine.platformView;
-  if (!platformView) {
-    return;
-  }
+  BOOL enabled = NO;
   int32_t flags = self.accessibilityFlags;
 #if TARGET_OS_SIMULATOR
   // There doesn't appear to be any way to determine whether the accessibility
   // inspector is enabled on the simulator. We conservatively always turn on the
   // accessibility bridge in the simulator, but never assistive technology.
-  platformView->SetSemanticsEnabled(true);
-  platformView->SetAccessibilityFeatures(flags);
+  enabled = YES;
 #else
   _isVoiceOverRunning = UIAccessibilityIsVoiceOverRunning();
-  bool enabled = _isVoiceOverRunning || UIAccessibilityIsSwitchControlRunning();
+  enabled = _isVoiceOverRunning || UIAccessibilityIsSwitchControlRunning();
   if (enabled) {
     flags |= static_cast<int32_t>(flutter::AccessibilityFeatureFlag::kAccessibleNavigation);
   }
-  platformView->SetSemanticsEnabled(enabled || UIAccessibilityIsSpeakScreenEnabled());
-  platformView->SetAccessibilityFeatures(flags);
+  enabled |= UIAccessibilityIsSpeakScreenEnabled();
 #endif
+  [self.engine enableSemantics:enabled withFlags:flags];
 }
 
 - (int32_t)accessibilityFlags {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -14,6 +14,7 @@
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEmbedderKeyResponder.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterFakeKeyEvents.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterView.h"
@@ -26,14 +27,6 @@
 FLUTTER_ASSERT_ARC
 
 using namespace flutter::testing;
-
-@interface FlutterEngine ()
-- (FlutterTextInputPlugin*)textInputPlugin;
-- (void)sendKeyEvent:(const FlutterKeyEvent&)event
-            callback:(nullable FlutterKeyEventCallback)callback
-            userData:(nullable void*)userData;
-- (fml::RefPtr<fml::TaskRunner>)uiTaskRunner;
-@end
 
 /// Sometimes we have to use a custom mock to avoid retain cycles in OCMock.
 /// Used for testing low memory notification.

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -87,6 +87,38 @@ class PlatformViewIOS final : public PlatformView {
   // |PlatformView|
   void SetSemanticsEnabled(bool enabled) override;
 
+  // |PlatformView|
+  void HandlePlatformMessage(std::unique_ptr<flutter::PlatformMessage> message) override;
+
+  // |PlatformView|
+  std::unique_ptr<Surface> CreateRenderingSurface() override;
+
+  // |PlatformView|
+  std::shared_ptr<ExternalViewEmbedder> CreateExternalViewEmbedder() override;
+
+  // |PlatformView|
+  sk_sp<GrDirectContext> CreateResourceContext() const override;
+
+  // |PlatformView|
+  std::shared_ptr<impeller::Context> GetImpellerContext() const override;
+
+  // |PlatformView|
+  void SetAccessibilityFeatures(int32_t flags) override;
+
+  // |PlatformView|
+  void UpdateSemantics(flutter::SemanticsNodeUpdates update,
+                       flutter::CustomAccessibilityActionUpdates actions) override;
+
+  // |PlatformView|
+  std::unique_ptr<VsyncWaiter> CreateVSyncWaiter() override;
+
+  // |PlatformView|
+  void OnPreEngineRestart() const override;
+
+  // |PlatformView|
+  std::unique_ptr<std::vector<std::string>> ComputePlatformResolvedLocales(
+      const std::vector<std::string>& supported_locale_data) override;
+
   /** Accessor for the `IOSContext` associated with the platform view. */
   const std::shared_ptr<IOSContext>& GetIosContext() { return ios_context_; }
 
@@ -142,38 +174,6 @@ class PlatformViewIOS final : public PlatformView {
   ScopedObserver dealloc_view_controller_observer_;
   std::vector<std::string> platform_resolved_locale_;
   std::shared_ptr<PlatformMessageHandlerIos> platform_message_handler_;
-
-  // |PlatformView|
-  void HandlePlatformMessage(std::unique_ptr<flutter::PlatformMessage> message) override;
-
-  // |PlatformView|
-  std::unique_ptr<Surface> CreateRenderingSurface() override;
-
-  // |PlatformView|
-  std::shared_ptr<ExternalViewEmbedder> CreateExternalViewEmbedder() override;
-
-  // |PlatformView|
-  sk_sp<GrDirectContext> CreateResourceContext() const override;
-
-  // |PlatformView|
-  std::shared_ptr<impeller::Context> GetImpellerContext() const override;
-
-  // |PlatformView|
-  void SetAccessibilityFeatures(int32_t flags) override;
-
-  // |PlatformView|
-  void UpdateSemantics(flutter::SemanticsNodeUpdates update,
-                       flutter::CustomAccessibilityActionUpdates actions) override;
-
-  // |PlatformView|
-  std::unique_ptr<VsyncWaiter> CreateVSyncWaiter() override;
-
-  // |PlatformView|
-  void OnPreEngineRestart() const override;
-
-  // |PlatformView|
-  std::unique_ptr<std::vector<std::string>> ComputePlatformResolvedLocales(
-      const std::vector<std::string>& supported_locale_data) override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(PlatformViewIOS);
 };


### PR DESCRIPTION
Eliminates some cases where `FlutterViewController` was relying on `FlutterEngine` internals:
* `[FlutterEngine shell]`
* `[FlutterEngine platformView]`
* `[FlutterEngine iosPlatformView]`

Instead, `FlutterEngine` now exposes:
* `installFirstFrameCallback:`
* `enableSemantics:withFlags:`
* `notifyViewCreated`
* `notifyViewDestroyed`
* `waitForFirstFrameSync:callback:`

Also fixes a couple cases where we were relying on transitive header includes:
* `FlutterAppController` relied on `FlutterViewController_Internal.h` for `sendDeepLinkToFramework:completionHandler:`

This is a refactoring followup to https://github.com/flutter/engine/pull/57099 that introduces no semantic changes.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/engine/blob/main/docs/testing/Testing-the-engine.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
