### PR TITLE
Migrate mac_clang_tidy to a Linux orchestrator

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -462,7 +462,7 @@ targets:
       # at https://github.com/flutter/flutter/issues/152186.
       cores: "8"
 
-  - name: Mac mac_clang_tidy
+  - name: Linux mac_clang_tidy
     recipe: engine_v2/engine_v2
     timeout: 120
     properties:
@@ -481,6 +481,14 @@ targets:
       - "**.vert"
       - "**.m"
       - "**.mm"
+    drone_dimensions:
+      - os=Linux
+    dimensions:
+      # This is needed so that orchestrators that only spawn subbuilds are not
+      # assigned to the large 32 core workers when doing release builds.
+      # For more details see the issue
+      # at https://github.com/flutter/flutter/issues/152186.
+      cores: "8"
 
   - name: Mac mac_host_engine
     recipe: engine_v2/engine_v2

--- a/ci/builders/mac_clang_tidy.json
+++ b/ci/builders/mac_clang_tidy.json
@@ -26,6 +26,11 @@
             "description": "A debug mode macOS host build used only as the basis for a clang-tidy run.",
             "ninja": {
                 "config": "ci/host_debug_clang_tidy"
+            },
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "15a240d"
+                }
             }
         },
         {
@@ -55,6 +60,11 @@
             "description": "A debug mode iOS simulator build used only as the basis for a clang-tidy run.",
             "ninja": {
                 "config": "ci/ios_debug_sim_clang_tidy"
+            },
+            "properties": {
+                "$flutter/osx_sdk": {
+                    "sdk_version": "15a240d"
+                }
             }
         }
     ],


### PR DESCRIPTION
Manual application of the change from: https://github.com/flutter/flutter/pull/162042/files

Hack around https://github.com/flutter/flutter/issues/162518