### PR TITLE
embedder: fix bit-order in software pixel format description

### DIFF
--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -2011,6 +2011,14 @@ typedef struct {
   /// The callback should return true if the operation was successful.
   FlutterLayersPresentCallback present_layers_callback;
   /// Avoid caching backing stores provided by this compositor.
+  ///
+  /// The engine has an internal backing store cache. Instead of 
+  /// creating & destroying backing stores for every frame, created
+  /// backing stores are automatically reused for subsequent frames.
+  ///
+  /// If you wish to change this behavior and destroy backing stores after
+  /// they've been used once, and create new backing stores for every frame,
+  /// you can set this bool to true.
   bool avoid_backing_store_cache;
   /// Callback invoked by the engine to composite the contents of each layer
   /// onto the specified view.

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -353,16 +353,18 @@ typedef enum {
   ///   g = (p >> 5) & 0x3F;
   ///   b = p & 0x1F;
   ///
-  /// This is equivalent to wayland format RGB565 (WL_DRM_FORMAT_RGB565).
+  /// On most (== little-endian) systems, this is equivalent to wayland format
+  /// RGB565 (WL_DRM_FORMAT_RGB565, WL_SHM_FORMAT_RGB565).
   kFlutterSoftwarePixelFormatRGB565,
 
   /// Pixel with 4 bits each for alpha, red, green, blue; in 16-bit word.
   ///   r = (p >> 8) & 0xF;
   ///   g = (p >> 4) & 0xF;
   ///   b = p & 0xF;
-  ///
-  /// This is equivalent to wayland format RGBA4444 (WL_DRM_FORMAT_RGBA4444).
   ///   a = (p >> 12) & 0xF;
+  ///
+  /// On most (== little-endian) systems, this is equivalent to wayland format
+  /// RGBA4444 (WL_DRM_FORMAT_RGBA4444, WL_SHM_FORMAT_RGBA4444).
   kFlutterSoftwarePixelFormatRGBA4444,
 
   /// Pixel with 8 bits each for red, green, blue, alpha.
@@ -371,7 +373,8 @@ typedef enum {
   ///   b = p[2];
   ///   a = p[3];
   ///
-  /// This is equivalent to wayland format ABGR8888 (WL_DRM_FORMAT_ABGR8888).
+  /// This is equivalent to wayland format ABGR8888 (WL_DRM_FORMAT_ABGR8888,
+  /// WL_SHM_FORMAT_ABGR8888).
   kFlutterSoftwarePixelFormatRGBA8888,
 
   /// Pixel with 8 bits each for red, green and blue and 8 unused bits.
@@ -379,7 +382,8 @@ typedef enum {
   ///   g = p[1];
   ///   b = p[2];
   ///
-  /// This is equivalent to wayland format XBGR8888 (WL_DRM_FORMAT_XBGR8888)
+  /// This is equivalent to wayland format XBGR8888 (WL_DRM_FORMAT_XBGR8888,
+  /// WL_SHM_FORMAT_XBGR8888).
   kFlutterSoftwarePixelFormatRGBX8888,
 
   /// Pixel with 8 bits each for blue, green, red and alpha.
@@ -388,7 +392,8 @@ typedef enum {
   ///   b = p[0];
   ///   a = p[3];
   ///
-  /// This is equivalent to wayland format ARGB8888 (WL_DRM_FORMAT_ARGB8888).
+  /// This is equivalent to wayland format ARGB8888 (WL_DRM_FORMAT_ARGB8888,
+  /// WL_SHM_FORMAT_ARGB8888).
   kFlutterSoftwarePixelFormatBGRA8888,
 
   /// Either kFlutterSoftwarePixelFormatBGRA8888 or
@@ -2023,7 +2028,7 @@ typedef struct {
   FlutterLayersPresentCallback present_layers_callback;
   /// Avoid caching backing stores provided by this compositor.
   ///
-  /// The engine has an internal backing store cache. Instead of 
+  /// The engine has an internal backing store cache. Instead of
   /// creating & destroying backing stores for every frame, created
   /// backing stores are automatically reused for subsequent frames.
   ///

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -352,12 +352,16 @@ typedef enum {
   ///   r = (p >> 11) & 0x1F;
   ///   g = (p >> 5) & 0x3F;
   ///   b = p & 0x1F;
+  ///
+  /// This is equivalent to wayland format RGB565 (WL_DRM_FORMAT_RGB565).
   kFlutterSoftwarePixelFormatRGB565,
 
   /// Pixel with 4 bits each for alpha, red, green, blue; in 16-bit word.
   ///   r = (p >> 8) & 0xF;
   ///   g = (p >> 4) & 0xF;
   ///   b = p & 0xF;
+  ///
+  /// This is equivalent to wayland format RGBA4444 (WL_DRM_FORMAT_RGBA4444).
   ///   a = (p >> 12) & 0xF;
   kFlutterSoftwarePixelFormatRGBA4444,
 
@@ -366,12 +370,16 @@ typedef enum {
   ///   g = p[1];
   ///   b = p[2];
   ///   a = p[3];
+  ///
+  /// This is equivalent to wayland format ABGR8888 (WL_DRM_FORMAT_ABGR8888).
   kFlutterSoftwarePixelFormatRGBA8888,
 
   /// Pixel with 8 bits each for red, green and blue and 8 unused bits.
   ///   r = p[0];
   ///   g = p[1];
   ///   b = p[2];
+  ///
+  /// This is equivalent to wayland format XBGR8888 (WL_DRM_FORMAT_XBGR8888)
   kFlutterSoftwarePixelFormatRGBX8888,
 
   /// Pixel with 8 bits each for blue, green, red and alpha.
@@ -379,6 +387,8 @@ typedef enum {
   ///   g = p[1];
   ///   b = p[0];
   ///   a = p[3];
+  ///
+  /// This is equivalent to wayland format ARGB8888 (WL_DRM_FORMAT_ARGB8888).
   kFlutterSoftwarePixelFormatBGRA8888,
 
   /// Either kFlutterSoftwarePixelFormatBGRA8888 or

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -1751,7 +1751,8 @@ typedef struct {
   /// store.
   VoidCallback destruction_callback;
   /// The pixel format that the engine should use to render into the allocation.
-  /// In most cases, kR
+  ///
+  /// On Linux, kFlutterSoftwarePixelFormatBGRA8888 is most commonly used.
   FlutterSoftwarePixelFormat pixel_format;
 } FlutterSoftwareBackingStore2;
 


### PR DESCRIPTION
The order of the components for packed software pixel formats is incorrectly documented as being the order in the native type, least-significant-bit first. In reality it's the other way around. For example, for `RGB565`, the `R` is the 5 most significant bits in the 2-byte pixel value, rather than the least significant bits. The test even verify it is that way:

https://github.com/flutter/engine/blob/main/shell/platform/embedder/tests/embedder_unittests.cc#L2782-L2785

I assume noone used the software pixel formats until @sodiboo did, that's why it's gone unnoticed for so long.

Also contains some other minor documentation improvements.

- Issue: https://github.com/flutter/flutter/issues/160149

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/engine/blob/main/docs/testing/Testing-the-engine.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
