### PR TITLE
[DO NOT SUBMIT] format test

### DIFF
--- a/ci/bin/format.dart
+++ b/ci/bin/format.dart
@@ -845,6 +845,9 @@ class DartFormatChecker extends FormatChecker {
         continue;
       }
       for (final Directory subdir in dir.listSync(recursive: true).whereType<Directory>().where((Directory dir) => path.basename(dir.path) == '.dart_tool')) {
+        if (subdir.path.contains('third_party')) {
+          continue;
+        }
         print('Deleting ${subdir.path}');
         subdir.deleteSync(recursive: true);
       }

--- a/ci/bin/format.dart
+++ b/ci/bin/format.dart
@@ -844,7 +844,7 @@ class DartFormatChecker extends FormatChecker {
       if (path.basename(dir.path) == '.dart_tool') {
         continue;
       }
-      for (final Directory subdir in dir.listSync().whereType<Directory>().where((Directory dir) => path.basename(dir.path) == '.dart_tool')) {
+      for (final Directory subdir in dir.listSync(recursive: true).whereType<Directory>().where((Directory dir) => path.basename(dir.path) == '.dart_tool')) {
         print('Deleting ${subdir.path}');
         subdir.deleteSync(recursive: true);
       }

--- a/ci/bin/format.dart
+++ b/ci/bin/format.dart
@@ -921,6 +921,26 @@ class DartFormatChecker extends FormatChecker {
     } else {
       message('All dart files formatted correctly.');
     }
+
+    Directory dir = Directory(path.join(_processRunner.defaultWorkingDirectory.path, 'lib', 'web_ui', 'dev'));
+    while (true) {
+      final File file = File(path.join(dir.path, '.dart_tool', 'package_config.json'));
+      if (file.existsSync()) {
+        stdout.writeln();
+        stdout.writeln('HHHHHHHHHHHHHHHHH: ${file.path}');
+        stdout.write(file.readAsStringSync());
+        stdout.writeln();
+      }
+      if (dir.parent.path == dir.path) {
+        break;
+      }
+      dir = dir.parent;
+    }
+    stdout.writeln('dart --version: ${Process.runSync(_dartBin, ['--version']).stdout}');
+    stdout.writeln('dart format --version: ${Process.runSync(_dartBin, ['format', '--version']).stdout}');
+
+
+
     return incorrect.length;
   }
 }

--- a/ci/bin/format.dart
+++ b/ci/bin/format.dart
@@ -845,7 +845,7 @@ class DartFormatChecker extends FormatChecker {
         continue;
       }
       for (final Directory subdir in dir.listSync(recursive: true).whereType<Directory>().where((Directory dir) => path.basename(dir.path) == '.dart_tool')) {
-        if (subdir.path.contains('third_party')) {
+        if (subdir.path.contains('third_party') || subdir.path.contains('impeller/tessellator/dart') || subdir.path.contains('tools') || subdir.path.contains('shell/vmservice') || subdir.path.contains('ci') || subdir.path.contains('testing') || subdir.path.contains('flutter_frontend_server')) {
           continue;
         }
         print('Deleting ${subdir.path}');

--- a/ci/bin/format.dart
+++ b/ci/bin/format.dart
@@ -840,6 +840,16 @@ class DartFormatChecker extends FormatChecker {
   }
 
   Future<int> _runDartFormat({required bool fixing}) async {
+    for (final Directory dir in _processRunner.defaultWorkingDirectory.listSync().whereType<Directory>()) {
+      if (path.basename(dir.path) == '.dart_tool') {
+        continue;
+      }
+      for (final Directory subdir in dir.listSync().whereType<Directory>().where((Directory dir) => path.basename(dir.path) == '.dart_tool')) {
+        print('Deleting ${subdir.path}');
+        subdir.deleteSync(recursive: true);
+      }
+    }
+
     final List<String> filesToCheck = await getFileList(<String>['*.dart']);
 
     final List<String> cmd = <String>[

--- a/ci/bin/format.dart
+++ b/ci/bin/format.dart
@@ -1283,8 +1283,7 @@ Future<int> main(List<String> arguments) async {
   parser.addMultiOption('check',
       abbr: 'c',
       allowed: formatCheckNames(),
-      // TODO(goderbauer): Enable dart by default when we turned on the formatter.
-      defaultsTo: formatCheckNames()..remove(FormatCheck.dart.name),
+      defaultsTo: formatCheckNames(),
       help: 'Specifies which checks will be performed. Defaults to all checks. '
           'May be specified more than once to perform multiple types of checks. ');
   parser.addFlag('verbose', help: 'Print verbose output.', defaultsTo: verbose);

--- a/lib/web_ui/dev/build.dart
+++ b/lib/web_ui/dev/build.dart
@@ -28,29 +28,34 @@ class BuildCommand extends Command<bool> with ArgUtils<bool> {
     argParser.addFlag(
       'watch',
       abbr: 'w',
-      help: 'Run the build in watch mode so it rebuilds whenever a change is '
+      help:
+          'Run the build in watch mode so it rebuilds whenever a change is '
           'made. Disabled by default.',
     );
     argParser.addFlag(
       'host',
-      help: 'Build the host build instead of the wasm build, which is '
-          'currently needed for `flutter run --local-engine` to work.'
+      help:
+          'Build the host build instead of the wasm build, which is '
+          'currently needed for `flutter run --local-engine` to work.',
     );
     argParser.addFlag(
       'profile',
-      help: 'Build in profile mode instead of release mode. In this mode, the '
+      help:
+          'Build in profile mode instead of release mode. In this mode, the '
           'output will be located at "out/wasm_profile".\nThis only applies to '
           'the wasm build. The host build is always built in release mode.',
     );
     argParser.addFlag(
       'debug',
-      help: 'Build in debug mode instead of release mode. In this mode, the '
+      help:
+          'Build in debug mode instead of release mode. In this mode, the '
           'output will be located at "out/wasm_debug".\nThis only applies to '
           'the wasm build. The host build is always built in release mode.',
     );
     argParser.addFlag(
       'dwarf',
-      help: 'Embed DWARF debugging info into the output wasm modules. This is '
+      help:
+          'Embed DWARF debugging info into the output wasm modules. This is '
           'only valid in debug mode.',
     );
   }
@@ -75,11 +80,7 @@ class BuildCommand extends Command<bool> with ArgUtils<bool> {
     }
     final FilePath libPath = FilePath.fromWebUi('lib');
     final List<PipelineStep> steps = <PipelineStep>[
-      GnPipelineStep(
-        host: host,
-        runtimeMode: runtimeMode,
-        embedDwarf: embedDwarf,
-      ),
+      GnPipelineStep(host: host, runtimeMode: runtimeMode, embedDwarf: embedDwarf),
       NinjaPipelineStep(
         host: host,
         runtimeMode: runtimeMode,
@@ -108,11 +109,7 @@ class BuildCommand extends Command<bool> with ArgUtils<bool> {
 /// Not safe to interrupt as it may leave the `out/` directory in a corrupted
 /// state. GN is pretty quick though, so it's OK to not support interruption.
 class GnPipelineStep extends ProcessStep {
-  GnPipelineStep({
-    required this.host,
-    required this.runtimeMode,
-    required this.embedDwarf,
-  });
+  GnPipelineStep({required this.host, required this.runtimeMode, required this.embedDwarf});
 
   final bool host;
   final RuntimeMode runtimeMode;
@@ -126,18 +123,13 @@ class GnPipelineStep extends ProcessStep {
 
   List<String> get _gnArgs {
     if (host) {
-      return <String>[
-        '--unoptimized',
-        '--full-dart-sdk',
-      ];
+      return <String>['--unoptimized', '--full-dart-sdk'];
     } else {
       return <String>[
         '--web',
         '--runtime-mode=${runtimeMode.name}',
-        if (runtimeMode == RuntimeMode.debug)
-          '--unoptimized',
-        if (embedDwarf)
-          '--wasm-use-dwarf',
+        if (runtimeMode == RuntimeMode.debug) '--unoptimized',
+        if (embedDwarf) '--wasm-use-dwarf',
       ];
     }
   }
@@ -145,10 +137,7 @@ class GnPipelineStep extends ProcessStep {
   @override
   Future<ProcessManager> createProcess() {
     print('Running gn...');
-    return startProcess(
-      path.join(environment.flutterDirectory.path, 'tools', 'gn'),
-      _gnArgs,
-    );
+    return startProcess(path.join(environment.flutterDirectory.path, 'tools', 'gn'), _gnArgs);
   }
 }
 
@@ -156,11 +145,7 @@ class GnPipelineStep extends ProcessStep {
 ///
 /// Can be safely interrupted.
 class NinjaPipelineStep extends ProcessStep {
-  NinjaPipelineStep({
-    required this.host,
-    required this.runtimeMode,
-    required this.targets,
-  });
+  NinjaPipelineStep({required this.host, required this.runtimeMode, required this.targets});
 
   @override
   String get description => 'ninja';
@@ -182,13 +167,6 @@ class NinjaPipelineStep extends ProcessStep {
   @override
   Future<ProcessManager> createProcess() {
     print('Running autoninja...');
-    return startProcess(
-      'autoninja',
-      <String>[
-        '-C',
-        buildDirectory,
-        ...targets,
-      ],
-    );
+    return startProcess('autoninja', <String>['-C', buildDirectory, ...targets]);
   }
 }

--- a/lib/web_ui/dev/build.dart
+++ b/lib/web_ui/dev/build.dart
@@ -23,6 +23,15 @@ const Map<String, String> targetAliases = <String, String>{
   'archive': 'flutter/web_sdk:flutter_web_sdk_archive',
 };
 
+// Check new style
+enum Foo { 
+  a, 
+  b, 
+  c, 
+}
+// This line is 99 long
+List<int> a = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23];
+
 class BuildCommand extends Command<bool> with ArgUtils<bool> {
   BuildCommand() {
     argParser.addFlag(


### PR DESCRIPTION
Diff produced on CI:
```
diff --git a/lib/web_ui/dev/build.dart b/lib/web_ui/dev/build.dart
index df1fe19123..0000000000 100644
--- a/lib/web_ui/dev/build.dart
+++ b/lib/web_ui/dev/build.dart
@@ -28,34 +28,29 @@ class BuildCommand extends Command<bool> with ArgUtils<bool> {
argParser.addFlag(
'watch',
abbr: 'w',
-      help:
-          'Run the build in watch mode so it rebuilds whenever a change is '
+      help: 'Run the build in watch mode so it rebuilds whenever a change is '
'made. Disabled by default.',
);
argParser.addFlag(
'host',
-      help:
-          'Build the host build instead of the wasm build, which is '
+      help: 'Build the host build instead of the wasm build, which is '
'currently needed for `flutter run --local-engine` to work.',
);
argParser.addFlag(
'profile',
-      help:
-          'Build in profile mode instead of release mode. In this mode, the '
+      help: 'Build in profile mode instead of release mode. In this mode, the '
'output will be located at "out/wasm_profile".\nThis only applies to '
'the wasm build. The host build is always built in release mode.',
);
argParser.addFlag(
'debug',
-      help:
-          'Build in debug mode instead of release mode. In this mode, the '
+      help: 'Build in debug mode instead of release mode. In this mode, the '
'output will be located at "out/wasm_debug".\nThis only applies to '
'the wasm build. The host build is always built in release mode.',
);
argParser.addFlag(
'dwarf',
-      help:
-          'Embed DWARF debugging info into the output wasm modules. This is '
+      help: 'Embed DWARF debugging info into the output wasm modules. This is '
'only valid in debug mode.',
);
}
@@ -170,3 +165,4 @@ class NinjaPipelineStep extends ProcessStep {
return startProcess('autoninja', <String>['-C', buildDirectory, ...targets]);
}
}
```