### PR TITLE
[Impeller] Fix render pass layout transition when resolve texture has mip levels.

### DIFF
--- a/impeller/display_list/aiks_dl_unittests.cc
+++ b/impeller/display_list/aiks_dl_unittests.cc
@@ -959,6 +959,31 @@ TEST_P(AiksTest, CanPictureConvertToImage) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.Build()));
 }
 
+TEST_P(AiksTest, CanPictureConvertToImageWithMips) {
+  DisplayListBuilder recorder_canvas;
+  DlPaint paint;
+  paint.setColor(DlColor::RGBA(0.9568, 0.2627, 0.2118, 1.0));
+  recorder_canvas.DrawRect(SkRect::MakeXYWH(100.0, 100.0, 600, 600), paint);
+  paint.setColor(DlColor::RGBA(0.1294, 0.5882, 0.9529, 1.0));
+  recorder_canvas.DrawRect(SkRect::MakeXYWH(200.0, 200.0, 600, 600), paint);
+
+  DisplayListBuilder canvas;
+  AiksContext renderer(GetContext(), nullptr);
+  paint.setColor(DlColor::kTransparent());
+  canvas.DrawPaint(paint);
+
+  auto image =
+      DisplayListToTexture(recorder_canvas.Build(), {1000, 1000}, renderer,
+                           /*reset_host_buffer=*/true, /*generate_mips=*/true);
+  if (image) {
+    canvas.DrawImage(DlImageImpeller::Make(image), SkPoint{}, {});
+    paint.setColor(DlColor::RGBA(0.1, 0.1, 0.1, 0.2));
+    canvas.DrawRect(SkRect::MakeSize({1000, 1000}), paint);
+  }
+
+  ASSERT_TRUE(OpenPlaygroundHere(canvas.Build()));
+}
+
 // Regression test for https://github.com/flutter/flutter/issues/142358 .
 // Without a change to force render pass construction the image is left in an
 // undefined layout and triggers a validation error.

--- a/impeller/display_list/aiks_dl_unittests.cc
+++ b/impeller/display_list/aiks_dl_unittests.cc
@@ -959,31 +959,6 @@ TEST_P(AiksTest, CanPictureConvertToImage) {
   ASSERT_TRUE(OpenPlaygroundHere(canvas.Build()));
 }
 
-TEST_P(AiksTest, CanPictureConvertToImageWithMips) {
-  DisplayListBuilder recorder_canvas;
-  DlPaint paint;
-  paint.setColor(DlColor::RGBA(0.9568, 0.2627, 0.2118, 1.0));
-  recorder_canvas.DrawRect(SkRect::MakeXYWH(100.0, 100.0, 600, 600), paint);
-  paint.setColor(DlColor::RGBA(0.1294, 0.5882, 0.9529, 1.0));
-  recorder_canvas.DrawRect(SkRect::MakeXYWH(200.0, 200.0, 600, 600), paint);
-
-  DisplayListBuilder canvas;
-  AiksContext renderer(GetContext(), nullptr);
-  paint.setColor(DlColor::kTransparent());
-  canvas.DrawPaint(paint);
-
-  auto image =
-      DisplayListToTexture(recorder_canvas.Build(), {1000, 1000}, renderer,
-                           /*reset_host_buffer=*/true, /*generate_mips=*/true);
-  if (image) {
-    canvas.DrawImage(DlImageImpeller::Make(image), SkPoint{}, {});
-    paint.setColor(DlColor::RGBA(0.1, 0.1, 0.1, 0.2));
-    canvas.DrawRect(SkRect::MakeSize({1000, 1000}), paint);
-  }
-
-  ASSERT_TRUE(OpenPlaygroundHere(canvas.Build()));
-}
-
 // Regression test for https://github.com/flutter/flutter/issues/142358 .
 // Without a change to force render pass construction the image is left in an
 // undefined layout and triggers a validation error.

--- a/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -198,7 +198,7 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
         .SetLayoutWithoutEncoding(vk::ImageLayout::eGeneral);
   }
   if (color_image_vk_) {
-    TextureVK::Cast(*resolve_image_vk_)
+    TextureVK::Cast(*color_image_vk_)
         .SetLayoutWithoutEncoding(vk::ImageLayout::eGeneral);
   }
 

--- a/impeller/renderer/backend/vulkan/render_pass_vk.cc
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.cc
@@ -194,25 +194,10 @@ RenderPassVK::RenderPassVK(const std::shared_ptr<const Context>& context,
   pass_info.setClearValueCount(clear_count);
 
   if (resolve_image_vk_) {
-    // If the resolve image has mip levels, only mip level 0 will be
-    // transitioned by the render pass. All subsequent mip levels must have an
-    // explicit barrier inserted to transition from undefined.
-    if (resolve_image_vk_->GetTextureDescriptor().mip_count > 1) {
-      BarrierVK barrier;
-      barrier.new_layout = vk::ImageLayout::eGeneral;
-      barrier.cmd_buffer = command_buffer_vk_;
-      barrier.src_access = vk::AccessFlagBits::eShaderRead;
-      barrier.src_stage = vk::PipelineStageFlagBits::eFragmentShader;
-      barrier.dst_access = vk::AccessFlagBits::eColorAttachmentWrite |
-                           vk::AccessFlagBits::eTransferWrite;
-      barrier.dst_stage = vk::PipelineStageFlagBits::eColorAttachmentOutput |
-                          vk::PipelineStageFlagBits::eTransfer;
-      TextureVK::Cast(*resolve_image_vk_).SetLayout(barrier);
-    } else {
-      TextureVK::Cast(*resolve_image_vk_)
-          .SetLayoutWithoutEncoding(vk::ImageLayout::eGeneral);
-    }
-  } else if (color_image_vk_) {
+    TextureVK::Cast(*resolve_image_vk_)
+        .SetLayoutWithoutEncoding(vk::ImageLayout::eGeneral);
+  }
+  if (color_image_vk_) {
     TextureVK::Cast(*resolve_image_vk_)
         .SetLayoutWithoutEncoding(vk::ImageLayout::eGeneral);
   }

--- a/impeller/renderer/backend/vulkan/render_pass_vk.h
+++ b/impeller/renderer/backend/vulkan/render_pass_vk.h
@@ -12,7 +12,6 @@
 #include "impeller/renderer/command_buffer.h"
 #include "impeller/renderer/render_pass.h"
 #include "impeller/renderer/render_target.h"
-#include "vulkan/vulkan_handles.hpp"
 
 namespace impeller {
 


### PR DESCRIPTION
This fixed the validation error produced in [159876](https://github.com/flutter/flutter/issues/159876). Not clear yet if it fixes the actual rendering error.