### PR TITLE
Fix include path in fuchsia's analysis_options.yaml files

### DIFF
--- a/ci/licenses_golden/excluded_files
+++ b/ci/licenses_golden/excluded_files
@@ -347,10 +347,8 @@
 ../../../flutter/shell/platform/embedder/platform_view_embedder_unittests.cc
 ../../../flutter/shell/platform/embedder/tests
 ../../../flutter/shell/platform/fuchsia/dart-pkg/fuchsia/README.md
-../../../flutter/shell/platform/fuchsia/dart-pkg/fuchsia/analysis_options.yaml
 ../../../flutter/shell/platform/fuchsia/dart-pkg/fuchsia/pubspec.yaml
 ../../../flutter/shell/platform/fuchsia/dart-pkg/zircon/README.md
-../../../flutter/shell/platform/fuchsia/dart-pkg/zircon/analysis_options.yaml
 ../../../flutter/shell/platform/fuchsia/dart-pkg/zircon/pubspec.yaml
 ../../../flutter/shell/platform/fuchsia/dart-pkg/zircon/test
 ../../../flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/pubspec.yaml
@@ -360,7 +358,6 @@
 ../../../flutter/shell/platform/fuchsia/dart_runner/kernel/libraries.json
 ../../../flutter/shell/platform/fuchsia/dart_runner/kernel/libraries.yaml
 ../../../flutter/shell/platform/fuchsia/dart_runner/tests
-../../../flutter/shell/platform/fuchsia/dart_runner/vmservice/analysis_options.yaml
 ../../../flutter/shell/platform/fuchsia/dart_runner/vmservice/pubspec.yaml
 ../../../flutter/shell/platform/fuchsia/flutter/README.md
 ../../../flutter/shell/platform/fuchsia/flutter/accessibility_bridge_unittest.cc

--- a/shell/platform/fuchsia/dart-pkg/fuchsia/analysis_options.yaml
+++ b/shell/platform/fuchsia/dart-pkg/fuchsia/analysis_options.yaml
@@ -1,5 +1,0 @@
-# Copyright 2013 The Flutter Authors. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
-
-include: ../../analysis_options.yaml

--- a/shell/platform/fuchsia/dart-pkg/zircon/analysis_options.yaml
+++ b/shell/platform/fuchsia/dart-pkg/zircon/analysis_options.yaml
@@ -1,5 +1,0 @@
-# Copyright 2013 The Flutter Authors. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
-
-include: ../../analysis_options.yaml

--- a/shell/platform/fuchsia/dart_runner/vmservice/analysis_options.yaml
+++ b/shell/platform/fuchsia/dart_runner/vmservice/analysis_options.yaml
@@ -1,5 +1,0 @@
-# Copyright 2013 The Flutter Authors. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
-
-include: ../../../tools/analysis_options.yaml

--- a/shell/platform/fuchsia/flutter/kernel/analysis_options.yaml
+++ b/shell/platform/fuchsia/flutter/kernel/analysis_options.yaml
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-include: ../../../tools/analysis_options.yaml
+include: ../../../../../analysis_options.yaml
 analyzer:
   errors:
     avoid_catches_without_on_clauses: ignore


### PR DESCRIPTION
The old path doesn't exist.

`dart format` stumbles over this non-existent include.

`analysis_options.yaml` files that just imported something non-existent were deleted.

I am surprised that this never caused any other issues. Is this all dead code that isn't actually analyzed?