### PR TITLE
Delete stale package_config.json in gclient sync hook

### DIFF
--- a/tools/pub_get_offline.py
+++ b/tools/pub_get_offline.py
@@ -127,6 +127,16 @@ def find_unlisted_packages():
   return unlisted
 
 
+def deleteConfigFiles():
+  # Find all package_config.json that are not under version control.
+  gitCmd = ['git', 'ls-files', '-o', '**/.dart_tool/package_config.json']
+  filesToDelete = subprocess.check_output(
+      gitCmd, cwd=ENGINE_DIR, stderr=subprocess.STDOUT, text=True
+  ).splitlines()
+  for file in filesToDelete:
+    os.remove(os.path.join(ENGINE_DIR, file))
+
+
 def main():
   # Intentionally use the Dart SDK prebuilt instead of the Flutter prebuilt
   # (i.e. prebuilts/{platform}/dart-sdk/bin/dart) because the script has to run
@@ -134,6 +144,10 @@ def main():
   dart_sdk_bin = os.path.join(
       SRC_ROOT, 'flutter', 'third_party', 'dart', 'tools', 'sdks', 'dart-sdk', 'bin'
   )
+
+  # Delete all package_config.json files. These may be stale.
+  # Required ones will be regenerated fresh below.
+  deleteConfigFiles()
 
   # Ensure all relevant packages are listed in ALL_PACKAGES.
   unlisted = find_unlisted_packages()

--- a/tools/pub_get_offline.py
+++ b/tools/pub_get_offline.py
@@ -134,6 +134,7 @@ def delete_config_files():
       gitcmd, cwd=ENGINE_DIR, stderr=subprocess.STDOUT, text=True
   ).splitlines()
   for file in files_to_delete:
+    print('Deleting %s...' % file)
     os.remove(os.path.join(ENGINE_DIR, file))
 
 

--- a/tools/pub_get_offline.py
+++ b/tools/pub_get_offline.py
@@ -127,13 +127,13 @@ def find_unlisted_packages():
   return unlisted
 
 
-def deleteConfigFiles():
+def delete_config_files():
   # Find all package_config.json that are not under version control.
-  gitCmd = ['git', 'ls-files', '-o', '**/.dart_tool/package_config.json']
-  filesToDelete = subprocess.check_output(
-      gitCmd, cwd=ENGINE_DIR, stderr=subprocess.STDOUT, text=True
+  gitcmd = ['git', 'ls-files', '-o', '**/.dart_tool/package_config.json']
+  files_to_delete = subprocess.check_output(
+      gitcmd, cwd=ENGINE_DIR, stderr=subprocess.STDOUT, text=True
   ).splitlines()
-  for file in filesToDelete:
+  for file in files_to_delete:
     os.remove(os.path.join(ENGINE_DIR, file))
 
 
@@ -147,7 +147,7 @@ def main():
 
   # Delete all package_config.json files. These may be stale.
   # Required ones will be regenerated fresh below.
-  deleteConfigFiles()
+  delete_config_files()
 
   # Ensure all relevant packages are listed in ALL_PACKAGES.
   unlisted = find_unlisted_packages()


### PR DESCRIPTION
On the bots there were old and stale `package_config.json` files hanging around that confuse the `dart format` command. This PR adds a step to the `pub_get_offline.py` glcient sync hook to delete all of these files that are not under version control.