### PR TITLE
Build SDKs for the DDC library bundle format

### DIFF
--- a/web_sdk/BUILD.gn
+++ b/web_sdk/BUILD.gn
@@ -336,13 +336,17 @@ group("flutter_platform_dills") {
   ]
 }
 
-template("_compile_ddc_modules") {
+template("_compile_ddc_module") {
   assert(defined(invoker.sound_null_safety),
          "sound_null_safety must be defined for $target_name")
-  assert(defined(invoker.use_skia),
-         "use_skia must be defined  for $target_name")
+  assert(defined(invoker.use_skia), "use_skia must be defined for $target_name")
   assert(defined(invoker.auto_detect),
          "auto_detect must be defined for $target_name")
+  assert(defined(invoker.sdk_path_prefix),
+         "sdk_path_prefix must be defined for $target_name")
+  assert(defined(invoker.module_format),
+         "module_name must be defined for $target_name")
+  assert(defined(invoker.canary), "canary must be defined for $target_name")
 
   _dartdevc(target_name) {
     inputs = [ "sdk_rewriter.dart" ] + web_ui_sources
@@ -360,17 +364,11 @@ template("_compile_ddc_modules") {
       name_suffix += "-sound"
     }
 
-    amd_js_path =
-        "$root_out_dir/flutter_web_sdk/kernel/amd${name_suffix}/dart_sdk.js"
-
-    ddc_js_path =
-        "$root_out_dir/flutter_web_sdk/kernel/ddc${name_suffix}/dart_sdk.js"
+    dart_sdk_js_path = "$root_out_dir/flutter_web_sdk/kernel/${invoker.sdk_path_prefix}${name_suffix}/dart_sdk.js"
 
     outputs = [
-      amd_js_path,
-      amd_js_path + ".map",
-      ddc_js_path,
-      ddc_js_path + ".map",
+      dart_sdk_js_path,
+      dart_sdk_js_path + ".map",
     ]
 
     if (invoker.sound_null_safety) {
@@ -405,14 +403,13 @@ template("_compile_ddc_modules") {
       "-DFLUTTER_WEB_USE_SKIA=${invoker.use_skia}",
       "-DFLUTTER_WEB_AUTO_DETECT=${invoker.auto_detect}",
       "--modules",
-      "amd",
+      invoker.module_format,
       "-o",
-      rebase_path(amd_js_path),
-      "--modules",
-      "ddc",
-      "-o",
-      rebase_path(ddc_js_path),
+      rebase_path(dart_sdk_js_path),
     ]
+    if (invoker.canary) {
+      args += [ "--canary" ]
+    }
     if (flutter_prebuilt_dart_sdk) {
       args += [
         "--multi-root",
@@ -423,6 +420,38 @@ template("_compile_ddc_modules") {
         "--multi-root",
         "file:///" + rebase_path("$root_out_dir"),
       ]
+    }
+  }
+}
+
+template("_compile_ddc_modules") {
+  assert(defined(invoker.sound_null_safety),
+         "sound_null_safety must be defined for $target_name")
+  forward_variables_from(invoker, "*")
+
+  # We compile multiple times instead of passing multiple modules to a single
+  # compile as the DDC library bundle format cannot be used when passing
+  # multiple module formats as arguments.
+  _compile_ddc_module("${target_name}_amd") {
+    sdk_path_prefix = "amd"
+    module_format = "amd"
+    canary = false
+  }
+
+  # TODO(srujzs): Remove this when we no longer support the DDC module format in
+  # Flutter tools.
+  _compile_ddc_module("${target_name}_ddc") {
+    sdk_path_prefix = "ddc"
+    module_format = "ddc"
+    canary = false
+  }
+
+  # No support for unsound null safety with the DDC library bundle format.
+  if (sound_null_safety) {
+    _compile_ddc_module("${target_name}_ddcLibraryBundle") {
+      sdk_path_prefix = "ddcLibraryBundle"
+      module_format = "ddc"
+      canary = true
     }
   }
 }
@@ -471,12 +500,23 @@ _compile_ddc_modules("flutter_dartdevc_canvaskit_html_kernel_sdk_sound") {
 
 group("flutter_ddc_modules") {
   public_deps = [
-    ":flutter_dartdevc_canvaskit_html_kernel_sdk",
-    ":flutter_dartdevc_canvaskit_html_kernel_sdk_sound",
-    ":flutter_dartdevc_canvaskit_kernel_sdk",
-    ":flutter_dartdevc_canvaskit_kernel_sdk_sound",
-    ":flutter_dartdevc_kernel_sdk",
-    ":flutter_dartdevc_kernel_sdk_sound",
+    # TODO(srujzs): Remove the DDC module format targets when we no longer
+    # support it in Flutter tools.
+    ":flutter_dartdevc_canvaskit_html_kernel_sdk_amd",
+    ":flutter_dartdevc_canvaskit_html_kernel_sdk_ddc",
+    ":flutter_dartdevc_canvaskit_html_kernel_sdk_sound_amd",
+    ":flutter_dartdevc_canvaskit_html_kernel_sdk_sound_ddc",
+    ":flutter_dartdevc_canvaskit_html_kernel_sdk_sound_ddcLibraryBundle",
+    ":flutter_dartdevc_canvaskit_kernel_sdk_amd",
+    ":flutter_dartdevc_canvaskit_kernel_sdk_ddc",
+    ":flutter_dartdevc_canvaskit_kernel_sdk_sound_amd",
+    ":flutter_dartdevc_canvaskit_kernel_sdk_sound_ddc",
+    ":flutter_dartdevc_canvaskit_kernel_sdk_sound_ddcLibraryBundle",
+    ":flutter_dartdevc_kernel_sdk_amd",
+    ":flutter_dartdevc_kernel_sdk_ddc",
+    ":flutter_dartdevc_kernel_sdk_sound_amd",
+    ":flutter_dartdevc_kernel_sdk_sound_ddc",
+    ":flutter_dartdevc_kernel_sdk_sound_ddcLibraryBundle",
   ]
 }
 
@@ -500,14 +540,33 @@ if (!is_fuchsia) {
     deps += [ "//flutter/lib/web_ui/flutter_js" ]
 
     # flutter_ddc_modules
-    sources = get_target_outputs(":flutter_dartdevc_kernel_sdk")
-    sources += get_target_outputs(":flutter_dartdevc_canvaskit_kernel_sdk")
-    sources += get_target_outputs(":flutter_dartdevc_canvaskit_html_kernel_sdk")
-    sources += get_target_outputs(":flutter_dartdevc_kernel_sdk_sound")
+    sources = get_target_outputs(":flutter_dartdevc_kernel_sdk_amd")
+    sources += get_target_outputs(":flutter_dartdevc_canvaskit_kernel_sdk_amd")
     sources +=
-        get_target_outputs(":flutter_dartdevc_canvaskit_kernel_sdk_sound")
+        get_target_outputs(":flutter_dartdevc_canvaskit_html_kernel_sdk_amd")
+    sources += get_target_outputs(":flutter_dartdevc_kernel_sdk_sound_amd")
     sources +=
-        get_target_outputs(":flutter_dartdevc_canvaskit_html_kernel_sdk_sound")
+        get_target_outputs(":flutter_dartdevc_canvaskit_kernel_sdk_sound_amd")
+    sources += get_target_outputs(
+            ":flutter_dartdevc_canvaskit_html_kernel_sdk_sound_amd")
+
+    # TODO(srujzs): Remove these when we no longer support the DDC module format
+    # in Flutter tools.
+    sources += get_target_outputs(":flutter_dartdevc_kernel_sdk_ddc")
+    sources += get_target_outputs(":flutter_dartdevc_canvaskit_kernel_sdk_ddc")
+    sources +=
+        get_target_outputs(":flutter_dartdevc_canvaskit_html_kernel_sdk_ddc")
+    sources += get_target_outputs(":flutter_dartdevc_kernel_sdk_sound_ddc")
+    sources +=
+        get_target_outputs(":flutter_dartdevc_canvaskit_kernel_sdk_sound_ddc")
+    sources += get_target_outputs(
+            ":flutter_dartdevc_canvaskit_html_kernel_sdk_sound_ddc")
+    sources += get_target_outputs(
+            ":flutter_dartdevc_kernel_sdk_sound_ddcLibraryBundle")
+    sources += get_target_outputs(
+            ":flutter_dartdevc_canvaskit_kernel_sdk_sound_ddcLibraryBundle")
+    sources += get_target_outputs(
+            ":flutter_dartdevc_canvaskit_html_kernel_sdk_sound_ddcLibraryBundle")
 
     # flutter_platform_dills
     sources +=


### PR DESCRIPTION
In order to support hot reload, we initially planned to use the DDC module format. When that became infeasible, we introduced the library bundle format.

This format can only be emitted when passed as the single module arg to a DDC compile, so this change splits the generation of SDKs into multiple steps.

We also do not support unsound null safety with the new format, so it should never be generated.

When Flutter tools no longer tests for the DDC module format and removes support for it (which I'm tackling separately as well), the generated SDKs for that format can be deleted.

Part of the larger effort to support hot reload: https://github.com/dart-lang/webdev/issues/2516

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [x] All existing and new tests are passing.
