### PR TITLE
Migrate layers and layer_tree to DisplayList/Impeller geometry classes

### DIFF
--- a/display_list/geometry/dl_geometry_types.h
+++ b/display_list/geometry/dl_geometry_types.h
@@ -42,6 +42,7 @@ static_assert(sizeof(SkIRect) == sizeof(DlIRect));
 static_assert(sizeof(SkVector) == sizeof(DlSize));
 
 static constexpr DlScalar kEhCloseEnough = impeller::kEhCloseEnough;
+static constexpr DlScalar kPi = impeller::kPi;
 
 constexpr inline bool DlScalarNearlyZero(DlScalar x,
                                          DlScalar tolerance = kEhCloseEnough) {
@@ -142,6 +143,11 @@ inline const SkIRect& ToSkIRect(const DlIRect& rect) {
   return *reinterpret_cast<const SkIRect*>(&rect);
 }
 
+inline std::optional<const SkIRect> ToOptSkIRect(
+    std::optional<const DlIRect> rect) {
+  return rect.has_value() ? std::optional(ToSkIRect(*rect)) : std::nullopt;
+}
+
 inline const SkRect* ToSkRect(const DlRect* rect) {
   return rect == nullptr ? nullptr : reinterpret_cast<const SkRect*>(rect);
 }
@@ -156,6 +162,10 @@ inline SkRect* ToSkRect(DlRect* rect) {
 
 inline const SkRect* ToSkRects(const DlRect* rects) {
   return rects == nullptr ? nullptr : reinterpret_cast<const SkRect*>(rects);
+}
+
+inline const SkSize& ToSkSize(const DlSize& size) {
+  return *reinterpret_cast<const SkSize*>(&size);
 }
 
 inline const SkISize& ToSkISize(const DlISize& size) {

--- a/display_list/geometry/dl_path.cc
+++ b/display_list/geometry/dl_path.cc
@@ -10,6 +10,35 @@
 
 namespace flutter {
 
+DlPath DlPath::MakeRect(DlRect rect) {
+  return DlPath(SkPath::Rect(ToSkRect(rect)));
+}
+
+DlPath DlPath::MakeRectLTRB(DlScalar left,
+                            DlScalar top,
+                            DlScalar right,
+                            DlScalar bottom) {
+  return DlPath(SkPath().addRect(left, top, right, bottom));
+}
+
+DlPath DlPath::MakeRectXYWH(DlScalar x,
+                            DlScalar y,
+                            DlScalar width,
+                            DlScalar height) {
+  return DlPath(SkPath().addRect(SkRect::MakeXYWH(x, y, width, height)));
+}
+
+DlPath DlPath::MakeOval(DlRect bounds) {
+  return DlPath(SkPath::Oval(ToSkRect(bounds)));
+}
+
+DlPath DlPath::MakeOvalLTRB(DlScalar left,
+                            DlScalar top,
+                            DlScalar right,
+                            DlScalar bottom) {
+  return DlPath(SkPath::Oval(SkRect::MakeLTRB(left, top, right, bottom)));
+}
+
 const SkPath& DlPath::GetSkPath() const {
   return data_->sk_path;
 }
@@ -74,6 +103,12 @@ bool DlPath::IsConverted() const {
 
 bool DlPath::IsVolatile() const {
   return data_->sk_path.isVolatile();
+}
+
+DlPath DlPath::operator+(const DlPath& other) const {
+  SkPath path = data_->sk_path;
+  path.addPath(other.data_->sk_path);
+  return DlPath(path);
 }
 
 using Path = impeller::Path;

--- a/display_list/geometry/dl_path.h
+++ b/display_list/geometry/dl_path.h
@@ -15,6 +15,22 @@ class DlPath {
  public:
   static constexpr uint32_t kMaxVolatileUses = 2;
 
+  static DlPath MakeRect(DlRect rect);
+  static DlPath MakeRectLTRB(DlScalar left,
+                             DlScalar top,
+                             DlScalar right,
+                             DlScalar bottom);
+  static DlPath MakeRectXYWH(DlScalar x,
+                             DlScalar y,
+                             DlScalar width,
+                             DlScalar height);
+
+  static DlPath MakeOval(DlRect bounds);
+  static DlPath MakeOvalLTRB(DlScalar left,
+                             DlScalar top,
+                             DlScalar right,
+                             DlScalar bottom);
+
   DlPath() : data_(std::make_shared<Data>(SkPath())) {}
   explicit DlPath(const SkPath& path) : data_(std::make_shared<Data>(path)) {}
 
@@ -49,6 +65,8 @@ class DlPath {
 
   bool IsConverted() const;
   bool IsVolatile() const;
+
+  DlPath operator+(const DlPath& other) const;
 
  private:
   struct Data {

--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -57,8 +57,8 @@ class FrameDamage {
 
   // Adds additional damage (accumulated for double / triple buffering).
   // This is area that will be repainted alongside any changed part.
-  void AddAdditionalDamage(const SkIRect& damage) {
-    additional_damage_.join(damage);
+  void AddAdditionalDamage(const DlIRect& damage) {
+    additional_damage_ = additional_damage_.Union(damage);
   }
 
   // Specifies clip rect alignment.
@@ -72,17 +72,17 @@ class FrameDamage {
   // If previous layer tree is not specified, clip rect will be nullopt,
   // but the paint region of layer_tree will be calculated so that it can be
   // used for diffing of subsequent frames.
-  std::optional<SkRect> ComputeClipRect(flutter::LayerTree& layer_tree,
+  std::optional<DlRect> ComputeClipRect(flutter::LayerTree& layer_tree,
                                         bool has_raster_cache,
                                         bool impeller_enabled);
 
   // See Damage::frame_damage.
-  std::optional<SkIRect> GetFrameDamage() const {
+  std::optional<DlIRect> GetFrameDamage() const {
     return damage_ ? std::make_optional(damage_->frame_damage) : std::nullopt;
   }
 
   // See Damage::buffer_damage.
-  std::optional<SkIRect> GetBufferDamage() {
+  std::optional<DlIRect> GetBufferDamage() {
     return (damage_ && !ignore_damage_)
                ? std::make_optional(damage_->buffer_damage)
                : std::nullopt;
@@ -95,7 +95,7 @@ class FrameDamage {
   void Reset() { ignore_damage_ = true; }
 
  private:
-  SkIRect additional_damage_ = SkIRect::MakeEmpty();
+  DlIRect additional_damage_;
   std::optional<Damage> damage_;
   const LayerTree* prev_layer_tree_ = nullptr;
   int vertical_clip_alignment_ = 1;
@@ -141,12 +141,12 @@ class CompositorContext {
 
    private:
     void PaintLayerTreeSkia(flutter::LayerTree& layer_tree,
-                            std::optional<SkRect> clip_rect,
+                            std::optional<DlRect> clip_rect,
                             bool needs_save_layer,
                             bool ignore_raster_cache);
 
     void PaintLayerTreeImpeller(flutter::LayerTree& layer_tree,
-                                std::optional<SkRect> clip_rect,
+                                std::optional<DlRect> clip_rect,
                                 bool ignore_raster_cache);
 
     CompositorContext& context_;
@@ -154,7 +154,7 @@ class CompositorContext {
     DlCanvas* canvas_;
     impeller::AiksContext* aiks_context_;
     ExternalViewEmbedder* view_embedder_;
-    const SkMatrix& root_surface_transformation_;
+    const SkMatrix root_surface_transformation_;
     const bool instrumentation_enabled_;
     const bool surface_supports_readback_;
     fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger_;
@@ -210,8 +210,8 @@ class CompositorContext {
   /// @brief  Whether Impeller shouild attempt a partial repaint.
   ///         The Impeller backend requires an additional blit pass, which may
   ///         not be worthwhile if the damage region is large.
-  static bool ShouldPerformPartialRepaint(std::optional<SkRect> damage_rect,
-                                          SkISize layer_tree_size);
+  static bool ShouldPerformPartialRepaint(std::optional<DlRect> damage_rect,
+                                          DlISize layer_tree_size);
 
   FML_DISALLOW_COPY_AND_ASSIGN(CompositorContext);
 };

--- a/flow/diff_context_unittests.cc
+++ b/flow/diff_context_unittests.cc
@@ -10,32 +10,32 @@ namespace testing {
 TEST_F(DiffContextTest, ClipAlignment) {
   MockLayerTree t1;
   t1.root()->Add(CreateDisplayListLayer(
-      CreateDisplayList(SkRect::MakeLTRB(30, 30, 50, 50))));
-  auto damage = DiffLayerTree(t1, MockLayerTree(), SkIRect::MakeEmpty(), 0, 0);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(30, 30, 50, 50));
-  EXPECT_EQ(damage.buffer_damage, SkIRect::MakeLTRB(30, 30, 50, 50));
+      CreateDisplayList(DlRect::MakeLTRB(30, 30, 50, 50))));
+  auto damage = DiffLayerTree(t1, MockLayerTree(), DlIRect(), 0, 0);
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(30, 30, 50, 50));
+  EXPECT_EQ(damage.buffer_damage, DlIRect::MakeLTRB(30, 30, 50, 50));
 
-  damage = DiffLayerTree(t1, MockLayerTree(), SkIRect::MakeEmpty(), 1, 1);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(30, 30, 50, 50));
-  EXPECT_EQ(damage.buffer_damage, SkIRect::MakeLTRB(30, 30, 50, 50));
+  damage = DiffLayerTree(t1, MockLayerTree(), DlIRect(), 1, 1);
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(30, 30, 50, 50));
+  EXPECT_EQ(damage.buffer_damage, DlIRect::MakeLTRB(30, 30, 50, 50));
 
-  damage = DiffLayerTree(t1, MockLayerTree(), SkIRect::MakeEmpty(), 8, 1);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(24, 30, 56, 50));
-  EXPECT_EQ(damage.buffer_damage, SkIRect::MakeLTRB(24, 30, 56, 50));
+  damage = DiffLayerTree(t1, MockLayerTree(), DlIRect(), 8, 1);
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(24, 30, 56, 50));
+  EXPECT_EQ(damage.buffer_damage, DlIRect::MakeLTRB(24, 30, 56, 50));
 
-  damage = DiffLayerTree(t1, MockLayerTree(), SkIRect::MakeEmpty(), 1, 8);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(30, 24, 50, 56));
-  EXPECT_EQ(damage.buffer_damage, SkIRect::MakeLTRB(30, 24, 50, 56));
+  damage = DiffLayerTree(t1, MockLayerTree(), DlIRect(), 1, 8);
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(30, 24, 50, 56));
+  EXPECT_EQ(damage.buffer_damage, DlIRect::MakeLTRB(30, 24, 50, 56));
 
-  damage = DiffLayerTree(t1, MockLayerTree(), SkIRect::MakeEmpty(), 16, 16);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(16, 16, 64, 64));
-  EXPECT_EQ(damage.buffer_damage, SkIRect::MakeLTRB(16, 16, 64, 64));
+  damage = DiffLayerTree(t1, MockLayerTree(), DlIRect(), 16, 16);
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(16, 16, 64, 64));
+  EXPECT_EQ(damage.buffer_damage, DlIRect::MakeLTRB(16, 16, 64, 64));
 }
 
 TEST_F(DiffContextTest, DisjointDamage) {
-  SkISize frame_size = SkISize::Make(90, 90);
-  auto in_bounds_dl = CreateDisplayList(SkRect::MakeLTRB(30, 30, 50, 50));
-  auto out_bounds_dl = CreateDisplayList(SkRect::MakeLTRB(100, 100, 120, 120));
+  DlISize frame_size = DlISize(90, 90);
+  auto in_bounds_dl = CreateDisplayList(DlRect::MakeLTRB(30, 30, 50, 50));
+  auto out_bounds_dl = CreateDisplayList(DlRect::MakeLTRB(100, 100, 120, 120));
 
   // We need both DisplayLists to be non-empty.
   ASSERT_FALSE(in_bounds_dl->bounds().isEmpty());
@@ -43,8 +43,9 @@ TEST_F(DiffContextTest, DisjointDamage) {
 
   // We need the in_bounds DisplayList to be inside the frame size.
   // We need the out_bounds DisplayList to be completely outside the frame.
-  ASSERT_TRUE(SkRect::Make(frame_size).contains(in_bounds_dl->bounds()));
-  ASSERT_FALSE(SkRect::Make(frame_size).intersects(out_bounds_dl->bounds()));
+  ASSERT_TRUE(DlRect::MakeSize(frame_size).Contains(in_bounds_dl->GetBounds()));
+  ASSERT_FALSE(DlRect::MakeSize(frame_size)
+                   .IntersectsWithRect(out_bounds_dl->GetBounds()));
 
   MockLayerTree t1(frame_size);
   t1.root()->Add(CreateDisplayListLayer(in_bounds_dl));
@@ -58,14 +59,14 @@ TEST_F(DiffContextTest, DisjointDamage) {
   // Cannot use DiffLayerTree because it implicitly adds a clip layer
   // around the tree, but we want the out of bounds dl to not be pruned
   // to test the intersection code inside layer::Diff/ComputeDamage
-  // damage = DiffLayerTree(t2, t1, SkIRect::MakeEmpty(), 0, 0);
+  // damage = DiffLayerTree(t2, t1, DlIRect(), 0, 0);
 
   DiffContext dc(frame_size, t2.paint_region_map(), t1.paint_region_map(), true,
                  false);
   t2.root()->Diff(&dc, t1.root());
-  auto damage = dc.ComputeDamage(SkIRect::MakeEmpty(), 0, 0);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeEmpty());
-  EXPECT_EQ(damage.buffer_damage, SkIRect::MakeEmpty());
+  auto damage = dc.ComputeDamage(DlIRect(), 0, 0);
+  EXPECT_EQ(damage.frame_damage, DlIRect());
+  EXPECT_EQ(damage.buffer_damage, DlIRect());
 }
 
 }  // namespace testing

--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -117,6 +117,14 @@ class Mutator {
         filter_mutation_(
             std::make_shared<ImageFilterMutation>(filter, filter_rect)) {}
 
+  explicit Mutator(const DlRect& rect) : Mutator(ToSkRect(rect)) {}
+  explicit Mutator(const DlRoundRect& rrect) : Mutator(ToSkRRect(rrect)) {}
+  explicit Mutator(const DlPath& path) : Mutator(path.GetSkPath()) {}
+  explicit Mutator(const DlMatrix& matrix) : Mutator(ToSkMatrix(matrix)) {}
+  explicit Mutator(const std::shared_ptr<DlImageFilter>& filter,
+                   const DlRect& filter_rect)
+      : Mutator(filter, ToSkRect(filter_rect)) {}
+
   const MutatorType& GetType() const { return type_; }
   const SkRect& GetRect() const { return rect_; }
   const SkRRect& GetRRect() const { return rrect_; }

--- a/flow/layers/backdrop_filter_layer_unittests.cc
+++ b/flow/layers/backdrop_filter_layer_unittests.cc
@@ -22,12 +22,12 @@ TEST_F(BackdropFilterLayerTest, PaintingEmptyLayerDies) {
   auto filter = DlImageFilter::MakeBlur(5, 5, DlTileMode::kClamp);
   auto layer =
       std::make_shared<BackdropFilterLayer>(filter, DlBlendMode::kSrcOver);
-  auto parent = std::make_shared<ClipRectLayer>(kEmptyRect, Clip::kHardEdge);
+  auto parent = std::make_shared<ClipRectLayer>(DlRect(), Clip::kHardEdge);
   parent->Add(layer);
 
   parent->Preroll(preroll_context());
-  EXPECT_EQ(layer->paint_bounds(), kEmptyRect);
-  EXPECT_EQ(layer->child_paint_bounds(), kEmptyRect);
+  EXPECT_EQ(layer->paint_bounds(), DlRect());
+  EXPECT_EQ(layer->child_paint_bounds(), DlRect());
   EXPECT_FALSE(layer->needs_painting(paint_context()));
 
   EXPECT_DEATH_IF_SUPPORTED(layer->Paint(paint_context()),
@@ -35,25 +35,25 @@ TEST_F(BackdropFilterLayerTest, PaintingEmptyLayerDies) {
 }
 
 TEST_F(BackdropFilterLayerTest, PaintBeforePrerollDies) {
-  const SkRect child_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
-  const SkPath child_path = SkPath().addRect(child_bounds);
+  const DlRect child_bounds = DlRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  const DlPath child_path = DlPath::MakeRect(child_bounds);
   auto mock_layer = std::make_shared<MockLayer>(child_path);
   auto filter = DlImageFilter::MakeBlur(5, 5, DlTileMode::kClamp);
   auto layer =
       std::make_shared<BackdropFilterLayer>(filter, DlBlendMode::kSrcOver);
   layer->Add(mock_layer);
 
-  EXPECT_EQ(layer->paint_bounds(), kEmptyRect);
-  EXPECT_EQ(layer->child_paint_bounds(), kEmptyRect);
+  EXPECT_EQ(layer->paint_bounds(), DlRect());
+  EXPECT_EQ(layer->child_paint_bounds(), DlRect());
   EXPECT_DEATH_IF_SUPPORTED(layer->Paint(paint_context()),
                             "needs_painting\\(context\\)");
 }
 #endif
 
 TEST_F(BackdropFilterLayerTest, EmptyFilter) {
-  const SkMatrix initial_transform = SkMatrix::Translate(0.5f, 1.0f);
-  const SkRect child_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
-  const SkPath child_path = SkPath().addRect(child_bounds);
+  const DlMatrix initial_transform = DlMatrix::MakeTranslation({0.5f, 1.0f});
+  const DlRect child_bounds = DlRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  const DlPath child_path = DlPath::MakeRect(child_bounds);
   const DlPaint child_paint = DlPaint(DlColor::kYellow());
   auto mock_layer = std::make_shared<MockLayer>(child_path, child_paint);
   auto layer =
@@ -79,7 +79,7 @@ TEST_F(BackdropFilterLayerTest, EmptyFilter) {
       /* (BackdropFilter)layer::Paint */ {
         expected_builder.Save();
         {
-          expected_builder.SaveLayer(&child_bounds, nullptr, nullptr);
+          expected_builder.SaveLayer(child_bounds, nullptr, nullptr);
           {
             /* mock_layer::Paint */ {
               expected_builder.DrawPath(child_path, child_paint);
@@ -96,9 +96,9 @@ TEST_F(BackdropFilterLayerTest, EmptyFilter) {
 }
 
 TEST_F(BackdropFilterLayerTest, SimpleFilter) {
-  const SkMatrix initial_transform = SkMatrix::Translate(0.5f, 1.0f);
-  const SkRect child_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
-  const SkPath child_path = SkPath().addRect(child_bounds);
+  const DlMatrix initial_transform = DlMatrix::MakeTranslation({0.5f, 1.0f});
+  const DlRect child_bounds = DlRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  const DlPath child_path = DlPath::MakeRect(child_bounds);
   const DlPaint child_paint = DlPaint(DlColor::kYellow());
   auto layer_filter = DlImageFilter::MakeBlur(2.5, 3.2, DlTileMode::kClamp);
   auto mock_layer = std::make_shared<MockLayer>(child_path, child_paint);
@@ -125,8 +125,7 @@ TEST_F(BackdropFilterLayerTest, SimpleFilter) {
       /* (BackdropFilter)layer::Paint */ {
         expected_builder.Save();
         {
-          expected_builder.SaveLayer(&child_bounds, nullptr,
-                                     layer_filter.get());
+          expected_builder.SaveLayer(child_bounds, nullptr, layer_filter.get());
           {
             /* mock_layer::Paint */ {
               expected_builder.DrawPath(child_path, child_paint);
@@ -143,9 +142,9 @@ TEST_F(BackdropFilterLayerTest, SimpleFilter) {
 }
 
 TEST_F(BackdropFilterLayerTest, NonSrcOverBlend) {
-  const SkMatrix initial_transform = SkMatrix::Translate(0.5f, 1.0f);
-  const SkRect child_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
-  const SkPath child_path = SkPath().addRect(child_bounds);
+  const DlMatrix initial_transform = DlMatrix::MakeTranslation({0.5f, 1.0f});
+  const DlRect child_bounds = DlRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  const DlPath child_path = DlPath::MakeRect(child_bounds);
   const DlPaint child_paint = DlPaint(DlColor::kYellow());
   auto layer_filter = DlImageFilter::MakeBlur(2.5, 3.2, DlTileMode::kClamp);
   auto mock_layer = std::make_shared<MockLayer>(child_path, child_paint);
@@ -176,7 +175,7 @@ TEST_F(BackdropFilterLayerTest, NonSrcOverBlend) {
         expected_builder.Save();
         {
           DlPaint save_paint = DlPaint().setBlendMode(DlBlendMode::kSrc);
-          expected_builder.SaveLayer(&child_bounds, &save_paint,
+          expected_builder.SaveLayer(child_bounds, &save_paint,
                                      layer_filter.get());
           {
             /* mock_layer::Paint */ {
@@ -194,15 +193,14 @@ TEST_F(BackdropFilterLayerTest, NonSrcOverBlend) {
 }
 
 TEST_F(BackdropFilterLayerTest, MultipleChildren) {
-  const SkMatrix initial_transform = SkMatrix::Translate(0.5f, 1.0f);
-  const SkRect child_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 2.5f, 3.5f);
-  const SkPath child_path1 = SkPath().addRect(child_bounds);
-  const SkPath child_path2 =
-      SkPath().addRect(child_bounds.makeOffset(3.0f, 0.0f));
+  const DlMatrix initial_transform = DlMatrix::MakeTranslation({0.5f, 1.0f});
+  const DlRect child_bounds = DlRect::MakeLTRB(5.0f, 6.0f, 2.5f, 3.5f);
+  const DlPath child_path1 = DlPath::MakeRect(child_bounds);
+  const DlPath child_path2 = DlPath::MakeRect(child_bounds.Shift(3.0f, 0.0f));
   const DlPaint child_paint1 = DlPaint(DlColor::kYellow());
   const DlPaint child_paint2 = DlPaint(DlColor::kCyan());
-  SkRect children_bounds = child_path1.getBounds();
-  children_bounds.join(child_path2.getBounds());
+  const DlRect children_bounds =
+      child_path1.GetBounds().Union(child_path2.GetBounds());
   auto layer_filter = DlImageFilter::MakeBlur(2.5, 3.2, DlTileMode::kClamp);
   auto mock_layer1 = std::make_shared<MockLayer>(child_path1, child_paint1);
   auto mock_layer2 = std::make_shared<MockLayer>(child_path2, child_paint2);
@@ -216,8 +214,8 @@ TEST_F(BackdropFilterLayerTest, MultipleChildren) {
 
   preroll_context()->state_stack.set_preroll_delegate(initial_transform);
   parent->Preroll(preroll_context());
-  EXPECT_EQ(mock_layer1->paint_bounds(), child_path1.getBounds());
-  EXPECT_EQ(mock_layer2->paint_bounds(), child_path2.getBounds());
+  EXPECT_EQ(mock_layer1->paint_bounds(), child_path1.GetBounds());
+  EXPECT_EQ(mock_layer2->paint_bounds(), child_path2.GetBounds());
   EXPECT_EQ(layer->paint_bounds(), children_bounds);
   EXPECT_EQ(layer->child_paint_bounds(), children_bounds);
   EXPECT_TRUE(mock_layer1->needs_painting(paint_context()));
@@ -236,7 +234,7 @@ TEST_F(BackdropFilterLayerTest, MultipleChildren) {
       /* (BackdropFilter)layer::Paint */ {
         expected_builder.Save();
         {
-          expected_builder.SaveLayer(&children_bounds, nullptr,
+          expected_builder.SaveLayer(children_bounds, nullptr,
                                      layer_filter.get());
           {
             /* mock_layer1::Paint */ {
@@ -257,15 +255,14 @@ TEST_F(BackdropFilterLayerTest, MultipleChildren) {
 }
 
 TEST_F(BackdropFilterLayerTest, Nested) {
-  const SkMatrix initial_transform = SkMatrix::Translate(0.5f, 1.0f);
-  const SkRect child_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 2.5f, 3.5f);
-  const SkPath child_path1 = SkPath().addRect(child_bounds);
-  const SkPath child_path2 =
-      SkPath().addRect(child_bounds.makeOffset(3.0f, 0.0f));
+  const DlMatrix initial_transform = DlMatrix::MakeTranslation({0.5f, 1.0f});
+  const DlRect child_bounds = DlRect::MakeLTRB(5.0f, 6.0f, 2.5f, 3.5f);
+  const DlPath child_path1 = DlPath::MakeRect(child_bounds);
+  const DlPath child_path2 = DlPath::MakeRect(child_bounds.Shift(3.0f, 0.0f));
   const DlPaint child_paint1 = DlPaint(DlColor::kYellow());
   const DlPaint child_paint2 = DlPaint(DlColor::kCyan());
-  SkRect children_bounds = child_path1.getBounds();
-  children_bounds.join(child_path2.getBounds());
+  const DlRect children_bounds =
+      child_path1.GetBounds().Union(child_path2.GetBounds());
   auto layer_filter1 = DlImageFilter::MakeBlur(2.5, 3.2, DlTileMode::kClamp);
   auto layer_filter2 = DlImageFilter::MakeBlur(2.7, 3.1, DlTileMode::kDecal);
   auto mock_layer1 = std::make_shared<MockLayer>(child_path1, child_paint1);
@@ -284,8 +281,8 @@ TEST_F(BackdropFilterLayerTest, Nested) {
   preroll_context()->state_stack.set_preroll_delegate(initial_transform);
   parent->Preroll(preroll_context());
 
-  EXPECT_EQ(mock_layer1->paint_bounds(), child_path1.getBounds());
-  EXPECT_EQ(mock_layer2->paint_bounds(), child_path2.getBounds());
+  EXPECT_EQ(mock_layer1->paint_bounds(), child_path1.GetBounds());
+  EXPECT_EQ(mock_layer2->paint_bounds(), child_path2.GetBounds());
   EXPECT_EQ(layer1->paint_bounds(), children_bounds);
   EXPECT_EQ(layer2->paint_bounds(), children_bounds);
   EXPECT_TRUE(mock_layer1->needs_painting(paint_context()));
@@ -305,7 +302,7 @@ TEST_F(BackdropFilterLayerTest, Nested) {
       /* (BackdropFilter)layer1::Paint */ {
         expected_builder.Save();
         {
-          expected_builder.SaveLayer(&children_bounds, nullptr,
+          expected_builder.SaveLayer(children_bounds, nullptr,
                                      layer_filter1.get());
           {
             /* mock_layer1::Paint */ {
@@ -314,7 +311,7 @@ TEST_F(BackdropFilterLayerTest, Nested) {
             /* (BackdropFilter)layer2::Paint */ {
               expected_builder.Save();
               {
-                expected_builder.SaveLayer(&children_bounds, nullptr,
+                expected_builder.SaveLayer(children_bounds, nullptr,
                                            layer_filter2.get());
                 {
                   /* mock_layer2::Paint */ {
@@ -339,7 +336,7 @@ TEST_F(BackdropFilterLayerTest, Nested) {
 TEST_F(BackdropFilterLayerTest, Readback) {
   std::shared_ptr<DlImageFilter> no_filter;
   auto layer_filter = DlImageFilter::MakeBlur(5, 5, DlTileMode::kClamp);
-  auto initial_transform = SkMatrix();
+  auto initial_transform = DlMatrix();
 
   // BDF with filter always reads from surface
   auto layer1 = std::make_shared<BackdropFilterLayer>(layer_filter,
@@ -362,7 +359,7 @@ TEST_F(BackdropFilterLayerTest, Readback) {
   EXPECT_TRUE(preroll_context()->surface_needs_readback);
 
   // BDF with no filter blocks child with readback
-  auto mock_layer = std::make_shared<MockLayer>(SkPath(), DlPaint());
+  auto mock_layer = std::make_shared<MockLayer>(DlPath(), DlPaint());
   mock_layer->set_fake_reads_surface(true);
   layer2->Add(mock_layer);
   preroll_context()->surface_needs_readback = false;
@@ -372,12 +369,12 @@ TEST_F(BackdropFilterLayerTest, Readback) {
 
 TEST_F(BackdropFilterLayerTest, OpacityInheritance) {
   auto backdrop_filter = DlImageFilter::MakeBlur(5, 5, DlTileMode::kClamp);
-  const SkPath mock_path = SkPath().addRect(SkRect::MakeLTRB(0, 0, 10, 10));
+  const DlPath mock_path = DlPath::MakeRectLTRB(0, 0, 10, 10);
   const DlPaint mock_paint = DlPaint(DlColor::kRed());
-  const SkRect clip_rect = SkRect::MakeLTRB(0, 0, 100, 100);
+  const DlRect clip_rect = DlRect::MakeLTRB(0, 0, 100, 100);
 
   auto clip = std::make_shared<ClipRectLayer>(clip_rect, Clip::kHardEdge);
-  auto parent = std::make_shared<OpacityLayer>(128, SkPoint::Make(0, 0));
+  auto parent = std::make_shared<OpacityLayer>(128, DlPoint());
   auto layer = std::make_shared<BackdropFilterLayer>(backdrop_filter,
                                                      DlBlendMode::kSrcOver);
   auto child = std::make_shared<MockLayer>(mock_path, mock_paint);
@@ -399,7 +396,7 @@ TEST_F(BackdropFilterLayerTest, OpacityInheritance) {
         /* BackdropFilterLayer::Paint */ {
           DlPaint save_paint;
           save_paint.setAlpha(128);
-          expected_builder.SaveLayer(&clip_rect, &save_paint,
+          expected_builder.SaveLayer(clip_rect, &save_paint,
                                      backdrop_filter.get());
           {
             /* MockLayer::Paint */ {
@@ -431,75 +428,76 @@ TEST_F(BackdropLayerDiffTest, BackdropLayer) {
     EXPECT_EQ(readback, DlIRect::MakeLTRB(-30, -30, 40, 40));
   }
 
-  MockLayerTree l1(SkISize::Make(100, 100));
+  MockLayerTree l1(DlISize(100, 100));
   l1.root()->Add(
       std::make_shared<BackdropFilterLayer>(filter, DlBlendMode::kSrcOver));
 
   // no clip, effect over entire surface
-  auto damage = DiffLayerTree(l1, MockLayerTree(SkISize::Make(100, 100)));
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeWH(100, 100));
+  auto damage = DiffLayerTree(l1, MockLayerTree(DlISize(100, 100)));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeWH(100, 100));
 
-  MockLayerTree l2(SkISize::Make(100, 100));
+  MockLayerTree l2(DlISize(100, 100));
 
-  auto clip = std::make_shared<ClipRectLayer>(SkRect::MakeLTRB(20, 20, 60, 60),
+  auto clip = std::make_shared<ClipRectLayer>(DlRect::MakeLTRB(20, 20, 60, 60),
                                               Clip::kHardEdge);
   clip->Add(
       std::make_shared<BackdropFilterLayer>(filter, DlBlendMode::kSrcOver));
   l2.root()->Add(clip);
-  damage = DiffLayerTree(l2, MockLayerTree(SkISize::Make(100, 100)));
+  damage = DiffLayerTree(l2, MockLayerTree(DlISize(100, 100)));
 
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(0, 0, 90, 90));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(0, 0, 90, 90));
 
   MockLayerTree l3;
-  auto scale = std::make_shared<TransformLayer>(SkMatrix::Scale(2.0, 2.0));
+  auto scale =
+      std::make_shared<TransformLayer>(DlMatrix::MakeScale({2.0, 2.0, 1.0f}));
   scale->Add(clip);
   l3.root()->Add(scale);
 
   damage = DiffLayerTree(l3, MockLayerTree());
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(0, 0, 180, 180));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(0, 0, 180, 180));
 
   MockLayerTree l4;
   l4.root()->Add(scale);
 
   // path just outside of readback region, doesn't affect blur
-  auto path1 = SkPath().addRect(SkRect::MakeLTRB(180, 180, 190, 190));
+  auto path1 = DlPath::MakeRectLTRB(180, 180, 190, 190);
   l4.root()->Add(std::make_shared<MockLayer>(path1));
   damage = DiffLayerTree(l4, l3);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(180, 180, 190, 190));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(180, 180, 190, 190));
 
   MockLayerTree l5;
   l5.root()->Add(scale);
 
   // path just inside of readback region, must trigger backdrop repaint
-  auto path2 = SkPath().addRect(SkRect::MakeLTRB(179, 179, 189, 189));
+  auto path2 = DlPath::MakeRectLTRB(179, 179, 189, 189);
   l5.root()->Add(std::make_shared<MockLayer>(path2));
   damage = DiffLayerTree(l5, l4);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(0, 0, 190, 190));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(0, 0, 190, 190));
 }
 
 TEST_F(BackdropLayerDiffTest, ReadbackOutsideOfPaintArea) {
   auto filter = DlImageFilter::MakeMatrix(DlMatrix::MakeTranslation({50, 50}),
                                           DlImageSampling::kLinear);
 
-  MockLayerTree l1(SkISize::Make(100, 100));
+  MockLayerTree l1(DlISize(100, 100));
 
-  auto clip = std::make_shared<ClipRectLayer>(SkRect::MakeLTRB(60, 60, 80, 80),
+  auto clip = std::make_shared<ClipRectLayer>(DlRect::MakeLTRB(60, 60, 80, 80),
                                               Clip::kHardEdge);
   clip->Add(
       std::make_shared<BackdropFilterLayer>(filter, DlBlendMode::kSrcOver));
   l1.root()->Add(clip);
-  auto damage = DiffLayerTree(l1, MockLayerTree(SkISize::Make(100, 100)));
+  auto damage = DiffLayerTree(l1, MockLayerTree(DlISize(100, 100)));
 
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(60 - 50, 60 - 50, 80, 80));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(60 - 50, 60 - 50, 80, 80));
 
-  MockLayerTree l2(SkISize::Make(100, 100));
+  MockLayerTree l2(DlISize(100, 100));
   // path inside readback area must trigger whole readback repaint + filter
   // repaint.
-  auto path2 = SkPath().addRect(SkRect::MakeXYWH(60 - 50, 60 - 50, 10, 10));
+  auto path2 = DlPath::MakeRectXYWH(60 - 50, 60 - 50, 10, 10);
   l2.root()->Add(clip);
   l2.root()->Add(std::make_shared<MockLayer>(path2));
   damage = DiffLayerTree(l2, l1);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(60 - 50, 60 - 50, 80, 80));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(60 - 50, 60 - 50, 80, 80));
 }
 
 TEST_F(BackdropLayerDiffTest, BackdropLayerInvalidTransform) {
@@ -514,18 +512,23 @@ TEST_F(BackdropLayerDiffTest, BackdropLayerInvalidTransform) {
     EXPECT_EQ(readback, DlIRect::MakeLTRB(-30, -30, 40, 40));
   }
 
-  MockLayerTree l1(SkISize::Make(100, 100));
-  SkMatrix transform;
-  transform.setPerspX(0.1);
-  transform.setPerspY(0.1);
+  MockLayerTree l1(DlISize(100, 100));
+  // clang-format off
+  DlMatrix transform(
+      1, 0, 0, 0.1f,
+      0, 1, 0, 0.1f,
+      0, 0, 1, 0,
+      0, 0, 0, 1
+  );
+  // clang-format on
 
   auto transform_layer = std::make_shared<TransformLayer>(transform);
   l1.root()->Add(transform_layer);
   transform_layer->Add(
       std::make_shared<BackdropFilterLayer>(filter, DlBlendMode::kSrcOver));
 
-  auto damage = DiffLayerTree(l1, MockLayerTree(SkISize::Make(100, 100)));
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeWH(100, 100));
+  auto damage = DiffLayerTree(l1, MockLayerTree(DlISize(100, 100)));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeWH(100, 100));
 }
 
 }  // namespace testing

--- a/flow/layers/cacheable_layer.cc
+++ b/flow/layers/cacheable_layer.cc
@@ -8,7 +8,7 @@ namespace flutter {
 
 AutoCache::AutoCache(RasterCacheItem* raster_cache_item,
                      PrerollContext* context,
-                     const SkMatrix& matrix)
+                     const DlMatrix& matrix)
     : raster_cache_item_(raster_cache_item),
       context_(context),
       matrix_(matrix) {

--- a/flow/layers/cacheable_layer.h
+++ b/flow/layers/cacheable_layer.h
@@ -17,7 +17,7 @@ class AutoCache {
  public:
   AutoCache(RasterCacheItem* raster_cache_item,
             PrerollContext* context,
-            const SkMatrix& matrix);
+            const DlMatrix& matrix);
 
   void ShouldNotBeCached() { raster_cache_item_ = nullptr; }
 
@@ -27,7 +27,7 @@ class AutoCache {
   inline bool IsCacheEnabled();
   RasterCacheItem* raster_cache_item_ = nullptr;
   [[maybe_unused]] PrerollContext* context_ = nullptr;
-  const SkMatrix matrix_;
+  const DlMatrix matrix_;
 };
 
 class CacheableContainerLayer : public ContainerLayer {

--- a/flow/layers/clip_path_layer.cc
+++ b/flow/layers/clip_path_layer.cc
@@ -9,14 +9,13 @@ namespace flutter {
 ClipPathLayer::ClipPathLayer(const DlPath& clip_path, Clip clip_behavior)
     : ClipShapeLayer(clip_path, clip_behavior) {}
 
-const SkRect& ClipPathLayer::clip_shape_bounds() const {
-  return clip_shape().GetSkPath().getBounds();
+const DlRect ClipPathLayer::clip_shape_bounds() const {
+  return clip_shape().GetBounds();
 }
 
 void ClipPathLayer::ApplyClip(LayerStateStack::MutatorContext& mutator) const {
   clip_shape().WillRenderSkPath();
-  mutator.clipPath(clip_shape().GetSkPath(),
-                   clip_behavior() != Clip::kHardEdge);
+  mutator.clipPath(clip_shape(), clip_behavior() != Clip::kHardEdge);
 }
 
 }  // namespace flutter

--- a/flow/layers/clip_path_layer.h
+++ b/flow/layers/clip_path_layer.h
@@ -17,7 +17,7 @@ class ClipPathLayer : public ClipShapeLayer<DlPath> {
                          Clip clip_behavior = Clip::kAntiAlias);
 
  protected:
-  const SkRect& clip_shape_bounds() const override;
+  const DlRect clip_shape_bounds() const override;
 
   void ApplyClip(LayerStateStack::MutatorContext& mutator) const override;
 

--- a/flow/layers/clip_rect_layer.cc
+++ b/flow/layers/clip_rect_layer.cc
@@ -6,10 +6,10 @@
 
 namespace flutter {
 
-ClipRectLayer::ClipRectLayer(const SkRect& clip_rect, Clip clip_behavior)
+ClipRectLayer::ClipRectLayer(const DlRect& clip_rect, Clip clip_behavior)
     : ClipShapeLayer(clip_rect, clip_behavior) {}
 
-const SkRect& ClipRectLayer::clip_shape_bounds() const {
+const DlRect ClipRectLayer::clip_shape_bounds() const {
   return clip_shape();
 }
 

--- a/flow/layers/clip_rect_layer.h
+++ b/flow/layers/clip_rect_layer.h
@@ -9,12 +9,12 @@
 
 namespace flutter {
 
-class ClipRectLayer : public ClipShapeLayer<SkRect> {
+class ClipRectLayer : public ClipShapeLayer<DlRect> {
  public:
-  ClipRectLayer(const SkRect& clip_rect, Clip clip_behavior);
+  ClipRectLayer(const DlRect& clip_rect, Clip clip_behavior);
 
  protected:
-  const SkRect& clip_shape_bounds() const override;
+  const DlRect clip_shape_bounds() const override;
 
   void ApplyClip(LayerStateStack::MutatorContext& mutator) const override;
 

--- a/flow/layers/clip_rrect_layer.cc
+++ b/flow/layers/clip_rrect_layer.cc
@@ -6,11 +6,12 @@
 
 namespace flutter {
 
-ClipRRectLayer::ClipRRectLayer(const SkRRect& clip_rrect, Clip clip_behavior)
+ClipRRectLayer::ClipRRectLayer(const DlRoundRect& clip_rrect,
+                               Clip clip_behavior)
     : ClipShapeLayer(clip_rrect, clip_behavior) {}
 
-const SkRect& ClipRRectLayer::clip_shape_bounds() const {
-  return clip_shape().getBounds();
+const DlRect ClipRRectLayer::clip_shape_bounds() const {
+  return clip_shape().GetBounds();
 }
 
 void ClipRRectLayer::ApplyClip(LayerStateStack::MutatorContext& mutator) const {

--- a/flow/layers/clip_rrect_layer.h
+++ b/flow/layers/clip_rrect_layer.h
@@ -9,12 +9,12 @@
 
 namespace flutter {
 
-class ClipRRectLayer : public ClipShapeLayer<SkRRect> {
+class ClipRRectLayer : public ClipShapeLayer<DlRoundRect> {
  public:
-  ClipRRectLayer(const SkRRect& clip_rrect, Clip clip_behavior);
+  ClipRRectLayer(const DlRoundRect& clip_rrect, Clip clip_behavior);
 
  protected:
-  const SkRect& clip_shape_bounds() const override;
+  const DlRect clip_shape_bounds() const override;
 
   void ApplyClip(LayerStateStack::MutatorContext& mutator) const override;
 

--- a/flow/layers/clip_shape_layer.h
+++ b/flow/layers/clip_shape_layer.h
@@ -50,7 +50,7 @@ class ClipShapeLayer : public CacheableContainerLayer {
     // nullptr which mean we don't do raster cache logic.
     AutoCache cache =
         AutoCache(uses_save_layer ? layer_raster_cache_item_.get() : nullptr,
-                  context, context->state_stack.transform_3x3());
+                  context, context->state_stack.matrix());
 #endif  //  !SLIMPELLER
 
     Layer::AutoPrerollSaveLayerState save =
@@ -59,13 +59,10 @@ class ClipShapeLayer : public CacheableContainerLayer {
     auto mutator = context->state_stack.save();
     ApplyClip(mutator);
 
-    SkRect child_paint_bounds = SkRect::MakeEmpty();
+    DlRect child_paint_bounds;
     PrerollChildren(context, &child_paint_bounds);
-    if (child_paint_bounds.intersect(clip_shape_bounds())) {
-      set_paint_bounds(child_paint_bounds);
-    } else {
-      set_paint_bounds(SkRect::MakeEmpty());
-    }
+    set_paint_bounds(
+        child_paint_bounds.IntersectionOrEmpty(clip_shape_bounds()));
 
     // If we use a SaveLayer then we can accept opacity on behalf
     // of our children and apply it in the saveLayer.
@@ -108,7 +105,7 @@ class ClipShapeLayer : public CacheableContainerLayer {
   }
 
  protected:
-  virtual const SkRect& clip_shape_bounds() const = 0;
+  virtual const DlRect clip_shape_bounds() const = 0;
   virtual void ApplyClip(LayerStateStack::MutatorContext& mutator) const = 0;
   virtual ~ClipShapeLayer() = default;
 

--- a/flow/layers/color_filter_layer.cc
+++ b/flow/layers/color_filter_layer.cc
@@ -41,7 +41,7 @@ void ColorFilterLayer::Preroll(PrerollContext* context) {
       Layer::AutoPrerollSaveLayerState::Create(context);
 #if !SLIMPELLER
   AutoCache cache = AutoCache(layer_raster_cache_item_.get(), context,
-                              context->state_stack.transform_3x3());
+                              context->state_stack.matrix());
 #endif  //  !SLIMPELLER
 
   ContainerLayer::Preroll(context);

--- a/flow/layers/container_layer.h
+++ b/flow/layers/container_layer.h
@@ -32,8 +32,8 @@ class ContainerLayer : public Layer {
 
   const ContainerLayer* as_container_layer() const override { return this; }
 
-  const SkRect& child_paint_bounds() const { return child_paint_bounds_; }
-  void set_child_paint_bounds(const SkRect& bounds) {
+  const DlRect& child_paint_bounds() const { return child_paint_bounds_; }
+  void set_child_paint_bounds(const DlRect& bounds) {
     child_paint_bounds_ = bounds;
   }
 
@@ -45,11 +45,11 @@ class ContainerLayer : public Layer {
   }
 
  protected:
-  void PrerollChildren(PrerollContext* context, SkRect* child_paint_bounds);
+  void PrerollChildren(PrerollContext* context, DlRect* child_paint_bounds);
 
  private:
   std::vector<std::shared_ptr<Layer>> layers_;
-  SkRect child_paint_bounds_;
+  DlRect child_paint_bounds_;
   int children_renderable_state_flags_ = 0;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ContainerLayer);

--- a/flow/layers/container_layer_unittests.cc
+++ b/flow/layers/container_layer_unittests.cc
@@ -11,7 +11,6 @@
 #include "flutter/flow/testing/mock_layer.h"
 #include "flutter/fml/macros.h"
 #include "gtest/gtest.h"
-#include "include/core/SkMatrix.h"
 
 // TODO(zanderso): https://github.com/flutter/flutter/issues/127701
 // NOLINTBEGIN(bugprone-unchecked-optional-access)
@@ -42,8 +41,8 @@ TEST_F(ContainerLayerTest, PaintingEmptyLayerDies) {
   auto layer = std::make_shared<ContainerLayer>();
 
   layer->Preroll(preroll_context());
-  EXPECT_EQ(layer->paint_bounds(), SkRect::MakeEmpty());
-  EXPECT_EQ(layer->child_paint_bounds(), SkRect::MakeEmpty());
+  EXPECT_EQ(layer->paint_bounds(), DlRect());
+  EXPECT_EQ(layer->child_paint_bounds(), DlRect());
   EXPECT_FALSE(layer->needs_painting(paint_context()));
 
   EXPECT_DEATH_IF_SUPPORTED(layer->Paint(paint_context()),
@@ -51,24 +50,21 @@ TEST_F(ContainerLayerTest, PaintingEmptyLayerDies) {
 }
 
 TEST_F(ContainerLayerTest, PaintBeforePrerollDies) {
-  SkPath child_path;
-  child_path.addRect(5.0f, 6.0f, 20.5f, 21.5f);
+  DlPath child_path = DlPath::MakeRectLTRB(5.0f, 6.0f, 20.5f, 21.5f);
   auto mock_layer = std::make_shared<MockLayer>(child_path);
   auto layer = std::make_shared<ContainerLayer>();
   layer->Add(mock_layer);
 
-  EXPECT_EQ(layer->paint_bounds(), SkRect::MakeEmpty());
-  EXPECT_EQ(layer->child_paint_bounds(), SkRect::MakeEmpty());
+  EXPECT_EQ(layer->paint_bounds(), DlRect());
+  EXPECT_EQ(layer->child_paint_bounds(), DlRect());
   EXPECT_DEATH_IF_SUPPORTED(layer->Paint(paint_context()),
                             "needs_painting\\(context\\)");
 }
 #endif
 
 TEST_F(ContainerLayerTest, LayerWithParentHasTextureLayerNeedsResetFlag) {
-  SkPath child_path1;
-  child_path1.addRect(5.0f, 6.0f, 20.5f, 21.5f);
-  SkPath child_path2;
-  child_path2.addRect(8.0f, 2.0f, 16.5f, 14.5f);
+  DlPath child_path1 = DlPath::MakeRectLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  DlPath child_path2 = DlPath::MakeRectLTRB(8.0f, 2.0f, 16.5f, 14.5f);
   DlPaint child_paint1 = DlPaint(DlColor::kMidGrey());
   DlPaint child_paint2 = DlPaint(DlColor::kGreen());
 
@@ -92,10 +88,9 @@ TEST_F(ContainerLayerTest, LayerWithParentHasTextureLayerNeedsResetFlag) {
 }
 
 TEST_F(ContainerLayerTest, Simple) {
-  SkPath child_path;
-  child_path.addRect(5.0f, 6.0f, 20.5f, 21.5f);
+  DlPath child_path = DlPath::MakeRectLTRB(5.0f, 6.0f, 20.5f, 21.5f);
   DlPaint child_paint = DlPaint(DlColor::kGreen());
-  SkMatrix initial_transform = SkMatrix::Translate(-0.5f, -0.5f);
+  DlMatrix initial_transform = DlMatrix::MakeTranslation({-0.5f, -0.5f});
 
   auto mock_layer = std::make_shared<MockLayer>(child_path, child_paint);
   auto layer = std::make_shared<ContainerLayer>();
@@ -104,8 +99,8 @@ TEST_F(ContainerLayerTest, Simple) {
   preroll_context()->state_stack.set_preroll_delegate(initial_transform);
   layer->Preroll(preroll_context());
   EXPECT_FALSE(preroll_context()->has_platform_view);
-  EXPECT_EQ(mock_layer->paint_bounds(), child_path.getBounds());
-  EXPECT_EQ(layer->paint_bounds(), child_path.getBounds());
+  EXPECT_EQ(mock_layer->paint_bounds(), child_path.GetBounds());
+  EXPECT_EQ(layer->paint_bounds(), child_path.GetBounds());
   EXPECT_EQ(layer->child_paint_bounds(), layer->paint_bounds());
   EXPECT_TRUE(mock_layer->needs_painting(paint_context()));
   EXPECT_TRUE(layer->needs_painting(paint_context()));
@@ -123,13 +118,11 @@ TEST_F(ContainerLayerTest, Simple) {
 }
 
 TEST_F(ContainerLayerTest, Multiple) {
-  SkPath child_path1;
-  child_path1.addRect(5.0f, 6.0f, 20.5f, 21.5f);
-  SkPath child_path2;
-  child_path2.addRect(8.0f, 2.0f, 16.5f, 14.5f);
+  DlPath child_path1 = DlPath::MakeRectLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  DlPath child_path2 = DlPath::MakeRectLTRB(8.0f, 2.0f, 16.5f, 14.5f);
   DlPaint child_paint1 = DlPaint(DlColor::kMidGrey());
   DlPaint child_paint2 = DlPaint(DlColor::kGreen());
-  SkMatrix initial_transform = SkMatrix::Translate(-0.5f, -0.5f);
+  DlMatrix initial_transform = DlMatrix::MakeTranslation({-0.5f, -0.5f});
 
   auto mock_layer1 = std::make_shared<MockLayer>(child_path1, child_paint1);
   mock_layer1->set_fake_has_platform_view(true);
@@ -138,13 +131,13 @@ TEST_F(ContainerLayerTest, Multiple) {
   layer->Add(mock_layer1);
   layer->Add(mock_layer2);
 
-  SkRect expected_total_bounds = child_path1.getBounds();
-  expected_total_bounds.join(child_path2.getBounds());
+  DlRect expected_total_bounds =
+      child_path1.GetBounds().Union(child_path2.GetBounds());
   preroll_context()->state_stack.set_preroll_delegate(initial_transform);
   layer->Preroll(preroll_context());
   EXPECT_TRUE(preroll_context()->has_platform_view);
-  EXPECT_EQ(mock_layer1->paint_bounds(), child_path1.getBounds());
-  EXPECT_EQ(mock_layer2->paint_bounds(), child_path2.getBounds());
+  EXPECT_EQ(mock_layer1->paint_bounds(), child_path1.GetBounds());
+  EXPECT_EQ(mock_layer2->paint_bounds(), child_path2.GetBounds());
   EXPECT_EQ(layer->paint_bounds(), expected_total_bounds);
   EXPECT_EQ(layer->child_paint_bounds(), layer->paint_bounds());
   EXPECT_TRUE(mock_layer1->needs_painting(paint_context()));
@@ -170,14 +163,13 @@ TEST_F(ContainerLayerTest, Multiple) {
 }
 
 TEST_F(ContainerLayerTest, MultipleWithEmpty) {
-  SkPath child_path1;
-  child_path1.addRect(5.0f, 6.0f, 20.5f, 21.5f);
+  DlPath child_path1 = DlPath::MakeRectLTRB(5.0f, 6.0f, 20.5f, 21.5f);
   DlPaint child_paint1 = DlPaint(DlColor::kMidGrey());
   DlPaint child_paint2 = DlPaint(DlColor::kGreen());
-  SkMatrix initial_transform = SkMatrix::Translate(-0.5f, -0.5f);
+  DlMatrix initial_transform = DlMatrix::MakeTranslation({-0.5f, -0.5f});
 
   auto mock_layer1 = std::make_shared<MockLayer>(child_path1, child_paint1);
-  auto mock_layer2 = std::make_shared<MockLayer>(SkPath(), child_paint2);
+  auto mock_layer2 = std::make_shared<MockLayer>(DlPath(), child_paint2);
   auto layer = std::make_shared<ContainerLayer>();
   layer->Add(mock_layer1);
   layer->Add(mock_layer2);
@@ -185,9 +177,9 @@ TEST_F(ContainerLayerTest, MultipleWithEmpty) {
   preroll_context()->state_stack.set_preroll_delegate(initial_transform);
   layer->Preroll(preroll_context());
   EXPECT_FALSE(preroll_context()->has_platform_view);
-  EXPECT_EQ(mock_layer1->paint_bounds(), child_path1.getBounds());
-  EXPECT_EQ(mock_layer2->paint_bounds(), SkPath().getBounds());
-  EXPECT_EQ(layer->paint_bounds(), child_path1.getBounds());
+  EXPECT_EQ(mock_layer1->paint_bounds(), child_path1.GetBounds());
+  EXPECT_EQ(mock_layer2->paint_bounds(), DlPath().GetBounds());
+  EXPECT_EQ(layer->paint_bounds(), child_path1.GetBounds());
   EXPECT_EQ(layer->child_paint_bounds(), layer->paint_bounds());
   EXPECT_TRUE(mock_layer1->needs_painting(paint_context()));
   EXPECT_FALSE(mock_layer2->needs_painting(paint_context()));
@@ -209,13 +201,11 @@ TEST_F(ContainerLayerTest, MultipleWithEmpty) {
 }
 
 TEST_F(ContainerLayerTest, NeedsSystemComposite) {
-  SkPath child_path1;
-  child_path1.addRect(5.0f, 6.0f, 20.5f, 21.5f);
-  SkPath child_path2;
-  child_path2.addRect(8.0f, 2.0f, 16.5f, 14.5f);
+  DlPath child_path1 = DlPath::MakeRectLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  DlPath child_path2 = DlPath::MakeRectLTRB(8.0f, 2.0f, 16.5f, 14.5f);
   DlPaint child_paint1 = DlPaint(DlColor::kMidGrey());
   DlPaint child_paint2 = DlPaint(DlColor::kGreen());
-  SkMatrix initial_transform = SkMatrix::Translate(-0.5f, -0.5f);
+  DlMatrix initial_transform = DlMatrix::MakeTranslation({-0.5f, -0.5f});
 
   auto mock_layer1 = std::make_shared<MockLayer>(child_path1, child_paint1);
   mock_layer1->set_fake_has_platform_view(false);
@@ -224,13 +214,13 @@ TEST_F(ContainerLayerTest, NeedsSystemComposite) {
   layer->Add(mock_layer1);
   layer->Add(mock_layer2);
 
-  SkRect expected_total_bounds = child_path1.getBounds();
-  expected_total_bounds.join(child_path2.getBounds());
+  DlRect expected_total_bounds =
+      child_path1.GetBounds().Union(child_path2.GetBounds());
   preroll_context()->state_stack.set_preroll_delegate(initial_transform);
   layer->Preroll(preroll_context());
   EXPECT_FALSE(preroll_context()->has_platform_view);
-  EXPECT_EQ(mock_layer1->paint_bounds(), child_path1.getBounds());
-  EXPECT_EQ(mock_layer2->paint_bounds(), child_path2.getBounds());
+  EXPECT_EQ(mock_layer1->paint_bounds(), child_path1.GetBounds());
+  EXPECT_EQ(mock_layer2->paint_bounds(), child_path2.GetBounds());
   EXPECT_EQ(layer->paint_bounds(), expected_total_bounds);
   EXPECT_EQ(layer->child_paint_bounds(), layer->paint_bounds());
   EXPECT_TRUE(mock_layer1->needs_painting(paint_context()));
@@ -256,9 +246,9 @@ TEST_F(ContainerLayerTest, NeedsSystemComposite) {
 
 TEST_F(ContainerLayerTest, RasterCacheTest) {
   // LTRB
-  const SkPath child_path1 = SkPath().addRect(5.0f, 6.0f, 20.5f, 21.5f);
-  const SkPath child_path2 = SkPath().addRect(21.0f, 6.0f, 25.5f, 21.5f);
-  const SkPath child_path3 = SkPath().addRect(26.0f, 6.0f, 30.5f, 21.5f);
+  const DlPath child_path1 = DlPath::MakeRectLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  const DlPath child_path2 = DlPath::MakeRectLTRB(21.0f, 6.0f, 25.5f, 21.5f);
+  const DlPath child_path3 = DlPath::MakeRectLTRB(26.0f, 6.0f, 30.5f, 21.5f);
   const DlPaint child_paint1 = DlPaint(DlColor::kMidGrey());
   const DlPaint child_paint2 = DlPaint(DlColor::kGreen());
   const DlPaint paint;
@@ -289,7 +279,7 @@ TEST_F(ContainerLayerTest, RasterCacheTest) {
   // clang-format on
 
   auto mock_layer1 = std::make_shared<MockLayer>(child_path1, child_paint1);
-  auto mock_layer2 = std::make_shared<MockLayer>(SkPath(), child_paint2);
+  auto mock_layer2 = std::make_shared<MockLayer>(DlPath(), child_paint2);
   auto mock_layer3 = std::make_shared<MockLayer>(child_path2, paint);
 
   cacheable_container_layer1->Add(mock_layer1);
@@ -311,13 +301,13 @@ TEST_F(ContainerLayerTest, RasterCacheTest) {
   layer->Preroll(preroll_context());
 
   EXPECT_EQ(mock_layer1->paint_bounds(),
-            SkRect::MakeLTRB(5.f, 6.f, 20.5f, 21.5f));
+            DlRect::MakeLTRB(5.f, 6.f, 20.5f, 21.5f));
   EXPECT_EQ(mock_layer3->paint_bounds(),
-            SkRect::MakeLTRB(21.0f, 6.0f, 25.5f, 21.5f));
+            DlRect::MakeLTRB(21.0f, 6.0f, 25.5f, 21.5f));
   EXPECT_EQ(cacheable_layer111->paint_bounds(),
-            SkRect::MakeLTRB(26.0f, 6.0f, 30.5f, 21.5f));
+            DlRect::MakeLTRB(26.0f, 6.0f, 30.5f, 21.5f));
   EXPECT_EQ(cacheable_container_layer1->paint_bounds(),
-            SkRect::MakeLTRB(5.f, 6.f, 30.5f, 21.5f));
+            DlRect::MakeLTRB(5.f, 6.f, 30.5f, 21.5f));
 
   // the preroll context's raster cache is nullptr
   EXPECT_EQ(preroll_context()->raster_cached_entries->size(),
@@ -476,7 +466,7 @@ TEST_F(ContainerLayerTest, RasterCacheTest) {
 }
 
 TEST_F(ContainerLayerTest, OpacityInheritance) {
-  auto path1 = SkPath().addRect({10, 10, 30, 30});
+  auto path1 = DlPath::MakeRectLTRB(10, 10, 30, 30);
   auto mock1 = MockLayer::MakeOpacityCompatible(path1);
   auto container1 = std::make_shared<ContainerLayer>();
   container1->Add(mock1);
@@ -487,7 +477,7 @@ TEST_F(ContainerLayerTest, OpacityInheritance) {
   EXPECT_EQ(context->renderable_state_flags,
             LayerStateStack::kCallerCanApplyOpacity);
 
-  auto path2 = SkPath().addRect({40, 40, 50, 50});
+  auto path2 = DlPath::MakeRectLTRB(40, 40, 50, 50);
   auto mock2 = MockLayer::MakeOpacityCompatible(path2);
   container1->Add(mock2);
 
@@ -497,7 +487,7 @@ TEST_F(ContainerLayerTest, OpacityInheritance) {
   EXPECT_EQ(context->renderable_state_flags,
             LayerStateStack::kCallerCanApplyOpacity);
 
-  auto path3 = SkPath().addRect({20, 20, 40, 40});
+  auto path3 = DlPath::MakeRectLTRB(20, 20, 40, 40);
   auto mock3 = MockLayer::MakeOpacityCompatible(path3);
   container1->Add(mock3);
 
@@ -515,7 +505,7 @@ TEST_F(ContainerLayerTest, OpacityInheritance) {
   EXPECT_EQ(context->renderable_state_flags,
             LayerStateStack::kCallerCanApplyOpacity);
 
-  auto path4 = SkPath().addRect({60, 60, 70, 70});
+  auto path4 = DlPath::MakeRectLTRB(60, 60, 70, 70);
   auto mock4 = MockLayer::Make(path4);
   container2->Add(mock4);
 
@@ -526,12 +516,11 @@ TEST_F(ContainerLayerTest, OpacityInheritance) {
 }
 
 TEST_F(ContainerLayerTest, CollectionCacheableLayer) {
-  SkPath child_path;
-  child_path.addRect(5.0f, 6.0f, 20.5f, 21.5f);
+  DlPath child_path = DlPath::MakeRectLTRB(5.0f, 6.0f, 20.5f, 21.5f);
   DlPaint child_paint = DlPaint(DlColor::kGreen());
-  SkMatrix initial_transform = SkMatrix::Translate(-0.5f, -0.5f);
+  DlMatrix initial_transform = DlMatrix::MakeTranslation({-0.5f, -0.5f});
 
-  auto mock_layer1 = std::make_shared<MockLayer>(SkPath(), child_paint);
+  auto mock_layer1 = std::make_shared<MockLayer>(DlPath(), child_paint);
   auto mock_cacheable_container_layer1 =
       std::make_shared<MockCacheableContainerLayer>();
   auto mock_container_layer = std::make_shared<ContainerLayer>();
@@ -564,9 +553,9 @@ using ContainerLayerDiffTest = DiffContextTest;
 
 // Insert PictureLayer amongst container layers
 TEST_F(ContainerLayerDiffTest, PictureLayerInsertion) {
-  auto pic1 = CreateDisplayList(SkRect::MakeLTRB(0, 0, 50, 50));
-  auto pic2 = CreateDisplayList(SkRect::MakeLTRB(100, 0, 150, 50));
-  auto pic3 = CreateDisplayList(SkRect::MakeLTRB(200, 0, 250, 50));
+  auto pic1 = CreateDisplayList(DlRect::MakeLTRB(0, 0, 50, 50));
+  auto pic2 = CreateDisplayList(DlRect::MakeLTRB(100, 0, 150, 50));
+  auto pic3 = CreateDisplayList(DlRect::MakeLTRB(200, 0, 250, 50));
 
   MockLayerTree t1;
 
@@ -577,7 +566,7 @@ TEST_F(ContainerLayerDiffTest, PictureLayerInsertion) {
   t1.root()->Add(t1_c2);
 
   auto damage = DiffLayerTree(t1, MockLayerTree());
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(0, 0, 150, 50));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(0, 0, 150, 50));
 
   // Add in the middle
 
@@ -593,7 +582,7 @@ TEST_F(ContainerLayerDiffTest, PictureLayerInsertion) {
   t2.root()->Add(t2_c2);
 
   damage = DiffLayerTree(t2, t1);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(200, 0, 250, 50));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(200, 0, 250, 50));
 
   // Add in the beginning
 
@@ -602,7 +591,7 @@ TEST_F(ContainerLayerDiffTest, PictureLayerInsertion) {
   t2.root()->Add(t2_c1);
   t2.root()->Add(t2_c2);
   damage = DiffLayerTree(t2, t1);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(200, 0, 250, 50));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(200, 0, 250, 50));
 
   // Add at the end
 
@@ -611,21 +600,21 @@ TEST_F(ContainerLayerDiffTest, PictureLayerInsertion) {
   t2.root()->Add(t2_c2);
   t2.root()->Add(CreateDisplayListLayer(pic3));
   damage = DiffLayerTree(t2, t1);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(200, 0, 250, 50));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(200, 0, 250, 50));
 }
 
 // Insert picture layer amongst other picture layers
 TEST_F(ContainerLayerDiffTest, PictureInsertion) {
-  auto pic1 = CreateDisplayList(SkRect::MakeLTRB(0, 0, 50, 50));
-  auto pic2 = CreateDisplayList(SkRect::MakeLTRB(100, 0, 150, 50));
-  auto pic3 = CreateDisplayList(SkRect::MakeLTRB(200, 0, 250, 50));
+  auto pic1 = CreateDisplayList(DlRect::MakeLTRB(0, 0, 50, 50));
+  auto pic2 = CreateDisplayList(DlRect::MakeLTRB(100, 0, 150, 50));
+  auto pic3 = CreateDisplayList(DlRect::MakeLTRB(200, 0, 250, 50));
 
   MockLayerTree t1;
   t1.root()->Add(CreateDisplayListLayer(pic1));
   t1.root()->Add(CreateDisplayListLayer(pic2));
 
   auto damage = DiffLayerTree(t1, MockLayerTree());
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(0, 0, 150, 50));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(0, 0, 150, 50));
 
   MockLayerTree t2;
   t2.root()->Add(CreateDisplayListLayer(pic3));
@@ -633,7 +622,7 @@ TEST_F(ContainerLayerDiffTest, PictureInsertion) {
   t2.root()->Add(CreateDisplayListLayer(pic2));
 
   damage = DiffLayerTree(t2, t1);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(200, 0, 250, 50));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(200, 0, 250, 50));
 
   MockLayerTree t3;
   t3.root()->Add(CreateDisplayListLayer(pic1));
@@ -641,7 +630,7 @@ TEST_F(ContainerLayerDiffTest, PictureInsertion) {
   t3.root()->Add(CreateDisplayListLayer(pic2));
 
   damage = DiffLayerTree(t3, t1);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(200, 0, 250, 50));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(200, 0, 250, 50));
 
   MockLayerTree t4;
   t4.root()->Add(CreateDisplayListLayer(pic1));
@@ -649,13 +638,13 @@ TEST_F(ContainerLayerDiffTest, PictureInsertion) {
   t4.root()->Add(CreateDisplayListLayer(pic3));
 
   damage = DiffLayerTree(t4, t1);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(200, 0, 250, 50));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(200, 0, 250, 50));
 }
 
 TEST_F(ContainerLayerDiffTest, LayerDeletion) {
-  auto path1 = SkPath().addRect(SkRect::MakeLTRB(0, 0, 50, 50));
-  auto path2 = SkPath().addRect(SkRect::MakeLTRB(100, 0, 150, 50));
-  auto path3 = SkPath().addRect(SkRect::MakeLTRB(200, 0, 250, 50));
+  auto path1 = DlPath::MakeRectLTRB(0, 0, 50, 50);
+  auto path2 = DlPath::MakeRectLTRB(100, 0, 150, 50);
+  auto path3 = DlPath::MakeRectLTRB(200, 0, 250, 50);
 
   auto c1 = CreateContainerLayer(std::make_shared<MockLayer>(path1));
   auto c2 = CreateContainerLayer(std::make_shared<MockLayer>(path2));
@@ -667,56 +656,56 @@ TEST_F(ContainerLayerDiffTest, LayerDeletion) {
   t1.root()->Add(c3);
 
   auto damage = DiffLayerTree(t1, MockLayerTree());
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(0, 0, 250, 50));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(0, 0, 250, 50));
 
   MockLayerTree t2;
   t2.root()->Add(c2);
   t2.root()->Add(c3);
 
   damage = DiffLayerTree(t2, t1);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(0, 0, 50, 50));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(0, 0, 50, 50));
 
   MockLayerTree t3;
   t3.root()->Add(c1);
   t3.root()->Add(c3);
 
   damage = DiffLayerTree(t3, t1);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(100, 0, 150, 50));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(100, 0, 150, 50));
 
   MockLayerTree t4;
   t4.root()->Add(c1);
   t4.root()->Add(c2);
 
   damage = DiffLayerTree(t4, t1);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(200, 0, 250, 50));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(200, 0, 250, 50));
 
   MockLayerTree t5;
   t5.root()->Add(c1);
 
   damage = DiffLayerTree(t5, t1);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(100, 0, 250, 50));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(100, 0, 250, 50));
 
   MockLayerTree t6;
   t6.root()->Add(c2);
 
   damage = DiffLayerTree(t6, t1);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(0, 0, 250, 50));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(0, 0, 250, 50));
 
   MockLayerTree t7;
   t7.root()->Add(c3);
 
   damage = DiffLayerTree(t7, t1);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(0, 0, 150, 50));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(0, 0, 150, 50));
 }
 
 TEST_F(ContainerLayerDiffTest, ReplaceLayer) {
-  auto path1 = SkPath().addRect(SkRect::MakeLTRB(0, 0, 50, 50));
-  auto path2 = SkPath().addRect(SkRect::MakeLTRB(100, 0, 150, 50));
-  auto path3 = SkPath().addRect(SkRect::MakeLTRB(200, 0, 250, 50));
+  auto path1 = DlPath::MakeRectLTRB(0, 0, 50, 50);
+  auto path2 = DlPath::MakeRectLTRB(100, 0, 150, 50);
+  auto path3 = DlPath::MakeRectLTRB(200, 0, 250, 50);
 
-  auto path1a = SkPath().addRect(SkRect::MakeLTRB(0, 100, 50, 150));
-  auto path2a = SkPath().addRect(SkRect::MakeLTRB(100, 100, 150, 150));
-  auto path3a = SkPath().addRect(SkRect::MakeLTRB(200, 100, 250, 150));
+  auto path1a = DlPath::MakeRectLTRB(0, 100, 50, 150);
+  auto path2a = DlPath::MakeRectLTRB(100, 100, 150, 150);
+  auto path3a = DlPath::MakeRectLTRB(200, 100, 250, 150);
 
   auto c1 = CreateContainerLayer(std::make_shared<MockLayer>(path1));
   auto c2 = CreateContainerLayer(std::make_shared<MockLayer>(path2));
@@ -728,7 +717,7 @@ TEST_F(ContainerLayerDiffTest, ReplaceLayer) {
   t1.root()->Add(c3);
 
   auto damage = DiffLayerTree(t1, MockLayerTree());
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(0, 0, 250, 50));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(0, 0, 250, 50));
 
   MockLayerTree t2;
   t2.root()->Add(c1);
@@ -736,7 +725,7 @@ TEST_F(ContainerLayerDiffTest, ReplaceLayer) {
   t2.root()->Add(c3);
 
   damage = DiffLayerTree(t2, t1);
-  EXPECT_TRUE(damage.frame_damage.isEmpty());
+  EXPECT_TRUE(damage.frame_damage.IsEmpty());
 
   MockLayerTree t3;
   t3.root()->Add(CreateContainerLayer({std::make_shared<MockLayer>(path1a)}));
@@ -744,7 +733,7 @@ TEST_F(ContainerLayerDiffTest, ReplaceLayer) {
   t3.root()->Add(c3);
 
   damage = DiffLayerTree(t3, t1);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(0, 0, 50, 150));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(0, 0, 50, 150));
 
   MockLayerTree t4;
   t4.root()->Add(c1);
@@ -752,7 +741,7 @@ TEST_F(ContainerLayerDiffTest, ReplaceLayer) {
   t4.root()->Add(c3);
 
   damage = DiffLayerTree(t4, t1);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(100, 0, 150, 150));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(100, 0, 150, 150));
 
   MockLayerTree t5;
   t5.root()->Add(c1);
@@ -760,7 +749,7 @@ TEST_F(ContainerLayerDiffTest, ReplaceLayer) {
   t5.root()->Add(CreateContainerLayer(std::make_shared<MockLayer>(path3a)));
 
   damage = DiffLayerTree(t5, t1);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(200, 0, 250, 150));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(200, 0, 250, 150));
 }
 
 }  // namespace testing

--- a/flow/layers/display_list_layer.h
+++ b/flow/layers/display_list_layer.h
@@ -19,7 +19,7 @@ class DisplayListLayer : public Layer {
  public:
   static constexpr size_t kMaxBytesToCompare = 10000;
 
-  DisplayListLayer(const SkPoint& offset,
+  DisplayListLayer(const DlPoint& offset,
                    sk_sp<DisplayList> display_list,
                    bool is_complex,
                    bool will_change);
@@ -53,8 +53,8 @@ class DisplayListLayer : public Layer {
   NOT_SLIMPELLER(std::unique_ptr<DisplayListRasterCacheItem>
                      display_list_raster_cache_item_);
 
-  SkPoint offset_;
-  SkRect bounds_;
+  DlPoint offset_;
+  DlRect bounds_;
 
   sk_sp<DisplayList> display_list_;
 

--- a/flow/layers/display_list_layer_unittests.cc
+++ b/flow/layers/display_list_layer_unittests.cc
@@ -21,7 +21,7 @@ using DisplayListLayerTest = LayerTest;
 
 #ifndef NDEBUG
 TEST_F(DisplayListLayerTest, PaintBeforePrerollInvalidDisplayListDies) {
-  const SkPoint layer_offset = SkPoint::Make(0.0f, 0.0f);
+  const DlPoint layer_offset = DlPoint(0.0f, 0.0f);
   auto layer = std::make_shared<DisplayListLayer>(
       layer_offset, sk_sp<DisplayList>(), false, false);
 
@@ -29,22 +29,22 @@ TEST_F(DisplayListLayerTest, PaintBeforePrerollInvalidDisplayListDies) {
 }
 
 TEST_F(DisplayListLayerTest, PaintBeforePrerollDies) {
-  const SkPoint layer_offset = SkPoint::Make(0.0f, 0.0f);
-  const SkRect picture_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  const DlPoint layer_offset = DlPoint(0.0f, 0.0f);
+  const DlRect picture_bounds = DlRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
   DisplayListBuilder builder;
   builder.DrawRect(picture_bounds, DlPaint());
   auto display_list = builder.Build();
   auto layer = std::make_shared<DisplayListLayer>(layer_offset, display_list,
                                                   false, false);
 
-  EXPECT_EQ(layer->paint_bounds(), SkRect::MakeEmpty());
+  EXPECT_EQ(layer->paint_bounds(), DlRect());
   EXPECT_DEATH_IF_SUPPORTED(layer->Paint(paint_context()),
                             "needs_painting\\(context\\)");
 }
 
 TEST_F(DisplayListLayerTest, PaintingEmptyLayerDies) {
-  const SkPoint layer_offset = SkPoint::Make(0.0f, 0.0f);
-  const SkRect picture_bounds = SkRect::MakeEmpty();
+  const DlPoint layer_offset = DlPoint(0.0f, 0.0f);
+  const DlRect picture_bounds;
   DisplayListBuilder builder;
   builder.DrawRect(picture_bounds, DlPaint());
   auto display_list = builder.Build();
@@ -52,7 +52,7 @@ TEST_F(DisplayListLayerTest, PaintingEmptyLayerDies) {
                                                   false, false);
 
   layer->Preroll(preroll_context());
-  EXPECT_EQ(layer->paint_bounds(), SkRect::MakeEmpty());
+  EXPECT_EQ(layer->paint_bounds(), DlRect());
   EXPECT_FALSE(layer->needs_painting(paint_context()));
 
   EXPECT_DEATH_IF_SUPPORTED(layer->Paint(paint_context()),
@@ -60,7 +60,7 @@ TEST_F(DisplayListLayerTest, PaintingEmptyLayerDies) {
 }
 
 TEST_F(DisplayListLayerTest, InvalidDisplayListDies) {
-  const SkPoint layer_offset = SkPoint::Make(0.0f, 0.0f);
+  const DlPoint layer_offset = DlPoint(0.0f, 0.0f);
   auto layer = std::make_shared<DisplayListLayer>(
       layer_offset, sk_sp<DisplayList>(), false, false);
 
@@ -70,8 +70,8 @@ TEST_F(DisplayListLayerTest, InvalidDisplayListDies) {
 #endif
 
 TEST_F(DisplayListLayerTest, SimpleDisplayList) {
-  const SkPoint layer_offset = SkPoint::Make(1.5f, -0.5f);
-  const SkRect picture_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  const DlPoint layer_offset = DlPoint(1.5f, -0.5f);
+  const DlRect picture_bounds = DlRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
   DisplayListBuilder builder;
   builder.DrawRect(picture_bounds, DlPaint());
   auto display_list = builder.Build();
@@ -80,7 +80,7 @@ TEST_F(DisplayListLayerTest, SimpleDisplayList) {
 
   layer->Preroll(preroll_context());
   EXPECT_EQ(layer->paint_bounds(),
-            picture_bounds.makeOffset(layer_offset.fX, layer_offset.fY));
+            picture_bounds.Shift(layer_offset.x, layer_offset.y));
   EXPECT_EQ(layer->display_list(), display_list.get());
   EXPECT_TRUE(layer->needs_painting(paint_context()));
 
@@ -89,7 +89,7 @@ TEST_F(DisplayListLayerTest, SimpleDisplayList) {
   /* (DisplayList)layer::Paint */ {
     expected_builder.Save();
     {
-      expected_builder.Translate(layer_offset.fX, layer_offset.fY);
+      expected_builder.Translate(layer_offset.x, layer_offset.y);
       expected_builder.DrawDisplayList(display_list);
     }
     expected_builder.Restore();
@@ -99,14 +99,14 @@ TEST_F(DisplayListLayerTest, SimpleDisplayList) {
 }
 
 TEST_F(DisplayListLayerTest, CachingDoesNotChangeCullRect) {
-  const SkPoint layer_offset = SkPoint::Make(10, 10);
+  const DlPoint layer_offset = DlPoint(10, 10);
   DisplayListBuilder builder;
-  builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
+  builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), DlPaint());
   auto display_list = builder.Build();
   auto layer = std::make_shared<DisplayListLayer>(layer_offset, display_list,
                                                   true, false);
 
-  SkRect original_cull_rect = preroll_context()->state_stack.device_cull_rect();
+  DlRect original_cull_rect = preroll_context()->state_stack.device_cull_rect();
   use_mock_raster_cache();
   layer->Preroll(preroll_context());
   ASSERT_EQ(preroll_context()->state_stack.device_cull_rect(),
@@ -114,8 +114,8 @@ TEST_F(DisplayListLayerTest, CachingDoesNotChangeCullRect) {
 }
 
 TEST_F(DisplayListLayerTest, SimpleDisplayListOpacityInheritance) {
-  const SkPoint layer_offset = SkPoint::Make(1.5f, -0.5f);
-  const SkRect picture_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  const DlPoint layer_offset = DlPoint(1.5f, -0.5f);
+  const DlRect picture_bounds = DlRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
   DisplayListBuilder builder;
   builder.DrawRect(picture_bounds, DlPaint());
   auto display_list = builder.Build();
@@ -129,8 +129,8 @@ TEST_F(DisplayListLayerTest, SimpleDisplayListOpacityInheritance) {
             LayerStateStack::kCallerCanApplyOpacity);
 
   int opacity_alpha = 0x7F;
-  SkScalar opacity = opacity_alpha / 255.0;
-  SkPoint opacity_offset = SkPoint::Make(10, 10);
+  DlScalar opacity = DlColor::toOpacity(opacity_alpha);
+  DlPoint opacity_offset = DlPoint(10, 10);
   auto opacity_layer =
       std::make_shared<OpacityLayer>(opacity_alpha, opacity_offset);
   opacity_layer->Add(display_list_layer);
@@ -145,11 +145,11 @@ TEST_F(DisplayListLayerTest, SimpleDisplayListOpacityInheritance) {
   /* opacity_layer::Paint() */ {
     expected_builder.Save();
     {
-      expected_builder.Translate(opacity_offset.fX, opacity_offset.fY);
+      expected_builder.Translate(opacity_offset.x, opacity_offset.y);
       /* display_list_layer::Paint() */ {
         expected_builder.Save();
         {
-          expected_builder.Translate(layer_offset.fX, layer_offset.fY);
+          expected_builder.Translate(layer_offset.x, layer_offset.y);
           expected_builder.DrawDisplayList(child_display_list, opacity);
         }
         expected_builder.Restore();
@@ -164,9 +164,9 @@ TEST_F(DisplayListLayerTest, SimpleDisplayListOpacityInheritance) {
 }
 
 TEST_F(DisplayListLayerTest, IncompatibleDisplayListOpacityInheritance) {
-  const SkPoint layer_offset = SkPoint::Make(1.5f, -0.5f);
-  const SkRect picture1_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
-  const SkRect picture2_bounds = SkRect::MakeLTRB(10.0f, 15.0f, 30.0f, 35.0f);
+  const DlPoint layer_offset = DlPoint(1.5f, -0.5f);
+  const DlRect picture1_bounds = DlRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  const DlRect picture2_bounds = DlRect::MakeLTRB(10.0f, 15.0f, 30.0f, 35.0f);
   DisplayListBuilder builder;
   builder.DrawRect(picture1_bounds, DlPaint());
   builder.DrawRect(picture2_bounds, DlPaint());
@@ -180,7 +180,7 @@ TEST_F(DisplayListLayerTest, IncompatibleDisplayListOpacityInheritance) {
   EXPECT_EQ(context->renderable_state_flags, 0);
 
   int opacity_alpha = 0x7F;
-  SkPoint opacity_offset = SkPoint::Make(10, 10);
+  DlPoint opacity_offset = DlPoint(10, 10);
   auto opacity_layer =
       std::make_shared<OpacityLayer>(opacity_alpha, opacity_offset);
   opacity_layer->Add(display_list_layer);
@@ -192,22 +192,21 @@ TEST_F(DisplayListLayerTest, IncompatibleDisplayListOpacityInheritance) {
   child_builder.DrawRect(picture2_bounds, DlPaint());
   auto child_display_list = child_builder.Build();
 
-  auto display_list_bounds = picture1_bounds;
-  display_list_bounds.join(picture2_bounds);
+  auto display_list_bounds = picture1_bounds.Union(picture2_bounds);
   auto save_layer_bounds =
-      display_list_bounds.makeOffset(layer_offset.fX, layer_offset.fY);
+      display_list_bounds.Shift(layer_offset.x, layer_offset.y);
   DisplayListBuilder expected_builder;
   /* opacity_layer::Paint() */ {
     expected_builder.Save();
     {
-      expected_builder.Translate(opacity_offset.fX, opacity_offset.fY);
-      expected_builder.SaveLayer(&save_layer_bounds,
+      expected_builder.Translate(opacity_offset.x, opacity_offset.y);
+      expected_builder.SaveLayer(save_layer_bounds,
                                  &DlPaint().setAlpha(opacity_alpha));
       {
         /* display_list_layer::Paint() */ {
           expected_builder.Save();
           {
-            expected_builder.Translate(layer_offset.fX, layer_offset.fY);
+            expected_builder.Translate(layer_offset.x, layer_offset.y);
             expected_builder.DrawDisplayList(child_display_list);
           }
           expected_builder.Restore();
@@ -224,9 +223,9 @@ TEST_F(DisplayListLayerTest, IncompatibleDisplayListOpacityInheritance) {
 }
 
 TEST_F(DisplayListLayerTest, CachedIncompatibleDisplayListOpacityInheritance) {
-  const SkPoint layer_offset = SkPoint::Make(1.5f, -0.5f);
-  const SkRect picture1_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
-  const SkRect picture2_bounds = SkRect::MakeLTRB(10.0f, 15.0f, 30.0f, 35.0f);
+  const DlPoint layer_offset = DlPoint(1.5f, -0.5f);
+  const DlRect picture1_bounds = DlRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  const DlRect picture2_bounds = DlRect::MakeLTRB(10.0f, 15.0f, 30.0f, 35.0f);
   DisplayListBuilder builder;
   builder.DrawRect(picture1_bounds, DlPaint());
   builder.DrawRect(picture2_bounds, DlPaint());
@@ -249,35 +248,30 @@ TEST_F(DisplayListLayerTest, CachedIncompatibleDisplayListOpacityInheritance) {
                               &paint_context(), false);
 
   int opacity_alpha = 0x7F;
-  SkPoint opacity_offset = SkPoint::Make(10.2, 10.2);
+  DlPoint opacity_offset = DlPoint(10.2, 10.2);
   auto opacity_layer =
       std::make_shared<OpacityLayer>(opacity_alpha, opacity_offset);
   opacity_layer->Add(display_list_layer);
   opacity_layer->Preroll(context);
   EXPECT_TRUE(opacity_layer->children_can_accept_opacity());
 
-  auto display_list_bounds = picture1_bounds;
-  display_list_bounds.join(picture2_bounds);
-  auto save_layer_bounds =
-      display_list_bounds.makeOffset(layer_offset.fX, layer_offset.fY);
-  save_layer_bounds.roundOut(&save_layer_bounds);
-  auto opacity_integral_matrix =
-      RasterCacheUtil::GetIntegralTransCTM(SkMatrix::Translate(opacity_offset));
-  SkMatrix layer_offset_matrix = opacity_integral_matrix;
-  layer_offset_matrix.postTranslate(layer_offset.fX, layer_offset.fY);
+  auto opacity_integral_matrix = RasterCacheUtil::GetIntegralTransCTM(
+      DlMatrix::MakeTranslation(opacity_offset));
+  DlMatrix layer_offset_matrix =
+      DlMatrix::MakeTranslation(layer_offset) * opacity_integral_matrix;
   auto layer_offset_integral_matrix =
       RasterCacheUtil::GetIntegralTransCTM(layer_offset_matrix);
-  DisplayListBuilder expected(SkRect::MakeWH(1000, 1000));
+  DisplayListBuilder expected(DlRect::MakeWH(1000, 1000));
   /* opacity_layer::Paint() */ {
     expected.Save();
     {
-      expected.Translate(opacity_offset.fX, opacity_offset.fY);
+      expected.Translate(opacity_offset.x, opacity_offset.y);
       expected.TransformReset();
       expected.Transform(opacity_integral_matrix);
       /* display_list_layer::Paint() */ {
         expected.Save();
         {
-          expected.Translate(layer_offset.fX, layer_offset.fY);
+          expected.Translate(layer_offset.x, layer_offset.y);
           expected.TransformReset();
           expected.Transform(layer_offset_integral_matrix);
           context->raster_cache->Draw(display_list_layer->caching_key_id(),
@@ -295,21 +289,21 @@ TEST_F(DisplayListLayerTest, CachedIncompatibleDisplayListOpacityInheritance) {
 }
 
 TEST_F(DisplayListLayerTest, RasterCachePreservesRTree) {
-  const SkRect picture1_bounds = SkRect::MakeXYWH(10, 10, 10, 10);
-  const SkRect picture2_bounds = SkRect::MakeXYWH(15, 15, 10, 10);
+  const DlRect picture1_bounds = DlRect::MakeXYWH(10, 10, 10, 10);
+  const DlRect picture2_bounds = DlRect::MakeXYWH(15, 15, 10, 10);
   DisplayListBuilder builder(true);
   builder.DrawRect(picture1_bounds, DlPaint());
   builder.DrawRect(picture2_bounds, DlPaint());
   auto display_list = builder.Build();
   auto display_list_layer = std::make_shared<DisplayListLayer>(
-      SkPoint::Make(3, 3), display_list, true, false);
+      DlPoint(3, 3), display_list, true, false);
 
   use_skia_raster_cache();
 
   auto context = preroll_context();
   {
     auto mutator = context->state_stack.save();
-    mutator.transform(SkMatrix::Scale(2.0, 2.0));
+    mutator.transform(DlMatrix::MakeScale({2.0f, 2.0f, 1.0f}));
     display_list_layer->Preroll(preroll_context());
     EXPECT_EQ(context->renderable_state_flags, 0);
 
@@ -328,7 +322,8 @@ TEST_F(DisplayListLayerTest, RasterCachePreservesRTree) {
                                           false));
   auto root_canvas_dl = expected_root_canvas.Build();
   const auto root_canvas_rects =
-      root_canvas_dl->rtree()->searchAndConsolidateRects(kGiantRect, true);
+      root_canvas_dl->rtree()->searchAndConsolidateRects(ToSkRect(kGiantRect),
+                                                         true);
   std::list<SkRect> root_canvas_rects_expected = {
       SkRect::MakeLTRB(26, 26, 56, 56),
   };
@@ -341,7 +336,8 @@ TEST_F(DisplayListLayerTest, RasterCachePreservesRTree) {
                                           true));
   auto overlay_canvas_dl = expected_overlay_canvas.Build();
   const auto overlay_canvas_rects =
-      overlay_canvas_dl->rtree()->searchAndConsolidateRects(kGiantRect, true);
+      overlay_canvas_dl->rtree()->searchAndConsolidateRects(
+          ToSkRect(kGiantRect), true);
 
   // Same bounds as root canvas, but preserves individual rects.
   std::list<SkRect> overlay_canvas_rects_expected = {
@@ -355,95 +351,89 @@ TEST_F(DisplayListLayerTest, RasterCachePreservesRTree) {
 using DisplayListLayerDiffTest = DiffContextTest;
 
 TEST_F(DisplayListLayerDiffTest, SimpleDisplayList) {
-  auto display_list = CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60));
+  auto display_list = CreateDisplayList(DlRect::MakeLTRB(10, 10, 60, 60));
 
   MockLayerTree tree1;
   tree1.root()->Add(CreateDisplayListLayer(display_list));
 
   auto damage = DiffLayerTree(tree1, MockLayerTree());
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(10, 10, 60, 60));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(10, 10, 60, 60));
 
   MockLayerTree tree2;
   tree2.root()->Add(CreateDisplayListLayer(display_list));
 
   damage = DiffLayerTree(tree2, tree1);
-  EXPECT_TRUE(damage.frame_damage.isEmpty());
+  EXPECT_TRUE(damage.frame_damage.IsEmpty());
 
   MockLayerTree tree3;
   damage = DiffLayerTree(tree3, tree2);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(10, 10, 60, 60));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(10, 10, 60, 60));
 }
 
 TEST_F(DisplayListLayerDiffTest, FractionalTranslation) {
-  auto display_list = CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60));
+  auto display_list = CreateDisplayList(DlRect::MakeLTRB(10, 10, 60, 60));
 
   MockLayerTree tree1;
-  tree1.root()->Add(
-      CreateDisplayListLayer(display_list, SkPoint::Make(0.5, 0.5)));
+  tree1.root()->Add(CreateDisplayListLayer(display_list, DlPoint(0.5f, 0.5f)));
 
-  auto damage =
-      DiffLayerTree(tree1, MockLayerTree(), SkIRect::MakeEmpty(), 0, 0,
-                    /*use_raster_cache=*/false);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(10, 10, 61, 61));
+  auto damage = DiffLayerTree(tree1, MockLayerTree(), DlIRect(), 0, 0,
+                              /*use_raster_cache=*/false);
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(10, 10, 61, 61));
 }
 
 TEST_F(DisplayListLayerDiffTest, FractionalTranslationWithRasterCache) {
-  auto display_list = CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60));
+  auto display_list = CreateDisplayList(DlRect::MakeLTRB(10, 10, 60, 60));
 
   MockLayerTree tree1;
-  tree1.root()->Add(
-      CreateDisplayListLayer(display_list, SkPoint::Make(0.5, 0.5)));
+  tree1.root()->Add(CreateDisplayListLayer(display_list, DlPoint(0.5f, 0.5f)));
 
-  auto damage =
-      DiffLayerTree(tree1, MockLayerTree(), SkIRect::MakeEmpty(), 0, 0,
-                    /*use_raster_cache=*/true);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(11, 11, 61, 61));
+  auto damage = DiffLayerTree(tree1, MockLayerTree(), DlIRect(), 0, 0,
+                              /*use_raster_cache=*/true);
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(11, 11, 61, 61));
 }
 
 TEST_F(DisplayListLayerDiffTest, DisplayListCompare) {
   MockLayerTree tree1;
   auto display_list1 =
-      CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60), DlColor::kGreen());
+      CreateDisplayList(DlRect::MakeLTRB(10, 10, 60, 60), DlColor::kGreen());
   tree1.root()->Add(CreateDisplayListLayer(display_list1));
 
   auto damage = DiffLayerTree(tree1, MockLayerTree());
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(10, 10, 60, 60));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(10, 10, 60, 60));
 
   MockLayerTree tree2;
   // same DL, same offset
   auto display_list2 =
-      CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60), DlColor::kGreen());
+      CreateDisplayList(DlRect::MakeLTRB(10, 10, 60, 60), DlColor::kGreen());
   tree2.root()->Add(CreateDisplayListLayer(display_list2));
 
   damage = DiffLayerTree(tree2, tree1);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeEmpty());
+  EXPECT_EQ(damage.frame_damage, DlIRect());
 
   MockLayerTree tree3;
   auto display_list3 =
-      CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60), DlColor::kGreen());
+      CreateDisplayList(DlRect::MakeLTRB(10, 10, 60, 60), DlColor::kGreen());
   // add offset
-  tree3.root()->Add(
-      CreateDisplayListLayer(display_list3, SkPoint::Make(10, 10)));
+  tree3.root()->Add(CreateDisplayListLayer(display_list3, DlPoint(10, 10)));
 
   damage = DiffLayerTree(tree3, tree2);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(10, 10, 70, 70));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(10, 10, 70, 70));
 
   MockLayerTree tree4;
   // different color
   auto display_list4 =
-      CreateDisplayList(SkRect::MakeLTRB(10, 10, 60, 60), DlColor::kRed());
-  tree4.root()->Add(
-      CreateDisplayListLayer(display_list4, SkPoint::Make(10, 10)));
+      CreateDisplayList(DlRect::MakeLTRB(10, 10, 60, 60), DlColor::kRed());
+  tree4.root()->Add(CreateDisplayListLayer(display_list4, DlPoint(10, 10)));
 
   damage = DiffLayerTree(tree4, tree3);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(20, 20, 70, 70));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(20, 20, 70, 70));
 }
 
 TEST_F(DisplayListLayerTest, DisplayListAccessCountDependsOnVisibility) {
-  const SkPoint layer_offset = SkPoint::Make(1.5f, -0.5f);
-  const SkRect picture_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
-  const SkRect missed_cull_rect = SkRect::MakeLTRB(100, 100, 200, 200);
-  const SkRect hit_cull_rect = SkRect::MakeLTRB(0, 0, 200, 200);
+  const DlPoint layer_offset = DlPoint(1.5f, -0.5f);
+  const DlRect picture_bounds = DlRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  const DlRect missed_cull_rect = DlRect::MakeLTRB(100, 100, 200, 200);
+  const DlRect hit_cull_rect = DlRect::MakeLTRB(0, 0, 200, 200);
   DisplayListBuilder builder;
   builder.DrawRect(picture_bounds, DlPaint());
   auto display_list = builder.Build();
@@ -541,16 +531,16 @@ TEST_F(DisplayListLayerTest, OverflowCachedDisplayListOpacityInheritance) {
   int per_frame =
       RasterCacheUtil::kDefaultPictureAndDisplayListCacheLimitPerFrame;
   int layer_count = per_frame + 1;
-  SkPoint opacity_offset = {10, 10};
+  DlPoint opacity_offset = DlPoint(10, 10);
   auto opacity_layer = std::make_shared<OpacityLayer>(0.5f, opacity_offset);
   std::vector<std::shared_ptr<DisplayListLayer>> layers;
   for (int i = 0; i < layer_count; i++) {
     DisplayListBuilder builder(false);
-    builder.DrawRect(SkRect{0, 0, 100, 100}, DlPaint());
-    builder.DrawRect(SkRect{50, 50, 100, 100}, DlPaint());
+    builder.DrawRect(DlRect::MakeLTRB(0, 0, 100, 100), DlPaint());
+    builder.DrawRect(DlRect::MakeLTRB(50, 50, 100, 100), DlPaint());
     auto display_list = builder.Build();
     ASSERT_FALSE(display_list->can_apply_group_opacity());
-    SkPoint offset = {i * 200.0f, 0};
+    DlPoint offset = DlPoint(i * 200.0f, 0);
 
     layers.push_back(
         std::make_shared<DisplayListLayer>(offset, display_list, true, false));

--- a/flow/layers/display_list_raster_cache_item.h
+++ b/flow/layers/display_list_raster_cache_item.h
@@ -31,10 +31,10 @@ class DisplayListRasterCacheItem : public RasterCacheItem {
       bool is_complex,
       bool will_change);
 
-  void PrerollSetup(PrerollContext* context, const SkMatrix& matrix) override;
+  void PrerollSetup(PrerollContext* context, const DlMatrix& matrix) override;
 
   void PrerollFinalize(PrerollContext* context,
-                       const SkMatrix& matrix) override;
+                       const DlMatrix& matrix) override;
 
   bool Draw(const PaintContext& context, const DlPaint* paint) const override;
 

--- a/flow/layers/image_filter_layer.h
+++ b/flow/layers/image_filter_layer.h
@@ -13,7 +13,7 @@ namespace flutter {
 class ImageFilterLayer : public CacheableContainerLayer {
  public:
   explicit ImageFilterLayer(const std::shared_ptr<DlImageFilter>& filter,
-                            const SkPoint& offset = SkPoint::Make(0, 0));
+                            const DlPoint& offset = DlPoint());
 
   void Diff(DiffContext* context, const Layer* old_layer) override;
 
@@ -22,7 +22,7 @@ class ImageFilterLayer : public CacheableContainerLayer {
   void Paint(PaintContext& context) const override;
 
  private:
-  SkPoint offset_;
+  DlPoint offset_;
   const std::shared_ptr<DlImageFilter> filter_;
   std::shared_ptr<DlImageFilter> transformed_filter_;
 

--- a/flow/layers/layer.cc
+++ b/flow/layers/layer.cc
@@ -8,10 +8,7 @@
 
 namespace flutter {
 
-Layer::Layer()
-    : paint_bounds_(SkRect::MakeEmpty()),
-      unique_id_(NextUniqueID()),
-      original_layer_id_(unique_id_) {}
+Layer::Layer() : unique_id_(NextUniqueID()), original_layer_id_(unique_id_) {}
 
 Layer::~Layer() = default;
 

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -22,14 +22,6 @@
 #include "flutter/fml/logging.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/trace_event.h"
-#include "third_party/skia/include/core/SkCanvas.h"
-#include "third_party/skia/include/core/SkColor.h"
-#include "third_party/skia/include/core/SkColorFilter.h"
-#include "third_party/skia/include/core/SkMatrix.h"
-#include "third_party/skia/include/core/SkPath.h"
-#include "third_party/skia/include/core/SkRRect.h"
-#include "third_party/skia/include/core/SkRect.h"
-#include "third_party/skia/include/utils/SkNWayCanvas.h"
 
 class GrDirectContext;
 
@@ -45,7 +37,7 @@ class PerformanceOverlayLayer;
 class TextureLayer;
 class RasterCacheItem;
 
-static constexpr SkRect kGiantRect = SkRect::MakeLTRB(-1E9F, -1E9F, 1E9F, 1E9F);
+static constexpr DlRect kGiantRect = DlRect::MakeLTRB(-1E9F, -1E9F, 1E9F, 1E9F);
 
 // This should be an exact copy of the Clip enum in painting.dart.
 enum Clip { kNone, kHardEdge, kAntiAlias, kAntiAliasWithSaveLayer };
@@ -201,7 +193,7 @@ class Layer {
   // as determined during Preroll().  The bounds should include any
   // transform, clip or distortions performed by the layer itself,
   // but not any similar modifications inherited from its ancestors.
-  const SkRect& paint_bounds() const { return paint_bounds_; }
+  const DlRect& paint_bounds() const { return paint_bounds_; }
 
   // This must be set by the time Preroll() returns otherwise the layer will
   // be assumed to have empty paint bounds (paints no content).
@@ -214,12 +206,12 @@ class Layer {
   // paint operation that arises due to the caching, the clip will
   // be the bounds of the layer needing caching, not the cull_rect
   // that we saw in the overall Preroll operation.
-  void set_paint_bounds(const SkRect& paint_bounds) {
+  void set_paint_bounds(const DlRect& paint_bounds) {
     paint_bounds_ = paint_bounds;
   }
 
   // Determines if the layer has any content.
-  bool is_empty() const { return paint_bounds_.isEmpty(); }
+  bool is_empty() const { return paint_bounds_.IsEmpty(); }
 
   // Determines if the Paint() method is necessary based on the properties
   // of the indicated PaintContext object.
@@ -260,7 +252,7 @@ class Layer {
   virtual const testing::MockLayer* as_mock_layer() const { return nullptr; }
 
  private:
-  SkRect paint_bounds_;
+  DlRect paint_bounds_;
   uint64_t unique_id_;
   uint64_t original_layer_id_;
   bool subtree_has_platform_view_ = false;

--- a/flow/layers/layer_raster_cache_item.cc
+++ b/flow/layers/layer_raster_cache_item.cc
@@ -24,12 +24,12 @@ LayerRasterCacheItem::LayerRasterCacheItem(Layer* layer,
       can_cache_children_(can_cache_children) {}
 
 void LayerRasterCacheItem::PrerollSetup(PrerollContext* context,
-                                        const SkMatrix& matrix) {
+                                        const DlMatrix& matrix) {
   cache_state_ = CacheState::kNone;
   if (context->raster_cache && context->raster_cached_entries) {
     context->raster_cached_entries->push_back(this);
     child_items_ = context->raster_cached_entries->size();
-    matrix_ = matrix;
+    set_matrix(matrix);
   }
 }
 
@@ -42,7 +42,7 @@ std::unique_ptr<LayerRasterCacheItem> LayerRasterCacheItem::Make(
 }
 
 void LayerRasterCacheItem::PrerollFinalize(PrerollContext* context,
-                                           const SkMatrix& matrix) {
+                                           const DlMatrix& matrix) {
   if (!context->raster_cache || !context->raster_cached_entries) {
     return;
   }
@@ -91,10 +91,10 @@ std::optional<RasterCacheKeyID> LayerRasterCacheItem::GetId() const {
 const SkRect* LayerRasterCacheItem::GetPaintBoundsFromLayer() const {
   switch (cache_state_) {
     case CacheState::kCurrent:
-      return &(layer_->paint_bounds());
+      return &ToSkRect(layer_->paint_bounds());
     case CacheState::kChildren:
       FML_DCHECK(layer_->as_container_layer());
-      return &(layer_->as_container_layer()->child_paint_bounds());
+      return &ToSkRect(layer_->as_container_layer()->child_paint_bounds());
     default:
       FML_DCHECK(cache_state_ != CacheState::kNone);
       return nullptr;

--- a/flow/layers/layer_raster_cache_item.h
+++ b/flow/layers/layer_raster_cache_item.h
@@ -33,10 +33,10 @@ class LayerRasterCacheItem : public RasterCacheItem {
 
   std::optional<RasterCacheKeyID> GetId() const override;
 
-  void PrerollSetup(PrerollContext* context, const SkMatrix& matrix) override;
+  void PrerollSetup(PrerollContext* context, const DlMatrix& matrix) override;
 
   void PrerollFinalize(PrerollContext* context,
-                       const SkMatrix& matrix) override;
+                       const DlMatrix& matrix) override;
 
   bool Draw(const PaintContext& context, const DlPaint* paint) const override;
 

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -18,7 +18,7 @@
 namespace flutter {
 
 LayerTree::LayerTree(const std::shared_ptr<Layer>& root_layer,
-                     const SkISize& frame_size)
+                     const DlISize& frame_size)
     : root_layer_(root_layer), frame_size_(frame_size) {}
 
 inline SkColorSpace* GetColorSpace(DlCanvas* canvas) {
@@ -27,7 +27,7 @@ inline SkColorSpace* GetColorSpace(DlCanvas* canvas) {
 
 bool LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
                         bool ignore_raster_cache,
-                        SkRect cull_rect) {
+                        DlRect cull_rect) {
   TRACE_EVENT0("flutter", "LayerTree::Preroll");
 
   if (!root_layer_) {
@@ -37,8 +37,8 @@ bool LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
 
   SkColorSpace* color_space = GetColorSpace(frame.canvas());
   LayerStateStack state_stack;
-  state_stack.set_preroll_delegate(cull_rect,
-                                   frame.root_surface_transformation());
+  state_stack.set_preroll_delegate(
+      cull_rect, ToDlMatrix(frame.root_surface_transformation()));
 
   raster_cache_items_.clear();
 
@@ -145,7 +145,7 @@ void LayerTree::Paint(CompositorContext::ScopedFrame& frame,
 }
 
 sk_sp<DisplayList> LayerTree::Flatten(
-    const SkRect& bounds,
+    const DlRect& bounds,
     const std::shared_ptr<TextureRegistry>& texture_registry,
     GrDirectContext* gr_context) {
   TRACE_EVENT0("flutter", "LayerTree::Flatten");

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -22,7 +22,7 @@ namespace flutter {
 class LayerTree {
  public:
   LayerTree(const std::shared_ptr<Layer>& root_layer,
-            const SkISize& frame_size);
+            const DlISize& frame_size);
 
   // Perform a preroll pass on the tree and return information about
   // the tree that affects rendering this frame.
@@ -33,7 +33,7 @@ class LayerTree {
   //   from the root surface.
   bool Preroll(CompositorContext::ScopedFrame& frame,
                bool ignore_raster_cache = false,
-               SkRect cull_rect = kGiantRect);
+               DlRect cull_rect = kGiantRect);
 
 #if !SLIMPELLER
   static void TryToRasterCache(
@@ -46,19 +46,19 @@ class LayerTree {
              bool ignore_raster_cache = false) const;
 
   sk_sp<DisplayList> Flatten(
-      const SkRect& bounds,
+      const DlRect& bounds,
       const std::shared_ptr<TextureRegistry>& texture_registry = nullptr,
       GrDirectContext* gr_context = nullptr);
 
   Layer* root_layer() const { return root_layer_.get(); }
-  const SkISize& frame_size() const { return frame_size_; }
+  const DlISize& frame_size() const { return frame_size_; }
 
   const PaintRegionMap& paint_region_map() const { return paint_region_map_; }
   PaintRegionMap& paint_region_map() { return paint_region_map_; }
 
  private:
   std::shared_ptr<Layer> root_layer_;
-  SkISize frame_size_ = SkISize::MakeEmpty();  // Physical pixels.
+  DlISize frame_size_;  // Physical pixels.
 
   PaintRegionMap paint_region_map_;
 

--- a/flow/layers/offscreen_surface.cc
+++ b/flow/layers/offscreen_surface.cc
@@ -18,9 +18,9 @@
 namespace flutter {
 
 static sk_sp<SkSurface> CreateSnapshotSurface(GrDirectContext* surface_context,
-                                              const SkISize& size) {
-  const auto image_info = SkImageInfo::MakeN32Premul(
-      size.width(), size.height(), SkColorSpace::MakeSRGB());
+                                              const DlISize& size) {
+  const auto image_info = SkImageInfo::MakeN32Premul(size.width, size.height,
+                                                     SkColorSpace::MakeSRGB());
   if (surface_context) {
     // There is a rendering surface that may contain textures that are going to
     // be referenced in the layer tree about to be drawn.
@@ -69,7 +69,7 @@ static sk_sp<SkData> GetRasterData(const sk_sp<SkSurface>& offscreen_surface,
 }
 
 OffscreenSurface::OffscreenSurface(GrDirectContext* surface_context,
-                                   const SkISize& size) {
+                                   const DlISize& size) {
   offscreen_surface_ = CreateSnapshotSurface(surface_context, size);
   if (offscreen_surface_) {
     adapter_.set_canvas(offscreen_surface_->getCanvas());

--- a/flow/layers/offscreen_surface.h
+++ b/flow/layers/offscreen_surface.h
@@ -13,8 +13,6 @@
 #include "flutter/display_list/dl_canvas.h"
 #include "flutter/display_list/skia/dl_sk_canvas.h"
 #include "third_party/skia/include/core/SkData.h"
-#include "third_party/skia/include/core/SkRefCnt.h"
-#include "third_party/skia/include/core/SkSize.h"
 #include "third_party/skia/include/core/SkSurface.h"
 
 class GrDirectContext;
@@ -24,7 +22,7 @@ namespace flutter {
 class OffscreenSurface {
  public:
   explicit OffscreenSurface(GrDirectContext* surface_context,
-                            const SkISize& size);
+                            const DlISize& size);
 
   ~OffscreenSurface() = default;
 

--- a/flow/layers/offscreen_surface_unittests.cc
+++ b/flow/layers/offscreen_surface_unittests.cc
@@ -7,27 +7,21 @@
 #include <memory>
 
 #include "gtest/gtest.h"
-#include "include/core/SkColor.h"
-#include "third_party/skia/include/core/SkCanvas.h"
-#include "third_party/skia/include/core/SkData.h"
 
 namespace flutter::testing {
 
 TEST(OffscreenSurfaceTest, EmptySurfaceIsInvalid) {
-  auto surface =
-      std::make_unique<OffscreenSurface>(nullptr, SkISize::MakeEmpty());
+  auto surface = std::make_unique<OffscreenSurface>(nullptr, DlISize());
   ASSERT_FALSE(surface->IsValid());
 }
 
 TEST(OffscreenSurfaceTest, OnexOneSurfaceIsValid) {
-  auto surface =
-      std::make_unique<OffscreenSurface>(nullptr, SkISize::Make(1, 1));
+  auto surface = std::make_unique<OffscreenSurface>(nullptr, DlISize(1, 1));
   ASSERT_TRUE(surface->IsValid());
 }
 
 TEST(OffscreenSurfaceTest, PaintSurfaceBlack) {
-  auto surface =
-      std::make_unique<OffscreenSurface>(nullptr, SkISize::Make(1, 1));
+  auto surface = std::make_unique<OffscreenSurface>(nullptr, DlISize(1, 1));
 
   DlCanvas* canvas = surface->GetCanvas();
   canvas->Clear(DlColor::kBlack());

--- a/flow/layers/opacity_layer.h
+++ b/flow/layers/opacity_layer.h
@@ -7,7 +7,6 @@
 
 #include "flutter/flow/layers/cacheable_layer.h"
 #include "flutter/flow/layers/layer.h"
-#include "include/core/SkMatrix.h"
 
 namespace flutter {
 
@@ -27,7 +26,7 @@ class OpacityLayer : public CacheableContainerLayer {
   // the retained rendering inefficient as a small offset change could propagate
   // to many leaf layers. Therefore we try to capture that offset here to stop
   // the propagation as repainting the OpacityLayer is expensive.
-  OpacityLayer(SkAlpha alpha, const SkPoint& offset);
+  OpacityLayer(uint8_t alpha, const DlPoint& offset);
 
   void Diff(DiffContext* context, const Layer* old_layer) override;
 
@@ -45,11 +44,11 @@ class OpacityLayer : public CacheableContainerLayer {
     children_can_accept_opacity_ = value;
   }
 
-  SkScalar opacity() const { return alpha_ * 1.0f / SK_AlphaOPAQUE; }
+  DlScalar opacity() const { return DlColor::toOpacity(alpha_); }
 
  private:
-  SkAlpha alpha_;
-  SkPoint offset_;
+  uint8_t alpha_;
+  DlPoint offset_;
   bool children_can_accept_opacity_ = false;
 
   FML_DISALLOW_COPY_AND_ASSIGN(OpacityLayer);

--- a/flow/layers/performance_overlay_layer.cc
+++ b/flow/layers/performance_overlay_layer.cc
@@ -132,10 +132,10 @@ void PerformanceOverlayLayer::Paint(PaintContext& context) const {
     return;
   }
 
-  SkScalar x = paint_bounds().x() + padding;
-  SkScalar y = paint_bounds().y() + padding;
-  SkScalar width = paint_bounds().width() - (padding * 2);
-  SkScalar height = paint_bounds().height() / 2;
+  DlScalar x = paint_bounds().GetX() + padding;
+  DlScalar y = paint_bounds().GetY() + padding;
+  DlScalar width = paint_bounds().GetWidth() - (padding * 2);
+  DlScalar height = paint_bounds().GetHeight() / 2;
   auto mutator = context.state_stack.save();
   // Cached storage for vertex output.
   std::vector<DlPoint> vertices_storage;

--- a/flow/layers/performance_overlay_layer_unittests.cc
+++ b/flow/layers/performance_overlay_layer_unittests.cc
@@ -84,7 +84,7 @@ static void TestPerformanceOverlayLayerGold(int refresh_rate) {
           flutter::kDisplayEngineStatistics |
           flutter::kVisualizeEngineStatistics,
       flutter::GetFontFile().c_str());
-  layer.set_paint_bounds(SkRect::MakeWH(1000, 400));
+  layer.set_paint_bounds(DlRect::MakeWH(1000, 400));
   surface->getCanvas()->clear(SK_ColorTRANSPARENT);
   layer.Paint(paint_context);
 
@@ -166,7 +166,7 @@ TEST_F(PerformanceOverlayLayerTest, PaintingEmptyLayerDies) {
   auto layer = std::make_shared<PerformanceOverlayLayer>(overlay_opts);
 
   layer->Preroll(preroll_context());
-  EXPECT_EQ(layer->paint_bounds(), SkRect::MakeEmpty());
+  EXPECT_EQ(layer->paint_bounds(), DlRect());
   EXPECT_FALSE(layer->needs_painting(paint_context()));
 
   // Crashes reading a nullptr.
@@ -174,7 +174,7 @@ TEST_F(PerformanceOverlayLayerTest, PaintingEmptyLayerDies) {
 }
 
 TEST_F(PerformanceOverlayLayerTest, InvalidOptions) {
-  const SkRect layer_bounds = SkRect::MakeLTRB(0.0f, 0.0f, 64.0f, 64.0f);
+  const DlRect layer_bounds = DlRect::MakeLTRB(0.0f, 0.0f, 64.0f, 64.0f);
   const uint64_t overlay_opts = 0;
   auto layer = std::make_shared<PerformanceOverlayLayer>(overlay_opts);
 
@@ -196,7 +196,7 @@ TEST_F(PerformanceOverlayLayerTest, InvalidOptions) {
 }
 
 TEST_F(PerformanceOverlayLayerTest, SimpleRasterizerStatistics) {
-  const SkRect layer_bounds = SkRect::MakeLTRB(0.0f, 0.0f, 64.0f, 64.0f);
+  const DlRect layer_bounds = DlRect::MakeLTRB(0.0f, 0.0f, 64.0f, 64.0f);
   const uint64_t overlay_opts = kDisplayRasterizerStatistics;
   auto layer = std::make_shared<PerformanceOverlayLayer>(overlay_opts);
   auto font = PerformanceOverlayLayer::MakeStatisticsFont("");
@@ -239,7 +239,7 @@ TEST_F(PerformanceOverlayLayerTest, MarkAsDirtyWhenResized) {
   // Create a PerformanceOverlayLayer.
   const uint64_t overlay_opts = kVisualizeRasterizerStatistics;
   auto layer = std::make_shared<PerformanceOverlayLayer>(overlay_opts);
-  layer->set_paint_bounds(SkRect::MakeLTRB(0.0f, 0.0f, 48.0f, 48.0f));
+  layer->set_paint_bounds(DlRect::MakeLTRB(0.0f, 0.0f, 48.0f, 48.0f));
   layer->Preroll(preroll_context());
   layer->Paint(display_list_paint_context());
   DlISize first_draw_size;
@@ -254,7 +254,7 @@ TEST_F(PerformanceOverlayLayerTest, MarkAsDirtyWhenResized) {
 
   // Create a second PerformanceOverlayLayer with different bounds.
   layer = std::make_shared<PerformanceOverlayLayer>(overlay_opts);
-  layer->set_paint_bounds(SkRect::MakeLTRB(0.0f, 0.0f, 64.0f, 64.0f));
+  layer->set_paint_bounds(DlRect::MakeLTRB(0.0f, 0.0f, 64.0f, 64.0f));
   layer->Preroll(preroll_context());
   reset_display_list();
   layer->Paint(display_list_paint_context());

--- a/flow/layers/platform_view_layer.cc
+++ b/flow/layers/platform_view_layer.cc
@@ -8,14 +8,13 @@
 
 namespace flutter {
 
-PlatformViewLayer::PlatformViewLayer(const SkPoint& offset,
-                                     const SkSize& size,
+PlatformViewLayer::PlatformViewLayer(const DlPoint& offset,
+                                     const DlSize& size,
                                      int64_t view_id)
     : offset_(offset), size_(size), view_id_(view_id) {}
 
 void PlatformViewLayer::Preroll(PrerollContext* context) {
-  set_paint_bounds(SkRect::MakeXYWH(offset_.x(), offset_.y(), size_.width(),
-                                    size_.height()));
+  set_paint_bounds(DlRect::MakeOriginSize(offset_, size_));
 
   if (context->view_embedder == nullptr) {
     FML_DLOG(ERROR) << "Trying to embed a platform view but the PrerollContext "
@@ -27,8 +26,8 @@ void PlatformViewLayer::Preroll(PrerollContext* context) {
   MutatorsStack mutators;
   context->state_stack.fill(&mutators);
   std::unique_ptr<EmbeddedViewParams> params =
-      std::make_unique<EmbeddedViewParams>(context->state_stack.transform_3x3(),
-                                           size_, mutators);
+      std::make_unique<EmbeddedViewParams>(
+          ToSkMatrix(context->state_stack.matrix()), ToSkSize(size_), mutators);
   context->view_embedder->PrerollCompositeEmbeddedView(view_id_,
                                                        std::move(params));
   context->view_embedder->PushVisitedPlatformView(view_id_);

--- a/flow/layers/platform_view_layer.h
+++ b/flow/layers/platform_view_layer.h
@@ -14,14 +14,14 @@ namespace flutter {
 
 class PlatformViewLayer : public Layer {
  public:
-  PlatformViewLayer(const SkPoint& offset, const SkSize& size, int64_t view_id);
+  PlatformViewLayer(const DlPoint& offset, const DlSize& size, int64_t view_id);
 
   void Preroll(PrerollContext* context) override;
   void Paint(PaintContext& context) const override;
 
  private:
-  SkPoint offset_;
-  SkSize size_;
+  DlPoint offset_;
+  DlSize size_;
   int64_t view_id_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(PlatformViewLayer);

--- a/flow/layers/platform_view_layer_unittests.cc
+++ b/flow/layers/platform_view_layer_unittests.cc
@@ -19,8 +19,8 @@ using PlatformViewLayerTest = LayerTest;
 using ClipOp = DlCanvas::ClipOp;
 
 TEST_F(PlatformViewLayerTest, NullViewEmbedderDoesntPrerollCompositeOrPaint) {
-  const SkPoint layer_offset = SkPoint::Make(0.0f, 0.0f);
-  const SkSize layer_size = SkSize::Make(8.0f, 8.0f);
+  const DlPoint layer_offset = DlPoint();
+  const DlSize layer_size = DlSize(8.0f, 8.0f);
   const int64_t view_id = 0;
   auto layer =
       std::make_shared<PlatformViewLayer>(layer_offset, layer_size, view_id);
@@ -28,8 +28,7 @@ TEST_F(PlatformViewLayerTest, NullViewEmbedderDoesntPrerollCompositeOrPaint) {
   layer->Preroll(preroll_context());
   EXPECT_FALSE(preroll_context()->has_platform_view);
   EXPECT_EQ(layer->paint_bounds(),
-            SkRect::MakeSize(layer_size)
-                .makeOffset(layer_offset.fX, layer_offset.fY));
+            DlRect::MakeOriginSize(layer_offset, layer_size));
   EXPECT_TRUE(layer->needs_painting(paint_context()));
   EXPECT_FALSE(layer->subtree_has_platform_view());
 
@@ -42,10 +41,10 @@ TEST_F(PlatformViewLayerTest, NullViewEmbedderDoesntPrerollCompositeOrPaint) {
 }
 
 TEST_F(PlatformViewLayerTest, ClippedPlatformViewPrerollsAndPaintsNothing) {
-  const SkPoint layer_offset = SkPoint::Make(0.0f, 0.0f);
-  const SkSize layer_size = SkSize::Make(8.0f, 8.0f);
-  const SkRect child_clip = SkRect::MakeLTRB(20.0f, 20.0f, 40.0f, 40.0f);
-  const SkRect parent_clip = SkRect::MakeLTRB(50.0f, 50.0f, 80.0f, 80.0f);
+  const DlPoint layer_offset = DlPoint();
+  const DlSize layer_size = DlSize(8.0f, 8.0f);
+  const DlRect child_clip = DlRect::MakeLTRB(20.0f, 20.0f, 40.0f, 40.0f);
+  const DlRect parent_clip = DlRect::MakeLTRB(50.0f, 50.0f, 80.0f, 80.0f);
   const int64_t view_id = 0;
   auto layer =
       std::make_shared<PlatformViewLayer>(layer_offset, layer_size, view_id);
@@ -62,8 +61,7 @@ TEST_F(PlatformViewLayerTest, ClippedPlatformViewPrerollsAndPaintsNothing) {
   parent_clip_layer->Preroll(preroll_context());
   EXPECT_TRUE(preroll_context()->has_platform_view);
   EXPECT_EQ(layer->paint_bounds(),
-            SkRect::MakeSize(layer_size)
-                .makeOffset(layer_offset.fX, layer_offset.fY));
+            DlRect::MakeOriginSize(layer_offset, layer_size));
   EXPECT_TRUE(layer->needs_painting(paint_context()));
   EXPECT_TRUE(child_clip_layer->needs_painting(paint_context()));
   EXPECT_TRUE(parent_clip_layer->needs_painting(paint_context()));
@@ -92,8 +90,8 @@ TEST_F(PlatformViewLayerTest, ClippedPlatformViewPrerollsAndPaintsNothing) {
 }
 
 TEST_F(PlatformViewLayerTest, OpacityInheritance) {
-  const SkPoint layer_offset = SkPoint::Make(0.0f, 0.0f);
-  const SkSize layer_size = SkSize::Make(8.0f, 8.0f);
+  const DlPoint layer_offset = DlPoint();
+  const DlSize layer_size = DlSize(8.0f, 8.0f);
   const int64_t view_id = 0;
   auto layer =
       std::make_shared<PlatformViewLayer>(layer_offset, layer_size, view_id);
@@ -104,14 +102,14 @@ TEST_F(PlatformViewLayerTest, OpacityInheritance) {
 }
 
 TEST_F(PlatformViewLayerTest, StateTransfer) {
-  const SkMatrix transform1 = SkMatrix::Translate(5, 5);
-  const SkMatrix transform2 = SkMatrix::Translate(15, 15);
-  const SkMatrix combined_transform = SkMatrix::Translate(20, 20);
-  const SkPoint layer_offset = SkPoint::Make(0.0f, 0.0f);
-  const SkSize layer_size = SkSize::Make(8.0f, 8.0f);
+  const DlMatrix transform1 = DlMatrix::MakeTranslation({5.0f, 5.0f});
+  const DlMatrix transform2 = DlMatrix::MakeTranslation({15.0f, 15.0f});
+  const DlMatrix combined_transform = DlMatrix::MakeTranslation({20.0f, 20.0f});
+  const DlPoint layer_offset = DlPoint(0.0f, 0.0f);
+  const DlSize layer_size = DlSize(8.0f, 8.0f);
   const int64_t view_id = 0;
-  const SkPath path1 = SkPath().addOval({10, 10, 20, 20});
-  const SkPath path2 = SkPath().addOval({15, 15, 30, 30});
+  const DlPath path1 = DlPath::MakeOvalLTRB(10, 10, 20, 20);
+  const DlPath path2 = DlPath::MakeOvalLTRB(15, 15, 30, 30);
 
   // transform_layer1
   //   |- child1

--- a/flow/layers/shader_mask_layer.cc
+++ b/flow/layers/shader_mask_layer.cc
@@ -8,7 +8,7 @@
 namespace flutter {
 
 ShaderMaskLayer::ShaderMaskLayer(std::shared_ptr<DlColorSource> color_source,
-                                 const SkRect& mask_rect,
+                                 const DlRect& mask_rect,
                                  DlBlendMode blend_mode)
     : CacheableContainerLayer(
           RasterCacheUtil::kMinimumRendersBeforeCachingFilterLayer),
@@ -39,7 +39,7 @@ void ShaderMaskLayer::Preroll(PrerollContext* context) {
       Layer::AutoPrerollSaveLayerState::Create(context);
 #if !SLIMPELLER
   AutoCache cache = AutoCache(layer_raster_cache_item_.get(), context,
-                              context->state_stack.transform_3x3());
+                              context->state_stack.matrix());
 #endif  //  !SLIMPELLER
   ContainerLayer::Preroll(context);
   // We always paint with a saveLayer (or a cached rendering),
@@ -63,7 +63,7 @@ void ShaderMaskLayer::Paint(PaintContext& context) const {
     }
   }
 #endif  //  !SLIMPELLER
-  auto shader_rect = SkRect::MakeWH(mask_rect_.width(), mask_rect_.height());
+  auto shader_rect = DlRect::MakeSize(mask_rect_.GetSize());
 
   mutator.saveLayer(paint_bounds());
 
@@ -74,7 +74,7 @@ void ShaderMaskLayer::Paint(PaintContext& context) const {
   if (color_source_) {
     dl_paint.setColorSource(color_source_.get());
   }
-  context.canvas->Translate(mask_rect_.left(), mask_rect_.top());
+  context.canvas->Translate(mask_rect_.GetLeft(), mask_rect_.GetTop());
   context.canvas->DrawRect(shader_rect, dl_paint);
 }
 

--- a/flow/layers/shader_mask_layer.h
+++ b/flow/layers/shader_mask_layer.h
@@ -13,7 +13,7 @@ namespace flutter {
 class ShaderMaskLayer : public CacheableContainerLayer {
  public:
   ShaderMaskLayer(std::shared_ptr<DlColorSource> color_source,
-                  const SkRect& mask_rect,
+                  const DlRect& mask_rect,
                   DlBlendMode blend_mode);
 
   void Diff(DiffContext* context, const Layer* old_layer) override;
@@ -24,7 +24,7 @@ class ShaderMaskLayer : public CacheableContainerLayer {
 
  private:
   std::shared_ptr<DlColorSource> color_source_;
-  SkRect mask_rect_;
+  DlRect mask_rect_;
   DlBlendMode blend_mode_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ShaderMaskLayer);

--- a/flow/layers/texture_layer.cc
+++ b/flow/layers/texture_layer.cc
@@ -8,8 +8,8 @@
 
 namespace flutter {
 
-TextureLayer::TextureLayer(const SkPoint& offset,
-                           const SkSize& size,
+TextureLayer::TextureLayer(const DlPoint& offset,
+                           const DlSize& size,
                            int64_t texture_id,
                            bool freeze,
                            DlImageSampling sampling)
@@ -35,14 +35,12 @@ void TextureLayer::Diff(DiffContext* context, const Layer* old_layer) {
   // See ContainerLayer::DiffChildren
   // https://github.com/flutter/flutter/issues/92925
   context->MarkSubtreeHasTextureLayer();
-  context->AddLayerBounds(SkRect::MakeXYWH(offset_.x(), offset_.y(),
-                                           size_.width(), size_.height()));
+  context->AddLayerBounds(DlRect::MakeOriginSize(offset_, size_));
   context->SetLayerPaintRegion(this, context->CurrentSubtreeRegion());
 }
 
 void TextureLayer::Preroll(PrerollContext* context) {
-  set_paint_bounds(SkRect::MakeXYWH(offset_.x(), offset_.y(), size_.width(),
-                                    size_.height()));
+  set_paint_bounds(DlRect::MakeOriginSize(offset_, size_));
   context->has_texture_layer = true;
   context->renderable_state_flags = LayerStateStack::kCallerCanApplyOpacity;
 }
@@ -65,7 +63,7 @@ void TextureLayer::Paint(PaintContext& context) const {
       .aiks_context = context.aiks_context,
       .paint = context.state_stack.fill(paint),
   };
-  texture->Paint(ctx, paint_bounds(), freeze_, sampling_);
+  texture->Paint(ctx, ToSkRect(paint_bounds()), freeze_, sampling_);
 }
 
 }  // namespace flutter

--- a/flow/layers/texture_layer.h
+++ b/flow/layers/texture_layer.h
@@ -6,15 +6,13 @@
 #define FLUTTER_FLOW_LAYERS_TEXTURE_LAYER_H_
 
 #include "flutter/flow/layers/layer.h"
-#include "third_party/skia/include/core/SkPoint.h"
-#include "third_party/skia/include/core/SkSize.h"
 
 namespace flutter {
 
 class TextureLayer : public Layer {
  public:
-  TextureLayer(const SkPoint& offset,
-               const SkSize& size,
+  TextureLayer(const DlPoint& offset,
+               const DlSize& size,
                int64_t texture_id,
                bool freeze,
                DlImageSampling sampling);
@@ -31,8 +29,8 @@ class TextureLayer : public Layer {
   void Paint(PaintContext& context) const override;
 
  private:
-  SkPoint offset_;
-  SkSize size_;
+  DlPoint offset_;
+  DlSize size_;
   int64_t texture_id_;
   bool freeze_;
   DlImageSampling sampling_;

--- a/flow/layers/transform_layer.cc
+++ b/flow/layers/transform_layer.cc
@@ -8,20 +8,12 @@
 
 namespace flutter {
 
-TransformLayer::TransformLayer(const SkM44& transform) : transform_(transform) {
-  // Checks (in some degree) that SkM44 transform_ is valid and initialized.
-  //
-  // If transform_ is uninitialized, this assert may look flaky as it doesn't
-  // fail all the time, and some rerun may make it pass. But don't ignore it and
-  // just rerun the test if this is triggered, since even a flaky failure here
-  // may signify a potentially big problem in the code.
-  //
-  // We have to write this flaky test because there is no reliable way to test
-  // whether a variable is initialized or not in C++.
-  FML_DCHECK(transform_.isFinite());
-  if (!transform_.isFinite()) {
+TransformLayer::TransformLayer(const DlMatrix& transform)
+    : transform_(transform) {
+  FML_DCHECK(transform_.IsFinite());
+  if (!transform_.IsFinite()) {
     FML_LOG(ERROR) << "TransformLayer is constructed with an invalid matrix.";
-    transform_.setIdentity();
+    transform_ = {};
   }
 }
 
@@ -43,25 +35,10 @@ void TransformLayer::Preroll(PrerollContext* context) {
   auto mutator = context->state_stack.save();
   mutator.transform(transform_);
 
-  SkRect child_paint_bounds = SkRect::MakeEmpty();
+  DlRect child_paint_bounds;
   PrerollChildren(context, &child_paint_bounds);
 
-  // We convert to a 3x3 matrix here primarily because the SkM44 object
-  // does not support a mapRect operation.
-  // https://bugs.chromium.org/p/skia/issues/detail?id=11720&q=mapRect&can=2
-  //
-  // All geometry is X,Y only which means the 3rd row of the 4x4 matrix
-  // is ignored and the output of the 3rd column is also ignored.
-  // So we can transform the rectangle using just the 3x3 SkMatrix
-  // equivalent without any loss of information.
-  //
-  // Performance consideration:
-  // Skia has an internal mapRect for their SkM44 object that is faster
-  // than what SkMatrix does when it has perspective elements. But SkMatrix
-  // is otherwise optimal for non-perspective matrices. If SkM44 ever exposes
-  // a mapRect operation, or if SkMatrix ever optimizes its handling of
-  // the perspective elements, this issue will become moot.
-  transform_.asM33().mapRect(&child_paint_bounds);
+  child_paint_bounds = child_paint_bounds.TransformAndClipBounds(transform_);
   set_paint_bounds(child_paint_bounds);
 }
 

--- a/flow/layers/transform_layer.h
+++ b/flow/layers/transform_layer.h
@@ -9,13 +9,9 @@
 
 namespace flutter {
 
-// Be careful that SkMatrix's default constructor doesn't initialize the matrix
-// at all. Hence |set_transform| must be called with an initialized SkMatrix.
 class TransformLayer : public ContainerLayer {
  public:
-  explicit TransformLayer(const SkMatrix& transform)
-      : TransformLayer(SkM44(transform)) {}
-  explicit TransformLayer(const SkM44& transform);
+  explicit TransformLayer(const DlMatrix& transform);
 
   void Diff(DiffContext* context, const Layer* old_layer) override;
 
@@ -24,7 +20,7 @@ class TransformLayer : public ContainerLayer {
   void Paint(PaintContext& context) const override;
 
  private:
-  SkM44 transform_;
+  DlMatrix transform_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(TransformLayer);
 };

--- a/flow/layers/transform_layer_unittests.cc
+++ b/flow/layers/transform_layer_unittests.cc
@@ -16,11 +16,11 @@ using TransformLayerTest = LayerTest;
 
 #ifndef NDEBUG
 TEST_F(TransformLayerTest, PaintingEmptyLayerDies) {
-  auto layer = std::make_shared<TransformLayer>(SkMatrix());  // identity
+  auto layer = std::make_shared<TransformLayer>(DlMatrix());  // identity
 
   layer->Preroll(preroll_context());
-  EXPECT_EQ(layer->paint_bounds(), SkRect::MakeEmpty());
-  EXPECT_EQ(layer->child_paint_bounds(), SkRect::MakeEmpty());
+  EXPECT_EQ(layer->paint_bounds(), DlRect());
+  EXPECT_EQ(layer->child_paint_bounds(), DlRect());
   EXPECT_FALSE(layer->needs_painting(paint_context()));
 
   EXPECT_DEATH_IF_SUPPORTED(layer->Paint(paint_context()),
@@ -28,10 +28,9 @@ TEST_F(TransformLayerTest, PaintingEmptyLayerDies) {
 }
 
 TEST_F(TransformLayerTest, PaintBeforePrerollDies) {
-  SkPath child_path;
-  child_path.addRect(5.0f, 6.0f, 20.5f, 21.5f);
+  const DlPath child_path = DlPath::MakeRectLTRB(5.0f, 6.0f, 20.5f, 21.5f);
   auto mock_layer = std::make_shared<MockLayer>(child_path, DlPaint());
-  auto layer = std::make_shared<TransformLayer>(SkMatrix());  // identity
+  auto layer = std::make_shared<TransformLayer>(DlMatrix());  // identity
   layer->Add(mock_layer);
 
   EXPECT_DEATH_IF_SUPPORTED(layer->Paint(paint_context()),
@@ -40,21 +39,20 @@ TEST_F(TransformLayerTest, PaintBeforePrerollDies) {
 #endif
 
 TEST_F(TransformLayerTest, Identity) {
-  SkPath child_path;
-  child_path.addRect(5.0f, 6.0f, 20.5f, 21.5f);
-  SkRect cull_rect = SkRect::MakeXYWH(2.0f, 2.0f, 14.0f, 14.0f);
+  const DlPath child_path = DlPath::MakeRectLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  DlRect cull_rect = DlRect::MakeXYWH(2.0f, 2.0f, 14.0f, 14.0f);
   auto mock_layer = std::make_shared<MockLayer>(child_path, DlPaint());
-  auto layer = std::make_shared<TransformLayer>(SkMatrix());  // identity
+  auto layer = std::make_shared<TransformLayer>(DlMatrix());  // identity
   layer->Add(mock_layer);
 
   preroll_context()->state_stack.set_preroll_delegate(cull_rect);
   layer->Preroll(preroll_context());
-  EXPECT_EQ(mock_layer->paint_bounds(), child_path.getBounds());
+  EXPECT_EQ(mock_layer->paint_bounds(), child_path.GetBounds());
   EXPECT_EQ(layer->paint_bounds(), mock_layer->paint_bounds());
   EXPECT_EQ(layer->child_paint_bounds(), mock_layer->paint_bounds());
   EXPECT_TRUE(mock_layer->needs_painting(paint_context()));
   EXPECT_TRUE(layer->needs_painting(paint_context()));
-  EXPECT_EQ(mock_layer->parent_matrix(), SkMatrix());  // identity
+  EXPECT_EQ(mock_layer->parent_matrix(), DlMatrix());  // identity
   EXPECT_EQ(mock_layer->parent_cull_rect(), cull_rect);
   EXPECT_EQ(mock_layer->parent_mutators().stack_count(), 0u);
   EXPECT_EQ(mock_layer->parent_mutators(), MutatorsStack());
@@ -64,7 +62,7 @@ TEST_F(TransformLayerTest, Identity) {
   /* (Transform)layer::Paint */ {
     expected_builder.Save();
     {
-      expected_builder.Transform(SkMatrix());
+      expected_builder.Transform(DlMatrix());
       /* mock_layer::Paint */ {
         expected_builder.DrawPath(child_path, DlPaint());
       }
@@ -75,14 +73,14 @@ TEST_F(TransformLayerTest, Identity) {
 }
 
 TEST_F(TransformLayerTest, Simple) {
-  SkPath child_path;
-  child_path.addRect(5.0f, 6.0f, 20.5f, 21.5f);
-  SkMatrix initial_transform = SkMatrix::Translate(-0.5f, -0.5f);
-  SkRect local_cull_rect = SkRect::MakeXYWH(2.0f, 2.0f, 14.0f, 14.0f);
-  SkRect device_cull_rect = initial_transform.mapRect(local_cull_rect);
-  SkMatrix layer_transform = SkMatrix::Translate(2.5f, 2.5f);
-  SkMatrix inverse_layer_transform;
-  EXPECT_TRUE(layer_transform.invert(&inverse_layer_transform));
+  const DlPath child_path = DlPath::MakeRectLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  DlMatrix initial_transform = DlMatrix::MakeTranslation({-0.5f, -0.5f});
+  DlRect local_cull_rect = DlRect::MakeXYWH(2.0f, 2.0f, 14.0f, 14.0f);
+  DlRect device_cull_rect =
+      local_cull_rect.TransformAndClipBounds(initial_transform);
+  DlMatrix layer_transform = DlMatrix::MakeTranslation({2.5f, 2.5f});
+  EXPECT_TRUE(layer_transform.IsInvertible());
+  DlMatrix inverse_layer_transform = layer_transform.Invert();
 
   auto mock_layer = std::make_shared<MockLayer>(child_path, DlPaint());
   auto layer = std::make_shared<TransformLayer>(layer_transform);
@@ -91,16 +89,15 @@ TEST_F(TransformLayerTest, Simple) {
   preroll_context()->state_stack.set_preroll_delegate(device_cull_rect,
                                                       initial_transform);
   layer->Preroll(preroll_context());
-  EXPECT_EQ(mock_layer->paint_bounds(), child_path.getBounds());
+  EXPECT_EQ(mock_layer->paint_bounds(), child_path.GetBounds());
   EXPECT_EQ(layer->paint_bounds(),
-            layer_transform.mapRect(mock_layer->paint_bounds()));
+            mock_layer->paint_bounds().TransformAndClipBounds(layer_transform));
   EXPECT_EQ(layer->child_paint_bounds(), mock_layer->paint_bounds());
   EXPECT_TRUE(mock_layer->needs_painting(paint_context()));
   EXPECT_TRUE(layer->needs_painting(paint_context()));
-  EXPECT_EQ(mock_layer->parent_matrix(),
-            SkMatrix::Concat(initial_transform, layer_transform));
+  EXPECT_EQ(mock_layer->parent_matrix(), initial_transform * layer_transform);
   EXPECT_EQ(mock_layer->parent_cull_rect(),
-            inverse_layer_transform.mapRect(local_cull_rect));
+            local_cull_rect.TransformAndClipBounds(inverse_layer_transform));
   EXPECT_EQ(mock_layer->parent_mutators(),
             std::vector({Mutator(layer_transform)}));
 
@@ -119,95 +116,49 @@ TEST_F(TransformLayerTest, Simple) {
   EXPECT_TRUE(DisplayListsEQ_Verbose(display_list(), expected_builder.Build()));
 }
 
-TEST_F(TransformLayerTest, SimpleM44) {
-  SkPath child_path;
-  child_path.addRect(5.0f, 6.0f, 20.5f, 21.5f);
-  SkMatrix initial_transform = SkMatrix::Translate(-0.5f, -0.5f);
-  SkRect local_cull_rect = SkRect::MakeXYWH(2.0f, 2.0f, 14.0f, 14.0f);
-  SkRect device_cull_rect = initial_transform.mapRect(local_cull_rect);
-  SkMatrix layer_transform = SkMatrix::Translate(2.5f, 3.5f);
-  SkMatrix inverse_layer_transform;
-  EXPECT_TRUE(layer_transform.invert(&inverse_layer_transform));
+TEST_F(TransformLayerTest, ComplexMatrix) {
+  const DlPath child_path = DlPath::MakeRectLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  DlMatrix initial_transform = DlMatrix::MakeTranslation({-2.0f, -2.0f});
+  DlRect local_cull_rect = DlRect::MakeXYWH(4.0f, 4.0f, 16.0f, 16.0f);
+  DlRect device_cull_rect =
+      local_cull_rect.TransformAndClipBounds(initial_transform);
+  DlMatrix layer_transform = (DlMatrix::MakeTranslation({1.0f, 1.0f}) *
+                              DlMatrix::MakeRotationX(DlDegrees(20.0f))) *
+                             DlMatrix::MakeRotationY(DlDegrees(10.0f));
+
+  EXPECT_TRUE(layer_transform.IsInvertible());
+  DlMatrix inverse_layer_transform = layer_transform.Invert();
 
   auto mock_layer = std::make_shared<MockLayer>(child_path, DlPaint());
-  auto layer = std::make_shared<TransformLayer>(SkM44::Translate(2.5f, 3.5f));
+  auto layer = std::make_shared<TransformLayer>(layer_transform);
   layer->Add(mock_layer);
 
   preroll_context()->state_stack.set_preroll_delegate(device_cull_rect,
                                                       initial_transform);
   layer->Preroll(preroll_context());
-  EXPECT_EQ(mock_layer->paint_bounds(), child_path.getBounds());
+  EXPECT_EQ(mock_layer->paint_bounds(), child_path.GetBounds());
   EXPECT_EQ(layer->paint_bounds(),
-            layer_transform.mapRect(mock_layer->paint_bounds()));
+            mock_layer->paint_bounds().TransformAndClipBounds(layer_transform));
   EXPECT_EQ(layer->child_paint_bounds(), mock_layer->paint_bounds());
   EXPECT_TRUE(mock_layer->needs_painting(paint_context()));
   EXPECT_TRUE(layer->needs_painting(paint_context()));
-  EXPECT_EQ(mock_layer->parent_matrix(),
-            SkMatrix::Concat(initial_transform, layer_transform));
-  EXPECT_EQ(mock_layer->parent_cull_rect(),
-            inverse_layer_transform.mapRect(local_cull_rect));
-  EXPECT_EQ(mock_layer->parent_mutators(),
-            std::vector({Mutator(layer_transform)}));
-
-  layer->Paint(display_list_paint_context());
-  DisplayListBuilder expected_builder;
-  /* (Transform)layer::Paint */ {
-    expected_builder.Save();
-    {
-      expected_builder.Transform(layer_transform);
-      /* mock_layer::Paint */ {
-        expected_builder.DrawPath(child_path, DlPaint());
-      }
-    }
-    expected_builder.Restore();
-  }
-  EXPECT_TRUE(DisplayListsEQ_Verbose(display_list(), expected_builder.Build()));
-}
-
-TEST_F(TransformLayerTest, ComplexM44) {
-  SkPath child_path;
-  child_path.addRect(5.0f, 6.0f, 20.5f, 21.5f);
-  SkMatrix initial_transform = SkMatrix::Translate(-2.0f, -2.0f);
-  SkRect local_cull_rect = SkRect::MakeXYWH(4.0f, 4.0f, 16.0f, 16.0f);
-  SkRect device_cull_rect = initial_transform.mapRect(local_cull_rect);
-  SkM44 layer_transform44 = SkM44();
-  layer_transform44.preTranslate(1.0f, 1.0f);
-  // 20 degrees around the X axis
-  layer_transform44.preConcat(SkM44::Rotate({1.0f, 0.0f, 0.0f}, M_PI / 9.0f));
-  // 10 degrees around the Y axis
-  layer_transform44.preConcat(SkM44::Rotate({0.0f, 1.0f, 0.0f}, M_PI / 18.0f));
-  SkM44 inverse_layer_transform44;
-  EXPECT_TRUE(layer_transform44.invert(&inverse_layer_transform44));
-  SkMatrix layer_transform = layer_transform44.asM33();
-  SkMatrix inverse_layer_transform = inverse_layer_transform44.asM33();
-
-  auto mock_layer = std::make_shared<MockLayer>(child_path, DlPaint());
-  auto layer = std::make_shared<TransformLayer>(layer_transform44);
-  layer->Add(mock_layer);
-
-  preroll_context()->state_stack.set_preroll_delegate(device_cull_rect,
-                                                      initial_transform);
-  layer->Preroll(preroll_context());
-  EXPECT_EQ(mock_layer->paint_bounds(), child_path.getBounds());
-  EXPECT_EQ(layer->paint_bounds(),
-            layer_transform.mapRect(mock_layer->paint_bounds()));
-  EXPECT_EQ(layer->child_paint_bounds(), mock_layer->paint_bounds());
-  EXPECT_TRUE(mock_layer->needs_painting(paint_context()));
-  EXPECT_TRUE(layer->needs_painting(paint_context()));
-  EXPECT_EQ(mock_layer->parent_matrix(),
-            SkMatrix::Concat(initial_transform, layer_transform));
+  EXPECT_EQ(mock_layer->parent_matrix(), initial_transform * layer_transform);
 
   // Even having switched to binary-ieee friendly numbers for the
   // initial conditions, these numbers which are based on a matrix
   // concatenation and inversion still aren't exact, so we are using
   // fuzzy float comparisons to check them.
-  SkRect parent_cull_rect = mock_layer->parent_cull_rect();
-  SkRect expect_parent_cull_rect =
-      inverse_layer_transform.mapRect(local_cull_rect);
-  EXPECT_FLOAT_EQ(parent_cull_rect.fLeft, expect_parent_cull_rect.fLeft);
-  EXPECT_FLOAT_EQ(parent_cull_rect.fTop, expect_parent_cull_rect.fTop);
-  EXPECT_FLOAT_EQ(parent_cull_rect.fRight, expect_parent_cull_rect.fRight);
-  EXPECT_FLOAT_EQ(parent_cull_rect.fBottom, expect_parent_cull_rect.fBottom);
+  DlRect parent_cull_rect = mock_layer->parent_cull_rect();
+  DlRect expect_parent_cull_rect =
+      local_cull_rect.TransformAndClipBounds(inverse_layer_transform);
+  EXPECT_FLOAT_EQ(parent_cull_rect.GetLeft(),
+                  expect_parent_cull_rect.GetLeft());
+  EXPECT_FLOAT_EQ(parent_cull_rect.GetTop(),  //
+                  expect_parent_cull_rect.GetTop());
+  EXPECT_FLOAT_EQ(parent_cull_rect.GetRight(),
+                  expect_parent_cull_rect.GetRight());
+  EXPECT_FLOAT_EQ(parent_cull_rect.GetBottom(),
+                  expect_parent_cull_rect.GetBottom());
 
   EXPECT_EQ(mock_layer->parent_mutators(),
             std::vector({Mutator(layer_transform)}));
@@ -217,7 +168,7 @@ TEST_F(TransformLayerTest, ComplexM44) {
   /* (Transform)layer::Paint */ {
     expected_builder.Save();
     {
-      expected_builder.Transform(layer_transform44);
+      expected_builder.Transform(layer_transform);
       /* mock_layer::Paint */ {
         expected_builder.DrawPath(child_path, DlPaint());
       }
@@ -228,16 +179,17 @@ TEST_F(TransformLayerTest, ComplexM44) {
 }
 
 TEST_F(TransformLayerTest, Nested) {
-  SkPath child_path;
-  child_path.addRect(5.0f, 6.0f, 20.5f, 21.5f);
-  SkMatrix initial_transform = SkMatrix::Translate(-0.5f, -0.5f);
-  SkRect local_cull_rect = SkRect::MakeXYWH(2.0f, 2.0f, 14.0f, 14.0f);
-  SkRect device_cull_rect = initial_transform.mapRect(local_cull_rect);
-  SkMatrix layer1_transform = SkMatrix::Translate(2.5f, 2.5f);
-  SkMatrix layer2_transform = SkMatrix::Translate(3.5f, 3.5f);
-  SkMatrix inverse_layer1_transform, inverse_layer2_transform;
-  EXPECT_TRUE(layer1_transform.invert(&inverse_layer1_transform));
-  EXPECT_TRUE(layer2_transform.invert(&inverse_layer2_transform));
+  DlPath child_path = DlPath::MakeRectLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  DlMatrix initial_transform = DlMatrix::MakeTranslation({-0.5f, -0.5f});
+  DlRect local_cull_rect = DlRect::MakeXYWH(2.0f, 2.0f, 14.0f, 14.0f);
+  DlRect device_cull_rect =
+      local_cull_rect.TransformAndClipBounds(initial_transform);
+  DlMatrix layer1_transform = DlMatrix::MakeTranslation({2.5f, 2.5f});
+  DlMatrix layer2_transform = DlMatrix::MakeTranslation({3.5f, 3.5f});
+  EXPECT_TRUE(layer1_transform.IsInvertible());
+  EXPECT_TRUE(layer2_transform.IsInvertible());
+  DlMatrix inverse_layer1_transform = layer1_transform.Invert();
+  DlMatrix inverse_layer2_transform = layer2_transform.Invert();
 
   auto mock_layer = std::make_shared<MockLayer>(child_path, DlPaint());
   auto layer1 = std::make_shared<TransformLayer>(layer1_transform);
@@ -248,23 +200,22 @@ TEST_F(TransformLayerTest, Nested) {
   preroll_context()->state_stack.set_preroll_delegate(device_cull_rect,
                                                       initial_transform);
   layer1->Preroll(preroll_context());
-  EXPECT_EQ(mock_layer->paint_bounds(), child_path.getBounds());
-  EXPECT_EQ(layer2->paint_bounds(),
-            layer2_transform.mapRect(mock_layer->paint_bounds()));
+  EXPECT_EQ(mock_layer->paint_bounds(), child_path.GetBounds());
+  EXPECT_EQ(
+      layer2->paint_bounds(),
+      mock_layer->paint_bounds().TransformAndClipBounds(layer2_transform));
   EXPECT_EQ(layer2->child_paint_bounds(), mock_layer->paint_bounds());
   EXPECT_EQ(layer1->paint_bounds(),
-            layer1_transform.mapRect(layer2->paint_bounds()));
+            layer2->paint_bounds().TransformAndClipBounds(layer1_transform));
   EXPECT_EQ(layer1->child_paint_bounds(), layer2->paint_bounds());
   EXPECT_TRUE(mock_layer->needs_painting(paint_context()));
   EXPECT_TRUE(layer2->needs_painting(paint_context()));
   EXPECT_TRUE(layer1->needs_painting(paint_context()));
-  EXPECT_EQ(
-      mock_layer->parent_matrix(),
-      SkMatrix::Concat(SkMatrix::Concat(initial_transform, layer1_transform),
-                       layer2_transform));
+  EXPECT_EQ(mock_layer->parent_matrix(),
+            (initial_transform * layer1_transform) * layer2_transform);
   EXPECT_EQ(mock_layer->parent_cull_rect(),
-            inverse_layer2_transform.mapRect(
-                inverse_layer1_transform.mapRect(local_cull_rect)));
+            local_cull_rect.TransformAndClipBounds(inverse_layer1_transform)
+                .TransformAndClipBounds(inverse_layer2_transform));
   EXPECT_EQ(
       mock_layer->parent_mutators(),
       std::vector({Mutator(layer1_transform), Mutator(layer2_transform)}));
@@ -292,16 +243,17 @@ TEST_F(TransformLayerTest, Nested) {
 }
 
 TEST_F(TransformLayerTest, NestedSeparated) {
-  SkPath child_path;
-  child_path.addRect(5.0f, 6.0f, 20.5f, 21.5f);
-  SkMatrix initial_transform = SkMatrix::Translate(-0.5f, -0.5f);
-  SkRect local_cull_rect = SkRect::MakeXYWH(2.0f, 2.0f, 14.0f, 14.0f);
-  SkRect device_cull_rect = initial_transform.mapRect(local_cull_rect);
-  SkMatrix layer1_transform = SkMatrix::Translate(2.5f, 2.5f);
-  SkMatrix layer2_transform = SkMatrix::Translate(3.5f, 3.5f);
-  SkMatrix inverse_layer1_transform, inverse_layer2_transform;
-  EXPECT_TRUE(layer1_transform.invert(&inverse_layer1_transform));
-  EXPECT_TRUE(layer2_transform.invert(&inverse_layer2_transform));
+  DlPath child_path = DlPath::MakeRectLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  DlMatrix initial_transform = DlMatrix::MakeTranslation({-0.5f, -0.5f});
+  DlRect local_cull_rect = DlRect::MakeXYWH(2.0f, 2.0f, 14.0f, 14.0f);
+  DlRect device_cull_rect =
+      local_cull_rect.TransformAndClipBounds(initial_transform);
+  DlMatrix layer1_transform = DlMatrix::MakeTranslation({2.5f, 2.5f});
+  DlMatrix layer2_transform = DlMatrix::MakeTranslation({3.5f, 3.5f});
+  EXPECT_TRUE(layer1_transform.IsInvertible());
+  EXPECT_TRUE(layer2_transform.IsInvertible());
+  DlMatrix inverse_layer1_transform = layer1_transform.Invert();
+  DlMatrix inverse_layer2_transform = layer2_transform.Invert();
   DlPaint child_paint1(DlColor::kBlue());
   DlPaint child_paint2(DlColor::kGreen());
 
@@ -316,33 +268,31 @@ TEST_F(TransformLayerTest, NestedSeparated) {
   preroll_context()->state_stack.set_preroll_delegate(device_cull_rect,
                                                       initial_transform);
   layer1->Preroll(preroll_context());
-  SkRect layer1_child_bounds = layer2->paint_bounds();
-  layer1_child_bounds.join(mock_layer1->paint_bounds());
-  SkRect expected_layer1_bounds = layer1_child_bounds;
-  layer1_transform.mapRect(&expected_layer1_bounds);
+  DlRect layer1_child_bounds =
+      layer2->paint_bounds().Union(mock_layer1->paint_bounds());
+  DlRect expected_layer1_bounds =
+      layer1_child_bounds.TransformAndClipBounds(layer1_transform);
 
-  EXPECT_EQ(mock_layer2->paint_bounds(), child_path.getBounds());
-  EXPECT_EQ(layer2->paint_bounds(),
-            layer2_transform.mapRect(mock_layer2->paint_bounds()));
+  EXPECT_EQ(mock_layer2->paint_bounds(), child_path.GetBounds());
+  EXPECT_EQ(
+      layer2->paint_bounds(),
+      mock_layer2->paint_bounds().TransformAndClipBounds(layer2_transform));
   EXPECT_EQ(layer2->child_paint_bounds(), mock_layer2->paint_bounds());
-  EXPECT_EQ(mock_layer1->paint_bounds(), child_path.getBounds());
+  EXPECT_EQ(mock_layer1->paint_bounds(), child_path.GetBounds());
   EXPECT_EQ(layer1->paint_bounds(), expected_layer1_bounds);
   EXPECT_EQ(layer1->child_paint_bounds(), layer1_child_bounds);
   EXPECT_TRUE(mock_layer2->needs_painting(paint_context()));
   EXPECT_TRUE(layer2->needs_painting(paint_context()));
   EXPECT_TRUE(mock_layer1->needs_painting(paint_context()));
   EXPECT_TRUE(layer1->needs_painting(paint_context()));
-  EXPECT_EQ(mock_layer1->parent_matrix(),
-            SkMatrix::Concat(initial_transform, layer1_transform));
-  EXPECT_EQ(
-      mock_layer2->parent_matrix(),
-      SkMatrix::Concat(SkMatrix::Concat(initial_transform, layer1_transform),
-                       layer2_transform));
+  EXPECT_EQ(mock_layer1->parent_matrix(), initial_transform * layer1_transform);
+  EXPECT_EQ(mock_layer2->parent_matrix(),
+            (initial_transform * layer1_transform) * layer2_transform);
   EXPECT_EQ(mock_layer1->parent_cull_rect(),
-            inverse_layer1_transform.mapRect(local_cull_rect));
+            local_cull_rect.TransformAndClipBounds(inverse_layer1_transform));
   EXPECT_EQ(mock_layer2->parent_cull_rect(),
-            inverse_layer2_transform.mapRect(
-                inverse_layer1_transform.mapRect(local_cull_rect)));
+            local_cull_rect.TransformAndClipBounds(inverse_layer1_transform)
+                .TransformAndClipBounds(inverse_layer2_transform));
   EXPECT_EQ(mock_layer1->parent_mutators(),
             std::vector({Mutator(layer1_transform)}));
   EXPECT_EQ(
@@ -375,9 +325,10 @@ TEST_F(TransformLayerTest, NestedSeparated) {
 }
 
 TEST_F(TransformLayerTest, OpacityInheritance) {
-  auto path1 = SkPath().addRect({10, 10, 30, 30});
+  auto path1 = DlPath::MakeRectLTRB(10, 10, 30, 30);
   auto mock1 = MockLayer::MakeOpacityCompatible(path1);
-  auto transform1 = std::make_shared<TransformLayer>(SkMatrix::Scale(2, 2));
+  auto transform1 =
+      std::make_shared<TransformLayer>(DlMatrix::MakeScale({2.0f, 2.0f, 1.0f}));
   transform1->Add(mock1);
 
   // TransformLayer will pass through compatibility from a compatible child
@@ -386,7 +337,7 @@ TEST_F(TransformLayerTest, OpacityInheritance) {
   EXPECT_EQ(context->renderable_state_flags,
             LayerStateStack::kCallerCanApplyOpacity);
 
-  auto path2 = SkPath().addRect({40, 40, 50, 50});
+  auto path2 = DlPath::MakeRectLTRB(40, 40, 50, 50);
   auto mock2 = MockLayer::MakeOpacityCompatible(path2);
   transform1->Add(mock2);
 
@@ -396,7 +347,7 @@ TEST_F(TransformLayerTest, OpacityInheritance) {
   EXPECT_EQ(context->renderable_state_flags,
             LayerStateStack::kCallerCanApplyOpacity);
 
-  auto path3 = SkPath().addRect({20, 20, 40, 40});
+  auto path3 = DlPath::MakeRectLTRB(20, 20, 40, 40);
   auto mock3 = MockLayer::MakeOpacityCompatible(path3);
   transform1->Add(mock3);
 
@@ -405,7 +356,8 @@ TEST_F(TransformLayerTest, OpacityInheritance) {
   transform1->Preroll(context);
   EXPECT_EQ(context->renderable_state_flags, 0);
 
-  auto transform2 = std::make_shared<TransformLayer>(SkMatrix::Scale(2, 2));
+  auto transform2 =
+      std::make_shared<TransformLayer>(DlMatrix::MakeScale({2.0f, 2.0f, 1.0f}));
   transform2->Add(mock1);
   transform2->Add(mock2);
 
@@ -414,7 +366,7 @@ TEST_F(TransformLayerTest, OpacityInheritance) {
   EXPECT_EQ(context->renderable_state_flags,
             LayerStateStack::kCallerCanApplyOpacity);
 
-  auto path4 = SkPath().addRect({60, 60, 70, 70});
+  auto path4 = DlPath::MakeRectLTRB(60, 60, 70, 70);
   auto mock4 = MockLayer::Make(path4);
   transform2->Add(mock4);
 
@@ -425,11 +377,11 @@ TEST_F(TransformLayerTest, OpacityInheritance) {
 }
 
 TEST_F(TransformLayerTest, OpacityInheritancePainting) {
-  auto path1 = SkPath().addRect({10, 10, 30, 30});
+  auto path1 = DlPath::MakeRectLTRB(10, 10, 30, 30);
   auto mock1 = MockLayer::MakeOpacityCompatible(path1);
-  auto path2 = SkPath().addRect({40, 40, 50, 50});
+  auto path2 = DlPath::MakeRectLTRB(40, 40, 50, 50);
   auto mock2 = MockLayer::MakeOpacityCompatible(path2);
-  auto transform = SkMatrix::Scale(2, 2);
+  auto transform = DlMatrix::MakeScale({2.0f, 2.0f, 1.0f});
   auto transform_layer = std::make_shared<TransformLayer>(transform);
   transform_layer->Add(mock1);
   transform_layer->Add(mock2);
@@ -441,8 +393,8 @@ TEST_F(TransformLayerTest, OpacityInheritancePainting) {
   EXPECT_EQ(context->renderable_state_flags,
             LayerStateStack::kCallerCanApplyOpacity);
 
-  int opacity_alpha = 0x7F;
-  SkPoint offset = SkPoint::Make(10, 10);
+  uint8_t opacity_alpha = 0x7F;
+  DlPoint offset = DlPoint(10, 10);
   auto opacity_layer = std::make_shared<OpacityLayer>(opacity_alpha, offset);
   opacity_layer->Add(transform_layer);
   opacity_layer->Preroll(context);
@@ -452,7 +404,7 @@ TEST_F(TransformLayerTest, OpacityInheritancePainting) {
   /* opacity_layer paint */ {
     expected_builder.Save();
     {
-      expected_builder.Translate(offset.fX, offset.fY);
+      expected_builder.Translate(offset.x, offset.y);
       /* transform_layer paint */ {
         expected_builder.Save();
         expected_builder.Transform(transform);
@@ -475,21 +427,21 @@ TEST_F(TransformLayerTest, OpacityInheritancePainting) {
 using TransformLayerLayerDiffTest = DiffContextTest;
 
 TEST_F(TransformLayerLayerDiffTest, Transform) {
-  auto path1 = SkPath().addRect(SkRect::MakeLTRB(0, 0, 50, 50));
+  auto path1 = DlPath::MakeRectLTRB(0, 0, 50, 50);
   auto m1 = std::make_shared<MockLayer>(path1);
 
   auto transform1 =
-      std::make_shared<TransformLayer>(SkMatrix::Translate(10, 10));
+      std::make_shared<TransformLayer>(DlMatrix::MakeTranslation({10, 10}));
   transform1->Add(m1);
 
   MockLayerTree t1;
   t1.root()->Add(transform1);
 
   auto damage = DiffLayerTree(t1, MockLayerTree());
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(10, 10, 60, 60));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(10, 10, 60, 60));
 
   auto transform2 =
-      std::make_shared<TransformLayer>(SkMatrix::Translate(20, 20));
+      std::make_shared<TransformLayer>(DlMatrix::MakeTranslation({20, 20}));
   transform2->Add(m1);
   transform2->AssignOldLayer(transform1.get());
 
@@ -497,10 +449,10 @@ TEST_F(TransformLayerLayerDiffTest, Transform) {
   t2.root()->Add(transform2);
 
   damage = DiffLayerTree(t2, t1);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(10, 10, 70, 70));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(10, 10, 70, 70));
 
   auto transform3 =
-      std::make_shared<TransformLayer>(SkMatrix::Translate(20, 20));
+      std::make_shared<TransformLayer>(DlMatrix::MakeTranslation({20, 20}));
   transform3->Add(m1);
   transform3->AssignOldLayer(transform2.get());
 
@@ -508,29 +460,30 @@ TEST_F(TransformLayerLayerDiffTest, Transform) {
   t3.root()->Add(transform3);
 
   damage = DiffLayerTree(t3, t2);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeEmpty());
+  EXPECT_EQ(damage.frame_damage, DlIRect());
 }
 
 TEST_F(TransformLayerLayerDiffTest, TransformNested) {
-  auto path1 = SkPath().addRect(SkRect::MakeLTRB(0, 0, 50, 50));
+  auto path1 = DlPath::MakeRectLTRB(0, 0, 50, 50);
   auto m1 = CreateContainerLayer(std::make_shared<MockLayer>(path1));
   auto m2 = CreateContainerLayer(std::make_shared<MockLayer>(path1));
   auto m3 = CreateContainerLayer(std::make_shared<MockLayer>(path1));
 
-  auto transform1 = std::make_shared<TransformLayer>(SkMatrix::Scale(2.0, 2.0));
+  auto transform1 =
+      std::make_shared<TransformLayer>(DlMatrix::MakeScale({2.0f, 2.0f, 1.0f}));
 
   auto transform1_1 =
-      std::make_shared<TransformLayer>(SkMatrix::Translate(10, 10));
+      std::make_shared<TransformLayer>(DlMatrix::MakeTranslation({10, 10}));
   transform1_1->Add(m1);
   transform1->Add(transform1_1);
 
   auto transform1_2 =
-      std::make_shared<TransformLayer>(SkMatrix::Translate(100, 100));
+      std::make_shared<TransformLayer>(DlMatrix::MakeTranslation({100, 100}));
   transform1_2->Add(m2);
   transform1->Add(transform1_2);
 
   auto transform1_3 =
-      std::make_shared<TransformLayer>(SkMatrix::Translate(200, 200));
+      std::make_shared<TransformLayer>(DlMatrix::MakeTranslation({200, 200}));
   transform1_3->Add(m3);
   transform1->Add(transform1_3);
 
@@ -538,25 +491,26 @@ TEST_F(TransformLayerLayerDiffTest, TransformNested) {
   l1.root()->Add(transform1);
 
   auto damage = DiffLayerTree(l1, MockLayerTree());
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(20, 20, 500, 500));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(20, 20, 500, 500));
 
-  auto transform2 = std::make_shared<TransformLayer>(SkMatrix::Scale(2.0, 2.0));
+  auto transform2 =
+      std::make_shared<TransformLayer>(DlMatrix::MakeScale({2.0f, 2.0f, 1.0f}));
 
   auto transform2_1 =
-      std::make_shared<TransformLayer>(SkMatrix::Translate(10, 10));
+      std::make_shared<TransformLayer>(DlMatrix::MakeTranslation({10, 10}));
   transform2_1->Add(m1);
   transform2_1->AssignOldLayer(transform1_1.get());
   transform2->Add(transform2_1);
 
   // Offset 1px from transform1_2 so that they're not the same
   auto transform2_2 =
-      std::make_shared<TransformLayer>(SkMatrix::Translate(100, 101));
+      std::make_shared<TransformLayer>(DlMatrix::MakeTranslation({100, 101}));
   transform2_2->Add(m2);
   transform2_2->AssignOldLayer(transform1_2.get());
   transform2->Add(transform2_2);
 
   auto transform2_3 =
-      std::make_shared<TransformLayer>(SkMatrix::Translate(200, 200));
+      std::make_shared<TransformLayer>(DlMatrix::MakeTranslation({200, 200}));
   transform2_3->Add(m3);
   transform2_3->AssignOldLayer(transform1_3.get());
   transform2->Add(transform2_3);
@@ -568,14 +522,14 @@ TEST_F(TransformLayerLayerDiffTest, TransformNested) {
 
   // transform2 has not transform1 assigned as old layer, so it should be
   // invalidated completely
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(20, 20, 500, 500));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(20, 20, 500, 500));
 
   // now diff the tree properly, the only difference being transform2_2 and
   // transform_2_1
   transform2->AssignOldLayer(transform1.get());
   damage = DiffLayerTree(l2, l1);
 
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(200, 200, 300, 302));
+  EXPECT_EQ(damage.frame_damage, DlIRect::MakeLTRB(200, 200, 300, 302));
 }
 
 }  // namespace testing

--- a/flow/paint_region.cc
+++ b/flow/paint_region.cc
@@ -6,10 +6,10 @@
 
 namespace flutter {
 
-SkRect PaintRegion::ComputeBounds() const {
-  SkRect res = SkRect::MakeEmpty();
+DlRect PaintRegion::ComputeBounds() const {
+  DlRect res;
   for (const auto& r : *this) {
-    res.join(r);
+    res = res.Union(r);
   }
   return res;
 }

--- a/flow/paint_region.h
+++ b/flow/paint_region.h
@@ -8,8 +8,9 @@
 #include <memory>
 #include <utility>
 #include <vector>
+
+#include "flutter/display_list/geometry/dl_geometry_types.h"
 #include "flutter/fml/logging.h"
-#include "third_party/skia/include/core/SkRect.h"
 
 namespace flutter {
 
@@ -27,7 +28,7 @@ namespace flutter {
 class PaintRegion {
  public:
   PaintRegion() = default;
-  PaintRegion(std::shared_ptr<std::vector<SkRect>> rects,
+  PaintRegion(std::shared_ptr<std::vector<DlRect>> rects,
               size_t from,
               size_t to,
               bool has_readback,
@@ -38,18 +39,18 @@ class PaintRegion {
         has_readback_(has_readback),
         has_texture_(has_texture) {}
 
-  std::vector<SkRect>::const_iterator begin() const {
+  std::vector<DlRect>::const_iterator begin() const {
     FML_DCHECK(is_valid());
     return rects_->begin() + from_;
   }
 
-  std::vector<SkRect>::const_iterator end() const {
+  std::vector<DlRect>::const_iterator end() const {
     FML_DCHECK(is_valid());
     return rects_->begin() + to_;
   }
 
   // Compute bounds for this region
-  SkRect ComputeBounds() const;
+  DlRect ComputeBounds() const;
 
   bool is_valid() const { return rects_ != nullptr; }
 
@@ -62,7 +63,7 @@ class PaintRegion {
   bool has_texture() const { return has_texture_; }
 
  private:
-  std::shared_ptr<std::vector<SkRect>> rects_;
+  std::shared_ptr<std::vector<DlRect>> rects_;
   size_t from_ = 0;
   size_t to_ = 0;
   bool has_readback_ = false;

--- a/flow/raster_cache_item.h
+++ b/flow/raster_cache_item.h
@@ -39,10 +39,10 @@ class RasterCacheItem {
         child_items_(child_entries) {}
 
   virtual void PrerollSetup(PrerollContext* context,
-                            const SkMatrix& matrix) = 0;
+                            const DlMatrix& matrix) = 0;
 
   virtual void PrerollFinalize(PrerollContext* context,
-                               const SkMatrix& matrix) = 0;
+                               const DlMatrix& matrix) = 0;
 
   virtual bool Draw(const PaintContext& context,
                     const DlPaint* paint) const = 0;
@@ -58,6 +58,7 @@ class RasterCacheItem {
 
   unsigned child_items() const { return child_items_; }
 
+  void set_matrix(const DlMatrix& matrix) { matrix_ = ToSkMatrix(matrix); }
   void set_matrix(const SkMatrix& matrix) { matrix_ = matrix; }
 
   CacheState cache_state() const { return cache_state_; }

--- a/flow/raster_cache_key.h
+++ b/flow/raster_cache_key.h
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "flutter/display_list/geometry/dl_geometry_types.h"
 #include "flutter/fml/hash_combine.h"
 #include "flutter/fml/logging.h"
 #include "third_party/skia/include/core/SkMatrix.h"

--- a/flow/raster_cache_util.h
+++ b/flow/raster_cache_util.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_FLOW_RASTER_CACHE_UTIL_H_
 #define FLUTTER_FLOW_RASTER_CACHE_UTIL_H_
 
+#include "flutter/display_list/geometry/dl_geometry_types.h"
 #include "flutter/fml/logging.h"
 #include "include/core/SkM44.h"
 #include "include/core/SkMatrix.h"
@@ -83,6 +84,24 @@ struct RasterCacheUtil {
   }
 
   /**
+   * @brief Snap the translation components of the matrix to integers.
+   *
+   * The snapping will only happen if the matrix only has scale and translation
+   * transformations. This is used, along with GetRoundedOutDeviceBounds, to
+   * ensure that the textures drawn by the raster cache are exactly aligned to
+   * physical pixels. Any layers that participate in raster caching must align
+   * themselves to physical pixels even when not cached to prevent a change in
+   * apparent location if caching is later applied.
+   *
+   * @param ctm the current transformation matrix.
+   * @return SkMatrix the snapped transformation matrix.
+   */
+  static DlMatrix GetIntegralTransCTM(const DlMatrix& ctm) {
+    DlMatrix integral;
+    return ComputeIntegralTransCTM(ctm, &integral) ? integral : ctm;
+  }
+
+  /**
    * @brief Snap the translation components of the |in| matrix to integers
    *        and store the snapped matrix in |out|.
    *
@@ -137,6 +156,25 @@ struct RasterCacheUtil {
    * @return true if the integral modification was needed, false otherwise.
    */
   static bool ComputeIntegralTransCTM(const SkM44& in, SkM44* out);
+
+  /**
+   * @brief Snap the translation components of the |in| matrix to integers
+   *        and store the snapped matrix in |out|.
+   *
+   * The snapping will only happen if the matrix only has scale and translation
+   * transformations. This is used, along with GetRoundedOutDeviceBounds, to
+   * ensure that the textures drawn by the raster cache are exactly aligned to
+   * physical pixels. Any layers that participate in raster caching must align
+   * themselves to physical pixels even when not cached to prevent a change in
+   * apparent location if caching is later applied.
+   *
+   * The |out| matrix will not be modified if this method returns false.
+   *
+   * @param in the current transformation matrix.
+   * @param out the storage for the snapped matrix.
+   * @return true if the integral modification was needed, false otherwise.
+   */
+  static bool ComputeIntegralTransCTM(const DlMatrix& in, DlMatrix* out);
 };
 
 }  // namespace flutter

--- a/flow/testing/diff_context_test.cc
+++ b/flow/testing/diff_context_test.cc
@@ -14,7 +14,7 @@ DiffContextTest::DiffContextTest() {}
 
 Damage DiffContextTest::DiffLayerTree(MockLayerTree& layer_tree,
                                       const MockLayerTree& old_layer_tree,
-                                      const SkIRect& additional_damage,
+                                      const DlIRect& additional_damage,
                                       int horizontal_clip_alignment,
                                       int vertical_clip_alignment,
                                       bool use_raster_cache,
@@ -24,14 +24,13 @@ Damage DiffContextTest::DiffLayerTree(MockLayerTree& layer_tree,
   DiffContext dc(layer_tree.size(), layer_tree.paint_region_map(),
                  old_layer_tree.paint_region_map(), use_raster_cache,
                  impeller_enabled);
-  dc.PushCullRect(
-      SkRect::MakeIWH(layer_tree.size().width(), layer_tree.size().height()));
+  dc.PushCullRect(DlRect::MakeSize(layer_tree.size()));
   layer_tree.root()->Diff(&dc, old_layer_tree.root());
   return dc.ComputeDamage(additional_damage, horizontal_clip_alignment,
                           vertical_clip_alignment);
 }
 
-sk_sp<DisplayList> DiffContextTest::CreateDisplayList(const SkRect& bounds,
+sk_sp<DisplayList> DiffContextTest::CreateDisplayList(const DlRect& bounds,
                                                       DlColor color) {
   DisplayListBuilder builder;
   builder.DrawRect(bounds, DlPaint().setColor(color));
@@ -40,7 +39,7 @@ sk_sp<DisplayList> DiffContextTest::CreateDisplayList(const SkRect& bounds,
 
 std::shared_ptr<DisplayListLayer> DiffContextTest::CreateDisplayListLayer(
     const sk_sp<DisplayList>& display_list,
-    const SkPoint& offset) {
+    const DlPoint& offset) {
   return std::make_shared<DisplayListLayer>(offset, display_list, false, false);
 }
 
@@ -55,8 +54,8 @@ std::shared_ptr<ContainerLayer> DiffContextTest::CreateContainerLayer(
 
 std::shared_ptr<OpacityLayer> DiffContextTest::CreateOpacityLater(
     std::initializer_list<std::shared_ptr<Layer>> layers,
-    SkAlpha alpha,
-    const SkPoint& offset) {
+    uint8_t alpha,
+    const DlPoint& offset) {
   auto res = std::make_shared<OpacityLayer>(alpha, offset);
   for (const auto& l : layers) {
     res->Add(l);

--- a/flow/testing/diff_context_test.h
+++ b/flow/testing/diff_context_test.h
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "flutter/display_list/geometry/dl_geometry_types.h"
 #include "flutter/flow/layers/container_layer.h"
 #include "flutter/flow/layers/display_list_layer.h"
 #include "flutter/flow/layers/opacity_layer.h"
@@ -17,7 +18,7 @@ namespace testing {
 
 class MockLayerTree {
  public:
-  explicit MockLayerTree(SkISize size = SkISize::Make(1000, 1000))
+  explicit MockLayerTree(DlISize size = DlISize(1000, 1000))
       : root_(std::make_shared<ContainerLayer>()), size_(size) {}
 
   ContainerLayer* root() { return root_.get(); }
@@ -26,12 +27,12 @@ class MockLayerTree {
   PaintRegionMap& paint_region_map() { return paint_region_map_; }
   const PaintRegionMap& paint_region_map() const { return paint_region_map_; }
 
-  const SkISize& size() const { return size_; }
+  const DlISize& size() const { return size_; }
 
  private:
   std::shared_ptr<ContainerLayer> root_;
   PaintRegionMap paint_region_map_;
-  SkISize size_;
+  DlISize size_;
 };
 
 class DiffContextTest : public LayerTest {
@@ -40,7 +41,7 @@ class DiffContextTest : public LayerTest {
 
   Damage DiffLayerTree(MockLayerTree& layer_tree,
                        const MockLayerTree& old_layer_tree,
-                       const SkIRect& additional_damage = SkIRect::MakeEmpty(),
+                       const DlIRect& additional_damage = DlIRect(),
                        int horizontal_clip_alignment = 0,
                        int vertical_alignment = 0,
                        bool use_raster_cache = true,
@@ -48,12 +49,12 @@ class DiffContextTest : public LayerTest {
 
   // Create display list consisting of filled rect with given color; Being able
   // to specify different color is useful to test deep comparison of pictures
-  sk_sp<DisplayList> CreateDisplayList(const SkRect& bounds,
+  sk_sp<DisplayList> CreateDisplayList(const DlRect& bounds,
                                        DlColor color = DlColor::kBlack());
 
   std::shared_ptr<DisplayListLayer> CreateDisplayListLayer(
       const sk_sp<DisplayList>& display_list,
-      const SkPoint& offset = SkPoint::Make(0, 0));
+      const DlPoint& offset = DlPoint(0, 0));
 
   std::shared_ptr<ContainerLayer> CreateContainerLayer(
       std::initializer_list<std::shared_ptr<Layer>> layers);
@@ -65,8 +66,8 @@ class DiffContextTest : public LayerTest {
 
   std::shared_ptr<OpacityLayer> CreateOpacityLater(
       std::initializer_list<std::shared_ptr<Layer>> layers,
-      SkAlpha alpha,
-      const SkPoint& offset = SkPoint::Make(0, 0));
+      uint8_t alpha,
+      const DlPoint& offset = DlPoint(0, 0));
 };
 
 }  // namespace testing

--- a/flow/testing/layer_test.h
+++ b/flow/testing/layer_test.h
@@ -24,8 +24,6 @@
 namespace flutter {
 namespace testing {
 
-static constexpr SkRect kEmptyRect = SkRect::MakeEmpty();
-
 // This fixture allows generating tests which can |Paint()| and |Preroll()|
 // |Layer|'s.
 // |LayerTest| is a default implementation based on |::testing::Test|.
@@ -76,7 +74,7 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
             // clang-format on
         } {
     use_null_raster_cache();
-    preroll_state_stack_.set_preroll_delegate(kGiantRect, SkMatrix::I());
+    preroll_state_stack_.set_preroll_delegate(kGiantRect, DlMatrix());
     display_list_state_stack_.set_delegate(&display_list_builder_);
   }
 

--- a/flow/testing/mock_layer.cc
+++ b/flow/testing/mock_layer.cc
@@ -14,7 +14,7 @@
 namespace flutter {
 namespace testing {
 
-MockLayer::MockLayer(const SkPath& path, DlPaint paint)
+MockLayer::MockLayer(const DlPath& path, DlPaint paint)
     : fake_paint_path_(path), fake_paint_(std::move(paint)) {}
 
 bool MockLayer::IsReplacing(DiffContext* context, const Layer* layer) const {
@@ -28,13 +28,13 @@ bool MockLayer::IsReplacing(DiffContext* context, const Layer* layer) const {
 
 void MockLayer::Diff(DiffContext* context, const Layer* old_layer) {
   DiffContext::AutoSubtreeRestore subtree(context);
-  context->AddLayerBounds(fake_paint_path_.getBounds());
+  context->AddLayerBounds(fake_paint_path_.GetBounds());
   context->SetLayerPaintRegion(this, context->CurrentSubtreeRegion());
 }
 
 void MockLayer::Preroll(PrerollContext* context) {
   context->state_stack.fill(&parent_mutators_);
-  parent_matrix_ = context->state_stack.transform_3x3();
+  parent_matrix_ = context->state_stack.matrix();
   parent_cull_rect_ = context->state_stack.local_cull_rect();
 
   set_parent_has_platform_view(context->has_platform_view);
@@ -42,7 +42,7 @@ void MockLayer::Preroll(PrerollContext* context) {
 
   context->has_platform_view = fake_has_platform_view();
   context->has_texture_layer = fake_has_texture_layer();
-  set_paint_bounds(fake_paint_path_.getBounds());
+  set_paint_bounds(fake_paint_path_.GetBounds());
   if (fake_reads_surface()) {
     context->surface_needs_readback = true;
   }
@@ -55,9 +55,7 @@ void MockLayer::Paint(PaintContext& context) const {
   FML_DCHECK(needs_painting(context));
 
   if (expected_paint_matrix_.has_value()) {
-    SkMatrix matrix = context.canvas->GetTransform();
-
-    EXPECT_EQ(matrix, expected_paint_matrix_.value());
+    EXPECT_EQ(context.canvas->GetMatrix(), expected_paint_matrix_.value());
   }
 
   DlPaint paint = fake_paint_;
@@ -69,7 +67,7 @@ void MockCacheableContainerLayer::Preroll(PrerollContext* context) {
   Layer::AutoPrerollSaveLayerState save =
       Layer::AutoPrerollSaveLayerState::Create(context);
   auto cache = AutoCache(layer_raster_cache_item_.get(), context,
-                         context->state_stack.transform_3x3());
+                         context->state_stack.matrix());
 
   ContainerLayer::Preroll(context);
 }
@@ -78,7 +76,7 @@ void MockCacheableLayer::Preroll(PrerollContext* context) {
   Layer::AutoPrerollSaveLayerState save =
       Layer::AutoPrerollSaveLayerState::Create(context);
   auto cache = AutoCache(raster_cache_item_.get(), context,
-                         context->state_stack.transform_3x3());
+                         context->state_stack.matrix());
 
   MockLayer::Preroll(context);
 }

--- a/flow/testing/mock_layer.h
+++ b/flow/testing/mock_layer.h
@@ -25,14 +25,14 @@ namespace testing {
 // verify the data against expected values.
 class MockLayer : public Layer {
  public:
-  explicit MockLayer(const SkPath& path, DlPaint paint = DlPaint());
+  explicit MockLayer(const DlPath& path, DlPaint paint = DlPaint());
 
-  static std::shared_ptr<MockLayer> Make(const SkPath& path,
+  static std::shared_ptr<MockLayer> Make(const DlPath& path,
                                          DlPaint paint = DlPaint()) {
     return std::make_shared<MockLayer>(path, std::move(paint));
   }
 
-  static std::shared_ptr<MockLayer> MakeOpacityCompatible(const SkPath& path) {
+  static std::shared_ptr<MockLayer> MakeOpacityCompatible(const DlPath& path) {
     auto mock_layer = std::make_shared<MockLayer>(path, DlPaint());
     mock_layer->set_fake_opacity_compatible(true);
     return mock_layer;
@@ -42,8 +42,8 @@ class MockLayer : public Layer {
   void Paint(PaintContext& context) const override;
 
   const MutatorsStack& parent_mutators() { return parent_mutators_; }
-  const SkMatrix& parent_matrix() { return parent_matrix_; }
-  const SkRect& parent_cull_rect() { return parent_cull_rect_; }
+  const DlMatrix& parent_matrix() { return parent_matrix_; }
+  const DlRect& parent_cull_rect() { return parent_cull_rect_; }
 
   bool IsReplacing(DiffContext* context, const Layer* layer) const override;
   void Diff(DiffContext* context, const Layer* old_layer) override;
@@ -103,17 +103,17 @@ class MockLayer : public Layer {
     return *this;
   }
 
-  void set_expected_paint_matrix(const SkMatrix& matrix) {
+  void set_expected_paint_matrix(const DlMatrix& matrix) {
     expected_paint_matrix_ = matrix;
   }
 
  private:
   MutatorsStack parent_mutators_;
-  SkMatrix parent_matrix_;
-  SkRect parent_cull_rect_ = SkRect::MakeEmpty();
-  SkPath fake_paint_path_;
+  DlMatrix parent_matrix_;
+  DlRect parent_cull_rect_;
+  DlPath fake_paint_path_;
   DlPaint fake_paint_;
-  std::optional<SkMatrix> expected_paint_matrix_;
+  std::optional<DlMatrix> expected_paint_matrix_;
 
   static constexpr int kParentHasPlatformView = 1 << 0;
   static constexpr int kParentHasTextureLayer = 1 << 1;
@@ -153,7 +153,7 @@ class MockLayerCacheableItem : public LayerRasterCacheItem {
 };
 class MockCacheableLayer : public MockLayer {
  public:
-  explicit MockCacheableLayer(const SkPath& path,
+  explicit MockCacheableLayer(const DlPath& path,
                               DlPaint paint = DlPaint(),
                               int render_limit = 3)
       : MockLayer(path, std::move(paint)) {

--- a/flow/testing/mock_raster_cache.cc
+++ b/flow/testing/mock_raster_cache.cc
@@ -19,8 +19,7 @@ MockRasterCacheResult::MockRasterCacheResult(SkRect device_rect)
 
 void MockRasterCache::AddMockLayer(int width, int height) {
   SkMatrix ctm = SkMatrix::I();
-  SkPath path;
-  path.addRect(100, 100, 100 + width, 100 + height);
+  DlPath path = DlPath::MakeRectLTRB(100, 100, 100 + width, 100 + height);
   int layer_cached_threshold = 1;
   MockCacheableLayer layer =
       MockCacheableLayer(path, DlPaint(), layer_cached_threshold);
@@ -31,7 +30,7 @@ void MockRasterCache::AddMockLayer(int width, int height) {
       .gr_context         = preroll_context_.gr_context,
       .dst_color_space    = preroll_context_.dst_color_space,
       .matrix             = ctm,
-      .logical_rect       = layer.paint_bounds(),
+      .logical_rect       = ToSkRect(layer.paint_bounds()),
       // clang-format on
   };
   UpdateCacheEntry(
@@ -62,7 +61,7 @@ void MockRasterCache::AddMockPicture(int width, int height) {
   DisplayListRasterCacheItem display_list_item(display_list, SkPoint(), true,
                                                false);
   for (size_t i = 0; i < access_threshold(); i++) {
-    AutoCache(&display_list_item, &preroll_context_, ctm);
+    AutoCache(&display_list_item, &preroll_context_, ToDlMatrix(ctm));
   }
   RasterCache::Context r_context = {
       // clang-format off
@@ -138,7 +137,7 @@ bool RasterCacheItemPrerollAndTryToRasterCache(
     DisplayListRasterCacheItem& display_list_item,
     PrerollContext& context,
     PaintContext& paint_context,
-    const SkMatrix& matrix) {
+    const DlMatrix& matrix) {
   RasterCacheItemPreroll(display_list_item, context, matrix);
   context.raster_cache->EvictUnusedCacheEntries();
   return RasterCacheItemTryToRasterCache(display_list_item, paint_context);
@@ -146,7 +145,7 @@ bool RasterCacheItemPrerollAndTryToRasterCache(
 
 void RasterCacheItemPreroll(DisplayListRasterCacheItem& display_list_item,
                             PrerollContext& context,
-                            const SkMatrix& matrix) {
+                            const DlMatrix& matrix) {
   display_list_item.PrerollSetup(&context, matrix);
   display_list_item.PrerollFinalize(&context, matrix);
 }

--- a/flow/testing/mock_raster_cache.h
+++ b/flow/testing/mock_raster_cache.h
@@ -11,7 +11,6 @@
 #include "flutter/flow/raster_cache_item.h"
 #include "flutter/flow/testing/mock_layer.h"
 #include "third_party/skia/include/core/SkColorSpace.h"
-#include "third_party/skia/include/core/SkRefCnt.h"
 #include "third_party/skia/include/core/SkSize.h"
 
 namespace flutter {
@@ -61,7 +60,7 @@ class MockRasterCache : public RasterCache {
           RasterCacheUtil::kDefaultPictureAndDisplayListCacheLimitPerFrame)
       : RasterCache(access_threshold,
                     picture_and_display_list_cache_limit_per_frame) {
-    preroll_state_stack_.set_preroll_delegate(SkMatrix::I());
+    preroll_state_stack_.set_preroll_delegate(DlMatrix());
     paint_state_stack_.set_delegate(&builder_);
   }
 
@@ -135,11 +134,11 @@ bool RasterCacheItemPrerollAndTryToRasterCache(
     DisplayListRasterCacheItem& display_list_item,
     PrerollContext& context,
     PaintContext& paint_context,
-    const SkMatrix& matrix);
+    const DlMatrix& matrix);
 
 void RasterCacheItemPreroll(DisplayListRasterCacheItem& display_list_item,
                             PrerollContext& context,
-                            const SkMatrix& matrix);
+                            const DlMatrix& matrix);
 
 bool RasterCacheItemTryToRasterCache(
     DisplayListRasterCacheItem& display_list_item,

--- a/impeller/geometry/round_rect.h
+++ b/impeller/geometry/round_rect.h
@@ -182,8 +182,8 @@ struct RoundRect {
   constexpr RoundRect(const Rect& bounds, const RoundingRadii& radii)
       : bounds_(bounds), radii_(radii) {}
 
-  const Rect bounds_;
-  const RoundingRadii radii_;
+  Rect bounds_;
+  RoundingRadii radii_;
 };
 
 }  // namespace impeller

--- a/lib/ui/compositing/scene.cc
+++ b/lib/ui/compositing/scene.cc
@@ -91,7 +91,7 @@ static sk_sp<DlImage> CreateDeferredImage(
 #else   // SLIMPELLER
   const auto& frame_size = layer_tree->frame_size();
   const SkImageInfo image_info =
-      SkImageInfo::Make(frame_size.width(), frame_size.height(),
+      SkImageInfo::Make(frame_size.width, frame_size.height,
                         kRGBA_8888_SkColorType, kPremul_SkAlphaType);
   return DlDeferredImageGPUSkia::MakeFromLayerTree(
       image_info, std::move(layer_tree), std::move(snapshot_delegate),
@@ -130,7 +130,7 @@ std::unique_ptr<LayerTree> Scene::BuildLayerTree(uint32_t width,
     return nullptr;
   }
   return std::make_unique<LayerTree>(layer_tree_root_layer_,
-                                     SkISize::Make(width, height));
+                                     DlISize(width, height));
 }
 
 }  // namespace flutter

--- a/lib/ui/painting/canvas.h
+++ b/lib/ui/painting/canvas.h
@@ -65,7 +65,7 @@ class Canvas : public RefCountedDartWrappable<Canvas>, DisplayListOpFlags {
   void getDestinationClipBounds(Dart_Handle rect_handle);
   void getLocalClipBounds(Dart_Handle rect_handle);
 
-  void drawColor(SkColor color, DlBlendMode blend_mode);
+  void drawColor(uint32_t color, DlBlendMode blend_mode);
 
   void drawLine(double x1,
                 double y1,
@@ -180,7 +180,7 @@ class Canvas : public RefCountedDartWrappable<Canvas>, DisplayListOpFlags {
                         Dart_Handle cull_rect_handle);
 
   void drawShadow(const CanvasPath* path,
-                  SkColor color,
+                  uint32_t color,
                   double elevation,
                   bool transparentOccluder);
 

--- a/lib/ui/painting/display_list_deferred_image_gpu_impeller.cc
+++ b/lib/ui/painting/display_list_deferred_image_gpu_impeller.cc
@@ -110,8 +110,8 @@ DlDeferredImageGPUImpeller::ImageWrapper::Make(
     fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
     fml::RefPtr<fml::TaskRunner> raster_task_runner) {
   auto wrapper = std::shared_ptr<ImageWrapper>(new ImageWrapper(
-      nullptr, layer_tree->frame_size(), std::move(snapshot_delegate),
-      std::move(raster_task_runner)));
+      nullptr, ToSkISize(layer_tree->frame_size()),
+      std::move(snapshot_delegate), std::move(raster_task_runner)));
   wrapper->SnapshotDisplayList(std::move(layer_tree));
   return wrapper;
 }
@@ -172,7 +172,7 @@ void DlDeferredImageGPUImpeller::ImageWrapper::SnapshotDisplayList(
 
         if (layer_tree) {
           wrapper->display_list_ = layer_tree->Flatten(
-              SkRect::MakeWH(wrapper->size_.width(), wrapper->size_.height()),
+              DlRect::MakeWH(wrapper->size_.width(), wrapper->size_.height()),
               wrapper->texture_registry_);
         }
         auto snapshot = snapshot_delegate->MakeRasterSnapshotSync(

--- a/lib/ui/painting/display_list_deferred_image_gpu_skia.cc
+++ b/lib/ui/painting/display_list_deferred_image_gpu_skia.cc
@@ -182,7 +182,7 @@ void DlDeferredImageGPUSkia::ImageWrapper::SnapshotDisplayList(
         }
         if (layer_tree) {
           auto display_list =
-              layer_tree->Flatten(SkRect::MakeWH(wrapper->image_info_.width(),
+              layer_tree->Flatten(DlRect::MakeWH(wrapper->image_info_.width(),
                                                  wrapper->image_info_.height()),
                                   snapshot_delegate->GetTextureRegistry(),
                                   snapshot_delegate->GetGrContext());

--- a/lib/ui/painting/path.cc
+++ b/lib/ui/painting/path.cc
@@ -198,7 +198,7 @@ void CanvasPath::addPolygon(const tonic::Float32List& points, bool close) {
 }
 
 void CanvasPath::addRRect(const RRect& rrect) {
-  sk_path_.addRRect(rrect.sk_rrect);
+  sk_path_.addRRect(ToSkRRect(rrect.rrect));
   resetVolatility();
 }
 

--- a/lib/ui/painting/picture.cc
+++ b/lib/ui/painting/picture.cc
@@ -131,8 +131,8 @@ Dart_Handle Picture::RasterizeLayerTreeToImage(
     Dart_Handle raw_image_callback) {
   FML_DCHECK(layer_tree != nullptr);
   auto frame_size = layer_tree->frame_size();
-  return DoRasterizeToImage(nullptr, std::move(layer_tree), frame_size.width(),
-                            frame_size.height(), raw_image_callback);
+  return DoRasterizeToImage(nullptr, std::move(layer_tree), frame_size.width,
+                            frame_size.height, raw_image_callback);
 }
 
 Dart_Handle Picture::DoRasterizeToImage(const sk_sp<DisplayList>& display_list,
@@ -206,17 +206,17 @@ Dart_Handle Picture::DoRasterizeToImage(const sk_sp<DisplayList>& display_list,
       fml::MakeCopyable([ui_task_runner, snapshot_delegate, display_list, width,
                          height, ui_task,
                          layer_tree = std::move(layer_tree)]() mutable {
-        auto picture_bounds = SkISize::Make(width, height);
+        auto picture_bounds = DlISize(width, height);
         sk_sp<DisplayList> snapshot_display_list = display_list;
         if (layer_tree) {
           FML_DCHECK(picture_bounds == layer_tree->frame_size());
           snapshot_display_list =
-              layer_tree->Flatten(SkRect::MakeWH(width, height),
+              layer_tree->Flatten(DlRect::MakeWH(width, height),
                                   snapshot_delegate->GetTextureRegistry(),
                                   snapshot_delegate->GetGrContext());
         }
         snapshot_delegate->MakeRasterSnapshot(
-            snapshot_display_list, picture_bounds,
+            snapshot_display_list, ToSkISize(picture_bounds),
             [ui_task_runner, ui_task](const sk_sp<DlImage>& image) {
               fml::TaskRunner::RunNowOrPostTask(
                   ui_task_runner, [ui_task, image]() { ui_task(image); });

--- a/lib/ui/painting/picture_recorder.cc
+++ b/lib/ui/painting/picture_recorder.cc
@@ -25,7 +25,7 @@ PictureRecorder::PictureRecorder() {}
 
 PictureRecorder::~PictureRecorder() {}
 
-sk_sp<DisplayListBuilder> PictureRecorder::BeginRecording(SkRect bounds) {
+sk_sp<DisplayListBuilder> PictureRecorder::BeginRecording(DlRect bounds) {
   display_list_builder_ =
       sk_make_sp<DisplayListBuilder>(bounds, /*prepare_rtree=*/true);
   return display_list_builder_;

--- a/lib/ui/painting/picture_recorder.h
+++ b/lib/ui/painting/picture_recorder.h
@@ -21,7 +21,7 @@ class PictureRecorder : public RefCountedDartWrappable<PictureRecorder> {
 
   ~PictureRecorder() override;
 
-  sk_sp<DisplayListBuilder> BeginRecording(SkRect bounds);
+  sk_sp<DisplayListBuilder> BeginRecording(DlRect bounds);
   void endRecording(Dart_Handle dart_picture);
 
   void set_canvas(fml::RefPtr<Canvas> canvas) { canvas_ = std::move(canvas); }

--- a/lib/ui/painting/rrect.cc
+++ b/lib/ui/painting/rrect.cc
@@ -12,7 +12,7 @@ using flutter::RRect;
 
 namespace tonic {
 
-// Construct an SkRRect from a Dart RRect object.
+// Construct an DlRoundRect from a Dart RRect object.
 // The Dart RRect is a Float32List containing
 //   [left, top, right, bottom, xRadius, yRadius]
 RRect DartConverter<flutter::RRect>::FromDart(Dart_Handle value) {
@@ -24,13 +24,14 @@ RRect DartConverter<flutter::RRect>::FromDart(Dart_Handle value) {
     return result;
   }
 
-  SkVector radii[4] = {{buffer[4], buffer[5]},
-                       {buffer[6], buffer[7]},
-                       {buffer[8], buffer[9]},
-                       {buffer[10], buffer[11]}};
+  impeller::RoundingRadii radii = {{buffer[4], buffer[5]},
+                                   {buffer[6], buffer[7]},
+                                   {buffer[10], buffer[11]},
+                                   {buffer[8], buffer[9]}};
 
-  result.sk_rrect.setRectRadii(
-      SkRect::MakeLTRB(buffer[0], buffer[1], buffer[2], buffer[3]), radii);
+  result.rrect = flutter::DlRoundRect::MakeRectRadii(
+      flutter::DlRect::MakeLTRB(buffer[0], buffer[1], buffer[2], buffer[3]),
+      radii);
 
   result.is_null = false;
   return result;

--- a/lib/ui/painting/rrect.h
+++ b/lib/ui/painting/rrect.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_LIB_UI_PAINTING_RRECT_H_
 #define FLUTTER_LIB_UI_PAINTING_RRECT_H_
 
+#include "flutter/display_list/geometry/dl_geometry_types.h"
 #include "third_party/dart/runtime/include/dart_api.h"
 #include "third_party/skia/include/core/SkRRect.h"
 #include "third_party/tonic/converter/dart_converter.h"
@@ -13,7 +14,7 @@ namespace flutter {
 
 class RRect {
  public:
-  SkRRect sk_rrect;
+  DlRoundRect rrect;
   bool is_null;
 };
 

--- a/shell/common/animator_unittests.cc
+++ b/shell/common/animator_unittests.cc
@@ -167,7 +167,7 @@ TEST_F(ShellTest, AnimatorDoesNotNotifyIdleBeforeRender) {
         ASSERT_FALSE(delegate.notify_idle_called_);
         EXPECT_CALL(delegate, OnAnimatorBeginFrame).WillOnce([&] {
           auto layer_tree =
-              std::make_unique<LayerTree>(nullptr, SkISize::Make(600, 800));
+              std::make_unique<LayerTree>(nullptr, DlISize(600, 800));
           animator->Render(kImplicitViewId, std::move(layer_tree), 1.0);
           render_latch.Signal();
         });
@@ -248,7 +248,7 @@ TEST_F(ShellTest, AnimatorDoesNotNotifyDelegateIfPipelineIsNotEmpty) {
     task_runners.GetUITaskRunner()->PostTask([&] {
       EXPECT_CALL(delegate, OnAnimatorBeginFrame).WillOnce([&] {
         auto layer_tree =
-            std::make_unique<LayerTree>(nullptr, SkISize::Make(600, 800));
+            std::make_unique<LayerTree>(nullptr, DlISize(600, 800));
         animator->Render(kImplicitViewId, std::move(layer_tree), 1.0);
         begin_frame_latch.Signal();
       });

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -483,7 +483,7 @@ void Engine::Render(int64_t view_id,
   }
 
   // Ensure frame dimensions are sane.
-  if (layer_tree->frame_size().isEmpty() || device_pixel_ratio <= 0.0f) {
+  if (layer_tree->frame_size().IsEmpty() || device_pixel_ratio <= 0.0f) {
     return;
   }
 

--- a/shell/common/rasterizer_unittests.cc
+++ b/shell/common/rasterizer_unittests.cc
@@ -243,7 +243,7 @@ TEST(RasterizerTest,
   thread_host.raster_thread->GetTaskRunner()->PostTask([&] {
     auto pipeline = std::make_shared<FramePipeline>(/*depth=*/10);
     auto layer_tree = std::make_unique<LayerTree>(/*root_layer=*/nullptr,
-                                                  /*frame_size=*/SkISize());
+                                                  /*frame_size=*/DlISize());
     auto layer_tree_item = std::make_unique<FrameItem>(
         SingleLayerTreeList(kImplicitViewId, std::move(layer_tree),
                             kDevicePixelRatio),
@@ -317,7 +317,7 @@ TEST(
   thread_host.raster_thread->GetTaskRunner()->PostTask([&] {
     auto pipeline = std::make_shared<FramePipeline>(/*depth=*/10);
     auto layer_tree = std::make_unique<LayerTree>(
-        /*root_layer=*/nullptr, /*frame_size=*/SkISize());
+        /*root_layer=*/nullptr, /*frame_size=*/DlISize());
     auto layer_tree_item = std::make_unique<FrameItem>(
         SingleLayerTreeList(kImplicitViewId, std::move(layer_tree),
                             kDevicePixelRatio),
@@ -397,7 +397,7 @@ TEST(
 
   auto pipeline = std::make_shared<FramePipeline>(/*depth=*/10);
   auto layer_tree = std::make_unique<LayerTree>(/*root_layer=*/nullptr,
-                                                /*frame_size=*/SkISize());
+                                                /*frame_size=*/DlISize());
   auto layer_tree_item = std::make_unique<FrameItem>(
       SingleLayerTreeList(kImplicitViewId, std::move(layer_tree),
                           kDevicePixelRatio),
@@ -482,7 +482,7 @@ TEST(RasterizerTest,
 
   auto pipeline = std::make_shared<FramePipeline>(/*depth=*/10);
   auto layer_tree = std::make_unique<LayerTree>(/*root_layer=*/nullptr,
-                                                /*frame_size=*/SkISize());
+                                                /*frame_size=*/DlISize());
   auto layer_tree_item = std::make_unique<FrameItem>(
       SingleLayerTreeList(kImplicitViewId, std::move(layer_tree),
                           kDevicePixelRatio),
@@ -534,7 +534,7 @@ TEST(RasterizerTest, externalViewEmbedderDoesntEndFrameWhenNoSurfaceIsSet) {
   thread_host.raster_thread->GetTaskRunner()->PostTask([&] {
     auto pipeline = std::make_shared<FramePipeline>(/*depth=*/10);
     auto layer_tree = std::make_unique<LayerTree>(
-        /*root_layer=*/nullptr, /*frame_size=*/SkISize());
+        /*root_layer=*/nullptr, /*frame_size=*/DlISize());
     auto layer_tree_item = std::make_unique<FrameItem>(
         SingleLayerTreeList(kImplicitViewId, std::move(layer_tree),
                             kDevicePixelRatio),
@@ -598,7 +598,7 @@ TEST(RasterizerTest, externalViewEmbedderDoesntEndFrameWhenNotUsedThisFrame) {
   thread_host.raster_thread->GetTaskRunner()->PostTask([&] {
     auto pipeline = std::make_shared<FramePipeline>(/*depth=*/10);
     auto layer_tree = std::make_unique<LayerTree>(
-        /*root_layer=*/nullptr, /*frame_size=*/SkISize());
+        /*root_layer=*/nullptr, /*frame_size=*/DlISize());
     auto layer_tree_item = std::make_unique<FrameItem>(
         SingleLayerTreeList(kImplicitViewId, std::move(layer_tree),
                             kDevicePixelRatio),
@@ -728,9 +728,9 @@ TEST(RasterizerTest, drawMultipleViewsWithExternalViewEmbedder) {
     auto pipeline = std::make_shared<FramePipeline>(/*depth=*/10);
     std::vector<std::unique_ptr<LayerTreeTask>> tasks;
     tasks.push_back(std::make_unique<LayerTreeTask>(
-        0, std::make_unique<LayerTree>(nullptr, SkISize()), 1.5));
+        0, std::make_unique<LayerTree>(nullptr, DlISize()), 1.5));
     tasks.push_back(std::make_unique<LayerTreeTask>(
-        1, std::make_unique<LayerTree>(nullptr, SkISize()), 2.0));
+        1, std::make_unique<LayerTree>(nullptr, DlISize()), 2.0));
     auto layer_tree_item = std::make_unique<FrameItem>(
         std::move(tasks), CreateFinishedBuildRecorder());
     PipelineProduceResult result =
@@ -789,7 +789,7 @@ TEST(RasterizerTest,
   thread_host.raster_thread->GetTaskRunner()->PostTask([&] {
     auto pipeline = std::make_shared<FramePipeline>(/*depth=*/10);
     auto layer_tree = std::make_unique<LayerTree>(
-        /*root_layer=*/nullptr, /*frame_size=*/SkISize());
+        /*root_layer=*/nullptr, /*frame_size=*/DlISize());
     auto layer_tree_item = std::make_unique<FrameItem>(
         SingleLayerTreeList(kImplicitViewId, std::move(layer_tree),
                             kDevicePixelRatio),
@@ -851,7 +851,7 @@ TEST(
   thread_host.raster_thread->GetTaskRunner()->PostTask([&] {
     auto pipeline = std::make_shared<FramePipeline>(/*depth=*/10);
     auto layer_tree = std::make_unique<LayerTree>(
-        /*root_layer=*/nullptr, /*frame_size=*/SkISize());
+        /*root_layer=*/nullptr, /*frame_size=*/DlISize());
     auto layer_tree_item = std::make_unique<FrameItem>(
         SingleLayerTreeList(kImplicitViewId, std::move(layer_tree),
                             kDevicePixelRatio),
@@ -913,7 +913,7 @@ TEST(
   thread_host.raster_thread->GetTaskRunner()->PostTask([&] {
     auto pipeline = std::make_shared<FramePipeline>(/*depth=*/10);
     auto layer_tree = std::make_unique<LayerTree>(
-        /*root_layer=*/nullptr, /*frame_size=*/SkISize());
+        /*root_layer=*/nullptr, /*frame_size=*/DlISize());
     auto layer_tree_item = std::make_unique<FrameItem>(
         SingleLayerTreeList(kImplicitViewId, std::move(layer_tree),
                             kDevicePixelRatio),
@@ -974,7 +974,7 @@ TEST(
   thread_host.raster_thread->GetTaskRunner()->PostTask([&] {
     auto pipeline = std::make_shared<FramePipeline>(/*depth=*/10);
     auto layer_tree = std::make_unique<LayerTree>(
-        /*root_layer=*/nullptr, /*frame_size=*/SkISize());
+        /*root_layer=*/nullptr, /*frame_size=*/DlISize());
     auto layer_tree_item = std::make_unique<FrameItem>(
         SingleLayerTreeList(kImplicitViewId, std::move(layer_tree),
                             kDevicePixelRatio),
@@ -1032,7 +1032,7 @@ TEST(
   thread_host.raster_thread->GetTaskRunner()->PostTask([&] {
     auto pipeline = std::make_shared<FramePipeline>(/*depth=*/10);
     auto layer_tree = std::make_unique<LayerTree>(
-        /*root_layer=*/nullptr, /*frame_size=*/SkISize());
+        /*root_layer=*/nullptr, /*frame_size=*/DlISize());
     auto layer_tree_item = std::make_unique<FrameItem>(
         SingleLayerTreeList(kImplicitViewId, std::move(layer_tree),
                             kDevicePixelRatio),
@@ -1117,7 +1117,7 @@ TEST(RasterizerTest,
     auto pipeline = std::make_shared<FramePipeline>(/*depth=*/10);
     for (int i = 0; i < 2; i++) {
       auto layer_tree = std::make_unique<LayerTree>(
-          /*root_layer=*/nullptr, /*frame_size=*/SkISize());
+          /*root_layer=*/nullptr, /*frame_size=*/DlISize());
       auto layer_tree_item = std::make_unique<FrameItem>(
           SingleLayerTreeList(kImplicitViewId, std::move(layer_tree),
                               kDevicePixelRatio),
@@ -1291,7 +1291,7 @@ TEST(RasterizerTest, presentationTimeSetWhenVsyncTargetInFuture) {
     auto pipeline = std::make_shared<FramePipeline>(/*depth=*/10);
     for (int i = 0; i < 2; i++) {
       auto layer_tree = std::make_unique<LayerTree>(
-          /*root_layer=*/nullptr, /*frame_size=*/SkISize());
+          /*root_layer=*/nullptr, /*frame_size=*/DlISize());
       auto layer_tree_item = std::make_unique<FrameItem>(
           SingleLayerTreeList(kImplicitViewId, std::move(layer_tree),
                              kDevicePixelRatio),
@@ -1374,7 +1374,7 @@ TEST(RasterizerTest, presentationTimeNotSetWhenVsyncTargetInPast) {
     rasterizer->Setup(std::move(surface));
     auto pipeline = std::make_shared<FramePipeline>(/*depth=*/10);
     auto layer_tree = std::make_unique<LayerTree>(
-        /*root_layer=*/nullptr, /*frame_size=*/SkISize());
+        /*root_layer=*/nullptr, /*frame_size=*/DlISize());
     auto layer_tree_item = std::make_unique<FrameItem>(
         SingleLayerTreeList(kImplicitViewId, std::move(layer_tree),
                            kDevicePixelRatio),

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1661,7 +1661,7 @@ bool Shell::ShouldDiscardLayerTree(int64_t view_id,
   std::scoped_lock<std::mutex> lock(resize_mutex_);
   auto expected_frame_size = ExpectedFrameSize(view_id);
   return !expected_frame_size.isEmpty() &&
-         tree.frame_size() != expected_frame_size;
+         ToSkISize(tree.frame_size()) != expected_frame_size;
 }
 
 // |ServiceProtocol::Handler|

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -245,13 +245,11 @@ void ShellTest::PumpOneFrame(Shell* shell, FrameContent frame_content) {
         // causing flaky assertion errors.
 
         for (auto& [view_id, view_content] : frame_content) {
-          SkMatrix identity;
-          identity.setIdentity();
-          auto root_layer = std::make_shared<TransformLayer>(identity);
+          auto root_layer = std::make_shared<TransformLayer>(DlMatrix());
           auto layer_tree = std::make_unique<LayerTree>(
               root_layer,
-              SkISize::Make(view_content.viewport_metrics.physical_width,
-                            view_content.viewport_metrics.physical_height));
+              DlISize(view_content.viewport_metrics.physical_width,
+                      view_content.viewport_metrics.physical_height));
           float device_pixel_ratio = static_cast<float>(
               view_content.viewport_metrics.device_pixel_ratio);
           if (view_content.builder) {

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -416,8 +416,8 @@ static void PostSync(const fml::RefPtr<fml::TaskRunner>& task_runner,
 }
 
 static sk_sp<DisplayList> MakeSizedDisplayList(int width, int height) {
-  DisplayListBuilder builder(SkRect::MakeXYWH(0, 0, width, height));
-  builder.DrawRect(SkRect::MakeXYWH(0, 0, width, height),
+  DisplayListBuilder builder(DlRect::MakeXYWH(0, 0, width, height));
+  builder.DrawRect(DlRect::MakeXYWH(0, 0, width, height),
                    DlPaint(DlColor::kRed()));
   return builder.Build();
 }
@@ -920,7 +920,7 @@ TEST_F(ShellTest, ExternalEmbedderNoThreadMerger) {
 
   LayerTreeBuilder builder = [&](const std::shared_ptr<ContainerLayer>& root) {
     auto display_list_layer = std::make_shared<DisplayListLayer>(
-        SkPoint::Make(10, 10), MakeSizedDisplayList(80, 80), false, false);
+        DlPoint(10, 10), MakeSizedDisplayList(80, 80), false, false);
     root->Add(display_list_layer);
   };
 
@@ -981,20 +981,20 @@ TEST_F(ShellTest, PushBackdropFilterToVisitedPlatformViews) {
 
   LayerTreeBuilder builder = [&](const std::shared_ptr<ContainerLayer>& root) {
     auto platform_view_layer = std::make_shared<PlatformViewLayer>(
-        SkPoint::Make(10, 10), SkSize::Make(10, 10), 50);
+        DlPoint(10, 10), DlSize(10, 10), 50);
     root->Add(platform_view_layer);
-    auto transform_layer =
-        std::make_shared<TransformLayer>(SkMatrix::Translate(1, 1));
+    auto transform_layer = std::make_shared<TransformLayer>(
+        DlMatrix::MakeTranslation({1.0f, 1.0f}));
     root->Add(transform_layer);
     auto clip_rect_layer = std::make_shared<ClipRectLayer>(
-        SkRect::MakeLTRB(0, 0, 30, 30), Clip::kHardEdge);
+        DlRect::MakeLTRB(0, 0, 30, 30), Clip::kHardEdge);
     transform_layer->Add(clip_rect_layer);
     auto filter = DlImageFilter::MakeBlur(5, 5, DlTileMode::kClamp);
     auto backdrop_filter_layer =
         std::make_shared<BackdropFilterLayer>(filter, DlBlendMode::kSrcOver);
     clip_rect_layer->Add(backdrop_filter_layer);
     auto platform_view_layer2 = std::make_shared<PlatformViewLayer>(
-        SkPoint::Make(10, 10), SkSize::Make(10, 10), 75);
+        DlPoint(10, 10), DlSize(10, 10), 75);
     backdrop_filter_layer->Add(platform_view_layer2);
   };
 
@@ -1055,7 +1055,7 @@ TEST_F(ShellTest,
 
   LayerTreeBuilder builder = [&](const std::shared_ptr<ContainerLayer>& root) {
     auto display_list_layer = std::make_shared<DisplayListLayer>(
-        SkPoint::Make(10, 10), MakeSizedDisplayList(80, 80), false, false);
+        DlPoint(10, 10), MakeSizedDisplayList(80, 80), false, false);
     root->Add(display_list_layer);
   };
 
@@ -1101,7 +1101,7 @@ TEST_F(ShellTest, OnPlatformViewDestroyDisablesThreadMerger) {
 
   LayerTreeBuilder builder = [&](const std::shared_ptr<ContainerLayer>& root) {
     auto display_list_layer = std::make_shared<DisplayListLayer>(
-        SkPoint::Make(10, 10), MakeSizedDisplayList(80, 80), false, false);
+        DlPoint(10, 10), MakeSizedDisplayList(80, 80), false, false);
     root->Add(display_list_layer);
   };
 
@@ -1171,7 +1171,7 @@ TEST_F(ShellTest, OnPlatformViewDestroyAfterMergingThreads) {
 
   LayerTreeBuilder builder = [&](const std::shared_ptr<ContainerLayer>& root) {
     auto display_list_layer = std::make_shared<DisplayListLayer>(
-        SkPoint::Make(10, 10), MakeSizedDisplayList(80, 80), false, false);
+        DlPoint(10, 10), MakeSizedDisplayList(80, 80), false, false);
     root->Add(display_list_layer);
   };
 
@@ -1240,7 +1240,7 @@ TEST_F(ShellTest, OnPlatformViewDestroyWhenThreadsAreMerging) {
 
   LayerTreeBuilder builder = [&](const std::shared_ptr<ContainerLayer>& root) {
     auto display_list_layer = std::make_shared<DisplayListLayer>(
-        SkPoint::Make(10, 10), MakeSizedDisplayList(80, 80), false, false);
+        DlPoint(10, 10), MakeSizedDisplayList(80, 80), false, false);
     root->Add(display_list_layer);
   };
 
@@ -1308,7 +1308,7 @@ TEST_F(ShellTest,
 
   LayerTreeBuilder builder = [&](const std::shared_ptr<ContainerLayer>& root) {
     auto display_list_layer = std::make_shared<DisplayListLayer>(
-        SkPoint::Make(10, 10), MakeSizedDisplayList(80, 80), false, false);
+        DlPoint(10, 10), MakeSizedDisplayList(80, 80), false, false);
     root->Add(display_list_layer);
   };
   PumpOneFrame(shell.get(), ViewContent::ImplicitView(100, 100, builder));
@@ -1347,7 +1347,7 @@ TEST_F(ShellTest, OnPlatformViewDestroyWithoutRasterThreadMerger) {
 
   LayerTreeBuilder builder = [&](const std::shared_ptr<ContainerLayer>& root) {
     auto display_list_layer = std::make_shared<DisplayListLayer>(
-        SkPoint::Make(10, 10), MakeSizedDisplayList(80, 80), false, false);
+        DlPoint(10, 10), MakeSizedDisplayList(80, 80), false, false);
     root->Add(display_list_layer);
   };
   PumpOneFrame(shell.get(), ViewContent::ImplicitView(100, 100, builder));
@@ -1413,7 +1413,7 @@ TEST_F(ShellTest, OnPlatformViewDestroyWithStaticThreadMerging) {
 
   LayerTreeBuilder builder = [&](const std::shared_ptr<ContainerLayer>& root) {
     auto display_list_layer = std::make_shared<DisplayListLayer>(
-        SkPoint::Make(10, 10), MakeSizedDisplayList(80, 80), false, false);
+        DlPoint(10, 10), MakeSizedDisplayList(80, 80), false, false);
     root->Add(display_list_layer);
   };
   PumpOneFrame(shell.get(), ViewContent::ImplicitView(100, 100, builder));
@@ -1459,7 +1459,7 @@ TEST_F(ShellTest, GetUsedThisFrameShouldBeSetBeforeEndFrame) {
 
   LayerTreeBuilder builder = [&](const std::shared_ptr<ContainerLayer>& root) {
     auto display_list_layer = std::make_shared<DisplayListLayer>(
-        SkPoint::Make(10, 10), MakeSizedDisplayList(80, 80), false, false);
+        DlPoint(10, 10), MakeSizedDisplayList(80, 80), false, false);
     root->Add(display_list_layer);
   };
   PumpOneFrame(shell.get(), ViewContent::ImplicitView(100, 100, builder));
@@ -2216,7 +2216,7 @@ TEST_F(ShellTest, Screenshot) {
 
   LayerTreeBuilder builder = [&](const std::shared_ptr<ContainerLayer>& root) {
     auto display_list_layer = std::make_shared<DisplayListLayer>(
-        SkPoint::Make(10, 10), MakeSizedDisplayList(80, 80), false, false);
+        DlPoint(10, 10), MakeSizedDisplayList(80, 80), false, false);
     root->Add(display_list_layer);
   };
 
@@ -2494,8 +2494,8 @@ TEST_F(ShellTest, OnServiceProtocolEstimateRasterCacheMemoryWorks) {
   // 1. Construct a picture and a picture layer to be raster cached.
   sk_sp<DisplayList> display_list = MakeSizedDisplayList(10, 10);
   auto display_list_layer = std::make_shared<DisplayListLayer>(
-      SkPoint::Make(0, 0), MakeSizedDisplayList(100, 100), false, false);
-  display_list_layer->set_paint_bounds(SkRect::MakeWH(100, 100));
+      DlPoint(0, 0), MakeSizedDisplayList(100, 100), false, false);
+  display_list_layer->set_paint_bounds(DlRect::MakeWH(100, 100));
 
   // 2. Rasterize the picture and the picture layer in the raster cache.
   std::promise<bool> rasterized;
@@ -2548,7 +2548,7 @@ TEST_F(ShellTest, OnServiceProtocolEstimateRasterCacheMemoryWorks) {
         DisplayListRasterCacheItem display_list_raster_cache_item(
             display_list, SkPoint(), true, false);
         for (int i = 0; i < 4; i += 1) {
-          SkMatrix matrix = SkMatrix::I();
+          DlMatrix matrix;
           state_stack.set_preroll_delegate(matrix);
           display_list_raster_cache_item.PrerollSetup(&preroll_context, matrix);
           display_list_raster_cache_item.PrerollFinalize(&preroll_context,
@@ -2564,10 +2564,9 @@ TEST_F(ShellTest, OnServiceProtocolEstimateRasterCacheMemoryWorks) {
 
         // 2.2. Rasterize the picture layer.
         LayerRasterCacheItem layer_raster_cache_item(display_list_layer.get());
-        state_stack.set_preroll_delegate(SkMatrix::I());
-        layer_raster_cache_item.PrerollSetup(&preroll_context, SkMatrix::I());
-        layer_raster_cache_item.PrerollFinalize(&preroll_context,
-                                                SkMatrix::I());
+        state_stack.set_preroll_delegate(DlMatrix());
+        layer_raster_cache_item.PrerollSetup(&preroll_context, DlMatrix());
+        layer_raster_cache_item.PrerollFinalize(&preroll_context, DlMatrix());
         state_stack.set_delegate(&dummy_canvas);
         layer_raster_cache_item.TryToPrepareRasterCache(paint_context);
         layer_raster_cache_item.Draw(paint_context, &dummy_canvas, &paint);


### PR DESCRIPTION
Migrates Layers and LayerTree and parts of the `flow/` utility classes to use DlGeometry (Impeller) classes.