### PR TITLE
[web] Make `FLUTTER_WEB_AUTO_DETECT` false by default

### DIFF
--- a/lib/web_ui/dev/steps/compile_bundle_step.dart
+++ b/lib/web_ui/dev/steps/compile_bundle_step.dart
@@ -215,10 +215,6 @@ class Dart2JSCompiler extends TestCompiler {
       '--disable-inlining',
       '--enable-asserts',
 
-      // We do not want to auto-select a renderer in tests. As of today, tests
-      // are designed to run in one specific mode. So instead, we specify the
-      // renderer explicitly.
-      '-DFLUTTER_WEB_AUTO_DETECT=false',
       '-DFLUTTER_WEB_USE_SKIA=${renderer == Renderer.canvaskit}',
       '-DFLUTTER_WEB_USE_SKWASM=${renderer == Renderer.skwasm}',
 
@@ -280,10 +276,6 @@ class Dart2WasmCompiler extends TestCompiler {
       '--enable-asserts',
       '--enable-experimental-wasm-interop',
 
-      // We do not want to auto-select a renderer in tests. As of today, tests
-      // are designed to run in one specific mode. So instead, we specify the
-      // renderer explicitly.
-      '-DFLUTTER_WEB_AUTO_DETECT=false',
       '-DFLUTTER_WEB_USE_SKIA=${renderer == Renderer.canvaskit}',
       '-DFLUTTER_WEB_USE_SKWASM=${renderer == Renderer.skwasm}',
 

--- a/lib/web_ui/lib/src/engine/configuration.dart
+++ b/lib/web_ui/lib/src/engine/configuration.dart
@@ -167,10 +167,10 @@ class FlutterConfiguration {
 
   /// Auto detect which rendering backend to use.
   ///
-  /// Using flutter tools option "--web-renderer=auto" or not specifying one
-  /// would set the value to true. Otherwise, it would be false.
+  /// Using flutter tools option "--web-renderer=auto" would set the value to
+  /// true. Otherwise, it would be false.
   static const bool flutterWebAutoDetect =
-      bool.fromEnvironment('FLUTTER_WEB_AUTO_DETECT', defaultValue: true);
+      bool.fromEnvironment('FLUTTER_WEB_AUTO_DETECT');
 
   static const bool flutterWebUseSkwasm =
       bool.fromEnvironment('FLUTTER_WEB_USE_SKWASM');


### PR DESCRIPTION
Now that "auto" is not supported anymore, it makes more sense to make this dart define false by default.

This will allows us to do the following cleanup: https://github.com/flutter/flutter/pull/160191