### PR TITLE
Updating AVD Dependency for Android 28 Emulator

### DIFF
--- a/ci/builders/linux_android_emulator.json
+++ b/ci/builders/linux_android_emulator.json
@@ -139,7 +139,7 @@
                         },
                         {
                             "dependency": "avd_cipd_version",
-                            "version": "build_id:8735216702926189361"
+                            "version": "build_id:8733065022087935185"
                         }
                     ],
                     "contexts": [

--- a/ci/builders/linux_android_emulator_34.json
+++ b/ci/builders/linux_android_emulator_34.json
@@ -139,7 +139,7 @@
                         },
                         {
                             "dependency": "avd_cipd_version",
-                            "version": "build_id:8740267484269553649"
+                            "version": "build_id:8733065022087935185"
                         }
                     ],
                     "contexts": [


### PR DESCRIPTION
Emulators depending on Android 28 API are currently failing. Advancing the AVD dependency to `8733065022087935185`, the same version used in other repos, should fix the errors. 

Fixes b/379736755

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/engine/blob/main/docs/testing/Testing-the-engine.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
