### PR TITLE
Use granular skparagraph targets

### DIFF
--- a/skia/modules/skparagraph/BUILD.gn
+++ b/skia/modules/skparagraph/BUILD.gn
@@ -18,10 +18,7 @@ declare_args() {
 
 config("public_config") {
   defines = [ "SK_ENABLE_PARAGRAPH" ]
-  include_dirs = [
-    "$_skia_root/modules/skparagraph/include",
-    "$_skia_root/modules/skparagraph/utils",
-  ]
+  include_dirs = [ "$_skia_root/modules/skparagraph/include" ]
 }
 
 skia_component("skparagraph") {
@@ -37,4 +34,17 @@ skia_component("skparagraph") {
     "../skunicode",
   ]
   deps = [ "../skshaper" ]
+}
+
+skia_component("utils") {
+  import("$_skia_root/modules/skparagraph/skparagraph.gni")
+
+  # Opted out of check_includes, due to this being test only.
+  check_includes = false
+  include_dirs = [ "$_skia_root/modules/skparagraph/utils" ]
+  sources = skparagraph_utils
+  deps = [
+    ":skparagraph",
+    "../skshaper",
+  ]
 }

--- a/third_party/txt/BUILD.gn
+++ b/third_party/txt/BUILD.gn
@@ -147,6 +147,7 @@ if (enable_unittests) {
       ":txt_fixtures",
       "//flutter/fml",
       "//flutter/skia/modules/skparagraph",
+      "//flutter/skia/modules/skparagraph:utils",
       "//flutter/testing:testing_lib",
       "//flutter/third_party/benchmark",
     ]


### PR DESCRIPTION
Skia would like to clean up the SkParagraph GNI lists (see http://review.skia.org/931916). Because Flutter uses paragraph's test utilities, we should make that an explicit target rather than bundling it into the main Skia target.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/engine/blob/main/docs/testing/Testing-the-engine.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
