### PR TITLE
[web] Don't close image source too early

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -7,6 +7,7 @@ import 'dart:js_interop';
 import 'dart:math' as math;
 import 'dart:typed_data';
 
+import 'package:meta/meta.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
@@ -658,10 +659,13 @@ sealed class ImageSource {
   /// image source.
   int refCount = 0;
 
+  @visibleForTesting
+  bool debugIsClosed = false;
+
   void close() {
-    print('Closing with refs = $refCount');
     if (refCount == 0) {
       _doClose();
+      debugIsClosed = true;
     }
   }
 
@@ -716,7 +720,6 @@ class ImageBitmapImageSource extends ImageSource {
 
   @override
   void _doClose() {
-    print('!!!!!!!');
     imageBitmap.close();
   }
 

--- a/lib/web_ui/lib/src/engine/dom.dart
+++ b/lib/web_ui/lib/src/engine/dom.dart
@@ -169,6 +169,12 @@ extension DomWindowExtension on DomWindow {
   /// The Trusted Types API (when available).
   /// See: https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API
   external DomTrustedTypePolicyFactory? get trustedTypes;
+
+  @JS('createImageBitmap')
+  external JSPromise<JSAny?> _createImageBitmap(DomImageData source);
+  Future<DomImageBitmap> createImageBitmap(DomImageData source) {
+    return js_util.promiseToFuture<DomImageBitmap>(_createImageBitmap(source));
+  }
 }
 
 typedef DomRequestAnimationFrameCallback = void Function(JSNumber highResTime);


### PR DESCRIPTION
A `CkImage` instance holds a reference to `ImageSource?`. When that `CkImage` gets cloned, the `ImageSource` instance becomes shared between the original `CkImage` and its new clone. Then when one of the `CkImage`s gets disposed of, it closes the shared `ImageSource` leaving other live `CkImage`s holding on to a closed `ImageSource`.

The quick solution to this is to have a ref count on the `ImageSource` to count how many `CkImage`s are referencing it. The `ImageSource` will only be closed if its ref count reaches 0.

Fixes https://github.com/flutter/flutter/issues/160199
Fixes https://github.com/flutter/flutter/issues/158093