### PR TITLE
Reland 'Delete stale package_config.json in gclient sync hook'

### DIFF
--- a/tools/pub_get_offline.py
+++ b/tools/pub_get_offline.py
@@ -134,8 +134,10 @@ def delete_config_files():
       gitcmd, cwd=ENGINE_DIR, stderr=subprocess.STDOUT, text=True
   ).splitlines()
   for file in files_to_delete:
-    print('Deleting %s...' % file)
-    os.remove(os.path.join(ENGINE_DIR, file))
+    file_path = os.path.join(ENGINE_DIR, file)
+    if os.path.exists(file_path):
+      print('Deleting %s...' % file)
+      os.remove(file_path)
 
 
 def main():


### PR DESCRIPTION
https://github.com/flutter/engine/pull/57195 was reverted because it tried to delete non-existing files. This adds a check to only attempt to delete the file if it exists.