### PR TITLE
Properly report `dart format` errors

### DIFF
--- a/ci/bin/format.dart
+++ b/ci/bin/format.dart
@@ -863,7 +863,7 @@ class DartFormatChecker extends FormatChecker {
       final Stream<WorkerJob> completedJobs = dartFmt.startWorkers(jobs);
       final List<WorkerJob> diffJobs = <WorkerJob>[];
       await for (final WorkerJob completedJob in completedJobs) {
-        if (completedJob.result.exitCode != 0 && (completedJob.result.stderr.isNotEmpty || completedJob.result.exitCode != 1)) {
+        if (completedJob.result.exitCode != 0 && completedJob.result.exitCode != 1) {
           // The formatter had a problem formatting the file.
           errorJobs.add(completedJob);
         } else if (completedJob.result.exitCode == 1) {
@@ -893,7 +893,7 @@ class DartFormatChecker extends FormatChecker {
       final List<WorkerJob> completedJobs = await dartFmt.runToCompletion(jobs);
       final List<WorkerJob> incorrectJobs = incorrect = [];
       for (final WorkerJob job in completedJobs) {
-        if (job.result.exitCode != 0 && (job.result.stderr.isNotEmpty || job.result.exitCode != 1)) {
+        if (job.result.exitCode != 0 && job.result.exitCode != 1) {
           // The formatter had a problem formatting the file.
           errorJobs.add(job);
         } else if (job.result.exitCode == 1) {

--- a/ci/bin/format.dart
+++ b/ci/bin/format.dart
@@ -834,9 +834,7 @@ class DartFormatChecker extends FormatChecker {
   @override
   Future<bool> fixFormatting() async {
     message('Fixing Dart formatting...');
-    await _runDartFormat(fixing: true);
-    // The dart formatter shouldn't fail when fixing errors.
-    return true;
+    return (await _runDartFormat(fixing: true)) == 0;
   }
 
   Future<int> _runDartFormat({required bool fixing}) async {
@@ -934,7 +932,7 @@ class DartFormatChecker extends FormatChecker {
     } else {
       message('All dart files formatted correctly.');
     }
-    return incorrect.length + errorJobs.length;
+    return fixing ? errorJobs.length : (incorrect.length + errorJobs.length);
   }
 
   void _printErrorJobs(List<WorkerJob> errorJobs) {

--- a/ci/bin/format.dart
+++ b/ci/bin/format.dart
@@ -863,7 +863,7 @@ class DartFormatChecker extends FormatChecker {
       final Stream<WorkerJob> completedJobs = dartFmt.startWorkers(jobs);
       final List<WorkerJob> diffJobs = <WorkerJob>[];
       await for (final WorkerJob completedJob in completedJobs) {
-        if ((completedJob.result.exitCode == 1 && completedJob.result.stderr.isNotEmpty) || completedJob.result.exitCode > 1)  {
+        if (completedJob.result.exitCode != 0 && (completedJob.result.stderr.isNotEmpty || completedJob.result.exitCode != 1)) {
           // The formatter had a problem formatting the file.
           errorJobs.add(completedJob);
         } else if (completedJob.result.exitCode == 1) {
@@ -893,7 +893,7 @@ class DartFormatChecker extends FormatChecker {
       final List<WorkerJob> completedJobs = await dartFmt.runToCompletion(jobs);
       final List<WorkerJob> incorrectJobs = incorrect = [];
       for (final WorkerJob job in completedJobs) {
-        if ((job.result.exitCode == 1 && job.result.stderr.isNotEmpty) || job.result.exitCode > 1)  {
+        if (job.result.exitCode != 0 && (job.result.stderr.isNotEmpty || job.result.exitCode != 1)) {
           // The formatter had a problem formatting the file.
           errorJobs.add(job);
         } else if (job.result.exitCode == 1) {

--- a/ci/bin/format.dart
+++ b/ci/bin/format.dart
@@ -934,7 +934,7 @@ class DartFormatChecker extends FormatChecker {
     } else {
       message('All dart files formatted correctly.');
     }
-    return incorrect.length;
+    return incorrect.length + errorJobs.length;
   }
 
   void _printErrorJobs(List<WorkerJob> errorJobs) {

--- a/ci/bin/format.dart
+++ b/ci/bin/format.dart
@@ -891,13 +891,13 @@ class DartFormatChecker extends FormatChecker {
       });
     } else {
       final List<WorkerJob> completedJobs = await dartFmt.runToCompletion(jobs);
-      final List<WorkerJob> incorrectList = incorrect = [];
+      final List<WorkerJob> incorrectJobs = incorrect = [];
       for (final WorkerJob job in completedJobs) {
         if ((job.result.exitCode == 1 && job.result.stderr.isNotEmpty) || job.result.exitCode > 1)  {
           // The formatter had a problem formatting the file.
           errorJobs.add(job);
         } else if (job.result.exitCode == 1) {
-          incorrectList.add(job);
+          incorrectJobs.add(job);
         }
       }
     }

--- a/ci/test/format_test.dart
+++ b/ci/test/format_test.dart
@@ -193,6 +193,24 @@ void main() {
     }
   });
 
+  test('Prints error if dart formatter fails', () {
+    final TestFileFixture fixture = TestFileFixture(target.FormatCheck.dart);
+    final io.File dartFile = io.File('${repoDir.path}/format_test2.dart');
+    dartFile.writeAsStringSync('P\n');
+    fixture.files.add(dartFile);
+
+    try {
+      fixture.gitAdd();
+      final io.ProcessResult result = io.Process.runSync(
+        formatterPath, <String>['--check', 'dart', '--fix'],
+        workingDirectory: repoDir.path,
+      );
+      expect(result.stderr, contains('format_test2.dart produced the following error'));
+    } finally {
+      fixture.gitRemove();
+    }
+  });
+
   test('Can fix GN formatting errors', () {
     final TestFileFixture fixture = TestFileFixture(target.FormatCheck.gn);
     try {

--- a/ci/test/format_test.dart
+++ b/ci/test/format_test.dart
@@ -205,7 +205,8 @@ void main() {
         formatterPath, <String>['--check', 'dart', '--fix'],
         workingDirectory: repoDir.path,
       );
-      expect(result.stderr, contains('format_test2.dart produced the following error'));
+      expect(result.stdout, contains('format_test2.dart produced the following error'));
+      expect(result.exitCode, isNot(0));
     } finally {
       fixture.gitRemove();
     }


### PR DESCRIPTION
`dart format` can fail (e.g. if a file contains invalid dart code). Previously, those failures were swallowed. This change adds logic to properly print those failures to the terminal.