### PR TITLE
Migrate DlRTree and DlRegion to DisplayList/Impeller geometry classes

### DIFF
--- a/display_list/benchmarking/dl_builder_benchmarks.cc
+++ b/display_list/benchmarking/dl_builder_benchmarks.cc
@@ -267,7 +267,7 @@ static void BM_DisplayListDispatchByVectorDefault(
   DlOpReceiverIgnore receiver;
   while (state.KeepRunning()) {
     std::vector<DlIndex> indices =
-        display_list->GetCulledIndices(display_list->bounds());
+        display_list->GetCulledIndices(display_list->GetBounds());
     for (DlIndex index : indices) {
       display_list->Dispatch(receiver, index);
     }
@@ -299,8 +299,8 @@ static void BM_DisplayListDispatchByVectorCull(
     InvokeAllOps(builder);
   }
   auto display_list = builder.Build();
-  SkRect rect = SkRect::MakeLTRB(0, 0, 100, 100);
-  EXPECT_FALSE(rect.contains(display_list->bounds()));
+  DlRect rect = DlRect::MakeLTRB(0, 0, 100, 100);
+  EXPECT_FALSE(rect.Contains(display_list->GetBounds()));
   DlOpReceiverIgnore receiver;
   while (state.KeepRunning()) {
     std::vector<DlIndex> indices = display_list->GetCulledIndices(rect);

--- a/display_list/benchmarking/dl_region_benchmarks.cc
+++ b/display_list/benchmarking/dl_region_benchmarks.cc
@@ -12,49 +12,54 @@
 
 namespace {
 
+using DlIRect = flutter::DlIRect;
+
 template <typename RNG>
-std::vector<SkIRect> GenerateRects(RNG& rng,
-                                   const SkIRect& bounds,
+std::vector<DlIRect> GenerateRects(RNG& rng,
+                                   const DlIRect& bounds,
                                    int numRects,
                                    int maxSize) {
-  auto max_size_x = std::min(maxSize, bounds.width());
-  auto max_size_y = std::min(maxSize, bounds.height());
+  auto max_size_x = std::min(maxSize, bounds.GetWidth());
+  auto max_size_y = std::min(maxSize, bounds.GetHeight());
 
-  std::uniform_int_distribution pos_x(bounds.fLeft, bounds.fRight - max_size_x);
-  std::uniform_int_distribution pos_y(bounds.fTop, bounds.fBottom - max_size_y);
+  std::uniform_int_distribution pos_x(bounds.GetLeft(),
+                                      bounds.GetRight() - max_size_x);
+  std::uniform_int_distribution pos_y(bounds.GetTop(),
+                                      bounds.GetBottom() - max_size_y);
   std::uniform_int_distribution size_x(1, max_size_x);
   std::uniform_int_distribution size_y(1, max_size_y);
 
-  std::vector<SkIRect> rects;
+  std::vector<DlIRect> rects;
   for (int i = 0; i < numRects; ++i) {
-    SkIRect rect =
-        SkIRect::MakeXYWH(pos_x(rng), pos_y(rng), size_x(rng), size_y(rng));
+    DlIRect rect =
+        DlIRect::MakeXYWH(pos_x(rng), pos_y(rng), size_x(rng), size_y(rng));
     rects.push_back(rect);
   }
   return rects;
 }
 
 template <typename RNG>
-SkIRect RandomSubRect(RNG& rng, const SkIRect& rect, double size_factor) {
+DlIRect RandomSubRect(RNG& rng, const DlIRect& rect, double size_factor) {
   FML_DCHECK(size_factor <= 1);
 
-  int32_t width = rect.width() * size_factor;
-  int32_t height = rect.height() * size_factor;
+  int32_t width = rect.GetWidth() * size_factor;
+  int32_t height = rect.GetHeight() * size_factor;
 
-  std::uniform_int_distribution pos_x(0, rect.width() - width);
-  std::uniform_int_distribution pos_y(0, rect.height() - height);
+  std::uniform_int_distribution pos_x(0, rect.GetWidth() - width);
+  std::uniform_int_distribution pos_y(0, rect.GetHeight() - height);
 
-  return SkIRect::MakeXYWH(rect.fLeft + pos_x(rng), rect.fTop + pos_y(rng),
+  return DlIRect::MakeXYWH(rect.GetLeft() + pos_x(rng),
+                           rect.GetTop() + pos_y(rng),  //
                            width, height);
 }
 
 class SkRegionAdapter {
  public:
-  explicit SkRegionAdapter(const std::vector<SkIRect>& rects) {
-    region_.setRects(rects.data(), rects.size());
+  explicit SkRegionAdapter(const std::vector<DlIRect>& rects) {
+    region_.setRects(flutter::ToSkIRects(rects.data()), rects.size());
   }
 
-  SkIRect getBounds() { return region_.getBounds(); }
+  DlIRect getBounds() { return flutter::ToDlIRect(region_.getBounds()); }
 
   static SkRegionAdapter unionRegions(const SkRegionAdapter& a1,
                                       const SkRegionAdapter& a2) {
@@ -74,13 +79,15 @@ class SkRegionAdapter {
     return region_.intersects(region.region_);
   }
 
-  bool intersects(const SkIRect& rect) { return region_.intersects(rect); }
+  bool intersects(const DlIRect& rect) {
+    return region_.intersects(flutter::ToSkIRect(rect));
+  }
 
-  std::vector<SkIRect> getRects() {
-    std::vector<SkIRect> rects;
+  std::vector<DlIRect> getRects() {
+    std::vector<DlIRect> rects;
     SkRegion::Iterator it(region_);
     while (!it.done()) {
-      rects.push_back(it.rect());
+      rects.push_back(flutter::ToDlIRect(it.rect()));
       it.next();
     }
     return rects;
@@ -92,7 +99,7 @@ class SkRegionAdapter {
 
 class DlRegionAdapter {
  public:
-  explicit DlRegionAdapter(const std::vector<SkIRect>& rects)
+  explicit DlRegionAdapter(const std::vector<DlIRect>& rects)
       : region_(rects) {}
 
   static DlRegionAdapter unionRegions(const DlRegionAdapter& a1,
@@ -107,15 +114,15 @@ class DlRegionAdapter {
         flutter::DlRegion::MakeIntersection(a1.region_, a2.region_));
   }
 
-  SkIRect getBounds() { return region_.bounds(); }
+  DlIRect getBounds() { return region_.bounds(); }
 
   bool intersects(const DlRegionAdapter& region) {
     return region_.intersects(region.region_);
   }
 
-  bool intersects(const SkIRect& rect) { return region_.intersects(rect); }
+  bool intersects(const DlIRect& rect) { return region_.intersects(rect); }
 
-  std::vector<SkIRect> getRects() { return region_.getRects(false); }
+  std::vector<DlIRect> getRects() { return region_.getRects(false); }
 
  private:
   explicit DlRegionAdapter(flutter::DlRegion&& region)
@@ -133,9 +140,9 @@ void RunFromRectsBenchmark(benchmark::State& state, int maxSize) {
   std::uniform_int_distribution pos(0, 4000);
   std::uniform_int_distribution size(1, maxSize);
 
-  std::vector<SkIRect> rects;
+  std::vector<DlIRect> rects;
   for (int i = 0; i < 2000; ++i) {
-    SkIRect rect = SkIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
+    DlIRect rect = DlIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
     rects.push_back(rect);
   }
 
@@ -153,9 +160,9 @@ void RunGetRectsBenchmark(benchmark::State& state, int maxSize) {
   std::uniform_int_distribution pos(0, 4000);
   std::uniform_int_distribution size(1, maxSize);
 
-  std::vector<SkIRect> rects;
+  std::vector<DlIRect> rects;
   for (int i = 0; i < 2000; ++i) {
-    SkIRect rect = SkIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
+    DlIRect rect = DlIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
     rects.push_back(rect);
   }
 
@@ -178,8 +185,8 @@ void RunRegionOpBenchmark(benchmark::State& state,
   std::seed_seq seed{2, 1, 3};
   std::mt19937 rng(seed);
 
-  SkIRect bounds1 = SkIRect::MakeWH(4000, 4000);
-  SkIRect bounds2 = RandomSubRect(rng, bounds1, sizeFactor);
+  DlIRect bounds1 = DlIRect::MakeWH(4000, 4000);
+  DlIRect bounds2 = RandomSubRect(rng, bounds1, sizeFactor);
 
   auto rects = GenerateRects(rng, bounds1, 500, maxSize);
   Region region1(rects);
@@ -210,8 +217,8 @@ void RunIntersectsRegionBenchmark(benchmark::State& state,
   std::seed_seq seed{2, 1, 3};
   std::mt19937 rng(seed);
 
-  SkIRect bounds1 = SkIRect::MakeWH(4000, 4000);
-  SkIRect bounds2 = RandomSubRect(rng, bounds1, sizeFactor);
+  DlIRect bounds1 = DlIRect::MakeWH(4000, 4000);
+  DlIRect bounds2 = RandomSubRect(rng, bounds1, sizeFactor);
 
   auto rects = GenerateRects(rng, bounds1, 500, maxSize);
   Region region1(rects);
@@ -233,16 +240,16 @@ void RunIntersectsSingleRectBenchmark(benchmark::State& state, int maxSize) {
   std::uniform_int_distribution pos(0, 4000);
   std::uniform_int_distribution size(1, maxSize);
 
-  std::vector<SkIRect> rects;
+  std::vector<DlIRect> rects;
   for (int i = 0; i < 500; ++i) {
-    SkIRect rect = SkIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
+    DlIRect rect = DlIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
     rects.push_back(rect);
   }
   Region region1(rects);
 
   rects.clear();
   for (int i = 0; i < 100; ++i) {
-    SkIRect rect = SkIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
+    DlIRect rect = DlIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
     rects.push_back(rect);
   }
 

--- a/display_list/display_list.cc
+++ b/display_list/display_list.cc
@@ -20,7 +20,6 @@ DisplayList::DisplayList()
       nested_op_count_(0),
       total_depth_(0),
       unique_id_(0),
-      bounds_({0, 0, 0, 0}),
       can_apply_group_opacity_(true),
       is_ui_thread_safe_(true),
       modifies_transparent_black_(false),
@@ -37,7 +36,7 @@ DisplayList::DisplayList(DisplayListStorage&& storage,
                          size_t nested_byte_count,
                          uint32_t nested_op_count,
                          uint32_t total_depth,
-                         const SkRect& bounds,
+                         const DlRect& bounds,
                          bool can_apply_group_opacity,
                          bool is_ui_thread_safe,
                          bool modifies_transparent_black,
@@ -187,16 +186,16 @@ void DisplayList::Dispatch(DlOpReceiver& receiver) const {
 }
 
 void DisplayList::Dispatch(DlOpReceiver& receiver,
-                           const SkIRect& cull_rect) const {
-  Dispatch(receiver, SkRect::Make(cull_rect));
+                           const DlIRect& cull_rect) const {
+  Dispatch(receiver, DlRect::Make(cull_rect));
 }
 
 void DisplayList::Dispatch(DlOpReceiver& receiver,
-                           const SkRect& cull_rect) const {
-  if (cull_rect.isEmpty()) {
+                           const DlRect& cull_rect) const {
+  if (cull_rect.IsEmpty()) {
     return;
   }
-  if (!has_rtree() || cull_rect.contains(bounds())) {
+  if (!has_rtree() || cull_rect.Contains(GetBounds())) {
     Dispatch(receiver);
   } else {
     auto op_indices = GetCulledIndices(cull_rect);
@@ -366,9 +365,9 @@ static void FillAllIndices(std::vector<DlIndex>& indices, DlIndex size) {
 }
 
 std::vector<DlIndex> DisplayList::GetCulledIndices(
-    const SkRect& cull_rect) const {
+    const DlRect& cull_rect) const {
   std::vector<DlIndex> indices;
-  if (!cull_rect.isEmpty()) {
+  if (!cull_rect.IsEmpty()) {
     if (rtree_) {
       std::vector<int> rect_indices;
       rtree_->search(cull_rect, &rect_indices);

--- a/display_list/display_list.h
+++ b/display_list/display_list.h
@@ -271,8 +271,14 @@ class DisplayList : public SkRefCnt {
   ~DisplayList();
 
   void Dispatch(DlOpReceiver& ctx) const;
-  void Dispatch(DlOpReceiver& ctx, const SkRect& cull_rect) const;
-  void Dispatch(DlOpReceiver& ctx, const SkIRect& cull_rect) const;
+  void Dispatch(DlOpReceiver& ctx, const SkRect& cull_rect) const {
+    Dispatch(ctx, ToDlRect(cull_rect));
+  }
+  void Dispatch(DlOpReceiver& ctx, const SkIRect& cull_rect) const {
+    Dispatch(ctx, ToDlIRect(cull_rect));
+  }
+  void Dispatch(DlOpReceiver& ctx, const DlRect& cull_rect) const;
+  void Dispatch(DlOpReceiver& ctx, const DlIRect& cull_rect) const;
 
   // From historical behavior, SkPicture always included nested bytes,
   // but nested ops are only included if requested. The defaults used
@@ -290,8 +296,8 @@ class DisplayList : public SkRefCnt {
 
   uint32_t unique_id() const { return unique_id_; }
 
-  const SkRect& bounds() const { return bounds_; }
-  const DlRect& GetBounds() const { return ToDlRect(bounds_); }
+  const SkRect& bounds() const { return ToSkRect(bounds_); }
+  const DlRect& GetBounds() const { return bounds_; }
 
   bool has_rtree() const { return rtree_ != nullptr; }
   sk_sp<const DlRTree> rtree() const { return rtree_; }
@@ -500,7 +506,7 @@ class DisplayList : public SkRefCnt {
   ///                  primarily for debugging use
   ///
   /// @see |Dispatch(receiver, index)|
-  std::vector<DlIndex> GetCulledIndices(const SkRect& cull_rect) const;
+  std::vector<DlIndex> GetCulledIndices(const DlRect& cull_rect) const;
 
  private:
   DisplayList(DisplayListStorage&& ptr,
@@ -509,7 +515,7 @@ class DisplayList : public SkRefCnt {
               size_t nested_byte_count,
               uint32_t nested_op_count,
               uint32_t total_depth,
-              const SkRect& bounds,
+              const DlRect& bounds,
               bool can_apply_group_opacity,
               bool is_ui_thread_safe,
               bool modifies_transparent_black,
@@ -533,7 +539,7 @@ class DisplayList : public SkRefCnt {
   const uint32_t total_depth_;
 
   const uint32_t unique_id_;
-  const SkRect bounds_;
+  const DlRect bounds_;
 
   const bool can_apply_group_opacity_;
   const bool is_ui_thread_safe_;

--- a/display_list/display_list_unittests.cc
+++ b/display_list/display_list_unittests.cc
@@ -2424,8 +2424,8 @@ TEST_F(DisplayListTest, FlatDrawPointsProducesBounds) {
   test_rtree(rtree, query, expected_rects, expected_indices, __FILE__, __LINE__)
 
 static void test_rtree(const sk_sp<const DlRTree>& rtree,
-                       const SkRect& query,
-                       std::vector<SkRect> expected_rects,
+                       const DlRect& query,
+                       std::vector<DlRect> expected_rects,
                        const std::vector<int>& expected_indices,
                        const std::string& file,
                        int line) {
@@ -2434,7 +2434,7 @@ static void test_rtree(const sk_sp<const DlRTree>& rtree,
   rtree->search(query, &indices);
   EXPECT_EQ(indices, expected_indices) << label;
   EXPECT_EQ(indices.size(), expected_indices.size()) << label;
-  std::list<SkRect> rects = rtree->searchAndConsolidateRects(query, false);
+  std::list<DlRect> rects = rtree->searchAndConsolidateRects(query, false);
   // ASSERT_EQ(rects.size(), expected_indices.size());
   auto iterator = rects.cbegin();
   for (int i : expected_indices) {
@@ -2445,9 +2445,9 @@ static void test_rtree(const sk_sp<const DlRTree>& rtree,
 
 TEST_F(DisplayListTest, RTreeOfSimpleScene) {
   DisplayListBuilder builder(/*prepare_rtree=*/true);
-  std::vector<SkRect> rects = {
-      {10, 10, 20, 20},
-      {50, 50, 60, 60},
+  std::vector<DlRect> rects = {
+      DlRect::MakeLTRB(10, 10, 20, 20),
+      DlRect::MakeLTRB(50, 50, 60, 60),
   };
   builder.DrawRect(rects[0], DlPaint());
   builder.DrawRect(rects[1], DlPaint());
@@ -2455,49 +2455,49 @@ TEST_F(DisplayListTest, RTreeOfSimpleScene) {
   auto rtree = display_list->rtree();
 
   // Missing all drawRect calls
-  TEST_RTREE(rtree, SkRect::MakeLTRB(5, 5, 10, 10), rects, {});
-  TEST_RTREE(rtree, SkRect::MakeLTRB(20, 20, 25, 25), rects, {});
-  TEST_RTREE(rtree, SkRect::MakeLTRB(45, 45, 50, 50), rects, {});
-  TEST_RTREE(rtree, SkRect::MakeLTRB(60, 60, 65, 65), rects, {});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(5, 5, 10, 10), rects, {});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(20, 20, 25, 25), rects, {});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(45, 45, 50, 50), rects, {});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(60, 60, 65, 65), rects, {});
 
   // Hitting just 1 of the drawRects
-  TEST_RTREE(rtree, SkRect::MakeLTRB(5, 5, 11, 11), rects, {0});
-  TEST_RTREE(rtree, SkRect::MakeLTRB(19, 19, 25, 25), rects, {0});
-  TEST_RTREE(rtree, SkRect::MakeLTRB(45, 45, 51, 51), rects, {1});
-  TEST_RTREE(rtree, SkRect::MakeLTRB(59, 59, 65, 65), rects, {1});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(5, 5, 11, 11), rects, {0});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(19, 19, 25, 25), rects, {0});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(45, 45, 51, 51), rects, {1});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(59, 59, 65, 65), rects, {1});
 
   // Hitting both drawRect calls
-  TEST_RTREE(rtree, SkRect::MakeLTRB(19, 19, 51, 51), rects,
+  TEST_RTREE(rtree, DlRect::MakeLTRB(19, 19, 51, 51), rects,
              std::vector<int>({0, 1}));
 }
 
 TEST_F(DisplayListTest, RTreeOfSaveRestoreScene) {
   DisplayListBuilder builder(/*prepare_rtree=*/true);
-  builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
+  builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), DlPaint());
   builder.Save();
-  builder.DrawRect(SkRect{50, 50, 60, 60}, DlPaint());
+  builder.DrawRect(DlRect::MakeLTRB(50, 50, 60, 60), DlPaint());
   builder.Restore();
   auto display_list = builder.Build();
   auto rtree = display_list->rtree();
-  std::vector<SkRect> rects = {
-      {10, 10, 20, 20},
-      {50, 50, 60, 60},
+  std::vector<DlRect> rects = {
+      DlRect::MakeLTRB(10, 10, 20, 20),
+      DlRect::MakeLTRB(50, 50, 60, 60),
   };
 
   // Missing all drawRect calls
-  TEST_RTREE(rtree, SkRect::MakeLTRB(5, 5, 10, 10), rects, {});
-  TEST_RTREE(rtree, SkRect::MakeLTRB(20, 20, 25, 25), rects, {});
-  TEST_RTREE(rtree, SkRect::MakeLTRB(45, 45, 50, 50), rects, {});
-  TEST_RTREE(rtree, SkRect::MakeLTRB(60, 60, 65, 65), rects, {});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(5, 5, 10, 10), rects, {});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(20, 20, 25, 25), rects, {});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(45, 45, 50, 50), rects, {});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(60, 60, 65, 65), rects, {});
 
   // Hitting just 1 of the drawRects
-  TEST_RTREE(rtree, SkRect::MakeLTRB(5, 5, 11, 11), rects, {0});
-  TEST_RTREE(rtree, SkRect::MakeLTRB(19, 19, 25, 25), rects, {0});
-  TEST_RTREE(rtree, SkRect::MakeLTRB(45, 45, 51, 51), rects, {1});
-  TEST_RTREE(rtree, SkRect::MakeLTRB(59, 59, 65, 65), rects, {1});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(5, 5, 11, 11), rects, {0});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(19, 19, 25, 25), rects, {0});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(45, 45, 51, 51), rects, {1});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(59, 59, 65, 65), rects, {1});
 
   // Hitting both drawRect calls
-  TEST_RTREE(rtree, SkRect::MakeLTRB(19, 19, 51, 51), rects,
+  TEST_RTREE(rtree, DlRect::MakeLTRB(19, 19, 51, 51), rects,
              std::vector<int>({0, 1}));
 }
 
@@ -2507,40 +2507,40 @@ TEST_F(DisplayListTest, RTreeOfSaveLayerFilterScene) {
   auto filter = DlBlurImageFilter(1.0, 1.0, DlTileMode::kClamp);
   DlPaint default_paint = DlPaint();
   DlPaint filter_paint = DlPaint().setImageFilter(&filter);
-  builder.DrawRect(SkRect{10, 10, 20, 20}, default_paint);
+  builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), default_paint);
   builder.SaveLayer(nullptr, &filter_paint);
   // the following rectangle will be expanded to 50,50,60,60
   // by the SaveLayer filter during the restore operation
-  builder.DrawRect(SkRect{53, 53, 57, 57}, default_paint);
+  builder.DrawRect(DlRect::MakeLTRB(53, 53, 57, 57), default_paint);
   builder.Restore();
   auto display_list = builder.Build();
   auto rtree = display_list->rtree();
-  std::vector<SkRect> rects = {
-      {10, 10, 20, 20},
-      {50, 50, 60, 60},
+  std::vector<DlRect> rects = {
+      DlRect::MakeLTRB(10, 10, 20, 20),
+      DlRect::MakeLTRB(50, 50, 60, 60),
   };
 
   // Missing all drawRect calls
-  TEST_RTREE(rtree, SkRect::MakeLTRB(5, 5, 10, 10), rects, {});
-  TEST_RTREE(rtree, SkRect::MakeLTRB(20, 20, 25, 25), rects, {});
-  TEST_RTREE(rtree, SkRect::MakeLTRB(45, 45, 50, 50), rects, {});
-  TEST_RTREE(rtree, SkRect::MakeLTRB(60, 60, 65, 65), rects, {});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(5, 5, 10, 10), rects, {});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(20, 20, 25, 25), rects, {});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(45, 45, 50, 50), rects, {});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(60, 60, 65, 65), rects, {});
 
   // Hitting just 1 of the drawRects
-  TEST_RTREE(rtree, SkRect::MakeLTRB(5, 5, 11, 11), rects, {0});
-  TEST_RTREE(rtree, SkRect::MakeLTRB(19, 19, 25, 25), rects, {0});
-  TEST_RTREE(rtree, SkRect::MakeLTRB(45, 45, 51, 51), rects, {1});
-  TEST_RTREE(rtree, SkRect::MakeLTRB(59, 59, 65, 65), rects, {1});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(5, 5, 11, 11), rects, {0});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(19, 19, 25, 25), rects, {0});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(45, 45, 51, 51), rects, {1});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(59, 59, 65, 65), rects, {1});
 
   // Hitting both drawRect calls
   auto expected_indices = std::vector<int>{0, 1};
-  TEST_RTREE(rtree, SkRect::MakeLTRB(19, 19, 51, 51), rects, expected_indices);
+  TEST_RTREE(rtree, DlRect::MakeLTRB(19, 19, 51, 51), rects, expected_indices);
 }
 
 TEST_F(DisplayListTest, NestedDisplayListRTreesAreSparse) {
   DisplayListBuilder nested_dl_builder(/**prepare_rtree=*/true);
-  nested_dl_builder.DrawRect(SkRect{10, 10, 20, 20}, DlPaint());
-  nested_dl_builder.DrawRect(SkRect{50, 50, 60, 60}, DlPaint());
+  nested_dl_builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), DlPaint());
+  nested_dl_builder.DrawRect(DlRect::MakeLTRB(50, 50, 60, 60), DlPaint());
   auto nested_display_list = nested_dl_builder.Build();
 
   DisplayListBuilder builder(/**prepare_rtree=*/true);
@@ -2548,13 +2548,13 @@ TEST_F(DisplayListTest, NestedDisplayListRTreesAreSparse) {
   auto display_list = builder.Build();
 
   auto rtree = display_list->rtree();
-  std::vector<SkRect> rects = {
-      {10, 10, 20, 20},
-      {50, 50, 60, 60},
+  std::vector<DlRect> rects = {
+      DlRect::MakeLTRB(10, 10, 20, 20),
+      DlRect::MakeLTRB(50, 50, 60, 60),
   };
 
   // Hitting both sub-dl drawRect calls
-  TEST_RTREE(rtree, SkRect::MakeLTRB(19, 19, 51, 51), rects,
+  TEST_RTREE(rtree, DlRect::MakeLTRB(19, 19, 51, 51), rects,
              std::vector<int>({0, 1}));
 }
 
@@ -3268,43 +3268,43 @@ TEST_F(DisplayListTest, RTreeOfClippedSaveLayerFilterScene) {
   auto filter = DlBlurImageFilter(10.0, 10.0, DlTileMode::kClamp);
   DlPaint default_paint = DlPaint();
   DlPaint filter_paint = DlPaint().setImageFilter(&filter);
-  builder.DrawRect(SkRect{10, 10, 20, 20}, default_paint);
-  builder.ClipRect(SkRect{50, 50, 60, 60}, ClipOp::kIntersect, false);
+  builder.DrawRect(DlRect::MakeLTRB(10, 10, 20, 20), default_paint);
+  builder.ClipRect(DlRect::MakeLTRB(50, 50, 60, 60), ClipOp::kIntersect, false);
   builder.SaveLayer(nullptr, &filter_paint);
   // the following rectangle will be expanded to 23,23,87,87
   // by the SaveLayer filter during the restore operation
   // but it will then be clipped to 50,50,60,60
-  builder.DrawRect(SkRect{53, 53, 57, 57}, default_paint);
+  builder.DrawRect(DlRect::MakeLTRB(53, 53, 57, 57), default_paint);
   builder.Restore();
   auto display_list = builder.Build();
   auto rtree = display_list->rtree();
-  std::vector<SkRect> rects = {
-      {10, 10, 20, 20},
-      {50, 50, 60, 60},
+  std::vector<DlRect> rects = {
+      DlRect::MakeLTRB(10, 10, 20, 20),
+      DlRect::MakeLTRB(50, 50, 60, 60),
   };
 
   // Missing all drawRect calls
-  TEST_RTREE(rtree, SkRect::MakeLTRB(5, 5, 10, 10), rects, {});
-  TEST_RTREE(rtree, SkRect::MakeLTRB(20, 20, 25, 25), rects, {});
-  TEST_RTREE(rtree, SkRect::MakeLTRB(45, 45, 50, 50), rects, {});
-  TEST_RTREE(rtree, SkRect::MakeLTRB(60, 60, 65, 65), rects, {});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(5, 5, 10, 10), rects, {});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(20, 20, 25, 25), rects, {});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(45, 45, 50, 50), rects, {});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(60, 60, 65, 65), rects, {});
 
   // Hitting just 1 of the drawRects
-  TEST_RTREE(rtree, SkRect::MakeLTRB(5, 5, 11, 11), rects, {0});
-  TEST_RTREE(rtree, SkRect::MakeLTRB(19, 19, 25, 25), rects, {0});
-  TEST_RTREE(rtree, SkRect::MakeLTRB(45, 45, 51, 51), rects, {1});
-  TEST_RTREE(rtree, SkRect::MakeLTRB(59, 59, 65, 65), rects, {1});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(5, 5, 11, 11), rects, {0});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(19, 19, 25, 25), rects, {0});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(45, 45, 51, 51), rects, {1});
+  TEST_RTREE(rtree, DlRect::MakeLTRB(59, 59, 65, 65), rects, {1});
 
   // Hitting both drawRect calls
-  TEST_RTREE(rtree, SkRect::MakeLTRB(19, 19, 51, 51), rects,
+  TEST_RTREE(rtree, DlRect::MakeLTRB(19, 19, 51, 51), rects,
              std::vector<int>({0, 1}));
 }
 
 TEST_F(DisplayListTest, RTreeRenderCulling) {
-  SkRect rect1 = SkRect::MakeLTRB(0, 0, 10, 10);
-  SkRect rect2 = SkRect::MakeLTRB(20, 0, 30, 10);
-  SkRect rect3 = SkRect::MakeLTRB(0, 20, 10, 30);
-  SkRect rect4 = SkRect::MakeLTRB(20, 20, 30, 30);
+  DlRect rect1 = DlRect::MakeLTRB(0, 0, 10, 10);
+  DlRect rect2 = DlRect::MakeLTRB(20, 0, 30, 10);
+  DlRect rect3 = DlRect::MakeLTRB(0, 20, 10, 30);
+  DlRect rect4 = DlRect::MakeLTRB(20, 20, 30, 30);
   DlPaint paint1 = DlPaint().setColor(DlColor::kRed());
   DlPaint paint2 = DlPaint().setColor(DlColor::kGreen());
   DlPaint paint3 = DlPaint().setColor(DlColor::kBlue());
@@ -3317,11 +3317,11 @@ TEST_F(DisplayListTest, RTreeRenderCulling) {
   main_builder.DrawRect(rect4, paint4);
   auto main = main_builder.Build();
 
-  auto test = [main](SkIRect cull_rect, const sk_sp<DisplayList>& expected,
+  auto test = [main](DlIRect cull_rect, const sk_sp<DisplayList>& expected,
                      const std::string& label) {
-    SkRect cull_rectf = SkRect::Make(cull_rect);
+    DlRect cull_rectf = DlRect::Make(cull_rect);
 
-    {  // Test SkIRect culling
+    {  // Test DlIRect culling
       DisplayListBuilder culling_builder;
       main->Dispatch(ToReceiver(culling_builder), cull_rect);
 
@@ -3330,7 +3330,7 @@ TEST_F(DisplayListTest, RTreeRenderCulling) {
           << " where " << label;
     }
 
-    {  // Test SkRect culling
+    {  // Test DlRect culling
       DisplayListBuilder culling_builder;
       main->Dispatch(ToReceiver(culling_builder), cull_rectf);
 
@@ -3354,7 +3354,7 @@ TEST_F(DisplayListTest, RTreeRenderCulling) {
   };
 
   {  // No rects
-    SkIRect cull_rect = {11, 11, 19, 19};
+    DlIRect cull_rect = DlIRect::MakeLTRB(11, 11, 19, 19);
 
     DisplayListBuilder expected_builder;
     auto expected = expected_builder.Build();
@@ -3363,7 +3363,7 @@ TEST_F(DisplayListTest, RTreeRenderCulling) {
   }
 
   {  // Rect 1
-    SkIRect cull_rect = {9, 9, 19, 19};
+    DlIRect cull_rect = DlIRect::MakeLTRB(9, 9, 19, 19);
 
     DisplayListBuilder expected_builder;
     expected_builder.DrawRect(rect1, paint1);
@@ -3373,7 +3373,7 @@ TEST_F(DisplayListTest, RTreeRenderCulling) {
   }
 
   {  // Rect 2
-    SkIRect cull_rect = {11, 9, 21, 19};
+    DlIRect cull_rect = DlIRect::MakeLTRB(11, 9, 21, 19);
 
     DisplayListBuilder expected_builder;
     // Unfortunately we don't cull attribute records (yet?), so we forcibly
@@ -3386,7 +3386,7 @@ TEST_F(DisplayListTest, RTreeRenderCulling) {
   }
 
   {  // Rect 3
-    SkIRect cull_rect = {9, 11, 19, 21};
+    DlIRect cull_rect = DlIRect::MakeLTRB(9, 11, 19, 21);
 
     DisplayListBuilder expected_builder;
     // Unfortunately we don't cull attribute records (yet?), so we forcibly
@@ -3400,7 +3400,7 @@ TEST_F(DisplayListTest, RTreeRenderCulling) {
   }
 
   {  // Rect 4
-    SkIRect cull_rect = {11, 11, 21, 21};
+    DlIRect cull_rect = DlIRect::MakeLTRB(11, 11, 21, 21);
 
     DisplayListBuilder expected_builder;
     // Unfortunately we don't cull attribute records (yet?), so we forcibly
@@ -3415,7 +3415,7 @@ TEST_F(DisplayListTest, RTreeRenderCulling) {
   }
 
   {  // All 4 rects
-    SkIRect cull_rect = {9, 9, 21, 21};
+    DlIRect cull_rect = DlIRect::MakeLTRB(9, 9, 21, 21);
 
     test(cull_rect, main, "all rects intersect");
   }
@@ -4221,7 +4221,7 @@ TEST_F(DisplayListTest, SaveContentDepthTest) {
 
 TEST_F(DisplayListTest, FloodingFilteredLayerPushesRestoreOpIndex) {
   DisplayListBuilder builder(true);
-  builder.ClipRect(SkRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f));
+  builder.ClipRect(DlRect::MakeLTRB(100.0f, 100.0f, 200.0f, 200.0f));
   // ClipRect does not contribute to rtree rects, no id needed
 
   DlPaint save_paint;
@@ -4238,7 +4238,7 @@ TEST_F(DisplayListTest, FloodingFilteredLayerPushesRestoreOpIndex) {
   builder.SaveLayer(nullptr, &save_paint);
   int save_layer_id = DisplayListBuilderTestingLastOpIndex(builder);
 
-  builder.DrawRect(SkRect::MakeLTRB(120.0f, 120.0f, 125.0f, 125.0f), DlPaint());
+  builder.DrawRect(DlRect::MakeLTRB(120.0f, 120.0f, 125.0f, 125.0f), DlPaint());
   int draw_rect_id = DisplayListBuilderTestingLastOpIndex(builder);
 
   builder.Restore();
@@ -4246,7 +4246,7 @@ TEST_F(DisplayListTest, FloodingFilteredLayerPushesRestoreOpIndex) {
 
   auto dl = builder.Build();
   std::vector<int> indices;
-  dl->rtree()->search(SkRect::MakeLTRB(0.0f, 0.0f, 500.0f, 500.0f), &indices);
+  dl->rtree()->search(DlRect::MakeLTRB(0.0f, 0.0f, 500.0f, 500.0f), &indices);
   ASSERT_EQ(indices.size(), 3u);
   EXPECT_EQ(dl->rtree()->id(indices[0]), save_layer_id);
   EXPECT_EQ(dl->rtree()->id(indices[1]), draw_rect_id);

--- a/display_list/dl_builder.h
+++ b/display_list/dl_builder.h
@@ -519,7 +519,7 @@ class DisplayListBuilder final : public virtual DlCanvas,
   void* Push(size_t extra, Args&&... args);
 
   struct RTreeData {
-    std::vector<SkRect> rects;
+    std::vector<DlRect> rects;
     std::vector<int> indices;
   };
 
@@ -628,7 +628,7 @@ class DisplayListBuilder final : public virtual DlCanvas,
 
     // Records the given bounds after transforming by the global and
     // layer matrices.
-    bool AccumulateBoundsLocal(const SkRect& bounds);
+    bool AccumulateBoundsLocal(const DlRect& bounds);
 
     // Simply transfers the local bounds to the parent
     void TransferBoundsToParent(const SaveInfo& parent);
@@ -698,7 +698,7 @@ class DisplayListBuilder final : public virtual DlCanvas,
   }
 
   void RestoreLayer();
-  void TransferLayerBounds(const SkRect& content_bounds);
+  void TransferLayerBounds(const DlRect& content_bounds);
   bool AdjustRTreeRects(RTreeData& data,
                         const DlImageFilter& filter,
                         const DlMatrix& matrix,
@@ -811,7 +811,7 @@ class DisplayListBuilder final : public virtual DlCanvas,
 
   // Adjusts the indicated bounds for the given flags and returns true if
   // the calculation was possible, or false if it could not be estimated.
-  bool AdjustBoundsForPaint(SkRect& bounds, DisplayListAttributeFlags flags);
+  bool AdjustBoundsForPaint(DlRect& bounds, DisplayListAttributeFlags flags);
 
   // Records the fact that we encountered an op that either could not
   // estimate its bounds or that fills all of the destination space.
@@ -822,21 +822,21 @@ class DisplayListBuilder final : public virtual DlCanvas,
 
   // Records the bounds for an op after modifying them according to the
   // supplied attribute flags and transforming by the current matrix.
-  bool AccumulateOpBounds(const SkRect& bounds,
+  bool AccumulateOpBounds(const DlRect& bounds,
                           DisplayListAttributeFlags flags) {
-    SkRect safe_bounds = bounds;
+    DlRect safe_bounds = bounds;
     return AccumulateOpBounds(safe_bounds, flags);
   }
 
   // Records the bounds for an op after modifying them according to the
   // supplied attribute flags and transforming by the current matrix
   // and clipping against the current clip.
-  bool AccumulateOpBounds(SkRect& bounds, DisplayListAttributeFlags flags);
+  bool AccumulateOpBounds(DlRect& bounds, DisplayListAttributeFlags flags);
 
   // Records the given bounds after transforming by the current matrix
   // and clipping against the current clip.
-  bool AccumulateBounds(const SkRect& bounds, SaveInfo& layer, int id);
-  bool AccumulateBounds(const SkRect& bounds) {
+  bool AccumulateBounds(const DlRect& bounds, SaveInfo& layer, int id);
+  bool AccumulateBounds(const DlRect& bounds) {
     return AccumulateBounds(bounds, current_info(), op_index_);
   }
 };

--- a/display_list/dl_vertices.h
+++ b/display_list/dl_vertices.h
@@ -195,6 +195,7 @@ class DlVertices {
 
   /// Returns the bounds of the vertices.
   SkRect bounds() const { return bounds_; }
+  DlRect GetBounds() const { return ToDlRect(bounds_); }
 
   /// Returns the vertex mode that defines how the vertices (or the indices)
   /// are turned into triangles.

--- a/display_list/geometry/dl_geometry_types.h
+++ b/display_list/geometry/dl_geometry_types.h
@@ -164,6 +164,10 @@ inline const SkRect* ToSkRects(const DlRect* rects) {
   return rects == nullptr ? nullptr : reinterpret_cast<const SkRect*>(rects);
 }
 
+inline const SkIRect* ToSkIRects(const DlIRect* rects) {
+  return rects == nullptr ? nullptr : reinterpret_cast<const SkIRect*>(rects);
+}
+
 inline const SkSize& ToSkSize(const DlSize& size) {
   return *reinterpret_cast<const SkSize*>(&size);
 }

--- a/display_list/geometry/dl_path.h
+++ b/display_list/geometry/dl_path.h
@@ -36,6 +36,7 @@ class DlPath {
 
   DlPath(const DlPath& path) = default;
   DlPath(DlPath&& path) = default;
+  DlPath& operator=(const DlPath&) = default;
 
   const SkPath& GetSkPath() const;
   impeller::Path GetPath() const;

--- a/display_list/geometry/dl_region.h
+++ b/display_list/geometry/dl_region.h
@@ -5,10 +5,10 @@
 #ifndef FLUTTER_DISPLAY_LIST_GEOMETRY_DL_REGION_H_
 #define FLUTTER_DISPLAY_LIST_GEOMETRY_DL_REGION_H_
 
-#include "third_party/skia/include/core/SkRect.h"
-
 #include <memory>
 #include <vector>
+
+#include "flutter/display_list/geometry/dl_geometry_types.h"
 
 namespace flutter {
 
@@ -22,10 +22,10 @@ class DlRegion {
 
   /// Creates region by bulk adding the rectangles.
   /// Matches SkRegion::op(rect, SkRegion::kUnion_Op) behavior.
-  explicit DlRegion(const std::vector<SkIRect>& rects);
+  explicit DlRegion(const std::vector<DlIRect>& rects);
 
   /// Creates region covering area of a rectangle.
-  explicit DlRegion(const SkIRect& rect);
+  explicit DlRegion(const DlIRect& rect);
 
   DlRegion(const DlRegion&) = default;
   DlRegion(DlRegion&&) = default;
@@ -46,14 +46,17 @@ class DlRegion {
   /// closely matching SkRegion::Iterator behavior.
   /// If |deband| is true, matching rectangles from adjacent span lines will be
   /// merged into single rectangle.
-  std::vector<SkIRect> getRects(bool deband = true) const;
+  std::vector<DlIRect> getRects(bool deband = true) const;
 
   /// Returns maximum and minimum axis values of rectangles in this region.
   /// If region is empty returns SKIRect::MakeEmpty().
-  const SkIRect& bounds() const { return bounds_; }
+  const DlIRect& bounds() const { return bounds_; }
 
   /// Returns whether this region intersects with a rectangle.
-  bool intersects(const SkIRect& rect) const;
+  bool intersects(const DlIRect& rect) const;
+  bool intersects(const SkIRect& rect) const {
+    return intersects(ToDlIRect(rect));
+  }
 
   /// Returns whether this region intersects with another region.
   bool intersects(const DlRegion& region) const;
@@ -118,7 +121,7 @@ class DlRegion {
     SpanChunkHandle chunk_handle;
   };
 
-  void setRects(const std::vector<SkIRect>& rects);
+  void setRects(const std::vector<DlIRect>& rects);
 
   void appendLine(int32_t top,
                   int32_t bottom,
@@ -164,7 +167,7 @@ class DlRegion {
       std::vector<SpanLine>::const_iterator& b_it);
 
   std::vector<SpanLine> lines_;
-  SkIRect bounds_ = SkIRect::MakeEmpty();
+  DlIRect bounds_;
   SpanBuffer span_buffer_;
 };
 

--- a/display_list/geometry/dl_region_unittests.cc
+++ b/display_list/geometry/dl_region_unittests.cc
@@ -19,107 +19,122 @@ TEST(DisplayListRegion, EmptyRegion) {
 }
 
 TEST(DisplayListRegion, SingleRectangle) {
-  DlRegion region({SkIRect::MakeLTRB(10, 10, 50, 50)});
+  DlRegion region({DlIRect::MakeLTRB(10, 10, 50, 50)});
   auto rects = region.getRects();
   ASSERT_EQ(rects.size(), 1u);
-  EXPECT_EQ(rects.front(), SkIRect::MakeLTRB(10, 10, 50, 50));
+  EXPECT_EQ(rects.front(), DlIRect::MakeLTRB(10, 10, 50, 50));
 }
 
 TEST(DisplayListRegion, NonOverlappingRectangles1) {
-  std::vector<SkIRect> rects_in;
+  std::vector<DlIRect> rects_in;
   for (int i = 0; i < 10; ++i) {
-    SkIRect rect = SkIRect::MakeXYWH(50 * i, 50 * i, 50, 50);
+    DlIRect rect = DlIRect::MakeXYWH(50 * i, 50 * i, 50, 50);
     rects_in.push_back(rect);
   }
   DlRegion region(rects_in);
   auto rects = region.getRects();
-  std::vector<SkIRect> expected{
-      {0, 0, 50, 50},       {50, 50, 100, 100},   {100, 100, 150, 150},
-      {150, 150, 200, 200}, {200, 200, 250, 250}, {250, 250, 300, 300},
-      {300, 300, 350, 350}, {350, 350, 400, 400}, {400, 400, 450, 450},
-      {450, 450, 500, 500},
+  std::vector<DlIRect> expected{
+      DlIRect::MakeLTRB(0, 0, 50, 50),
+      DlIRect::MakeLTRB(50, 50, 100, 100),
+      DlIRect::MakeLTRB(100, 100, 150, 150),
+      DlIRect::MakeLTRB(150, 150, 200, 200),
+      DlIRect::MakeLTRB(200, 200, 250, 250),
+      DlIRect::MakeLTRB(250, 250, 300, 300),
+      DlIRect::MakeLTRB(300, 300, 350, 350),
+      DlIRect::MakeLTRB(350, 350, 400, 400),
+      DlIRect::MakeLTRB(400, 400, 450, 450),
+      DlIRect::MakeLTRB(450, 450, 500, 500),
   };
   EXPECT_EQ(rects, expected);
 }
 
 TEST(DisplayListRegion, NonOverlappingRectangles2) {
   DlRegion region({
-      SkIRect::MakeXYWH(5, 5, 10, 10),
-      SkIRect::MakeXYWH(25, 5, 10, 10),
-      SkIRect::MakeXYWH(5, 25, 10, 10),
-      SkIRect::MakeXYWH(25, 25, 10, 10),
+      DlIRect::MakeXYWH(5, 5, 10, 10),
+      DlIRect::MakeXYWH(25, 5, 10, 10),
+      DlIRect::MakeXYWH(5, 25, 10, 10),
+      DlIRect::MakeXYWH(25, 25, 10, 10),
   });
   auto rects = region.getRects();
-  std::vector<SkIRect> expected{
-      SkIRect::MakeXYWH(5, 5, 10, 10),
-      SkIRect::MakeXYWH(25, 5, 10, 10),
-      SkIRect::MakeXYWH(5, 25, 10, 10),
-      SkIRect::MakeXYWH(25, 25, 10, 10),
+  std::vector<DlIRect> expected{
+      DlIRect::MakeXYWH(5, 5, 10, 10),
+      DlIRect::MakeXYWH(25, 5, 10, 10),
+      DlIRect::MakeXYWH(5, 25, 10, 10),
+      DlIRect::MakeXYWH(25, 25, 10, 10),
   };
   EXPECT_EQ(rects, expected);
 }
 
 TEST(DisplayListRegion, NonOverlappingRectangles3) {
   DlRegion region({
-      SkIRect::MakeXYWH(0, 0, 10, 10),
-      SkIRect::MakeXYWH(-11, -11, 10, 10),
-      SkIRect::MakeXYWH(11, 11, 10, 10),
-      SkIRect::MakeXYWH(-11, 0, 10, 10),
-      SkIRect::MakeXYWH(0, 11, 10, 10),
-      SkIRect::MakeXYWH(0, -11, 10, 10),
-      SkIRect::MakeXYWH(11, 0, 10, 10),
-      SkIRect::MakeXYWH(11, -11, 10, 10),
-      SkIRect::MakeXYWH(-11, 11, 10, 10),
+      DlIRect::MakeXYWH(0, 0, 10, 10),
+      DlIRect::MakeXYWH(-11, -11, 10, 10),
+      DlIRect::MakeXYWH(11, 11, 10, 10),
+      DlIRect::MakeXYWH(-11, 0, 10, 10),
+      DlIRect::MakeXYWH(0, 11, 10, 10),
+      DlIRect::MakeXYWH(0, -11, 10, 10),
+      DlIRect::MakeXYWH(11, 0, 10, 10),
+      DlIRect::MakeXYWH(11, -11, 10, 10),
+      DlIRect::MakeXYWH(-11, 11, 10, 10),
   });
   auto rects = region.getRects();
-  std::vector<SkIRect> expected{
-      SkIRect::MakeXYWH(-11, -11, 10, 10),  //
-      SkIRect::MakeXYWH(0, -11, 10, 10),    //
-      SkIRect::MakeXYWH(11, -11, 10, 10),   //
-      SkIRect::MakeXYWH(-11, 0, 10, 10),    //
-      SkIRect::MakeXYWH(0, 0, 10, 10),      //
-      SkIRect::MakeXYWH(11, 0, 10, 10),     //
-      SkIRect::MakeXYWH(-11, 11, 10, 10),   //
-      SkIRect::MakeXYWH(0, 11, 10, 10),     //
-      SkIRect::MakeXYWH(11, 11, 10, 10),
+  std::vector<DlIRect> expected{
+      DlIRect::MakeXYWH(-11, -11, 10, 10),  //
+      DlIRect::MakeXYWH(0, -11, 10, 10),    //
+      DlIRect::MakeXYWH(11, -11, 10, 10),   //
+      DlIRect::MakeXYWH(-11, 0, 10, 10),    //
+      DlIRect::MakeXYWH(0, 0, 10, 10),      //
+      DlIRect::MakeXYWH(11, 0, 10, 10),     //
+      DlIRect::MakeXYWH(-11, 11, 10, 10),   //
+      DlIRect::MakeXYWH(0, 11, 10, 10),     //
+      DlIRect::MakeXYWH(11, 11, 10, 10),
   };
   EXPECT_EQ(rects, expected);
 }
 
 TEST(DisplayListRegion, MergeTouchingRectangles) {
   DlRegion region({
-      SkIRect::MakeXYWH(0, 0, 10, 10),
-      SkIRect::MakeXYWH(-10, -10, 10, 10),
-      SkIRect::MakeXYWH(10, 10, 10, 10),
-      SkIRect::MakeXYWH(-10, 0, 10, 10),
-      SkIRect::MakeXYWH(0, 10, 10, 10),
-      SkIRect::MakeXYWH(0, -10, 10, 10),
-      SkIRect::MakeXYWH(10, 0, 10, 10),
-      SkIRect::MakeXYWH(10, -10, 10, 10),
-      SkIRect::MakeXYWH(-10, 10, 10, 10),
+      DlIRect::MakeXYWH(0, 0, 10, 10),
+      DlIRect::MakeXYWH(-10, -10, 10, 10),
+      DlIRect::MakeXYWH(10, 10, 10, 10),
+      DlIRect::MakeXYWH(-10, 0, 10, 10),
+      DlIRect::MakeXYWH(0, 10, 10, 10),
+      DlIRect::MakeXYWH(0, -10, 10, 10),
+      DlIRect::MakeXYWH(10, 0, 10, 10),
+      DlIRect::MakeXYWH(10, -10, 10, 10),
+      DlIRect::MakeXYWH(-10, 10, 10, 10),
   });
 
   auto rects = region.getRects();
-  std::vector<SkIRect> expected{
-      SkIRect::MakeXYWH(-10, -10, 30, 30),
+  std::vector<DlIRect> expected{
+      DlIRect::MakeXYWH(-10, -10, 30, 30),
   };
   EXPECT_EQ(rects, expected);
 }
 
 TEST(DisplayListRegion, OverlappingRectangles) {
-  std::vector<SkIRect> rects_in;
+  std::vector<DlIRect> rects_in;
   for (int i = 0; i < 10; ++i) {
-    SkIRect rect = SkIRect::MakeXYWH(10 * i, 10 * i, 50, 50);
+    DlIRect rect = DlIRect::MakeXYWH(10 * i, 10 * i, 50, 50);
     rects_in.push_back(rect);
   }
   DlRegion region(rects_in);
   auto rects = region.getRects();
-  std::vector<SkIRect> expected{
-      {0, 0, 50, 10},      {0, 10, 60, 20},     {0, 20, 70, 30},
-      {0, 30, 80, 40},     {0, 40, 90, 50},     {10, 50, 100, 60},
-      {20, 60, 110, 70},   {30, 70, 120, 80},   {40, 80, 130, 90},
-      {50, 90, 140, 100},  {60, 100, 140, 110}, {70, 110, 140, 120},
-      {80, 120, 140, 130}, {90, 130, 140, 140},
+  std::vector<DlIRect> expected{
+      DlIRect::MakeLTRB(0, 0, 50, 10),
+      DlIRect::MakeLTRB(0, 10, 60, 20),
+      DlIRect::MakeLTRB(0, 20, 70, 30),
+      DlIRect::MakeLTRB(0, 30, 80, 40),
+      DlIRect::MakeLTRB(0, 40, 90, 50),
+      DlIRect::MakeLTRB(10, 50, 100, 60),
+      DlIRect::MakeLTRB(20, 60, 110, 70),
+      DlIRect::MakeLTRB(30, 70, 120, 80),
+      DlIRect::MakeLTRB(40, 80, 130, 90),
+      DlIRect::MakeLTRB(50, 90, 140, 100),
+      DlIRect::MakeLTRB(60, 100, 140, 110),
+      DlIRect::MakeLTRB(70, 110, 140, 120),
+      DlIRect::MakeLTRB(80, 120, 140, 130),
+      DlIRect::MakeLTRB(90, 130, 140, 140),
   };
 
   EXPECT_EQ(rects, expected);
@@ -127,38 +142,38 @@ TEST(DisplayListRegion, OverlappingRectangles) {
 
 TEST(DisplayListRegion, Deband) {
   DlRegion region({
-      SkIRect::MakeXYWH(0, 0, 50, 50),
-      SkIRect::MakeXYWH(60, 0, 20, 20),
-      SkIRect::MakeXYWH(90, 0, 50, 50),
+      DlIRect::MakeXYWH(0, 0, 50, 50),
+      DlIRect::MakeXYWH(60, 0, 20, 20),
+      DlIRect::MakeXYWH(90, 0, 50, 50),
   });
 
   auto rects_with_deband = region.getRects(true);
-  std::vector<SkIRect> expected{
-      SkIRect::MakeXYWH(60, 0, 20, 20),
-      SkIRect::MakeXYWH(0, 0, 50, 50),
-      SkIRect::MakeXYWH(90, 0, 50, 50),
+  std::vector<DlIRect> expected{
+      DlIRect::MakeXYWH(60, 0, 20, 20),
+      DlIRect::MakeXYWH(0, 0, 50, 50),
+      DlIRect::MakeXYWH(90, 0, 50, 50),
   };
   EXPECT_EQ(rects_with_deband, expected);
 
   auto rects_without_deband = region.getRects(false);
-  std::vector<SkIRect> expected_without_deband{
-      SkIRect::MakeXYWH(0, 0, 50, 20),   //
-      SkIRect::MakeXYWH(60, 0, 20, 20),  //
-      SkIRect::MakeXYWH(90, 0, 50, 20),  //
-      SkIRect::MakeXYWH(0, 20, 50, 30),  //
-      SkIRect::MakeXYWH(90, 20, 50, 30),
+  std::vector<DlIRect> expected_without_deband{
+      DlIRect::MakeXYWH(0, 0, 50, 20),   //
+      DlIRect::MakeXYWH(60, 0, 20, 20),  //
+      DlIRect::MakeXYWH(90, 0, 50, 20),  //
+      DlIRect::MakeXYWH(0, 20, 50, 30),  //
+      DlIRect::MakeXYWH(90, 20, 50, 30),
   };
   EXPECT_EQ(rects_without_deband, expected_without_deband);
 }
 
 TEST(DisplayListRegion, Intersects1) {
   DlRegion region1({
-      SkIRect::MakeXYWH(0, 0, 20, 20),
-      SkIRect::MakeXYWH(20, 20, 20, 20),
+      DlIRect::MakeXYWH(0, 0, 20, 20),
+      DlIRect::MakeXYWH(20, 20, 20, 20),
   });
   DlRegion region2({
-      SkIRect::MakeXYWH(20, 0, 20, 20),
-      SkIRect::MakeXYWH(0, 20, 20, 20),
+      DlIRect::MakeXYWH(20, 0, 20, 20),
+      DlIRect::MakeXYWH(0, 20, 20, 20),
   });
   EXPECT_FALSE(region1.intersects(region2));
   EXPECT_FALSE(region2.intersects(region1));
@@ -166,29 +181,29 @@ TEST(DisplayListRegion, Intersects1) {
   EXPECT_TRUE(region1.intersects(region2.bounds()));
   EXPECT_TRUE(region2.intersects(region1.bounds()));
 
-  EXPECT_TRUE(region1.intersects(SkIRect::MakeXYWH(0, 0, 20, 20)));
-  EXPECT_FALSE(region1.intersects(SkIRect::MakeXYWH(20, 0, 20, 20)));
+  EXPECT_TRUE(region1.intersects(DlIRect::MakeXYWH(0, 0, 20, 20)));
+  EXPECT_FALSE(region1.intersects(DlIRect::MakeXYWH(20, 0, 20, 20)));
 
   EXPECT_TRUE(region1.intersects(
-      DlRegion(std::vector<SkIRect>{SkIRect::MakeXYWH(0, 0, 20, 20)})));
+      DlRegion(std::vector<DlIRect>{DlIRect::MakeXYWH(0, 0, 20, 20)})));
   EXPECT_FALSE(region1.intersects(
-      DlRegion(std::vector<SkIRect>{SkIRect::MakeXYWH(20, 0, 20, 20)})));
+      DlRegion(std::vector<DlIRect>{DlIRect::MakeXYWH(20, 0, 20, 20)})));
 
-  EXPECT_FALSE(region1.intersects(SkIRect::MakeXYWH(-1, -1, 1, 1)));
-  EXPECT_TRUE(region1.intersects(SkIRect::MakeXYWH(0, 0, 1, 1)));
+  EXPECT_FALSE(region1.intersects(DlIRect::MakeXYWH(-1, -1, 1, 1)));
+  EXPECT_TRUE(region1.intersects(DlIRect::MakeXYWH(0, 0, 1, 1)));
 
-  EXPECT_FALSE(region1.intersects(SkIRect::MakeXYWH(40, 40, 1, 1)));
-  EXPECT_TRUE(region1.intersects(SkIRect::MakeXYWH(39, 39, 1, 1)));
+  EXPECT_FALSE(region1.intersects(DlIRect::MakeXYWH(40, 40, 1, 1)));
+  EXPECT_TRUE(region1.intersects(DlIRect::MakeXYWH(39, 39, 1, 1)));
 }
 
 TEST(DisplayListRegion, Intersects2) {
   DlRegion region1({
-      SkIRect::MakeXYWH(-10, -10, 20, 20),
-      SkIRect::MakeXYWH(-30, -30, 20, 20),
+      DlIRect::MakeXYWH(-10, -10, 20, 20),
+      DlIRect::MakeXYWH(-30, -30, 20, 20),
   });
   DlRegion region2({
-      SkIRect::MakeXYWH(20, 20, 5, 5),
-      SkIRect::MakeXYWH(0, 0, 20, 20),
+      DlIRect::MakeXYWH(20, 20, 5, 5),
+      DlIRect::MakeXYWH(0, 0, 20, 20),
   });
   EXPECT_TRUE(region1.intersects(region2));
   EXPECT_TRUE(region2.intersects(region1));
@@ -196,15 +211,15 @@ TEST(DisplayListRegion, Intersects2) {
 
 TEST(DisplayListRegion, Intersection1) {
   DlRegion region1({
-      SkIRect::MakeXYWH(0, 0, 20, 20),
-      SkIRect::MakeXYWH(20, 20, 20, 20),
+      DlIRect::MakeXYWH(0, 0, 20, 20),
+      DlIRect::MakeXYWH(20, 20, 20, 20),
   });
   DlRegion region2({
-      SkIRect::MakeXYWH(20, 0, 20, 20),
-      SkIRect::MakeXYWH(0, 20, 20, 20),
+      DlIRect::MakeXYWH(20, 0, 20, 20),
+      DlIRect::MakeXYWH(0, 20, 20, 20),
   });
   DlRegion i = DlRegion::MakeIntersection(region1, region2);
-  EXPECT_EQ(i.bounds(), SkIRect::MakeEmpty());
+  EXPECT_EQ(i.bounds(), DlIRect());
   EXPECT_TRUE(i.isEmpty());
   auto rects = i.getRects();
   EXPECT_TRUE(rects.empty());
@@ -212,146 +227,146 @@ TEST(DisplayListRegion, Intersection1) {
 
 TEST(DisplayListRegion, Intersection2) {
   DlRegion region1({
-      SkIRect::MakeXYWH(0, 0, 20, 20),
-      SkIRect::MakeXYWH(20, 20, 20, 20),
+      DlIRect::MakeXYWH(0, 0, 20, 20),
+      DlIRect::MakeXYWH(20, 20, 20, 20),
   });
   DlRegion region2({
-      SkIRect::MakeXYWH(0, 0, 20, 20),
-      SkIRect::MakeXYWH(20, 20, 20, 20),
+      DlIRect::MakeXYWH(0, 0, 20, 20),
+      DlIRect::MakeXYWH(20, 20, 20, 20),
   });
   DlRegion i = DlRegion::MakeIntersection(region1, region2);
-  EXPECT_EQ(i.bounds(), SkIRect::MakeXYWH(0, 0, 40, 40));
+  EXPECT_EQ(i.bounds(), DlIRect::MakeXYWH(0, 0, 40, 40));
   auto rects = i.getRects();
-  std::vector<SkIRect> expected{
-      SkIRect::MakeXYWH(0, 0, 20, 20),
-      SkIRect::MakeXYWH(20, 20, 20, 20),
+  std::vector<DlIRect> expected{
+      DlIRect::MakeXYWH(0, 0, 20, 20),
+      DlIRect::MakeXYWH(20, 20, 20, 20),
   };
   EXPECT_EQ(rects, expected);
 }
 
 TEST(DisplayListRegion, Intersection3) {
   DlRegion region1({
-      SkIRect::MakeXYWH(0, 0, 20, 20),
+      DlIRect::MakeXYWH(0, 0, 20, 20),
   });
   DlRegion region2({
-      SkIRect::MakeXYWH(-10, -10, 20, 20),
-      SkIRect::MakeXYWH(10, 10, 20, 20),
+      DlIRect::MakeXYWH(-10, -10, 20, 20),
+      DlIRect::MakeXYWH(10, 10, 20, 20),
   });
   DlRegion i = DlRegion::MakeIntersection(region1, region2);
-  EXPECT_EQ(i.bounds(), SkIRect::MakeXYWH(0, 0, 20, 20));
+  EXPECT_EQ(i.bounds(), DlIRect::MakeXYWH(0, 0, 20, 20));
   auto rects = i.getRects();
-  std::vector<SkIRect> expected{
-      SkIRect::MakeXYWH(0, 0, 10, 10),
-      SkIRect::MakeXYWH(10, 10, 10, 10),
+  std::vector<DlIRect> expected{
+      DlIRect::MakeXYWH(0, 0, 10, 10),
+      DlIRect::MakeXYWH(10, 10, 10, 10),
   };
   EXPECT_EQ(rects, expected);
 }
 
 TEST(DisplayListRegion, Union1) {
   DlRegion region1({
-      SkIRect::MakeXYWH(0, 0, 20, 20),
-      SkIRect::MakeXYWH(20, 20, 20, 20),
+      DlIRect::MakeXYWH(0, 0, 20, 20),
+      DlIRect::MakeXYWH(20, 20, 20, 20),
   });
   DlRegion region2({
-      SkIRect::MakeXYWH(20, 0, 20, 20),
-      SkIRect::MakeXYWH(0, 20, 20, 20),
+      DlIRect::MakeXYWH(20, 0, 20, 20),
+      DlIRect::MakeXYWH(0, 20, 20, 20),
   });
   DlRegion u = DlRegion::MakeUnion(region1, region2);
-  EXPECT_EQ(u.bounds(), SkIRect::MakeXYWH(0, 0, 40, 40));
+  EXPECT_EQ(u.bounds(), DlIRect::MakeXYWH(0, 0, 40, 40));
   EXPECT_TRUE(u.isSimple());
   auto rects = u.getRects();
-  std::vector<SkIRect> expected{
-      SkIRect::MakeXYWH(0, 0, 40, 40),  //
+  std::vector<DlIRect> expected{
+      DlIRect::MakeXYWH(0, 0, 40, 40),  //
   };
   EXPECT_EQ(rects, expected);
 }
 
 TEST(DisplayListRegion, Union2) {
   DlRegion region1({
-      SkIRect::MakeXYWH(0, 0, 20, 20),
-      SkIRect::MakeXYWH(21, 21, 20, 20),
+      DlIRect::MakeXYWH(0, 0, 20, 20),
+      DlIRect::MakeXYWH(21, 21, 20, 20),
   });
   DlRegion region2({
-      SkIRect::MakeXYWH(21, 0, 20, 20),
-      SkIRect::MakeXYWH(0, 21, 20, 20),
+      DlIRect::MakeXYWH(21, 0, 20, 20),
+      DlIRect::MakeXYWH(0, 21, 20, 20),
   });
   DlRegion u = DlRegion::MakeUnion(region1, region2);
-  EXPECT_EQ(u.bounds(), SkIRect::MakeXYWH(0, 0, 41, 41));
+  EXPECT_EQ(u.bounds(), DlIRect::MakeXYWH(0, 0, 41, 41));
   auto rects = u.getRects();
-  std::vector<SkIRect> expected{
-      SkIRect::MakeXYWH(0, 0, 20, 20),
-      SkIRect::MakeXYWH(21, 0, 20, 20),
-      SkIRect::MakeXYWH(0, 21, 20, 20),
-      SkIRect::MakeXYWH(21, 21, 20, 20),
+  std::vector<DlIRect> expected{
+      DlIRect::MakeXYWH(0, 0, 20, 20),
+      DlIRect::MakeXYWH(21, 0, 20, 20),
+      DlIRect::MakeXYWH(0, 21, 20, 20),
+      DlIRect::MakeXYWH(21, 21, 20, 20),
   };
   EXPECT_EQ(rects, expected);
 }
 
 TEST(DisplayListRegion, Union3) {
   DlRegion region1({
-      SkIRect::MakeXYWH(-10, -10, 20, 20),
+      DlIRect::MakeXYWH(-10, -10, 20, 20),
   });
   DlRegion region2({
-      SkIRect::MakeXYWH(0, 0, 20, 20),
+      DlIRect::MakeXYWH(0, 0, 20, 20),
   });
   DlRegion u = DlRegion::MakeUnion(region1, region2);
-  EXPECT_EQ(u.bounds(), SkIRect::MakeXYWH(-10, -10, 30, 30));
+  EXPECT_EQ(u.bounds(), DlIRect::MakeXYWH(-10, -10, 30, 30));
   auto rects = u.getRects();
-  std::vector<SkIRect> expected{
-      SkIRect::MakeXYWH(-10, -10, 20, 10),
-      SkIRect::MakeXYWH(-10, 0, 30, 10),
-      SkIRect::MakeXYWH(0, 10, 20, 10),
+  std::vector<DlIRect> expected{
+      DlIRect::MakeXYWH(-10, -10, 20, 10),
+      DlIRect::MakeXYWH(-10, 0, 30, 10),
+      DlIRect::MakeXYWH(0, 10, 20, 10),
   };
   EXPECT_EQ(rects, expected);
 }
 
 TEST(DisplayListRegion, UnionEmpty) {
   {
-    DlRegion region1(std::vector<SkIRect>{});
-    DlRegion region2(std::vector<SkIRect>{});
+    DlRegion region1(std::vector<DlIRect>{});
+    DlRegion region2(std::vector<DlIRect>{});
     DlRegion u = DlRegion::MakeUnion(region1, region2);
-    EXPECT_EQ(u.bounds(), SkIRect::MakeEmpty());
+    EXPECT_EQ(u.bounds(), DlIRect());
     EXPECT_TRUE(u.isEmpty());
     auto rects = u.getRects();
     EXPECT_TRUE(rects.empty());
   }
   {
-    DlRegion region1(std::vector<SkIRect>{});
+    DlRegion region1(std::vector<DlIRect>{});
     DlRegion region2({
-        SkIRect::MakeXYWH(0, 0, 20, 20),
+        DlIRect::MakeXYWH(0, 0, 20, 20),
     });
     DlRegion u = DlRegion::MakeUnion(region1, region2);
-    EXPECT_EQ(u.bounds(), SkIRect::MakeXYWH(0, 0, 20, 20));
+    EXPECT_EQ(u.bounds(), DlIRect::MakeXYWH(0, 0, 20, 20));
     auto rects = u.getRects();
-    std::vector<SkIRect> expected{
-        SkIRect::MakeXYWH(0, 0, 20, 20),
+    std::vector<DlIRect> expected{
+        DlIRect::MakeXYWH(0, 0, 20, 20),
     };
   }
   {
     DlRegion region1({
-        SkIRect::MakeXYWH(0, 0, 20, 20),
+        DlIRect::MakeXYWH(0, 0, 20, 20),
     });
-    DlRegion region2(std::vector<SkIRect>{});
+    DlRegion region2(std::vector<DlIRect>{});
     DlRegion u = DlRegion::MakeUnion(region1, region2);
-    EXPECT_EQ(u.bounds(), SkIRect::MakeXYWH(0, 0, 20, 20));
+    EXPECT_EQ(u.bounds(), DlIRect::MakeXYWH(0, 0, 20, 20));
     auto rects = u.getRects();
-    std::vector<SkIRect> expected{
-        SkIRect::MakeXYWH(0, 0, 20, 20),
+    std::vector<DlIRect> expected{
+        DlIRect::MakeXYWH(0, 0, 20, 20),
     };
   }
 }
 
 void CheckEquality(const DlRegion& dl_region, const SkRegion& sk_region) {
-  EXPECT_EQ(dl_region.bounds(), sk_region.getBounds());
+  EXPECT_EQ(dl_region.bounds(), ToDlIRect(sk_region.getBounds()));
 
   // Do not deband the rectangles - identical to SkRegion::Iterator
   auto rects = dl_region.getRects(false);
 
-  std::vector<SkIRect> skia_rects;
+  std::vector<DlIRect> skia_rects;
 
   auto iterator = SkRegion::Iterator(sk_region);
   while (!iterator.done()) {
-    skia_rects.push_back(iterator.rect());
+    skia_rects.push_back(ToDlIRect(iterator.rect()));
     iterator.next();
   }
 
@@ -379,27 +394,27 @@ TEST(DisplayListRegion, TestAgainstSkRegion) {
         std::uniform_int_distribution pos(0, 4000);
         std::uniform_int_distribution size(1, settings.max_size);
 
-        std::vector<SkIRect> rects_in1;
-        std::vector<SkIRect> rects_in2;
+        std::vector<DlIRect> rects_in1;
+        std::vector<DlIRect> rects_in2;
 
         for (size_t i = 0; i < iterations_1; ++i) {
-          SkIRect rect =
-              SkIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
+          DlIRect rect =
+              DlIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
           rects_in1.push_back(rect);
         }
 
         for (size_t i = 0; i < iterations_2; ++i) {
-          SkIRect rect =
-              SkIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
+          DlIRect rect =
+              DlIRect::MakeXYWH(pos(rng), pos(rng), size(rng), size(rng));
           rects_in2.push_back(rect);
         }
 
         DlRegion region1(rects_in1);
-        sk_region1.setRects(rects_in1.data(), rects_in1.size());
+        sk_region1.setRects(ToSkIRects(rects_in1.data()), rects_in1.size());
         CheckEquality(region1, sk_region1);
 
         DlRegion region2(rects_in2);
-        sk_region2.setRects(rects_in2.data(), rects_in2.size());
+        sk_region2.setRects(ToSkIRects(rects_in2.data()), rects_in2.size());
         CheckEquality(region2, sk_region2);
 
         auto intersects_1 = region1.intersects(region2);
@@ -411,7 +426,8 @@ TEST(DisplayListRegion, TestAgainstSkRegion) {
         {
           auto rects = region2.getRects(true);
           for (const auto& r : rects) {
-            EXPECT_EQ(region1.intersects(r), sk_region1.intersects(r));
+            EXPECT_EQ(region1.intersects(r),
+                      sk_region1.intersects(ToSkIRect(r)));
           }
         }
 

--- a/display_list/geometry/dl_rtree.h
+++ b/display_list/geometry/dl_rtree.h
@@ -11,8 +11,6 @@
 
 #include "flutter/display_list/geometry/dl_region.h"
 #include "flutter/fml/logging.h"
-#include "third_party/skia/include/core/SkColorSpace.h"
-#include "third_party/skia/include/core/SkRect.h"
 #include "third_party/skia/include/core/SkRefCnt.h"
 
 namespace flutter {
@@ -33,7 +31,7 @@ class DlRTree : public SkRefCnt {
   // Leaf nodes at start of vector have an ID,
   // Internal nodes after that have child index and count.
   struct Node {
-    SkRect bounds;
+    DlRect bounds;
     union {
       struct {
         uint32_t index;
@@ -62,7 +60,7 @@ class DlRTree : public SkRefCnt {
   /// way except to eliminate invalid rectangles and IDs that are rejected
   /// by the optional predicate function.
   DlRTree(
-      const SkRect rects[],
+      const DlRect rects[],
       int N,
       const int ids[] = nullptr,
       bool predicate(int id) = [](int) { return true; },
@@ -78,7 +76,7 @@ class DlRTree : public SkRefCnt {
   /// which they were passed into the constructor. The actual rectangle
   /// and ID associated with each index can be retrieved using the
   /// |DlRTree::id| and |DlRTree::bounds| methods.
-  void search(const SkRect& query, std::vector<int>* results) const;
+  void search(const DlRect& query, std::vector<int>* results) const;
 
   /// Return the ID for the indicated result of a query or
   /// invalid_id if the index is not a valid leaf node index.
@@ -89,12 +87,12 @@ class DlRTree : public SkRefCnt {
   }
 
   /// Returns maximum and minimum axis values of rectangles in this R-Tree.
-  /// If R-Tree is empty returns an empty SkRect.
-  const SkRect& bounds() const;
+  /// If R-Tree is empty returns an empty DlRect.
+  const DlRect& bounds() const;
 
   /// Return the rectangle bounds for the indicated result of a query
   /// or an empty rect if the index is not a valid leaf node index.
-  const SkRect& bounds(int result_index) const {
+  const DlRect& bounds(int result_index) const {
     return (result_index >= 0 && result_index < leaf_count_)
                ? nodes_[result_index].bounds
                : kEmpty;
@@ -123,7 +121,7 @@ class DlRTree : public SkRefCnt {
   /// If |deband| is true, then matching rectangles from adjacent DlRegion
   /// spanlines will be joined together. This reduces the number of
   /// rectangles returned, but requires some extra computation.
-  std::list<SkRect> searchAndConsolidateRects(const SkRect& query,
+  std::list<DlRect> searchAndConsolidateRects(const DlRect& query,
                                               bool deband = true) const;
 
   /// Returns DlRegion that represents the union of all rectangles in the
@@ -132,15 +130,16 @@ class DlRTree : public SkRefCnt {
 
   /// Returns DlRegion that represents the union of all rectangles in the
   /// R-Tree intersected with the query rect.
-  DlRegion region(const SkRect& query) const {
-    return DlRegion::MakeIntersection(region(), DlRegion(query.roundOut()));
+  DlRegion region(const DlRect& query) const {
+    return DlRegion::MakeIntersection(region(),
+                                      DlRegion(DlIRect::RoundOut(query)));
   }
 
  private:
-  static constexpr SkRect kEmpty = SkRect::MakeEmpty();
+  static constexpr DlRect kEmpty = DlRect();
 
   void search(const Node& parent,
-              const SkRect& query,
+              const DlRect& query,
               std::vector<int>* results) const;
 
   std::vector<Node> nodes_;

--- a/display_list/geometry/dl_rtree_unittests.cc
+++ b/display_list/geometry/dl_rtree_unittests.cc
@@ -5,8 +5,6 @@
 #include "flutter/display_list/geometry/dl_rtree.h"
 #include "gtest/gtest.h"
 
-#include "third_party/skia/include/core/SkRect.h"
-
 namespace flutter {
 namespace testing {
 
@@ -21,7 +19,7 @@ TEST(DisplayListRTree, NegativeCount) {
 
 TEST(DisplayListRTree, NullSearchResultVector) {
   DlRTree tree(nullptr, 0);
-  EXPECT_DEATH_IF_SUPPORTED(tree.search(SkRect::MakeLTRB(0, 0, 1, 1), nullptr),
+  EXPECT_DEATH_IF_SUPPORTED(tree.search(DlRect::MakeLTRB(0, 0, 1, 1), nullptr),
                             "results != nullptr");
 }
 #endif
@@ -31,7 +29,7 @@ TEST(DisplayListRTree, NullRectListZeroCount) {
   EXPECT_EQ(tree.leaf_count(), 0);
   EXPECT_EQ(tree.node_count(), 0);
   std::vector<int> results;
-  auto huge = SkRect::MakeLTRB(-1e6, -1e6, 1e6, 1e6);
+  auto huge = DlRect::MakeLTRB(-1e6, -1e6, 1e6, 1e6);
   tree.search(huge, &results);
   EXPECT_EQ(results.size(), 0u);
   auto list = tree.searchAndConsolidateRects(huge);
@@ -45,10 +43,10 @@ TEST(DisplayListRTree, ManySizes) {
   // Rect 2 goes from 20 to 30
   // etc. in both dimensions
   const int kMaxN = 250;
-  SkRect rects[kMaxN + 1];
+  DlRect rects[kMaxN + 1];
   int ids[kMaxN + 1];
   for (int i = 0; i <= kMaxN; i++) {
-    rects[i].setXYWH(i * 20, i * 20, 10, 10);
+    rects[i] = DlRect::MakeXYWH(i * 20, i * 20, 10, 10);
     ids[i] = i + 42;
   }
   std::vector<int> results;
@@ -58,14 +56,14 @@ TEST(DisplayListRTree, ManySizes) {
     EXPECT_EQ(tree.leaf_count(), N) << desc;
     EXPECT_GE(tree.node_count(), N) << desc;
     EXPECT_EQ(tree.id(-1), -1) << desc;
-    EXPECT_EQ(tree.bounds(-1), SkRect::MakeEmpty()) << desc;
+    EXPECT_EQ(tree.bounds(-1), DlRect()) << desc;
     EXPECT_EQ(tree.id(N), -1) << desc;
-    EXPECT_EQ(tree.bounds(N), SkRect::MakeEmpty()) << desc;
+    EXPECT_EQ(tree.bounds(N), DlRect()) << desc;
     results.clear();
-    tree.search(SkRect::MakeEmpty(), &results);
+    tree.search(DlRect(), &results);
     EXPECT_EQ(results.size(), 0u) << desc;
     results.clear();
-    tree.search(SkRect::MakeLTRB(2, 2, 8, 8), &results);
+    tree.search(DlRect::MakeLTRB(2, 2, 8, 8), &results);
     if (N == 0) {
       EXPECT_EQ(results.size(), 0u) << desc;
     } else {
@@ -75,7 +73,7 @@ TEST(DisplayListRTree, ManySizes) {
       EXPECT_EQ(tree.bounds(results[0]), rects[0]) << desc;
       for (int i = 1; i < N; i++) {
         results.clear();
-        auto query = SkRect::MakeXYWH(i * 20 + 2, i * 20 + 2, 6, 6);
+        auto query = DlRect::MakeXYWH(i * 20 + 2, i * 20 + 2, 6, 6);
         tree.search(query, &results);
         EXPECT_EQ(results.size(), 1u) << desc;
         EXPECT_EQ(results[0], i) << desc;
@@ -96,25 +94,25 @@ TEST(DisplayListRTree, HugeSize) {
   // Rect 2 goes from 20 to 30
   // etc. in both dimensions
   const int N = 10000;
-  SkRect rects[N];
+  DlRect rects[N];
   int ids[N];
   for (int i = 0; i < N; i++) {
-    rects[i].setXYWH(i * 20, i * 20, 10, 10);
+    rects[i] = DlRect::MakeXYWH(i * 20, i * 20, 10, 10);
     ids[i] = i + 42;
   }
   DlRTree tree(rects, N, ids);
   EXPECT_EQ(tree.leaf_count(), N);
   EXPECT_GE(tree.node_count(), N);
   EXPECT_EQ(tree.id(-1), -1);
-  EXPECT_EQ(tree.bounds(-1), SkRect::MakeEmpty());
+  EXPECT_EQ(tree.bounds(-1), DlRect());
   EXPECT_EQ(tree.id(N), -1);
-  EXPECT_EQ(tree.bounds(N), SkRect::MakeEmpty());
+  EXPECT_EQ(tree.bounds(N), DlRect());
   std::vector<int> results;
-  tree.search(SkRect::MakeEmpty(), &results);
+  tree.search(DlRect(), &results);
   EXPECT_EQ(results.size(), 0u);
   for (int i = 0; i < N; i++) {
     results.clear();
-    tree.search(SkRect::MakeXYWH(i * 20 + 2, i * 20 + 2, 6, 6), &results);
+    tree.search(DlRect::MakeXYWH(i * 20 + 2, i * 20 + 2, 6, 6), &results);
     EXPECT_EQ(results.size(), 1u);
     EXPECT_EQ(results[0], i);
     EXPECT_EQ(tree.id(results[0]), ids[i]);
@@ -131,14 +129,14 @@ TEST(DisplayListRTree, Grid) {
   const int ROWS = 10;
   const int COLS = 10;
   const int N = ROWS * COLS;
-  SkRect rects[N];
+  DlRect rects[N];
   int ids[N];
   for (int r = 0; r < ROWS; r++) {
     int y = r * 20 + 5;
     for (int c = 0; c < COLS; c++) {
       int x = c * 20 + 5;
       int i = r * COLS + c;
-      rects[i] = SkRect::MakeXYWH(x, y, 10, 10);
+      rects[i] = DlRect::MakeXYWH(x, y, 10, 10);
       ids[i] = i + 42;
     }
   }
@@ -146,11 +144,11 @@ TEST(DisplayListRTree, Grid) {
   EXPECT_EQ(tree.leaf_count(), N);
   EXPECT_GE(tree.node_count(), N);
   EXPECT_EQ(tree.id(-1), -1);
-  EXPECT_EQ(tree.bounds(-1), SkRect::MakeEmpty());
+  EXPECT_EQ(tree.bounds(-1), DlRect());
   EXPECT_EQ(tree.id(N), -1);
-  EXPECT_EQ(tree.bounds(N), SkRect::MakeEmpty());
+  EXPECT_EQ(tree.bounds(N), DlRect());
   std::vector<int> results;
-  tree.search(SkRect::MakeEmpty(), &results);
+  tree.search(DlRect(), &results);
   EXPECT_EQ(results.size(), 0u);
   // Testing eqch rect for a single hit
   for (int r = 0; r < ROWS; r++) {
@@ -161,7 +159,7 @@ TEST(DisplayListRTree, Grid) {
       auto desc =
           "row " + std::to_string(r + 1) + ", col " + std::to_string(c + 1);
       results.clear();
-      auto query = SkRect::MakeXYWH(x + 2, y + 2, 6, 6);
+      auto query = DlRect::MakeXYWH(x + 2, y + 2, 6, 6);
       tree.search(query, &results);
       EXPECT_EQ(results.size(), 1u) << desc;
       EXPECT_EQ(results[0], i) << desc;
@@ -180,7 +178,7 @@ TEST(DisplayListRTree, Grid) {
       auto desc =
           "row " + std::to_string(r + 1) + ", col " + std::to_string(c + 1);
       results.clear();
-      auto query = SkRect::MakeXYWH(x - 8, y - 8, 6, 6);
+      auto query = DlRect::MakeXYWH(x - 8, y - 8, 6, 6);
       tree.search(query, &results);
       EXPECT_EQ(results.size(), 0u) << desc;
       auto list = tree.searchAndConsolidateRects(query);
@@ -197,7 +195,7 @@ TEST(DisplayListRTree, Grid) {
       auto desc =
           "row " + std::to_string(r + 1) + ", col " + std::to_string(c + 1);
       results.clear();
-      auto query = SkRect::MakeXYWH(x - 11, y - 11, 12, 12);
+      auto query = DlRect::MakeXYWH(x - 11, y - 11, 12, 12);
       tree.search(query, &results);
       EXPECT_EQ(results.size(), 4u) << desc;
 
@@ -254,12 +252,12 @@ TEST(DisplayListRTree, OverlappingRects) {
   //                     |            rect2            |
   //                                         |  2 & 3  |
   //                                         |                rect3        |
-  SkRect rects[9];
+  DlRect rects[9];
   for (int r = 0; r < 3; r++) {
     int y = 15 + 20 * r;
     for (int c = 0; c < 3; c++) {
       int x = 15 + 20 * c;
-      rects[r * 3 + c].setLTRB(x - 15, y - 15, x + 15, y + 15);
+      rects[r * 3 + c] = DlRect::MakeLTRB(x - 15, y - 15, x + 15, y + 15);
     }
   }
   DlRTree tree(rects, 9);
@@ -268,7 +266,7 @@ TEST(DisplayListRTree, OverlappingRects) {
     int y = 15 + 20 * r;
     for (int c = 0; c < 3; c++) {
       int x = 15 + 20 * c;
-      auto query = SkRect::MakeLTRB(x - 1, y - 1, x + 1, y + 1);
+      auto query = DlRect::MakeLTRB(x - 1, y - 1, x + 1, y + 1);
       auto list = tree.searchAndConsolidateRects(query);
       EXPECT_EQ(list.size(), 1u);
       EXPECT_EQ(list.front(), rects[r * 3 + c]);
@@ -279,42 +277,42 @@ TEST(DisplayListRTree, OverlappingRects) {
     int c = 1;
     int y = 15 + 20 * r;
     int x = 15 + 20 * c;
-    auto query = SkRect::MakeLTRB(x - 6, y - 1, x + 6, y + 1);
+    auto query = DlRect::MakeLTRB(x - 6, y - 1, x + 6, y + 1);
     auto list = tree.searchAndConsolidateRects(query);
     EXPECT_EQ(list.size(), 1u);
-    EXPECT_EQ(list.front(), SkRect::MakeLTRB(x - 35, y - 15, x + 35, y + 15));
+    EXPECT_EQ(list.front(), DlRect::MakeLTRB(x - 35, y - 15, x + 35, y + 15));
   }
   // Tall rects intersecting 3 source rects vertically
   for (int c = 0; c < 3; c++) {
     int r = 1;
     int x = 15 + 20 * c;
     int y = 15 + 20 * r;
-    auto query = SkRect::MakeLTRB(x - 1, y - 6, x + 1, y + 6);
+    auto query = DlRect::MakeLTRB(x - 1, y - 6, x + 1, y + 6);
     auto list = tree.searchAndConsolidateRects(query);
     EXPECT_EQ(list.size(), 1u);
-    EXPECT_EQ(list.front(), SkRect::MakeLTRB(x - 15, y - 35, x + 15, y + 35));
+    EXPECT_EQ(list.front(), DlRect::MakeLTRB(x - 15, y - 35, x + 15, y + 35));
   }
   // Finally intersecting all 9 rects
-  auto query = SkRect::MakeLTRB(35 - 6, 35 - 6, 35 + 6, 35 + 6);
+  auto query = DlRect::MakeLTRB(35 - 6, 35 - 6, 35 + 6, 35 + 6);
   auto list = tree.searchAndConsolidateRects(query);
   EXPECT_EQ(list.size(), 1u);
-  EXPECT_EQ(list.front(), SkRect::MakeLTRB(0, 0, 70, 70));
+  EXPECT_EQ(list.front(), DlRect::MakeLTRB(0, 0, 70, 70));
 }
 
 TEST(DisplayListRTree, Region) {
-  SkRect rect[9];
+  DlRect rect[9];
   for (int i = 0; i < 9; i++) {
-    rect[i] = SkRect::MakeXYWH(i * 10, i * 10, 20, 20);
+    rect[i] = DlRect::MakeXYWH(i * 10, i * 10, 20, 20);
   }
   DlRTree rtree(rect, 9);
   const auto& region = rtree.region();
   auto rects = region.getRects(true);
-  std::vector<SkIRect> expected_rects{
-      SkIRect::MakeLTRB(0, 0, 20, 10),    SkIRect::MakeLTRB(0, 10, 30, 20),
-      SkIRect::MakeLTRB(10, 20, 40, 30),  SkIRect::MakeLTRB(20, 30, 50, 40),
-      SkIRect::MakeLTRB(30, 40, 60, 50),  SkIRect::MakeLTRB(40, 50, 70, 60),
-      SkIRect::MakeLTRB(50, 60, 80, 70),  SkIRect::MakeLTRB(60, 70, 90, 80),
-      SkIRect::MakeLTRB(70, 80, 100, 90), SkIRect::MakeLTRB(80, 90, 100, 100),
+  std::vector<DlIRect> expected_rects{
+      DlIRect::MakeLTRB(0, 0, 20, 10),    DlIRect::MakeLTRB(0, 10, 30, 20),
+      DlIRect::MakeLTRB(10, 20, 40, 30),  DlIRect::MakeLTRB(20, 30, 50, 40),
+      DlIRect::MakeLTRB(30, 40, 60, 50),  DlIRect::MakeLTRB(40, 50, 70, 60),
+      DlIRect::MakeLTRB(50, 60, 80, 70),  DlIRect::MakeLTRB(60, 70, 90, 80),
+      DlIRect::MakeLTRB(70, 80, 100, 90), DlIRect::MakeLTRB(80, 90, 100, 100),
   };
   EXPECT_EQ(rects.size(), expected_rects.size());
 }

--- a/display_list/utils/dl_matrix_clip_tracker.cc
+++ b/display_list/utils/dl_matrix_clip_tracker.cc
@@ -66,6 +66,18 @@ bool DisplayListMatrixClipState::mapAndClipRect(const SkRect& src,
   return false;
 }
 
+bool DisplayListMatrixClipState::mapAndClipRect(const DlRect& src,
+                                                DlRect* mapped) const {
+  DlRect dl_mapped = src.TransformAndClipBounds(matrix_);
+  auto dl_intersected = dl_mapped.Intersection(cull_rect_);
+  if (dl_intersected.has_value()) {
+    *mapped = dl_intersected.value();
+    return true;
+  }
+  *mapped = DlRect();
+  return false;
+}
+
 void DisplayListMatrixClipState::clipRect(const DlRect& rect,
                                           ClipOp op,
                                           bool is_aa) {

--- a/display_list/utils/dl_matrix_clip_tracker.h
+++ b/display_list/utils/dl_matrix_clip_tracker.h
@@ -149,6 +149,10 @@ class DisplayListMatrixClipState {
     return mapAndClipRect(*rect, rect);
   }
   bool mapAndClipRect(const SkRect& src, SkRect* mapped) const;
+  bool mapAndClipRect(DlRect* rect) const {
+    return mapAndClipRect(*rect, rect);
+  }
+  bool mapAndClipRect(const DlRect& src, DlRect* mapped) const;
 
   void clipRect(const DlRect& rect, ClipOp op, bool is_aa);
   void clipRect(const SkRect& rect, ClipOp op, bool is_aa) {

--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -347,8 +347,9 @@ class EmbedderViewSlice {
   virtual DlCanvas* canvas() = 0;
   virtual void end_recording() = 0;
   virtual const DlRegion& getRegion() const = 0;
-  DlRegion region(const SkRect& query) const {
-    return DlRegion::MakeIntersection(getRegion(), DlRegion(query.roundOut()));
+  DlRegion region(const DlRect& query) const {
+    DlRegion rquery = DlRegion(DlIRect::RoundOut(query));
+    return DlRegion::MakeIntersection(getRegion(), rquery);
   }
 
   virtual void render_into(DlCanvas* canvas) = 0;

--- a/flow/layers/display_list_layer_unittests.cc
+++ b/flow/layers/display_list_layer_unittests.cc
@@ -322,10 +322,9 @@ TEST_F(DisplayListLayerTest, RasterCachePreservesRTree) {
                                           false));
   auto root_canvas_dl = expected_root_canvas.Build();
   const auto root_canvas_rects =
-      root_canvas_dl->rtree()->searchAndConsolidateRects(ToSkRect(kGiantRect),
-                                                         true);
-  std::list<SkRect> root_canvas_rects_expected = {
-      SkRect::MakeLTRB(26, 26, 56, 56),
+      root_canvas_dl->rtree()->searchAndConsolidateRects(kGiantRect, true);
+  std::list<DlRect> root_canvas_rects_expected = {
+      DlRect::MakeLTRB(26, 26, 56, 56),
   };
   EXPECT_EQ(root_canvas_rects_expected, root_canvas_rects);
 
@@ -336,14 +335,13 @@ TEST_F(DisplayListLayerTest, RasterCachePreservesRTree) {
                                           true));
   auto overlay_canvas_dl = expected_overlay_canvas.Build();
   const auto overlay_canvas_rects =
-      overlay_canvas_dl->rtree()->searchAndConsolidateRects(
-          ToSkRect(kGiantRect), true);
+      overlay_canvas_dl->rtree()->searchAndConsolidateRects(kGiantRect, true);
 
   // Same bounds as root canvas, but preserves individual rects.
-  std::list<SkRect> overlay_canvas_rects_expected = {
-      SkRect::MakeLTRB(26, 26, 46, 36),
-      SkRect::MakeLTRB(26, 36, 56, 46),
-      SkRect::MakeLTRB(36, 46, 56, 56),
+  std::list<DlRect> overlay_canvas_rects_expected = {
+      DlRect::MakeLTRB(26, 26, 46, 36),
+      DlRect::MakeLTRB(26, 36, 56, 46),
+      DlRect::MakeLTRB(36, 46, 56, 56),
   };
   EXPECT_EQ(overlay_canvas_rects_expected, overlay_canvas_rects);
 };

--- a/flow/layers/display_list_raster_cache_item.cc
+++ b/flow/layers/display_list_raster_cache_item.cc
@@ -16,7 +16,8 @@
 #include "flutter/flow/raster_cache_item.h"
 #include "flutter/flow/raster_cache_key.h"
 #include "flutter/flow/raster_cache_util.h"
-#include "third_party/skia/include/gpu/ganesh/GrDirectContext.h"
+#include "flutter/third_party/skia/include/core/SkColorSpace.h"
+#include "flutter/third_party/skia/include/gpu/ganesh/GrDirectContext.h"
 
 namespace flutter {
 

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -58,11 +58,11 @@ void RasterCacheResult::draw(DlCanvas& canvas,
 
     canvas.Translate(bounds.fLeft, bounds.fTop);
 
-    SkRect rtree_bounds =
-        RasterCacheUtil::GetRoundedOutDeviceBounds(rtree_->bounds(), matrix);
+    SkRect rtree_bounds = RasterCacheUtil::GetRoundedOutDeviceBounds(
+        ToSkRect(rtree_->bounds()), matrix);
     for (auto rect : rects) {
       SkRect device_rect = RasterCacheUtil::GetRoundedOutDeviceBounds(
-          SkRect::Make(rect), matrix);
+          SkRect::Make(ToSkIRect(rect)), matrix);
       device_rect.offset(-rtree_bounds.fLeft, -rtree_bounds.fTop);
       canvas.DrawImageRect(image_, device_rect, device_rect,
                            DlImageSampling::kNearestNeighbor, paint);

--- a/impeller/geometry/rect.h
+++ b/impeller/geometry/rect.h
@@ -688,6 +688,14 @@ struct TRect {
   }
 
   ONLY_ON_FLOAT_M([[nodiscard]] constexpr static, TRect)
+  RoundIn(const TRect<U>& r) {
+    return TRect::MakeLTRB(saturated::Cast<U, Type>(ceil(r.GetLeft())),
+                           saturated::Cast<U, Type>(ceil(r.GetTop())),
+                           saturated::Cast<U, Type>(floor(r.GetRight())),
+                           saturated::Cast<U, Type>(floor(r.GetBottom())));
+  }
+
+  ONLY_ON_FLOAT_M([[nodiscard]] constexpr static, TRect)
   Round(const TRect<U>& r) {
     return TRect::MakeLTRB(saturated::Cast<U, Type>(round(r.GetLeft())),
                            saturated::Cast<U, Type>(round(r.GetTop())),

--- a/shell/platform/android/surface_texture_external_texture_gl_skia.cc
+++ b/shell/platform/android/surface_texture_external_texture_gl_skia.cc
@@ -8,6 +8,7 @@
 #define GL_GLEXT_PROTOTYPES
 #include <GLES2/gl2ext.h>
 
+#include "flutter/third_party/skia/include/core/SkColorSpace.h"
 #include "flutter/third_party/skia/include/gpu/ganesh/GrBackendSurface.h"
 #include "flutter/third_party/skia/include/gpu/ganesh/GrDirectContext.h"
 #include "flutter/third_party/skia/include/gpu/ganesh/SkImageGanesh.h"

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -12,6 +12,7 @@
 #include "flutter/fml/platform/darwin/cf_utils.h"
 #include "flutter/fml/trace_event.h"
 
+#include "third_party/skia/include/core/SkColorSpace.h"
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/utils/mac/SkCGUtils.h"
 

--- a/shell/platform/embedder/embedder_external_view_embedder.cc
+++ b/shell/platform/embedder/embedder_external_view_embedder.cc
@@ -268,7 +268,7 @@ class Layer {
 
   EmbedderRenderTarget* render_target() { return render_target_.get(); }
 
-  std::vector<SkIRect> coverage() {
+  std::vector<DlIRect> coverage() {
     return flutter_contents_region_.getRects();
   }
 

--- a/shell/platform/embedder/embedder_layers.cc
+++ b/shell/platform/embedder/embedder_layers.cc
@@ -21,7 +21,7 @@ EmbedderLayers::~EmbedderLayers() = default;
 
 void EmbedderLayers::PushBackingStoreLayer(
     const FlutterBackingStore* store,
-    const std::vector<SkIRect>& paint_region_vec) {
+    const std::vector<DlIRect>& paint_region_vec) {
   FlutterLayer layer = {};
 
   layer.struct_size = sizeof(FlutterLayer);
@@ -44,7 +44,7 @@ void EmbedderLayers::PushBackingStoreLayer(
 
   for (const auto& rect : paint_region_vec) {
     auto transformed_rect =
-        root_surface_transformation_.mapRect(SkRect::Make(rect));
+        root_surface_transformation_.mapRect(SkRect::Make(ToSkIRect(rect)));
     paint_region_rects->push_back(FlutterRect{
         transformed_rect.x(),
         transformed_rect.y(),

--- a/shell/platform/embedder/embedder_layers.h
+++ b/shell/platform/embedder/embedder_layers.h
@@ -26,7 +26,7 @@ class EmbedderLayers {
   ~EmbedderLayers();
 
   void PushBackingStoreLayer(const FlutterBackingStore* store,
-                             const std::vector<SkIRect>& drawn_region);
+                             const std::vector<DlIRect>& drawn_region);
 
   void PushPlatformViewLayer(FlutterPlatformViewIdentifier identifier,
                              const EmbeddedViewParams& params);

--- a/shell/platform/fuchsia/flutter/rtree.cc
+++ b/shell/platform/fuchsia/flutter/rtree.cc
@@ -42,7 +42,7 @@ std::list<SkRect> RTree::searchNonOverlappingDrawnRects(
   std::vector<int> intermediary_results;
   search(query, &intermediary_results);
 
-  std::vector<SkIRect> rects;
+  std::vector<DlIRect> rects;
   for (int index : intermediary_results) {
     auto draw_op = draw_op_.find(index);
     // Ignore records that don't draw anything.
@@ -51,14 +51,14 @@ std::list<SkRect> RTree::searchNonOverlappingDrawnRects(
     }
     SkIRect current_record_rect;
     draw_op->second.roundOut(&current_record_rect);
-    rects.push_back(current_record_rect);
+    rects.push_back(ToDlIRect(current_record_rect));
   }
 
   DlRegion region(rects);
   auto non_overlapping_rects = region.getRects(true);
   std::list<SkRect> final_results;
   for (const auto& rect : non_overlapping_rects) {
-    final_results.push_back(SkRect::Make(rect));
+    final_results.push_back(SkRect::Make(ToSkIRect(rect)));
   }
   return final_results;
 }


### PR DESCRIPTION
Continuing the migration of engine code to the new geometry classes. Only DlRTree and DlRegion are converted in this pass, plus a small amount of associated code.