### PR TITLE
Adjust some ignores for 'dart format'

### DIFF
--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -294,7 +294,8 @@ typedef _ListStringArgFunction = Object? Function(List<String> args);
 void _runMain(Function startMainIsolateFunction,
               Function userMainFunction,
               List<String> args) {
-  startMainIsolateFunction(() { // ignore: avoid_dynamic_calls
+  // ignore: avoid_dynamic_calls
+  startMainIsolateFunction(() {
     if (userMainFunction is _ListStringArgFunction) {
       userMainFunction(args);
     } else {

--- a/lib/web_ui/lib/src/engine/services/message_codecs.dart
+++ b/lib/web_ui/lib/src/engine/services/message_codecs.dart
@@ -310,7 +310,8 @@ class StandardMessageCodec implements MessageCodec<dynamic> {
     } else if (value is double) {
       buffer.putUint8(_valueFloat64);
       buffer.putFloat64(value);
-    } else if (value is int) { // ignore: avoid_double_and_int_checks
+      // ignore: avoid_double_and_int_checks
+    } else if (value is int) {
       if (-0x7fffffff - 1 <= value && value <= 0x7fffffff) {
         buffer.putUint8(_valueInt32);
         buffer.putInt32(value);

--- a/lib/web_ui/test/engine/view/view_constraints_test.dart
+++ b/lib/web_ui/test/engine/view/view_constraints_test.dart
@@ -145,10 +145,12 @@ Future<void> testMain() async {
       expect(
           ViewConstraints.fromJs(constraints, size),
           const ViewConstraints(
+            minWidth: 500,
             // ignore: avoid_redundant_argument_values
-            minWidth: 500, maxWidth: double.infinity,
+            maxWidth: double.infinity,
+            minHeight: 300,
             // ignore: avoid_redundant_argument_values
-            minHeight: 300, maxHeight: double.infinity,
+            maxHeight: double.infinity,
           ));
     });
   });

--- a/testing/dart/image_filter_test.dart
+++ b/testing/dart/image_filter_test.dart
@@ -92,7 +92,8 @@ void main() async {
 
   List<ColorFilter> colorFilters() {
     // Create new color filter instances on each invocation.
-    return <ColorFilter> [                        // ignore: prefer_const_constructors
+    // ignore: prefer_const_constructors
+    return <ColorFilter> [
       ColorFilter.mode(green, BlendMode.color),   // ignore: prefer_const_constructors
       ColorFilter.mode(red, BlendMode.color),     // ignore: prefer_const_constructors
       ColorFilter.mode(red, BlendMode.screen),    // ignore: prefer_const_constructors

--- a/testing/scenario_app/lib/src/platform_view.dart
+++ b/testing/scenario_app/lib/src/platform_view.dart
@@ -22,7 +22,8 @@ List<int> _to64(num value) {
   final Uint8List temp = Uint8List(15);
   if (value is double) {
     temp.buffer.asByteData().setFloat64(7, value, Endian.little);
-  } else if (value is int) {  // ignore: avoid_double_and_int_checks
+    // ignore: avoid_double_and_int_checks
+  } else if (value is int) {
     temp.buffer.asByteData().setInt64(7, value, Endian.little);
   }
   return temp;

--- a/tools/const_finder/test/fixtures/lib/box.dart
+++ b/tools/const_finder/test/fixtures/lib/box.dart
@@ -217,7 +217,11 @@ const Box box2_98 = Box(box2_97, box2_97);
 const Box box2_99 = Box(box2_98, box2_98);
 
 Object confuse(Box x) {
-  try { throw x; } catch (e) { return e; } // ignore: only_throw_errors
+  try {
+    throw x; // ignore: only_throw_errors
+  } catch (e) {
+    return e;
+  }
 }
 
 void main() {


### PR DESCRIPTION
When running `dart format` over these lines the `// ignore` ended up on a line where it wasn't properly ignoring the lint. This adjusts the placement of `// ignore`s so they will continue to ignore the right thing even after the code is auto formatted.

I am hoping that if we do this now the large PR that formats the entire repo will go in smoother without manual intervention.