### PR TITLE
[CP][3.27][ios]enable the webview non tappable workaround by checking subviews recursively #57168

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -2932,9 +2932,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                /*raster=*/GetDefaultTaskRunner(),
                                /*ui=*/GetDefaultTaskRunner(),
                                /*io=*/GetDefaultTaskRunner());
-  FlutterPlatformViewsController* flutterPlatformViewsController =
-      [[FlutterPlatformViewsController alloc] init];
-  flutterPlatformViewsController.taskRunner = GetDefaultTaskRunner();
+  auto flutterPlatformViewsController = std::make_shared<flutter::PlatformViewsController>();
+  flutterPlatformViewsController->SetTaskRunner(GetDefaultTaskRunner());
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/mock_delegate.settings_.enable_impeller
@@ -2947,17 +2946,15 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
 
   FlutterPlatformViewsTestMockWrapperWebViewFactory* factory =
       [[FlutterPlatformViewsTestMockWrapperWebViewFactory alloc] init];
-  [flutterPlatformViewsController
-                   registerViewFactory:factory
-                                withId:@"MockWrapperWebView"
-      gestureRecognizersBlockingPolicy:FlutterPlatformViewGestureRecognizersBlockingPolicyEager];
+  flutterPlatformViewsController->RegisterViewFactory(
+      factory, @"MockWrapperWebView", FlutterPlatformViewGestureRecognizersBlockingPolicyEager);
   FlutterResult result = ^(id result) {
   };
-  [flutterPlatformViewsController
-      onMethodCall:[FlutterMethodCall
-                       methodCallWithMethodName:@"create"
-                                      arguments:@{@"id" : @2, @"viewType" : @"MockWrapperWebView"}]
-            result:result];
+  flutterPlatformViewsController->OnMethodCall(
+      [FlutterMethodCall
+          methodCallWithMethodName:@"create"
+                         arguments:@{@"id" : @2, @"viewType" : @"MockWrapperWebView"}],
+      result);
 
   XCTAssertNotNil(gMockPlatformView);
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -69,6 +69,9 @@ const float kFloatCompareEpsilon = 0.001;
   self.viewCreated = YES;
 }
 
+- (void)dealloc {
+  gMockPlatformView = nil;
+}
 @end
 
 @interface FlutterPlatformViewsTestMockFlutterPlatformFactory
@@ -109,6 +112,10 @@ const float kFloatCompareEpsilon = 0.001;
     abort();
   }
   self.viewCreated = YES;
+}
+
+- (void)dealloc {
+  gMockPlatformView = nil;
 }
 @end
 
@@ -162,6 +169,10 @@ const float kFloatCompareEpsilon = 0.001;
   }
   self.viewCreated = YES;
 }
+
+- (void)dealloc {
+  gMockPlatformView = nil;
+}
 @end
 
 @interface FlutterPlatformViewsTestMockWrapperWebViewFactory : NSObject <FlutterPlatformViewFactory>
@@ -172,6 +183,49 @@ const float kFloatCompareEpsilon = 0.001;
                                    viewIdentifier:(int64_t)viewId
                                         arguments:(id _Nullable)args {
   return [[FlutterPlatformViewsTestMockWrapperWebView alloc] init];
+}
+@end
+
+@interface FlutterPlatformViewsTestMockNestedWrapperWebView : NSObject <FlutterPlatformView>
+@property(nonatomic, strong) UIView* view;
+@property(nonatomic, assign) BOOL viewCreated;
+@end
+
+@implementation FlutterPlatformViewsTestMockNestedWrapperWebView
+- (instancetype)init {
+  if (self = [super init]) {
+    _view = [[UIView alloc] init];
+    UIView* childView = [[UIView alloc] init];
+    [_view addSubview:childView];
+    [childView addSubview:[[WKWebView alloc] init]];
+    gMockPlatformView = _view;
+    _viewCreated = NO;
+  }
+  return self;
+}
+
+- (UIView*)view {
+  [self checkViewCreatedOnce];
+  return _view;
+}
+
+- (void)checkViewCreatedOnce {
+  if (self.viewCreated) {
+    abort();
+  }
+  self.viewCreated = YES;
+}
+@end
+
+@interface FlutterPlatformViewsTestMockNestedWrapperWebViewFactory
+    : NSObject <FlutterPlatformViewFactory>
+@end
+
+@implementation FlutterPlatformViewsTestMockNestedWrapperWebViewFactory
+- (NSObject<FlutterPlatformView>*)createWithFrame:(CGRect)frame
+                                   viewIdentifier:(int64_t)viewId
+                                        arguments:(id _Nullable)args {
+  return [[FlutterPlatformViewsTestMockNestedWrapperWebView alloc] init];
 }
 @end
 
@@ -2983,6 +3037,67 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
     XCTAssertEqual(touchInteceptorView.gestureRecognizers[0], delayingRecognizer);
     XCTAssertEqual(touchInteceptorView.gestureRecognizers[1], forwardingRecognizer);
   }
+}
+
+- (void)
+    testFlutterPlatformViewBlockGestureUnderEagerPolicyShouldNotRemoveAndAddBackDelayingRecognizerForNestedWrapperWebView {
+  flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
+
+  flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
+                               /*platform=*/GetDefaultTaskRunner(),
+                               /*raster=*/GetDefaultTaskRunner(),
+                               /*ui=*/GetDefaultTaskRunner(),
+                               /*io=*/GetDefaultTaskRunner());
+  FlutterPlatformViewsController* flutterPlatformViewsController =
+      [[FlutterPlatformViewsController alloc] init];
+  flutterPlatformViewsController.taskRunner = GetDefaultTaskRunner();
+  auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
+      /*delegate=*/mock_delegate,
+      /*rendering_api=*/mock_delegate.settings_.enable_impeller
+          ? flutter::IOSRenderingAPI::kMetal
+          : flutter::IOSRenderingAPI::kSoftware,
+      /*platform_views_controller=*/flutterPlatformViewsController,
+      /*task_runners=*/runners,
+      /*worker_task_runner=*/nil,
+      /*is_gpu_disabled_jsync_switch=*/std::make_shared<fml::SyncSwitch>());
+
+  FlutterPlatformViewsTestMockNestedWrapperWebViewFactory* factory =
+      [[FlutterPlatformViewsTestMockNestedWrapperWebViewFactory alloc] init];
+  [flutterPlatformViewsController
+                   registerViewFactory:factory
+                                withId:@"MockNestedWrapperWebView"
+      gestureRecognizersBlockingPolicy:FlutterPlatformViewGestureRecognizersBlockingPolicyEager];
+  FlutterResult result = ^(id result) {
+  };
+  [flutterPlatformViewsController
+      onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
+                                                     arguments:@{
+                                                       @"id" : @2,
+                                                       @"viewType" : @"MockNestedWrapperWebView"
+                                                     }]
+            result:result];
+
+  XCTAssertNotNil(gMockPlatformView);
+
+  // Find touch inteceptor view
+  UIView* touchInteceptorView = gMockPlatformView;
+  while (touchInteceptorView != nil &&
+         ![touchInteceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
+    touchInteceptorView = touchInteceptorView.superview;
+  }
+  XCTAssertNotNil(touchInteceptorView);
+
+  XCTAssert(touchInteceptorView.gestureRecognizers.count == 2);
+  UIGestureRecognizer* delayingRecognizer = touchInteceptorView.gestureRecognizers[0];
+  UIGestureRecognizer* forwardingRecognizer = touchInteceptorView.gestureRecognizers[1];
+
+  XCTAssert([delayingRecognizer isKindOfClass:[FlutterDelayingGestureRecognizer class]]);
+  XCTAssert([forwardingRecognizer isKindOfClass:[ForwardingGestureRecognizer class]]);
+
+  [(FlutterTouchInterceptingView*)touchInteceptorView blockGesture];
+
+  XCTAssertEqual(touchInteceptorView.gestureRecognizers[0], delayingRecognizer);
+  XCTAssertEqual(touchInteceptorView.gestureRecognizers[1], forwardingRecognizer);
 }
 
 - (void)

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -135,6 +135,46 @@ const float kFloatCompareEpsilon = 0.001;
 
 @end
 
+@interface FlutterPlatformViewsTestMockWrapperWebView : NSObject <FlutterPlatformView>
+@property(nonatomic, strong) UIView* view;
+@property(nonatomic, assign) BOOL viewCreated;
+@end
+
+@implementation FlutterPlatformViewsTestMockWrapperWebView
+- (instancetype)init {
+  if (self = [super init]) {
+    _view = [[UIView alloc] init];
+    [_view addSubview:[[WKWebView alloc] init]];
+    gMockPlatformView = _view;
+    _viewCreated = NO;
+  }
+  return self;
+}
+
+- (UIView*)view {
+  [self checkViewCreatedOnce];
+  return _view;
+}
+
+- (void)checkViewCreatedOnce {
+  if (self.viewCreated) {
+    abort();
+  }
+  self.viewCreated = YES;
+}
+@end
+
+@interface FlutterPlatformViewsTestMockWrapperWebViewFactory : NSObject <FlutterPlatformViewFactory>
+@end
+
+@implementation FlutterPlatformViewsTestMockWrapperWebViewFactory
+- (NSObject<FlutterPlatformView>*)createWithFrame:(CGRect)frame
+                                   viewIdentifier:(int64_t)viewId
+                                        arguments:(id _Nullable)args {
+  return [[FlutterPlatformViewsTestMockWrapperWebView alloc] init];
+}
+@end
+
 namespace flutter {
 namespace {
 class FlutterPlatformViewsTestMockPlatformViewDelegate : public PlatformView::Delegate {
@@ -2853,6 +2893,71 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
       [FlutterMethodCall methodCallWithMethodName:@"create"
                                         arguments:@{@"id" : @2, @"viewType" : @"MockWebView"}],
       result);
+
+  XCTAssertNotNil(gMockPlatformView);
+
+  // Find touch inteceptor view
+  UIView* touchInteceptorView = gMockPlatformView;
+  while (touchInteceptorView != nil &&
+         ![touchInteceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
+    touchInteceptorView = touchInteceptorView.superview;
+  }
+  XCTAssertNotNil(touchInteceptorView);
+
+  XCTAssert(touchInteceptorView.gestureRecognizers.count == 2);
+  UIGestureRecognizer* delayingRecognizer = touchInteceptorView.gestureRecognizers[0];
+  UIGestureRecognizer* forwardingRecognizer = touchInteceptorView.gestureRecognizers[1];
+
+  XCTAssert([delayingRecognizer isKindOfClass:[FlutterDelayingGestureRecognizer class]]);
+  XCTAssert([forwardingRecognizer isKindOfClass:[ForwardingGestureRecognizer class]]);
+
+  [(FlutterTouchInterceptingView*)touchInteceptorView blockGesture];
+
+  if (@available(iOS 18.2, *)) {
+    // Since we remove and add back delayingRecognizer, it would be reordered to the last.
+    XCTAssertEqual(touchInteceptorView.gestureRecognizers[0], forwardingRecognizer);
+    XCTAssertEqual(touchInteceptorView.gestureRecognizers[1], delayingRecognizer);
+  } else {
+    XCTAssertEqual(touchInteceptorView.gestureRecognizers[0], delayingRecognizer);
+    XCTAssertEqual(touchInteceptorView.gestureRecognizers[1], forwardingRecognizer);
+  }
+}
+
+- (void)
+    testFlutterPlatformViewBlockGestureUnderEagerPolicyShouldRemoveAndAddBackDelayingRecognizerForWrapperWebView {
+  flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
+
+  flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
+                               /*platform=*/GetDefaultTaskRunner(),
+                               /*raster=*/GetDefaultTaskRunner(),
+                               /*ui=*/GetDefaultTaskRunner(),
+                               /*io=*/GetDefaultTaskRunner());
+  FlutterPlatformViewsController* flutterPlatformViewsController =
+      [[FlutterPlatformViewsController alloc] init];
+  flutterPlatformViewsController.taskRunner = GetDefaultTaskRunner();
+  auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
+      /*delegate=*/mock_delegate,
+      /*rendering_api=*/mock_delegate.settings_.enable_impeller
+          ? flutter::IOSRenderingAPI::kMetal
+          : flutter::IOSRenderingAPI::kSoftware,
+      /*platform_views_controller=*/flutterPlatformViewsController,
+      /*task_runners=*/runners,
+      /*worker_task_runner=*/nil,
+      /*is_gpu_disabled_jsync_switch=*/std::make_shared<fml::SyncSwitch>());
+
+  FlutterPlatformViewsTestMockWrapperWebViewFactory* factory =
+      [[FlutterPlatformViewsTestMockWrapperWebViewFactory alloc] init];
+  [flutterPlatformViewsController
+                   registerViewFactory:factory
+                                withId:@"MockWrapperWebView"
+      gestureRecognizersBlockingPolicy:FlutterPlatformViewGestureRecognizersBlockingPolicyEager];
+  FlutterResult result = ^(id result) {
+  };
+  [flutterPlatformViewsController
+      onMethodCall:[FlutterMethodCall
+                       methodCallWithMethodName:@"create"
+                                      arguments:@{@"id" : @2, @"viewType" : @"MockWrapperWebView"}]
+            result:result];
 
   XCTAssertNotNil(gMockPlatformView);
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -3048,9 +3048,8 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
                                /*raster=*/GetDefaultTaskRunner(),
                                /*ui=*/GetDefaultTaskRunner(),
                                /*io=*/GetDefaultTaskRunner());
-  FlutterPlatformViewsController* flutterPlatformViewsController =
-      [[FlutterPlatformViewsController alloc] init];
-  flutterPlatformViewsController.taskRunner = GetDefaultTaskRunner();
+  auto flutterPlatformViewsController = std::make_shared<flutter::PlatformViewsController>();
+  flutterPlatformViewsController->SetTaskRunner(GetDefaultTaskRunner());
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/mock_delegate.settings_.enable_impeller
@@ -3063,19 +3062,16 @@ fml::RefPtr<fml::TaskRunner> GetDefaultTaskRunner() {
 
   FlutterPlatformViewsTestMockNestedWrapperWebViewFactory* factory =
       [[FlutterPlatformViewsTestMockNestedWrapperWebViewFactory alloc] init];
-  [flutterPlatformViewsController
-                   registerViewFactory:factory
-                                withId:@"MockNestedWrapperWebView"
-      gestureRecognizersBlockingPolicy:FlutterPlatformViewGestureRecognizersBlockingPolicyEager];
+  flutterPlatformViewsController->RegisterViewFactory(
+      factory, @"MockNestedWrapperWebView",
+      FlutterPlatformViewGestureRecognizersBlockingPolicyEager);
   FlutterResult result = ^(id result) {
   };
-  [flutterPlatformViewsController
-      onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"create"
-                                                     arguments:@{
-                                                       @"id" : @2,
-                                                       @"viewType" : @"MockNestedWrapperWebView"
-                                                     }]
-            result:result];
+  flutterPlatformViewsController->OnMethodCall(
+      [FlutterMethodCall
+          methodCallWithMethodName:@"create"
+                         arguments:@{@"id" : @2, @"viewType" : @"MockNestedWrapperWebView"}],
+      result);
 
   XCTAssertNotNil(gMockPlatformView);
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -553,12 +553,15 @@ static BOOL _preparedOnce = NO;
   self.delayingRecognizer.state = UIGestureRecognizerStateFailed;
 }
 
-- (BOOL)containsWebView:(UIView*)view {
+- (BOOL)containsWebView:(UIView*)view remainingSubviewDepth:(int)remainingSubviewDepth {
+  if (remainingSubviewDepth < 0) {
+    return NO;
+  }
   if ([view isKindOfClass:[WKWebView class]]) {
     return YES;
   }
   for (UIView* subview in view.subviews) {
-    if ([self containsWebView:subview]) {
+    if ([self containsWebView:subview remainingSubviewDepth:remainingSubviewDepth - 1]) {
       return YES;
     }
   }
@@ -580,7 +583,13 @@ static BOOL _preparedOnce = NO;
       // FlutterPlatformViewGestureRecognizersBlockingPolicyEager, but we should try it if a similar
       // issue arises for the other policy.
       if (@available(iOS 18.2, *)) {
-        if ([self containsWebView:self.embeddedView]) {
+        // This workaround is designed for WKWebView only. The 1P web view plugin provides a
+        // WKWebView itself as the platform view. However, some 3P plugins provide wrappers of
+        // WKWebView instead. So we perform DFS to search the view hierarchy (with a depth limit).
+        // Passing a limit of 0 means only searching for platform view itself; Pass 1 to include its
+        // children as well, and so on. We should be conservative and start with a small number. The
+        // AdMob banner has a WKWebView at depth 7.
+        if ([self containsWebView:self.embeddedView remainingSubviewDepth:1]) {
           [self removeGestureRecognizer:self.delayingRecognizer];
           [self addGestureRecognizer:self.delayingRecognizer];
         }

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -553,6 +553,18 @@ static BOOL _preparedOnce = NO;
   self.delayingRecognizer.state = UIGestureRecognizerStateFailed;
 }
 
+- (BOOL)containsWebView:(UIView*)view {
+  if ([view isKindOfClass:[WKWebView class]]) {
+    return YES;
+  }
+  for (UIView* subview in view.subviews) {
+    if ([self containsWebView:subview]) {
+      return YES;
+    }
+  }
+  return NO;
+}
+
 - (void)blockGesture {
   switch (_blockingPolicy) {
     case FlutterPlatformViewGestureRecognizersBlockingPolicyEager:
@@ -568,7 +580,7 @@ static BOOL _preparedOnce = NO;
       // FlutterPlatformViewGestureRecognizersBlockingPolicyEager, but we should try it if a similar
       // issue arises for the other policy.
       if (@available(iOS 18.2, *)) {
-        if ([self.embeddedView isKindOfClass:[WKWebView class]]) {
+        if ([self containsWebView:self.embeddedView]) {
           [self removeGestureRecognizer:self.delayingRecognizer];
           [self addGestureRecognizer:self.delayingRecognizer];
         }


### PR DESCRIPTION
CP for https://github.com/flutter/engine/pull/57168 and https://github.com/flutter/engine/pull/57193


*List which issues are fixed by this PR. You must list at least one issue.*
https://github.com/flutter/flutter/issues/158961

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/engine/blob/main/docs/testing/Testing-the-engine.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
