### PR TITLE
[web] allow imports to line-break

### DIFF
--- a/lib/web_ui/lib/src/engine/renderer.dart
+++ b/lib/web_ui/lib/src/engine/renderer.dart
@@ -8,7 +8,8 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:ui/src/engine.dart';
-import 'package:ui/src/engine/skwasm/skwasm_impl.dart' if (dart.library.html) 'package:ui/src/engine/skwasm/skwasm_stub.dart';
+import 'package:ui/src/engine/skwasm/skwasm_impl.dart'
+    if (dart.library.html) 'package:ui/src/engine/skwasm/skwasm_stub.dart';
 import 'package:ui/ui.dart' as ui;
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
@@ -43,11 +44,12 @@ abstract class Renderer {
         if (!useCanvasKit) {
           // The user requested 'html' or 'auto' either in the command-line or JS.
           final String requested =
-            configuration.requestedRendererType ??
-            (FlutterConfiguration.flutterWebAutoDetect ? 'auto' : 'html');
+              configuration.requestedRendererType ??
+              (FlutterConfiguration.flutterWebAutoDetect ? 'auto' : 'html');
           printWarning(
             'The HTML Renderer is being deprecated. Stop using the "$requested" renderer mode.'
-            '\nSee: https://docs.flutter.dev/to/web-html-renderer-deprecation');
+            '\nSee: https://docs.flutter.dev/to/web-html-renderer-deprecation',
+          );
         }
         return true;
       }());
@@ -120,14 +122,18 @@ abstract class Renderer {
   ui.ImageFilter createBlurImageFilter({
     double sigmaX = 0.0,
     double sigmaY = 0.0,
-    ui.TileMode? tileMode});
-  ui.ImageFilter createDilateImageFilter({ double radiusX = 0.0, double radiusY = 0.0});
-  ui.ImageFilter createErodeImageFilter({ double radiusX = 0.0, double radiusY = 0.0});
+    ui.TileMode? tileMode,
+  });
+  ui.ImageFilter createDilateImageFilter({double radiusX = 0.0, double radiusY = 0.0});
+  ui.ImageFilter createErodeImageFilter({double radiusX = 0.0, double radiusY = 0.0});
   ui.ImageFilter createMatrixImageFilter(
     Float64List matrix4, {
-    ui.FilterQuality filterQuality = ui.FilterQuality.low
+    ui.FilterQuality filterQuality = ui.FilterQuality.low,
   });
-  ui.ImageFilter composeImageFilters({required ui.ImageFilter outer, required ui.ImageFilter inner});
+  ui.ImageFilter composeImageFilters({
+    required ui.ImageFilter outer,
+    required ui.ImageFilter inner,
+  });
 
   Future<ui.Codec> instantiateImageCodec(
     Uint8List list, {
@@ -143,8 +149,12 @@ abstract class Renderer {
 
   FutureOr<ui.Image> createImageFromImageBitmap(DomImageBitmap imageSource);
 
-  FutureOr<ui.Image> createImageFromTextureSource(JSAny object,
-      {required int width, required int height, required bool transferOwnership});
+  FutureOr<ui.Image> createImageFromTextureSource(
+    JSAny object, {
+    required int width,
+    required int height,
+    required bool transferOwnership,
+  });
 
   void decodeImageFromPixels(
     Uint8List pixels,
@@ -155,7 +165,7 @@ abstract class Renderer {
     int? rowBytes,
     int? targetWidth,
     int? targetHeight,
-    bool allowUpscaling = true
+    bool allowUpscaling = true,
   });
 
   ui.ImageShader createImageShader(

--- a/web_sdk/sdk_rewriter.dart
+++ b/web_sdk/sdk_rewriter.dart
@@ -79,7 +79,7 @@ List<Replacer> generatePartsPatterns(String libraryName, bool isPublic) {
     // Remove library directives.
     AllReplacer(RegExp(r'\nlibrary .+;'), ''),
     // Remove imports/exports from all part files.
-    AllReplacer(RegExp(r"\nimport '.+'\n\s*if \(dart.library.html\) '.*';"), ''),
+    AllReplacer(RegExp(r"\nimport '.+'\n\s*if \(dart\.library\..*\) '.*';"), ''),
     AllReplacer(RegExp(r'\nimport\s*.*'), ''),
     AllReplacer(RegExp(r'\nexport\s*.*'), ''),
     AllReplacer(RegExp(r'\n@DefaultAsset(.*)'), ''),

--- a/web_sdk/sdk_rewriter.dart
+++ b/web_sdk/sdk_rewriter.dart
@@ -79,6 +79,7 @@ List<Replacer> generatePartsPatterns(String libraryName, bool isPublic) {
     // Remove library directives.
     AllReplacer(RegExp(r'\nlibrary .+;'), ''),
     // Remove imports/exports from all part files.
+    AllReplacer(RegExp(r"\nimport '.+'\n\s*if \(dart.library.html\) '.*';"), ''),
     AllReplacer(RegExp(r'\nimport\s*.*'), ''),
     AllReplacer(RegExp(r'\nexport\s*.*'), ''),
     AllReplacer(RegExp(r'\n@DefaultAsset(.*)'), ''),

--- a/web_sdk/test/js_access_test.dart
+++ b/web_sdk/test/js_access_test.dart
@@ -60,22 +60,6 @@ export 'foo.dart';
       expect(result.violations, isEmpty);
     }
 
-    // Multi-line imports should fail.
-    {
-      final _CheckResult result = _checkFile(
-          File('lib/web_ui/lib/src/engine/alarm_clock.dart'),
-'''
-import 'dart:async';
-import 'package:ui/ui.dart'
-  as ui;
-''',
-      );
-      expect(result.failed, isTrue);
-      expect(result.violations, <String>[
-        "on line 2: import is broken up into multiple lines: import 'package:ui/ui.dart'",
-      ]);
-    }
-
     // A library that doesn't directly access JavaScript API should pass.
     expect(
       _checkFile(
@@ -177,12 +161,6 @@ _CheckResult _checkFile(File dartFile, String code) {
     final String line = lines[i].trim();
     final bool isImport = line.startsWith('import');
     if (!isImport) {
-      continue;
-    }
-
-    final bool isProperlyFormattedImport = line.endsWith(';');
-    if (!isProperlyFormattedImport) {
-      violations.add('on line $lineNumber: import is broken up into multiple lines: $line');
       continue;
     }
 

--- a/web_sdk/test/sdk_rewriter_test.dart
+++ b/web_sdk/test/sdk_rewriter_test.dart
@@ -192,4 +192,32 @@ void printSomething() {
     expect(getExtraImportsForLibrary('web_test_fonts'), isEmpty);
     expect(getExtraImportsForLibrary('web_locale_keymap'), isEmpty);
   });
+
+  test('allows imports to line-break', () {
+    const String source = '''
+import 'package:some_package/some_package.dart';
+import 'package:ui/src/engine/skwasm/skwasm_impl.dart'
+    if (dart.library.html) 'package:ui/src/engine/skwasm/skwasm_stub.dart';
+import 'package:some_package/some_package' as some_package;
+
+void printSomething() {
+  print('something');
+}
+''';
+
+    const String expected = '''
+part of dart._engine;
+
+void printSomething() {
+  print('something');
+}
+''';
+
+    final String result = processSource(
+      source,
+      (String source) => preprocessPartFile(source, 'engine'),
+      generatePartsPatterns('engine', false),
+    );
+    expect(result, expected);
+  });
 }

--- a/web_sdk/test/sdk_rewriter_test.dart
+++ b/web_sdk/test/sdk_rewriter_test.dart
@@ -198,6 +198,8 @@ void printSomething() {
 import 'package:some_package/some_package.dart';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart'
     if (dart.library.html) 'package:ui/src/engine/skwasm/skwasm_stub.dart';
+import 'package:ui/src/engine/skwasm/skwasm_impl.dart'
+    if (dart.library.js_interop) 'package:ui/src/engine/skwasm/skwasm_stub.dart';
 import 'package:some_package/some_package' as some_package;
 
 void printSomething() {


### PR DESCRIPTION
We are about to `dart format` all the Dart code in the repo, which line-breaks some of our imports.

This PR updates `sdk_rewriter.dart` to support line-broken imports.