### PR TITLE
fix: Problem with Japanease IME on macOS

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -742,6 +742,18 @@ static char markerKey;
 
     _activeModel->SetSelection(flutter::TextRange(base, extent));
   }
+  else if (_activeModel->composing() && !(_activeModel->composing_range() == _activeModel->selection())) {
+    // When confirmed by Japanese IME, string replaces range of composing_range.
+    // If selection == composing_range there is no problem.
+    // If selection ! = composing_range the range of selection is only a part of composing_range.
+    // Since _activeModel->AddText is processed first for selection, the finalization of the conversion 
+    // cannot be processed correctly unless selection == composing_range or selection.collapsed().
+    // Since _activeModel->SetSelection fails if (composing_ && !range.collapsed()), 
+    // selection == composing_range will failed.
+    // Therefore, the selection cursor should only be placed at the beginning of composing_range.
+    flutter::TextRange composing_range = _activeModel->composing_range();
+    _activeModel->SetSelection(flutter::TextRange(composing_range.start()));
+  }
 
   flutter::TextRange oldSelection = _activeModel->selection();
   flutter::TextRange composingBeforeChange = _activeModel->composing_range();


### PR DESCRIPTION
* Fix the Japanese IME problem on macOS reported in the following issue.
* https://github.com/flutter/flutter/issues/160935

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or the PR is [test-exempt]. See [testing the engine] for instructions on writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

CC @cbenhagen 